### PR TITLE
Fix "REPRODUCE WITH" output

### DIFF
--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -69,6 +69,9 @@ test {
         }
     }
 
+    // Used by `ReproduceInfoPrinter` to add a "REPRODUCE WITH: " notice
+    systemProperty "tests.task", path
+
     filter {
         setFailOnNoMatchingTests(false)
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Instead of outputing `./gradlew null ...` it will now print the proper
project/test task name.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)