### PR TITLE
Fix usage of regexp_matches wrapped inside subscript as GROUB BY 

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -66,6 +66,11 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in CrateDB >= ``4.3`` which prevents using
+  ``regexp_matches()`` wrapped inside a subscript expression from being used
+  as a ``GROUP BY`` expression.
+  This fixed the broken AdminUI->Montoring tab as it uses such an statement.
+
 - Fixed validation of ``GROUP BY`` expressions if an alias is used. The
   validation was by passed and resulted in an execution exception instead of
   an user friendly validation exception.

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -66,6 +66,10 @@ Changes
 Fixes
 =====
 
+- Fixed validation of ``GROUP BY`` expressions if an alias is used. The
+  validation was by passed and resulted in an execution exception instead of
+  an user friendly validation exception.
+
 - Fixed an issue that caused ``IS NULL`` and ``IS NOT NULL`` operators on
   columns of type ``OBJECT`` with the column policy ``IGNORED`` to match
   incorrect records.

--- a/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze.validator;
 
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.MatchPredicate;
 import io.crate.expression.symbol.Symbol;
@@ -72,6 +73,11 @@ public class GroupBySymbolValidator {
         @Override
         protected Void visitSymbol(Symbol symbol, String errorMsgTemplate) {
             return null;
+        }
+
+        @Override
+        public Void visitAlias(AliasSymbol aliasSymbol, String errorMsgTemplate) {
+            return aliasSymbol.symbol().accept(this, errorMsgTemplate);
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPoints.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPoints.java
@@ -47,13 +47,19 @@ public class SplitPoints {
     private final List<Symbol> toCollect;
     private final List<Function> aggregates;
     private final List<Function> tableFunctions;
+    private final List<Function> tableFunctionsBelowGroupBy;
     private final List<WindowFunction> windowFunctions;
 
 
-    SplitPoints(List<Symbol> toCollect, List<Function> aggregates, List<Function> tableFunctions, List<WindowFunction> windowFunctions) {
+    SplitPoints(List<Symbol> toCollect,
+                List<Function> aggregates,
+                List<Function> tableFunctions,
+                List<Function> tableFunctionsBelowGroupBy,
+                List<WindowFunction> windowFunctions) {
         this.toCollect = toCollect;
         this.aggregates = aggregates;
         this.tableFunctions = tableFunctions;
+        this.tableFunctionsBelowGroupBy = tableFunctionsBelowGroupBy;
         this.windowFunctions = windowFunctions;
     }
 
@@ -67,6 +73,10 @@ public class SplitPoints {
 
     public List<Function> tableFunctions() {
         return tableFunctions;
+    }
+
+    public List<Function> tableFunctionsBelowGroupBy() {
+        return tableFunctionsBelowGroupBy;
     }
 
     public List<WindowFunction> windowFunctions() {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -22,20 +22,6 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.expression.symbol.SelectSymbol.ResultType.SINGLE_COLUMN_SINGLE_VALUE;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
-import org.elasticsearch.Version;
-
 import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
@@ -102,6 +88,19 @@ import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToTopNDistinct;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
 import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static io.crate.expression.symbol.SelectSymbol.ResultType.SINGLE_COLUMN_SINGLE_VALUE;
 
 /**
  * Planner which can create a {@link ExecutionPlan} using intermediate {@link LogicalPlan} nodes.
@@ -383,7 +382,10 @@ public class LogicalPlanner {
                                     WindowAgg.create(
                                         Filter.create(
                                             groupByOrAggregate(
-                                                source,
+                                                ProjectSet.create(
+                                                    source,
+                                                    splitPoints.tableFunctionsBelowGroupBy()
+                                                ),
                                                 relation.groupBy(),
                                                 splitPoints.aggregates(),
                                                 tableStats

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2614,4 +2614,12 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         Function serializedTo41 = new Function(in);
         assertThat(serializedTo41.info().ident().argumentTypes().get(1), is(DataTypes.STRING));
     }
+
+    @Test
+    public void test_table_function_wrapped_inside_scalar_can_be_used_inside_group_by() {
+        var executor = SQLExecutor.builder(clusterService)
+            .build();
+        AnalyzedRelation rel = executor.analyze("select regexp_matches('foo', '.*')[1] from sys.cluster group by 1");
+        assertThat(rel.outputs().get(0).valueType().getName(), is("text"));
+    }
 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -21,38 +21,6 @@
 
 package io.crate.analyze;
 
-import static io.crate.testing.RelationMatchers.isDocTable;
-import static io.crate.testing.SymbolMatchers.isAlias;
-import static io.crate.testing.SymbolMatchers.isField;
-import static io.crate.testing.SymbolMatchers.isFunction;
-import static io.crate.testing.SymbolMatchers.isLiteral;
-import static io.crate.testing.SymbolMatchers.isReference;
-import static io.crate.testing.TestingHelpers.isSQL;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.hamcrest.Matchers;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
-
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
@@ -102,6 +70,38 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TimeTZ;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.RelationMatchers.isDocTable;
+import static io.crate.testing.SymbolMatchers.isAlias;
+import static io.crate.testing.SymbolMatchers.isField;
+import static io.crate.testing.SymbolMatchers.isFunction;
+import static io.crate.testing.SymbolMatchers.isLiteral;
+import static io.crate.testing.SymbolMatchers.isReference;
+import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 @SuppressWarnings("ConstantConditions")
 public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTest {
@@ -2360,6 +2360,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .build();
         expectedException.expectMessage("Table functions are not allowed in GROUP BY");
         executor.analyze("select count(*) from t1 group by unnest([1])");
+    }
+
+    @Test
+    public void test_aliased_table_function_in_group_by_is_prohibited() throws Exception {
+        var executor = SQLExecutor.builder(clusterService).build();
+        assertThrows(
+            () -> executor.analyze("select unnest([1]) as a from sys.cluster group by 1"),
+            IllegalArgumentException.class,
+            "Table functions are not allowed in GROUP BY"
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isReference;
 import static org.hamcrest.Matchers.contains;
@@ -108,5 +109,15 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mergePhase.projections().get(1), instanceOf(EvalProjection.class));
 
         assertThat(mergePhase.projections().get(1).outputs(), contains(isFunction("abs")));
+    }
+
+    @Test
+    public void test_group_by_scalar_containing_a_table_function_results_in_project_set() {
+        var logicalPlan = e.logicalPlan("SELECT regexp_matches(name, '.*')[1] FROM users GROUP BY 1");
+        var expectedPlan =
+            "GroupHashAggregate[regexp_matches(name, '.*')[1]]\n" +
+            "  └ ProjectSet[regexp_matches(name, '.*'), name]\n" +
+            "    └ Collect[doc.users | [name] | true]";
+        assertThat(logicalPlan, isPlan(expectedPlan));
     }
 }


### PR DESCRIPTION
Fixes a regression introduced in 4.3 when ``regexp_matches``
was converted into a table function
(8ad9ecf).

This also fixes the broken AdminUI->Monitoring tab as it uses such a statement.