### PR TITLE
Fix link to `Crash` inside SSL documentation

### DIFF
--- a/docs/admin/ssl.rst
+++ b/docs/admin/ssl.rst
@@ -7,7 +7,7 @@ Secured communications (SSL/TLS)
 Secured communication allows you to encrypt traffic between the CrateDB node
 and a client. This applies to connections using HTTP (i.e. `Admin UI
 <https://crate.io/docs/crate/tutorials/en/latest/first-use.html#admin-ui>`_,
-`Crash <https://crate.io/docs/crate/tutorials/en/latest/first-use.html#crash>`_,
+`Crash <https://crate.io/docs/crate/crash/en/latest/>`_,
 :ref:`sql_http_endpoint`) and the :ref:`postgres_wire_protocol` (i.e. JDBC, psql).
 
 Connections are secured using Transport Layer Security (TLS).


### PR DESCRIPTION
The existing link/anchor does not exists anymore, changed link to point to the official crash documentation instead.

Relates https://github.com/crate/crate-tutorials/pull/30.