### PR TITLE
Fix NPE causing stuck queries in insert returning

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -66,6 +66,8 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to stuck ``INSERT INTO .. RETURNING`` queries.
+
 - Fixed a regression introduced in CrateDB >= ``4.3`` which prevents using
   ``regexp_matches()`` wrapped inside a subscript expression from being used
   as a ``GROUP BY`` expression.

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,5 +1,5 @@
 # crate and components deps
-guava=28.0-jre
+guava=30.0-jre
 antlr=4.8-1
 jodatime=2.10.1
 commonscli=1.3.1
@@ -21,7 +21,7 @@ jackson_xc=1.9.13
 jacksonasl=1.9.13
 
 crate_admin_ui = 1.17.0
-jdbc=42.2.14
+jdbc=42.2.18
 
 lucene=8.7.0
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/UpsertResultCollectors.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/UpsertResultCollectors.java
@@ -86,8 +86,11 @@ final class UpsertResultCollectors {
         void processShardResponse(UpsertResults upsertResults,
                                   ShardResponse shardResponse,
                                   List<RowSourceInfo> rowSourceInfosIgnored) {
-            synchronized (lock) {
-                upsertResults.addResultRows(shardResponse.getResultRows());
+            List<Object[]> resultRows = shardResponse.getResultRows();
+            if (resultRows != null) {
+                synchronized (lock) {
+                    upsertResults.addResultRows(resultRows);
+                }
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -84,6 +84,7 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.SQLExceptions;
 
 /**
  * Base class for requests that should be executed on a primary copy followed by replica copies.
@@ -861,7 +862,7 @@ public abstract class TransportReplicationAction<
                 logger.trace(() -> new ParameterizedMessage("operation failed. action [{}], request [{}]", actionName, request), failure);
                 listener.onFailure(failure);
             } else {
-                assert false : "finishAsFailed called but operation is already finished";
+                assert false : "finishAsFailed called but operation is already finished. Error=" + SQLExceptions.unwrap(failure);
             }
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If there is a failure on an individual item the results are `null` which 
caused a NullPointerException in the result collection for `RETURNING`.

An example where the failure happened is if the insert contains a duplicate
primary key.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)