### PR TITLE
Try to fix flaky DiskDisruptionIT.testGlobalCheckpointIsSafe

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiskDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiskDisruptionIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -99,6 +100,7 @@ public class DiskDisruptionIT extends AbstractDisruptionTestCase {
      * all un-fsynced data will be lost.
      */
     @UseRandomizedSchema(random = false)
+    @Test
     public void testGlobalCheckpointIsSafe() throws Exception {
         startCluster(rarely() ? 5 : 3);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The insert from unnest logic in the BackgroundIndexer was broken.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)