### PR TITLE
Backport AllocationService related patches

### DIFF
--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -242,7 +242,7 @@ public class SysShardsTableInfo {
 
         Map<String, Map<String, IntIndexedContainer>> locations = new TreeMap<>();
         GroupShardsIterator<ShardIterator> groupShardsIterator =
-            clusterState.getRoutingTable().allAssignedShardsGrouped(concreteIndices, true, true);
+            clusterState.getRoutingTable().allAssignedShardsGrouped(concreteIndices, true);
         for (final ShardIterator shardIt : groupShardsIterator) {
             final ShardRouting shardRouting = shardIt.nextOrNull();
             processShardRouting(clusterState.getNodes().getLocalNodeId(), locations, shardRouting, shardIt.shardId());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -103,6 +103,10 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
                 // create the target initializing shard routing on the node the shard is relocating to
                 allInitializingShards.add(shard.getTargetRelocatingShard());
                 allAllocationIds.add(shard.getTargetRelocatingShard().allocationId().getId());
+
+                assert shard.assignedToNode() : "relocating from unassigned " + shard;
+                assert shard.getTargetRelocatingShard().assignedToNode() : "relocating to unassigned " + shard.getTargetRelocatingShard();
+                assignedShards.add(shard.getTargetRelocatingShard());
             }
             if (shard.assignedToNode()) {
                 assignedShards.add(shard);
@@ -200,7 +204,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     }
 
     /**
-     * Returns a {@link List} of assigned shards
+     * Returns a {@link List} of assigned shards, including relocation targets
      *
      * @return a {@link List} of shards
      */
@@ -415,11 +419,6 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         for (ShardRouting shardRouting : assignedShards()) {
             if (shardRouting.allocationId().getId().equals(allocationId)) {
                 return shardRouting;
-            }
-            if (shardRouting.relocating()) {
-                if (shardRouting.getTargetRelocatingShard().allocationId().getId().equals(allocationId)) {
-                    return shardRouting.getTargetRelocatingShard();
-                }
             }
         }
         return null;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -66,11 +66,7 @@ public class OperationRouting {
                                                         DiscoveryNodes nodes,
                                                         @Nullable String preference) {
         if (preference == null || preference.isEmpty()) {
-            if (awarenessAttributes.isEmpty()) {
-                return indexShard.activeInitializingShardsRandomIt();
-            } else {
-                return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes);
-            }
+            return shardRoutings(indexShard, nodes);
         }
         if (preference.charAt(0) == '_') {
             Preference preferenceType = Preference.parse(preference);
@@ -97,11 +93,7 @@ public class OperationRouting {
                 }
                 // no more preference
                 if (index == -1 || index == preference.length() - 1) {
-                    if (awarenessAttributes.isEmpty()) {
-                        return indexShard.activeInitializingShardsRandomIt();
-                    } else {
-                        return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes);
-                    }
+                    return shardRoutings(indexShard, nodes);
                 } else {
                     // update the preference and continue
                     preference = preference.substring(index + 1);
@@ -138,6 +130,14 @@ public class OperationRouting {
             return indexShard.activeInitializingShardsIt(routingHash);
         } else {
             return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes, routingHash);
+        }
+    }
+
+    private ShardIterator shardRoutings(IndexShardRoutingTable indexShard, DiscoveryNodes nodes) {
+        if (awarenessAttributes.isEmpty()) {
+            return indexShard.activeInitializingShardsRandomIt();
+        } else {
+            return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingChangesObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingChangesObserver.java
@@ -60,11 +60,6 @@ public interface RoutingChangesObserver {
     void relocationSourceRemoved(ShardRouting removedReplicaRelocationSource);
 
     /**
-     * Called on started primary shard after it has been promoted from replica to primary and is reinitialized due to shadow replicas.
-     */
-    void startedPrimaryReinitialized(ShardRouting startedPrimaryShard, ShardRouting initializedShard);
-
-    /**
      * Called when started replica is promoted to primary.
      */
     void replicaPromoted(ShardRouting replicaShard);
@@ -114,11 +109,6 @@ public interface RoutingChangesObserver {
 
         @Override
         public void relocationSourceRemoved(ShardRouting removedReplicaRelocationSource) {
-
-        }
-
-        @Override
-        public void startedPrimaryReinitialized(ShardRouting startedPrimaryShard, ShardRouting initializedShard) {
 
         }
 
@@ -187,13 +177,6 @@ public interface RoutingChangesObserver {
         public void relocationSourceRemoved(ShardRouting removedReplicaRelocationSource) {
             for (RoutingChangesObserver routingChangesObserver : routingChangesObservers) {
                 routingChangesObserver.relocationSourceRemoved(removedReplicaRelocationSource);
-            }
-        }
-
-        @Override
-        public void startedPrimaryReinitialized(ShardRouting startedPrimaryShard, ShardRouting initializedShard) {
-            for (RoutingChangesObserver routingChangesObserver : routingChangesObservers) {
-                routingChangesObserver.startedPrimaryReinitialized(startedPrimaryShard, initializedShard);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingException.java
@@ -29,10 +29,6 @@ import java.io.IOException;
  */
 public class RoutingException extends ElasticsearchException {
 
-    public RoutingException(String message) {
-        super(message);
-    }
-
     public RoutingException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -577,13 +577,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             if (failedShard.relocatingNodeId() == null) {
                 if (failedShard.primary()) {
                     // promote active replica to primary if active replica exists (only the case for shadow replicas)
-                    ShardRouting activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
-                    if (activeReplica == null) {
-                        moveToUnassigned(failedShard, unassignedInfo);
-                    } else {
-                        movePrimaryToUnassignedAndDemoteToReplica(failedShard, unassignedInfo);
-                        promoteReplicaToPrimary(activeReplica, indexMetadata, routingChangesObserver);
-                    }
+                    unassignPrimaryAndPromoteActiveReplicaIfExists(failedShard, unassignedInfo, routingChangesObserver);
                 } else {
                     // initializing shard that is not relocation target, just move to unassigned
                     moveToUnassigned(failedShard, unassignedInfo);
@@ -601,34 +595,37 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                 cancelRelocation(sourceShard);
                 remove(failedShard);
             }
-            routingChangesObserver.shardFailed(failedShard, unassignedInfo);
         } else {
             assert failedShard.active();
             if (failedShard.primary()) {
                 // promote active replica to primary if active replica exists
-                ShardRouting activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
-                if (activeReplica == null) {
-                    moveToUnassigned(failedShard, unassignedInfo);
-                } else {
-                    movePrimaryToUnassignedAndDemoteToReplica(failedShard, unassignedInfo);
-                    promoteReplicaToPrimary(activeReplica, indexMetadata, routingChangesObserver);
-                }
+                unassignPrimaryAndPromoteActiveReplicaIfExists(failedShard, unassignedInfo, routingChangesObserver);
             } else {
-                assert failedShard.primary() == false;
                 if (failedShard.relocating()) {
                     remove(failedShard);
                 } else {
                     moveToUnassigned(failedShard, unassignedInfo);
                 }
             }
-            routingChangesObserver.shardFailed(failedShard, unassignedInfo);
         }
+        routingChangesObserver.shardFailed(failedShard, unassignedInfo);
         assert node(failedShard.currentNodeId()).getByShardId(failedShard.shardId()) == null : "failedShard " + failedShard +
             " was matched but wasn't removed";
     }
 
-    private void promoteReplicaToPrimary(ShardRouting activeReplica, IndexMetadata indexMetadata,
-                                         RoutingChangesObserver routingChangesObserver) {
+    private void unassignPrimaryAndPromoteActiveReplicaIfExists(ShardRouting failedShard, UnassignedInfo unassignedInfo,
+                                                                RoutingChangesObserver routingChangesObserver) {
+        assert failedShard.primary();
+        ShardRouting activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
+        if (activeReplica == null) {
+            moveToUnassigned(failedShard, unassignedInfo);
+        } else {
+            movePrimaryToUnassignedAndDemoteToReplica(failedShard, unassignedInfo);
+            promoteReplicaToPrimary(activeReplica, routingChangesObserver);
+        }
+    }
+
+    private void promoteReplicaToPrimary(ShardRouting activeReplica, RoutingChangesObserver routingChangesObserver) {
         // if the activeReplica was relocating before this call to failShard, its relocation was cancelled earlier when we
         // failed initializing replica shards (and moved replica relocation source back to started)
         assert activeReplica.started() : "replica relocation should have been cancelled: " + activeReplica;
@@ -1172,10 +1169,6 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         private static final Recoveries EMPTY = new Recoveries();
         private int incoming = 0;
         private int outgoing = 0;
-
-        int getTotal() {
-            return incoming + outgoing;
-        }
 
         void addOutgoing(int howMany) {
             assert outgoing + howMany >= 0 : outgoing + howMany + " must be >= 0";

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -63,9 +62,25 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     // index to IndexRoutingTable map
     private final ImmutableOpenMap<String, IndexRoutingTable> indicesRouting;
 
-    RoutingTable(long version, ImmutableOpenMap<String, IndexRoutingTable> indicesRouting) {
+    private RoutingTable(long version, ImmutableOpenMap<String, IndexRoutingTable> indicesRouting) {
         this.version = version;
         this.indicesRouting = indicesRouting;
+    }
+
+    /**
+     * Get's the {@link IndexShardRoutingTable} for the given shard id from the given {@link IndexRoutingTable}
+     * or throws a {@link ShardNotFoundException} if no shard by the given id is found in the IndexRoutingTable.
+     *
+     * @param indexRouting IndexRoutingTable
+     * @param shardId ShardId
+     * @return IndexShardRoutingTable
+     */
+    public static IndexShardRoutingTable shardRoutingTable(IndexRoutingTable indexRouting, int shardId) {
+        IndexShardRoutingTable indexShard = indexRouting.shard(shardId);
+        if (indexShard == null) {
+            throw new ShardNotFoundException(new ShardId(indexRouting.getIndex(), shardId));
+        }
+        return indexShard;
     }
 
     /**
@@ -118,11 +133,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         if (indexRouting == null) {
             throw new IndexNotFoundException(index);
         }
-        IndexShardRoutingTable shard = indexRouting.shard(shardId);
-        if (shard == null) {
-            throw new ShardNotFoundException(new ShardId(indexRouting.getIndex(), shardId));
-        }
-        return shard;
+        return shardRoutingTable(indexRouting, shardId);
     }
 
     /**
@@ -143,22 +154,15 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         return shard;
     }
 
-    public IndexShardRoutingTable shardRoutingTableOrNull(ShardId shardId) {
-        return Optional
-            .ofNullable(index(shardId.getIndexName()))
-            .flatMap(irt -> Optional.ofNullable(irt.shard(shardId.getId())))
-            .orElse(null);
-    }
-
     @Nullable
     public ShardRouting getByAllocationId(ShardId shardId, String allocationId) {
-        IndexShardRoutingTable shardRoutingTable = shardRoutingTableOrNull(shardId);
-        if (shardRoutingTable == null) {
+        final IndexRoutingTable indexRoutingTable = index(shardId.getIndexName());
+        if (indexRoutingTable == null) {
             return null;
         }
-        return shardRoutingTable.getByAllocationId(allocationId);
+        final IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId.getId());
+        return shardRoutingTable == null ? null : shardRoutingTable.getByAllocationId(allocationId);
     }
-
 
     public boolean validate(Metadata metadata) {
         for (IndexRoutingTable indexRoutingTable : this) {
@@ -213,40 +217,29 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         return shards;
     }
 
-    public GroupShardsIterator allActiveShardsGrouped(String[] indices, boolean includeEmpty) {
-        return allActiveShardsGrouped(indices, includeEmpty, false);
-    }
-
     /**
      * Return GroupShardsIterator where each active shard routing has it's own shard iterator.
      *
      * @param includeEmpty             if true, a shard iterator will be added for non-assigned shards as well
-     * @param includeRelocationTargets if true, an <b>extra</b> shard iterator will be added for relocating shards. The extra
-     *                                 iterator contains a single ShardRouting pointing at the relocating target
      */
-    public GroupShardsIterator allActiveShardsGrouped(String[] indices, boolean includeEmpty, boolean includeRelocationTargets) {
-        return allSatisfyingPredicateShardsGrouped(indices, includeEmpty, includeRelocationTargets, ACTIVE_PREDICATE);
-    }
-
-    public GroupShardsIterator<ShardIterator> allAssignedShardsGrouped(String[] indices, boolean includeEmpty) {
-        return allAssignedShardsGrouped(indices, includeEmpty, false);
+    public GroupShardsIterator<ShardIterator> allActiveShardsGrouped(String[] indices, boolean includeEmpty) {
+        return allSatisfyingPredicateShardsGrouped(indices, includeEmpty, ACTIVE_PREDICATE);
     }
 
     /**
      * Return GroupShardsIterator where each assigned shard routing has it's own shard iterator.
      *
-     * @param includeEmpty             if true, a shard iterator will be added for non-assigned shards as well
-     * @param includeRelocationTargets if true, an <b>extra</b> shard iterator will be added for relocating shards. The extra
-     *                                 iterator contains a single ShardRouting pointing at the relocating target
+     * @param includeEmpty if true, a shard iterator will be added for non-assigned shards as well
      */
-    public GroupShardsIterator<ShardIterator> allAssignedShardsGrouped(String[] indices, boolean includeEmpty, boolean includeRelocationTargets) {
-        return allSatisfyingPredicateShardsGrouped(indices, includeEmpty, includeRelocationTargets, ASSIGNED_PREDICATE);
+    public GroupShardsIterator<ShardIterator> allAssignedShardsGrouped(String[] indices, boolean includeEmpty) {
+        return allSatisfyingPredicateShardsGrouped(indices, includeEmpty, ASSIGNED_PREDICATE);
     }
 
     private static Predicate<ShardRouting> ACTIVE_PREDICATE = ShardRouting::active;
     private static Predicate<ShardRouting> ASSIGNED_PREDICATE = ShardRouting::assignedToNode;
 
-    private GroupShardsIterator<ShardIterator> allSatisfyingPredicateShardsGrouped(String[] indices, boolean includeEmpty, boolean includeRelocationTargets, Predicate<ShardRouting> predicate) {
+    private GroupShardsIterator<ShardIterator> allSatisfyingPredicateShardsGrouped(String[] indices, boolean includeEmpty,
+                                                                                   Predicate<ShardRouting> predicate) {
         // use list here since we need to maintain identity across shards
         ArrayList<ShardIterator> set = new ArrayList<>();
         for (String index : indices) {
@@ -259,9 +252,6 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 for (ShardRouting shardRouting : indexShardRoutingTable) {
                     if (predicate.test(shardRouting)) {
                         set.add(shardRouting.shardsIt());
-                        if (includeRelocationTargets && shardRouting.relocating()) {
-                            set.add(new PlainShardIterator(shardRouting.shardId(), Collections.singletonList(shardRouting.getTargetRelocatingShard())));
-                        }
                     } else if (includeEmpty) { // we need this for counting properly, just make it an empty one
                         set.add(new PlainShardIterator(shardRouting.shardId(), Collections.<ShardRouting>emptyList()));
                     }
@@ -428,33 +418,31 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                     if (shardRoutingEntry.initializing() && shardRoutingEntry.relocatingNodeId() != null)
                         continue;
 
-                    Index index = shardRoutingEntry.index();
-                    IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index.getName());
-                    if (indexBuilder == null) {
-                        indexBuilder = new IndexRoutingTable.Builder(index);
-                        indexRoutingTableBuilders.put(index.getName(), indexBuilder);
-                    }
-
-                    indexBuilder.addShard(shardRoutingEntry);
+                    addShard(indexRoutingTableBuilders, shardRoutingEntry);
                 }
             }
 
             Iterable<ShardRouting> shardRoutingEntries = Iterables.concat(routingNodes.unassigned(), routingNodes.unassigned().ignored());
 
             for (ShardRouting shardRoutingEntry : shardRoutingEntries) {
-                Index index = shardRoutingEntry.index();
-                IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index.getName());
-                if (indexBuilder == null) {
-                    indexBuilder = new IndexRoutingTable.Builder(index);
-                    indexRoutingTableBuilders.put(index.getName(), indexBuilder);
-                }
-                indexBuilder.addShard(shardRoutingEntry);
+                addShard(indexRoutingTableBuilders, shardRoutingEntry);
             }
 
             for (IndexRoutingTable.Builder indexBuilder : indexRoutingTableBuilders.values()) {
                 add(indexBuilder);
             }
             return this;
+        }
+
+        private static void addShard(final Map<String, IndexRoutingTable.Builder> indexRoutingTableBuilders,
+                final ShardRouting shardRoutingEntry) {
+            Index index = shardRoutingEntry.index();
+            IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index.getName());
+            if (indexBuilder == null) {
+                indexBuilder = new IndexRoutingTable.Builder(index);
+                indexRoutingTableBuilders.put(index.getName(), indexBuilder);
+            }
+            indexBuilder.addShard(shardRoutingEntry);
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -170,11 +170,6 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
             this.id = id;
         }
 
-        // package private for testing
-        byte getId() {
-            return id;
-        }
-
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeByte(id);
@@ -288,10 +283,6 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         out.writeException(failure);
         out.writeVInt(failedAllocations);
         lastAllocationStatus.writeTo(out);
-    }
-
-    public UnassignedInfo readFrom(StreamInput in) throws IOException {
-        return new UnassignedInfo(in);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -111,7 +111,7 @@ public class AllocationService {
         gatewayAllocator.applyStartedShards(allocation, startedShards);
         assert RoutingNodes.assertShardStats(allocation.routingNodes());
         String startedShardsAsString
-            = firstListElementsToCommaDelimitedString(startedShards, s -> s.shardId().toString());
+            = firstListElementsToCommaDelimitedString(startedShards, s -> s.shardId().toString(), LOGGER.isDebugEnabled());
         return buildResultAndLogHealthChange(clusterState, allocation, "shards started [" + startedShardsAsString + "]");
     }
 
@@ -199,8 +199,9 @@ public class AllocationService {
         gatewayAllocator.applyFailedShards(allocation, failedShards);
 
         reroute(allocation);
-        String failedShardsAsString = firstListElementsToCommaDelimitedString(failedShards, s -> s.getRoutingEntry().shardId().toString());
-        return buildResultAndLogHealthChange(clusterState, allocation, "shards failed [" + failedShardsAsString + "] ...");
+        String failedShardsAsString
+            = firstListElementsToCommaDelimitedString(failedShards, s -> s.getRoutingEntry().shardId().toString(), LOGGER.isDebugEnabled());
+        return buildResultAndLogHealthChange(clusterState, allocation, "shards failed [" + failedShardsAsString + "]");
     }
 
     /**
@@ -310,13 +311,14 @@ public class AllocationService {
      * @param <T>       The list element type.
      * @return A comma-separated string of the first few elements.
      */
-    private <T> String firstListElementsToCommaDelimitedString(List<T> elements, Function<T, String> formatter) {
+    static <T> String firstListElementsToCommaDelimitedString(List<T> elements, Function<T, String> formatter, boolean isDebugEnabled) {
         final int maxNumberOfElements = 10;
-        return elements
-                .stream()
-                .limit(maxNumberOfElements)
-                .map(formatter)
-                .collect(Collectors.joining(", "));
+        if (isDebugEnabled || elements.size() <= maxNumberOfElements) {
+            return elements.stream().map(formatter).collect(Collectors.joining(", "));
+        } else {
+            return elements.stream().limit(maxNumberOfElements).map(formatter).collect(Collectors.joining(", "))
+                + ", ... [" + elements.size() + " items in total]";
+        }
     }
 
     public CommandsResult reroute(final ClusterState clusterState, AllocationCommands commands, boolean explain, boolean retryFailed) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -149,6 +149,7 @@ public class AllocationService {
         return newStateBuilder.build();
     }
 
+
     /**
      * Applies the failed shards. Note, only assigned ShardRouting instances that exist in the routing table should be
      * provided as parameter. Also applies a list of allocation ids to remove from the in-sync set for shard copies for which there
@@ -332,16 +333,16 @@ public class AllocationService {
         allocation.debugDecision(true);
         // we ignore disable allocation, because commands are explicit
         allocation.ignoreDisable(true);
-        final RoutingExplanations explanations = commands.execute(allocation, explain);
-        // we revert the ignore disable flag, since when rerouting, we want the original setting to take place
-        allocation.ignoreDisable(false);
-        // the assumption is that commands will move / act on shards (or fail through exceptions)
-        // so, there will always be shard "movements", so no need to check on reroute
 
         if (retryFailed) {
             resetFailedAllocationCounter(allocation);
         }
 
+        RoutingExplanations explanations = commands.execute(allocation, explain);
+        // we revert the ignore disable flag, since when rerouting, we want the original setting to take place
+        allocation.ignoreDisable(false);
+        // the assumption is that commands will move / act on shards (or fail through exceptions)
+        // so, there will always be shard "movements", so no need to check on reroute
         reroute(allocation);
         return new CommandsResult(explanations, buildResultAndLogHealthChange(clusterState, allocation, "reroute commands"));
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
@@ -194,9 +194,13 @@ public class IndexMetadataUpdater extends RoutingChangesObserver.AbstractRouting
             // of replicas was decreased while shards were unassigned.
             int maxActiveShards = oldIndexMetadata.getNumberOfReplicas() + 1; // +1 for the primary
             IndexShardRoutingTable newShardRoutingTable = newRoutingTable.shardRoutingTable(shardId);
+            assert newShardRoutingTable.assignedShards().stream()
+                .filter(ShardRouting::isRelocationTarget).map(s -> s.allocationId().getId()).noneMatch(inSyncAllocationIds::contains)
+                : newShardRoutingTable.assignedShards() + " vs " + inSyncAllocationIds;
             if (inSyncAllocationIds.size() > oldInSyncAllocationIds.size() && inSyncAllocationIds.size() > maxActiveShards) {
                 // trim entries that have no corresponding shard routing in the cluster state (i.e. trim unavailable copies)
-                List<ShardRouting> assignedShards = newShardRoutingTable.assignedShards();
+                List<ShardRouting> assignedShards = newShardRoutingTable.assignedShards()
+                    .stream().filter(s -> s.isRelocationTarget() == false).collect(Collectors.toList());
                 assert assignedShards.size() <= maxActiveShards :
                     "cannot have more assigned shards " + assignedShards + " than maximum possible active shards " + maxActiveShards;
                 Set<String> assignedAllocations = assignedShards.stream().map(s -> s.allocationId().getId()).collect(Collectors.toSet());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -184,12 +184,7 @@ public class RoutingAllocation {
         if (ignoredShardToNodes == null) {
             ignoredShardToNodes = new HashMap<>();
         }
-        Set<String> nodes = ignoredShardToNodes.get(shardId);
-        if (nodes == null) {
-            nodes = new HashSet<>();
-            ignoredShardToNodes.put(shardId, nodes);
-        }
-        nodes.add(nodeId);
+        ignoredShardToNodes.computeIfAbsent(shardId, k -> new HashSet<>()).add(nodeId);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesChangedObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesChangedObserver.java
@@ -84,13 +84,6 @@ public class RoutingNodesChangedObserver implements RoutingChangesObserver {
     }
 
     @Override
-    public void startedPrimaryReinitialized(ShardRouting startedPrimaryShard, ShardRouting initializedShard) {
-        assert startedPrimaryShard.primary() && startedPrimaryShard.started() : "expected started primary shard " + startedPrimaryShard;
-        assert initializedShard.primary() && initializedShard.initializing() : "expected initializing primary shard " + initializedShard;
-        setChanged();
-    }
-
-    @Override
     public void replicaPromoted(ShardRouting replicaShard) {
         assert replicaShard.started() && replicaShard.primary() == false : "expected started replica shard " + replicaShard;
         setChanged();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cluster.routing.allocation;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -730,7 +730,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             final PriorityComparator secondaryComparator = PriorityComparator.getAllocationComparator(allocation);
             final Comparator<ShardRouting> comparator = (o1, o2) -> {
                 if (o1.primary() ^ o2.primary()) {
-                    return o1.primary() ? -1 : o2.primary() ? 1 : 0;
+                    return o1.primary() ? -1 : 1;
                 }
                 final int indexCmp;
                 if ((indexCmp = o1.getIndexName().compareTo(o2.getIndexName())) == 0) {
@@ -910,7 +910,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                             updateMinNode = ((((nodeHigh > repId && minNodeHigh > repId)
                                                    || (nodeHigh < repId && minNodeHigh < repId))
                                                   && (nodeHigh < minNodeHigh))
-                                                 || (nodeHigh > minNodeHigh && nodeHigh > repId && minNodeHigh < repId));
+                                                 || (nodeHigh > repId && minNodeHigh < repId));
                         } else {
                             updateMinNode = currentDecision.type() == Type.YES;
                         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
@@ -110,19 +110,26 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
             return explainOrThrowMissingRoutingNode(allocation, explain, discoNode);
         }
 
-        final ShardRouting shardRouting;
         try {
-            shardRouting = allocation.routingTable().shardRoutingTable(index, shardId).primaryShard();
+            allocation.routingTable().shardRoutingTable(index, shardId).primaryShard();
         } catch (IndexNotFoundException | ShardNotFoundException e) {
             return explainOrThrowRejectedCommand(explain, allocation, e);
         }
-        if (shardRouting.unassigned() == false) {
+
+        ShardRouting shardRouting = null;
+        for (ShardRouting shard : allocation.routingNodes().unassigned()) {
+            if (shard.getIndexName().equals(index) && shard.getId() == shardId && shard.primary()) {
+                shardRouting = shard;
+                break;
+            }
+        }
+        if (shardRouting == null) {
             return explainOrThrowRejectedCommand(explain, allocation, "primary [" + index + "][" + shardId + "] is already assigned");
         }
 
         if (shardRouting.recoverySource().getType() != RecoverySource.Type.EMPTY_STORE && acceptDataLoss == false) {
-            String dataLossWarning = "allocating an empty primary for [" + index + "][" + shardId + "] can result in data loss. Please confirm " +
-                "by setting the accept_data_loss parameter to true";
+            String dataLossWarning = "allocating an empty primary for [" + index + "][" + shardId +
+                "] can result in data loss. Please confirm by setting the accept_data_loss parameter to true";
             return explainOrThrowRejectedCommand(explain, allocation, dataLossWarning);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReplicaAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReplicaAllocationCommand.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.RerouteExplanation;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
@@ -35,6 +34,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -101,18 +101,33 @@ public class AllocateReplicaAllocationCommand extends AbstractAllocateAllocation
             return explainOrThrowMissingRoutingNode(allocation, explain, discoNode);
         }
 
-        final ShardRouting primaryShardRouting;
         try {
-            primaryShardRouting = allocation.routingTable().shardRoutingTable(index, shardId).primaryShard();
+            allocation.routingTable().shardRoutingTable(index, shardId).primaryShard();
         } catch (IndexNotFoundException | ShardNotFoundException e) {
             return explainOrThrowRejectedCommand(explain, allocation, e);
         }
-        if (primaryShardRouting.unassigned()) {
+
+        ShardRouting primaryShardRouting = null;
+        for (RoutingNode node : allocation.routingNodes()) {
+            for (ShardRouting shard : node) {
+                if (shard.getIndexName().equals(index) && shard.getId() == shardId && shard.primary()) {
+                    primaryShardRouting = shard;
+                    break;
+                }
+            }
+        }
+        if (primaryShardRouting == null) {
             return explainOrThrowRejectedCommand(explain, allocation,
                 "trying to allocate a replica shard [" + index + "][" + shardId + "], while corresponding primary shard is still unassigned");
         }
 
-        List<ShardRouting> replicaShardRoutings = allocation.routingTable().shardRoutingTable(index, shardId).replicaShardsWithState(ShardRoutingState.UNASSIGNED);
+        List<ShardRouting> replicaShardRoutings = new ArrayList<>();
+        for (ShardRouting shard : allocation.routingNodes().unassigned()) {
+            if (shard.getIndexName().equals(index) && shard.getId() == shardId && shard.primary() == false) {
+                replicaShardRoutings.add(shard);
+            }
+        }
+
         ShardRouting shardRouting;
         if (replicaShardRoutings.isEmpty()) {
             return explainOrThrowRejectedCommand(explain, allocation,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
@@ -61,6 +61,14 @@ public class AllocationCommands {
     }
 
     /**
+     * Get the commands wrapped by this instance
+     * @return {@link List} of commands
+     */
+    public List<AllocationCommand> commands() {
+        return this.commands;
+    }
+
+    /**
      * Executes all wrapped commands on a given {@link RoutingAllocation}
      * @param allocation {@link RoutingAllocation} to apply this command to
      * @throws org.elasticsearch.ElasticsearchException if something happens during execution

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
@@ -117,7 +117,6 @@ public class MoveAllocationCommand implements AllocationCommand {
                 + "] is not a data node.");
         }
 
-        assert fromRoutingNode != null;
         for (ShardRouting shardRouting : fromRoutingNode) {
             if (!shardRouting.shardId().getIndexName().equals(index)) {
                 continue;
@@ -142,12 +141,14 @@ public class MoveAllocationCommand implements AllocationCommand {
                 if (explain) {
                     return new RerouteExplanation(this, decision);
                 }
-                throw new IllegalArgumentException("[move_allocation] can't move " + shardId + ", from " + fromDiscoNode + ", to " + toDiscoNode + ", since its not allowed, reason: " + decision);
+                throw new IllegalArgumentException("[move_allocation] can't move " + shardId + ", from " + fromDiscoNode + ", to " +
+                    toDiscoNode + ", since its not allowed, reason: " + decision);
             }
             if (decision.type() == Decision.Type.THROTTLE) {
                 // its being throttled, maybe have a flag to take it into account and fail? for now, just do it since the "user" wants it...
             }
-            allocation.routingNodes().relocateShard(shardRouting, toRoutingNode.nodeId(), allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE), allocation.changes());
+            allocation.routingNodes().relocateShard(shardRouting, toRoutingNode.nodeId(),
+                allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE), allocation.changes());
         }
 
         if (!found) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -1,0 +1,740 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.UNASSIGNED;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.command.AbstractAllocateAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateStalePrimaryAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
+import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class AllocationCommandsTests extends ESAllocationTestCase {
+
+    private final Logger logger = LogManager.getLogger(AllocationCommandsTests.class);
+
+    @Test
+    public void testMoveShardCommand() {
+        AllocationService allocation = createAllocationService(Settings.builder()
+            .put("cluster.routing.allocation.node_concurrent_recoveries", 10).build());
+
+        logger.info("creating an index with 1 shard, no replica");
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .build()
+                )
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+            )
+            .build();
+        RoutingTable routingTable = RoutingTable.builder()
+                .addAsNew(metadata.index("test"))
+                .build();
+        ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+            .getDefault(Settings.EMPTY)).metadata(metadata).routingTable(routingTable).build();
+
+        logger.info("adding two nodes and performing rerouting");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder()
+            .add(newNode("node1")).add(newNode("node2"))).build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+
+        logger.info("start primary shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+
+        logger.info("move the shard");
+        String existingNodeId = clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId();
+        String toNodeId;
+        if ("node1".equals(existingNodeId)) {
+            toNodeId = "node2";
+        } else {
+            toNodeId = "node1";
+        }
+        ClusterState newState = allocation.reroute(clusterState,
+            new AllocationCommands(new MoveAllocationCommand("test", 0, existingNodeId, toNodeId)),
+            false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node(existingNodeId).iterator().next().state(), equalTo(ShardRoutingState.RELOCATING));
+        assertThat(clusterState.getRoutingNodes().node(toNodeId).iterator().next().state(), equalTo(ShardRoutingState.INITIALIZING));
+
+        logger.info("finish moving the shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+
+        assertThat(clusterState.getRoutingNodes().node(existingNodeId).isEmpty(), equalTo(true));
+        assertThat(clusterState.getRoutingNodes().node(toNodeId).iterator().next().state(), equalTo(ShardRoutingState.STARTED));
+    }
+
+    private AbstractAllocateAllocationCommand randomAllocateCommand(String index, int shardId, String node) {
+        return randomFrom(
+                new AllocateReplicaAllocationCommand(index, shardId, node),
+                new AllocateEmptyPrimaryAllocationCommand(index, shardId, node, true),
+                new AllocateStalePrimaryAllocationCommand(index, shardId, node, true)
+        );
+    }
+
+    @Test
+    public void testAllocateCommand() {
+        AllocationService allocation = createAllocationService(Settings.builder()
+                .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")
+                .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), "none")
+                .build());
+        final String index = "test";
+
+        logger.info("--> building initial routing table");
+        Metadata metadata = Metadata.builder()
+                .put(IndexMetadata.builder(index).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1)
+                    .putInSyncAllocationIds(0, Collections.singleton("asdf"))
+                    .putInSyncAllocationIds(1, Collections.singleton("qwertz")))
+                .build();
+        // shard routing is added as "from recovery" instead of "new index creation" so that we can test below that allocating an empty
+        // primary with accept_data_loss flag set to false fails
+        RoutingTable routingTable = RoutingTable.builder()
+                .addAsRecovery(metadata.index(index))
+                .build();
+        ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+            .getDefault(Settings.EMPTY)).metadata(metadata).routingTable(routingTable).build();
+        final ShardId shardId = new ShardId(metadata.index(index).getIndex(), 0);
+
+        logger.info("--> adding 3 nodes on same rack and do rerouting");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder()
+                .add(newNode("node1"))
+                .add(newNode("node2"))
+                .add(newNode("node3"))
+                .add(newNode("node4", singleton(DiscoveryNode.Role.MASTER)))
+        ).build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+        assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(0));
+
+        logger.info("--> allocating to non-existent node, should fail");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(index, shardId.id(), "node42")), false, false);
+            fail("expected IllegalArgumentException when allocating to non-existing node");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("failed to resolve [node42], no matching nodes"));
+        }
+
+        logger.info("--> allocating to non-data node, should fail");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(index, shardId.id(), "node4")), false, false);
+            fail("expected IllegalArgumentException when allocating to non-data node");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("allocation can only be done on data nodes"));
+        }
+
+        logger.info("--> allocating non-existing shard, should fail");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand("test", 1, "node2")), false, false);
+            fail("expected ShardNotFoundException when allocating non-existing shard");
+        } catch (ShardNotFoundException e) {
+            assertThat(e.getMessage(), containsString("no such shard"));
+        }
+
+        logger.info("--> allocating non-existing index, should fail");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand("test2", 0, "node2")), false, false);
+            fail("expected ShardNotFoundException when allocating non-existing index");
+        } catch (IndexNotFoundException e) {
+            assertThat(e.getMessage(), containsString("no such index"));
+        }
+
+        logger.info("--> allocating empty primary with acceptDataLoss flag set to false");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(
+                new AllocateEmptyPrimaryAllocationCommand("test", 0, "node1", false)), false, false);
+            fail("expected IllegalArgumentException when allocating empty primary with acceptDataLoss flag set to false");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("allocating an empty primary for " + shardId +
+                " can result in data loss. Please confirm by setting the accept_data_loss parameter to true"));
+        }
+
+        logger.info("--> allocating stale primary with acceptDataLoss flag set to false");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(
+                new AllocateStalePrimaryAllocationCommand(index, shardId.id(), "node1", false)), false, false);
+            fail("expected IllegalArgumentException when allocating stale primary with acceptDataLoss flag set to false");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("allocating an empty primary for " + shardId +
+                " can result in data loss. Please confirm by setting the accept_data_loss parameter to true"));
+        }
+
+        logger.info("--> allocating empty primary with acceptDataLoss flag set to true");
+        ClusterState newState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand("test", 0, "node1", true)),
+            false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(INITIALIZING).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+
+        logger.info("--> start the primary shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+
+        logger.info("--> allocate the replica shard on the primary shard node, should fail");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(
+                new AllocateReplicaAllocationCommand("test", 0, "node1")), false, false);
+            fail("expected IllegalArgumentException when allocating replica shard on the primary shard node");
+        } catch (IllegalArgumentException e) {
+        }
+
+        logger.info("--> allocate the replica shard on on the second node");
+        newState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")), false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(INITIALIZING).size(), equalTo(1));
+
+
+        logger.info("--> start the replica shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).size(), equalTo(1));
+
+        logger.info("--> verify that we fail when there are no unassigned shards");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand("test", 0, "node3")), false, false);
+            fail("expected IllegalArgumentException when allocating shard while no unassigned shard available");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+
+    @Test
+    public void testAllocateStalePrimaryCommand() {
+        AllocationService allocation = createAllocationService(Settings.builder()
+            .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")
+            .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), "none")
+            .build());
+        final String index = "test";
+
+        logger.info("--> building initial routing table");
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder(index).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1)
+                .putInSyncAllocationIds(0, Collections.singleton("asdf")).putInSyncAllocationIds(1, Collections.singleton("qwertz")))
+            .build();
+        // shard routing is added as "from recovery" instead of "new index creation" so that we can test below that allocating an empty
+        // primary with accept_data_loss flag set to false fails
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsRecovery(metadata.index(index))
+            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata).routingTable(routingTable).build();
+
+        final String node1 = "node1";
+        final String node2 = "node2";
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder()
+            .add(newNode(node1))
+            .add(newNode(node2))
+        ).build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+
+        // mark all shards as stale
+        final List<ShardRouting> shardRoutings = clusterState.getRoutingNodes().shardsWithState(UNASSIGNED);
+        assertThat(shardRoutings, hasSize(2));
+
+        logger.info("--> allocating empty primary with acceptDataLoss flag set to true");
+        clusterState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateStalePrimaryAllocationCommand(index, 0, node1, true)), false, false).getClusterState();
+        RoutingNode routingNode1 = clusterState.getRoutingNodes().node(node1);
+        assertThat(routingNode1.size(), equalTo(1));
+        assertThat(routingNode1.shardsWithState(INITIALIZING).size(), equalTo(1));
+        Set<String> inSyncAllocationIds = clusterState.metadata().index(index).inSyncAllocationIds(0);
+        assertThat(inSyncAllocationIds, equalTo(Collections.singleton(RecoverySource.ExistingStoreRecoverySource.FORCED_ALLOCATION_ID)));
+
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        routingNode1 = clusterState.getRoutingNodes().node(node1);
+        assertThat(routingNode1.size(), equalTo(1));
+        assertThat(routingNode1.shardsWithState(STARTED).size(), equalTo(1));
+        inSyncAllocationIds = clusterState.metadata().index(index).inSyncAllocationIds(0);
+        assertThat(inSyncAllocationIds, hasSize(1));
+        assertThat(inSyncAllocationIds, not(Collections.singleton(RecoverySource.ExistingStoreRecoverySource.FORCED_ALLOCATION_ID)));
+    }
+
+    @Test
+    public void testCancelCommand() {
+        AllocationService allocation = createAllocationService(Settings.builder()
+                .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")
+                .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), "none")
+                .build());
+
+        logger.info("--> building initial routing table");
+        Metadata metadata = Metadata.builder()
+                .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+                .build();
+        RoutingTable routingTable = RoutingTable.builder()
+                .addAsNew(metadata.index("test"))
+                .build();
+        ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+            .getDefault(Settings.EMPTY)).metadata(metadata).routingTable(routingTable).build();
+
+        logger.info("--> adding 3 nodes");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder()
+                .add(newNode("node1"))
+                .add(newNode("node2"))
+                .add(newNode("node3"))
+        ).build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+        assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(0));
+
+        logger.info("--> allocating empty primary shard with accept_data_loss flag set to true");
+        ClusterState newState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand("test", 0, "node1", true)), false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(INITIALIZING).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+
+        logger.info("--> cancel primary allocation, make sure it fails...");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", false)), false, false);
+            fail();
+        } catch (IllegalArgumentException e) {
+        }
+
+        logger.info("--> start the primary shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+
+        logger.info("--> cancel primary allocation, make sure it fails...");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", false)), false, false);
+            fail();
+        } catch (IllegalArgumentException e) {
+        }
+
+        logger.info("--> allocate the replica shard on on the second node");
+        newState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")), false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(INITIALIZING).size(), equalTo(1));
+
+        logger.info("--> cancel the relocation allocation");
+        newState = allocation.reroute(clusterState,
+            new AllocationCommands(new CancelAllocationCommand("test", 0, "node2", false)), false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+        assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(0));
+
+        logger.info("--> allocate the replica shard on on the second node");
+        newState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")), false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(INITIALIZING).size(), equalTo(1));
+
+        logger.info("--> cancel the primary being replicated, make sure it fails");
+        try {
+            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", false)), false, false);
+            fail();
+        } catch (IllegalArgumentException e) {
+        }
+
+        logger.info("--> start the replica shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).size(), equalTo(1));
+
+        logger.info("--> cancel allocation of the replica shard");
+        newState = allocation.reroute(clusterState,
+            new AllocationCommands(new CancelAllocationCommand("test", 0, "node2", false)), false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+        assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(0));
+
+        logger.info("--> allocate the replica shard on on the second node");
+        newState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")), false, false).getClusterState();
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(INITIALIZING).size(), equalTo(1));
+        logger.info("--> start the replica shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).size(), equalTo(1));
+
+        logger.info("--> move the replica shard");
+        clusterState = allocation.reroute(clusterState,
+            new AllocationCommands(new MoveAllocationCommand("test", 0, "node2", "node3")), false, false).getClusterState();
+        assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(RELOCATING).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().node("node3").shardsWithState(INITIALIZING).size(), equalTo(1));
+
+        if (randomBoolean()) {
+            logger.info("--> cancel the primary allocation (with allow_primary set to true)");
+            newState = allocation.reroute(clusterState,
+                new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", true)), false, false).getClusterState();
+            assertThat(newState, not(equalTo(clusterState)));
+            clusterState = newState;
+            assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(0));
+            assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).iterator().next().primary(), equalTo(true));
+            assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(0));
+        } else {
+            logger.info("--> cancel the move of the replica shard");
+            clusterState = allocation.reroute(clusterState,
+                new AllocationCommands(new CancelAllocationCommand("test", 0, "node3", false)), false, false).getClusterState();
+            assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).size(), equalTo(1));
+
+            logger.info("--> move the replica shard again");
+            clusterState = allocation.reroute(clusterState,
+                new AllocationCommands(new MoveAllocationCommand("test", 0, "node2", "node3")), false, false).getClusterState();
+            assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(RELOCATING).size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node3").shardsWithState(INITIALIZING).size(), equalTo(1));
+
+            logger.info("--> cancel the source replica shard");
+            clusterState = allocation.reroute(clusterState,
+                new AllocationCommands(new CancelAllocationCommand("test", 0, "node2", false)), false, false).getClusterState();
+            assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+            assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node3").shardsWithState(INITIALIZING).size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node3").shardsWithState(INITIALIZING).get(0).relocatingNodeId(), nullValue());
+
+            logger.info("--> start the former target replica shard");
+            clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+            assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
+            assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+            assertThat(clusterState.getRoutingNodes().node("node3").shardsWithState(STARTED).size(), equalTo(1));
+
+            logger.info("--> cancel the primary allocation (with allow_primary set to true)");
+            newState = allocation.reroute(clusterState,
+                new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", true)), false, false).getClusterState();
+            assertThat(newState, not(equalTo(clusterState)));
+            clusterState = newState;
+            assertThat(clusterState.getRoutingNodes().node("node3").shardsWithState(STARTED).iterator().next().primary(), equalTo(true));
+            assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(0));
+            assertThat(clusterState.getRoutingNodes().node("node2").size(), equalTo(0));
+        }
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        AllocationCommands commands = new AllocationCommands(
+                new AllocateEmptyPrimaryAllocationCommand("test", 1, "node1", true),
+                new AllocateStalePrimaryAllocationCommand("test", 2, "node1", true),
+                new AllocateReplicaAllocationCommand("test", 2, "node1"),
+                new MoveAllocationCommand("test", 3, "node2", "node3"),
+                new CancelAllocationCommand("test", 4, "node5", true)
+        );
+        BytesStreamOutput bytes = new BytesStreamOutput();
+        AllocationCommands.writeTo(commands, bytes);
+        StreamInput in = bytes.bytes().streamInput();
+
+        // Since the commands are named writeable we need to register them and wrap the input stream
+        NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(NetworkModule.getNamedWriteables());
+        in = new NamedWriteableAwareStreamInput(in, namedWriteableRegistry);
+
+        // Now we can read them!
+        AllocationCommands sCommands = AllocationCommands.readFrom(in);
+
+        assertThat(sCommands.commands().size(), equalTo(5));
+        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).shardId(), equalTo(1));
+        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).index(), equalTo("test"));
+        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).node(), equalTo("node1"));
+        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).acceptDataLoss(), equalTo(true));
+
+        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).shardId(), equalTo(2));
+        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).index(), equalTo("test"));
+        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).node(), equalTo("node1"));
+        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).acceptDataLoss(), equalTo(true));
+
+        assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).shardId(), equalTo(2));
+        assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).index(), equalTo("test"));
+        assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).node(), equalTo("node1"));
+
+        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).shardId(), equalTo(3));
+        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).index(), equalTo("test"));
+        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).fromNode(), equalTo("node2"));
+        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).toNode(), equalTo("node3"));
+
+        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).shardId(), equalTo(4));
+        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).index(), equalTo("test"));
+        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).node(), equalTo("node5"));
+        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).allowPrimary(), equalTo(true));
+    }
+
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(NetworkModule.getNamedXContents());
+    }
+
+    @Test
+    public void testMoveShardToNonDataNode() {
+        AllocationService allocation = createAllocationService(Settings.builder()
+            .put("cluster.routing.allocation.node_concurrent_recoveries", 10).build());
+
+        logger.info("creating an index with 1 shard, no replica");
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
+            .build();
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(metadata.index("test"))
+            .build();
+        ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+            .getDefault(Settings.EMPTY)).metadata(metadata).routingTable(routingTable).build();
+
+        logger.info("--> adding two nodes");
+
+        DiscoveryNode node1 = new DiscoveryNode("node1", "node1", "node1", "test1", "test1", buildNewFakeTransportAddress(), emptyMap(),
+            MASTER_DATA_ROLES, Version.CURRENT);
+        DiscoveryNode node2 = new DiscoveryNode("node2", "node2", "node2", "test2", "test2", buildNewFakeTransportAddress(), emptyMap(),
+            Set.of(DiscoveryNode.Role.MASTER), Version.CURRENT);
+
+        clusterState = ClusterState.builder(clusterState).nodes(
+            DiscoveryNodes.builder()
+                .add(node1)
+                .add(node2)).build();
+
+        logger.info("start primary shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+
+        Index index = clusterState.getMetadata().index("test").getIndex();
+        MoveAllocationCommand command = new MoveAllocationCommand(index.getName(), 0, "node1", "node2");
+        RoutingAllocation routingAllocation = new RoutingAllocation(new AllocationDeciders(Collections.emptyList()),
+            new RoutingNodes(clusterState, false), clusterState, ClusterInfo.EMPTY, System.nanoTime());
+        logger.info("--> executing move allocation command to non-data node");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));
+        assertEquals("[move_allocation] can't move [test][0] from " + node1 + " to " +
+            node2 + ": source [" + node2.getName() + "] is not a data node.", e.getMessage());
+    }
+
+    @Test
+    public void testMoveShardFromNonDataNode() {
+        AllocationService allocation = createAllocationService(Settings.builder()
+            .put("cluster.routing.allocation.node_concurrent_recoveries", 10).build());
+
+        logger.info("creating an index with 1 shard, no replica");
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
+            .build();
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(metadata.index("test"))
+            .build();
+        ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+            .getDefault(Settings.EMPTY)).metadata(metadata).routingTable(routingTable).build();
+
+        logger.info("--> adding two nodes");
+
+        DiscoveryNode node1 = new DiscoveryNode("node1", "node1", "node1", "test1", "test1", buildNewFakeTransportAddress(), emptyMap(),
+            MASTER_DATA_ROLES, Version.CURRENT);
+        DiscoveryNode node2 = new DiscoveryNode("node2", "node2", "node2", "test2", "test2", buildNewFakeTransportAddress(), emptyMap(),
+            Set.of(DiscoveryNode.Role.MASTER), Version.CURRENT);
+
+        clusterState = ClusterState.builder(clusterState).nodes(
+            DiscoveryNodes.builder()
+                .add(node1)
+                .add(node2)).build();
+        logger.info("start primary shard");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+
+        Index index = clusterState.getMetadata().index("test").getIndex();
+        MoveAllocationCommand command = new MoveAllocationCommand(index.getName(), 0, "node2", "node1");
+        RoutingAllocation routingAllocation = new RoutingAllocation(new AllocationDeciders(Collections.emptyList()),
+            new RoutingNodes(clusterState, false), clusterState, ClusterInfo.EMPTY, System.nanoTime());
+        logger.info("--> executing move allocation command from non-data node");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));
+        assertEquals("[move_allocation] can't move [test][0] from " + node2 + " to " + node1 +
+            ": source [" + node2.getName() + "] is not a data node.", e.getMessage());
+    }
+
+    @Test
+    @Ignore("Likely a backport missing. Will follow up on this")
+    public void testConflictingCommandsInSingleRequest() {
+        AllocationService allocation = createAllocationService(Settings.builder()
+            .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")
+            .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), "none")
+            .build());
+
+        final String index1 = "test1";
+        final String index2 = "test2";
+        final String index3 = "test3";
+        logger.info("--> building initial routing table");
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder(index1).settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .build()
+                ).numberOfShards(1).numberOfReplicas(1)
+                .putInSyncAllocationIds(0, Collections.singleton("randomAllocID"))
+                .putInSyncAllocationIds(1, Collections.singleton("randomAllocID2")))
+            .put(IndexMetadata.builder(index2).settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .build()
+                ).numberOfShards(1).numberOfReplicas(1)
+                .putInSyncAllocationIds(0, Collections.singleton("randomAllocID"))
+                .putInSyncAllocationIds(1, Collections.singleton("randomAllocID2")))
+            .put(IndexMetadata.builder(index3).settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .build()
+                ).numberOfShards(1).numberOfReplicas(1)
+                .putInSyncAllocationIds(0, Collections.singleton("randomAllocID"))
+                .putInSyncAllocationIds(1, Collections.singleton("randomAllocID2")))
+            .build();
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsRecovery(metadata.index(index1))
+            .addAsRecovery(metadata.index(index2))
+            .addAsRecovery(metadata.index(index3))
+            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata).routingTable(routingTable).build();
+
+        final String node1 = "node1";
+        final String node2 = "node2";
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder()
+            .add(newNode(node1))
+            .add(newNode(node2))
+        ).build();
+        final ClusterState finalClusterState = allocation.reroute(clusterState, "reroute");
+
+        logger.info("--> allocating same index primary in multiple commands should fail");
+        assertThat(expectThrows(IllegalArgumentException.class, () -> {
+            allocation.reroute(finalClusterState,
+                new AllocationCommands(
+                    new AllocateStalePrimaryAllocationCommand(index1, 0, node1, true),
+                    new AllocateStalePrimaryAllocationCommand(index1, 0, node2, true)
+                ), false, false);
+        }).getMessage(), containsString("primary [" + index1 + "][0] is already assigned"));
+
+        assertThat(expectThrows(IllegalArgumentException.class, () -> {
+            allocation.reroute(finalClusterState,
+                new AllocationCommands(
+                    new AllocateEmptyPrimaryAllocationCommand(index2, 0, node1, true),
+                    new AllocateEmptyPrimaryAllocationCommand(index2, 0, node2, true)
+                ), false, false);
+        }).getMessage(), containsString("primary [" + index2 + "][0] is already assigned"));
+
+
+        clusterState = allocation.reroute(clusterState,
+            new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand(index3, 0, node1, true)), false, false).getClusterState();
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+
+        final ClusterState updatedClusterState = clusterState;
+        assertThat(updatedClusterState.getRoutingNodes().node(node1).shardsWithState(STARTED).size(), equalTo(1));
+
+        logger.info("--> subsequent replica allocation fails as all configured replicas have been allocated");
+        assertThat(expectThrows(IllegalArgumentException.class, () -> {
+            allocation.reroute(updatedClusterState,
+                new AllocationCommands(
+                    new AllocateReplicaAllocationCommand(index3, 0, node2),
+                    new AllocateReplicaAllocationCommand(index3, 0, node2)
+                ), false, false);
+        }).getMessage(), containsString("all copies of [" + index3 + "][0] are already assigned. Use the move allocation command instead"));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+public class AllocationServiceTests extends ESTestCase {
+
+    @Test
+    public void testFirstListElementsToCommaDelimitedStringReportsAllElementsIfShort() {
+        List<String> strings = IntStream.range(0, between(0, 10)).mapToObj(i -> randomAlphaOfLength(10)).collect(Collectors.toList());
+        assertAllElementsReported(strings, randomBoolean());
+    }
+
+    @Test
+    public void testFirstListElementsToCommaDelimitedStringReportsAllElementsIfDebugEnabled() {
+        List<String> strings = IntStream.range(0, between(0, 100)).mapToObj(i -> randomAlphaOfLength(10)).collect(Collectors.toList());
+        assertAllElementsReported(strings, true);
+    }
+
+    private void assertAllElementsReported(List<String> strings, boolean isDebugEnabled) {
+        final String abbreviated = AllocationService.firstListElementsToCommaDelimitedString(strings, Function.identity(), isDebugEnabled);
+        for (String string : strings) {
+            assertThat(abbreviated, containsString(string));
+        }
+        assertThat(abbreviated, not(containsString("...")));
+    }
+
+    @Test
+    public void testFirstListElementsToCommaDelimitedStringReportsFirstElementsIfLong() {
+        List<String> strings = IntStream.range(0, between(11, 100)).mapToObj(i -> randomAlphaOfLength(10))
+            .distinct().collect(Collectors.toList());
+        final String abbreviated = AllocationService.firstListElementsToCommaDelimitedString(strings, Function.identity(), false);
+        for (int i = 0; i < strings.size(); i++) {
+            if (i < 10) {
+                assertThat(abbreviated, containsString(strings.get(i)));
+            } else {
+                assertThat(abbreviated, not(containsString(strings.get(i))));
+            }
+        }
+        assertThat(abbreviated, containsString("..."));
+        assertThat(abbreviated, containsString("[" + strings.size() + " items in total]"));
+    }
+
+    @Test
+    public void testFirstListElementsToCommaDelimitedStringUsesFormatterNotToString() {
+        List<String> strings = IntStream.range(0, between(1, 100)).mapToObj(i -> "original").collect(Collectors.toList());
+        final String abbreviated = AllocationService.firstListElementsToCommaDelimitedString(strings, s -> "formatted", randomBoolean());
+        assertThat(abbreviated, containsString("formatted"));
+        assertThat(abbreviated, not(containsString("original")));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RetryFailedAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RetryFailedAllocationTests.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
+import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+public class RetryFailedAllocationTests extends ESAllocationTestCase {
+
+    private MockAllocationService strategy;
+    private ClusterState clusterState;
+    private final String INDEX_NAME = "index";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Metadata metadata = Metadata.builder().put(
+            IndexMetadata.builder(INDEX_NAME)
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+            )
+            .build();
+        RoutingTable routingTable = RoutingTable.builder().addAsNew(metadata.index(INDEX_NAME)).build();
+        clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(metadata)
+            .routingTable(routingTable)
+            .nodes(DiscoveryNodes.builder()
+                .add(newNode("node1"))
+                .add(newNode("node2")))
+            .build();
+        strategy = createAllocationService(Settings.EMPTY);
+    }
+
+    private ShardRouting getPrimary() {
+        return clusterState.getRoutingTable().index(INDEX_NAME).shard(0).primaryShard();
+    }
+
+    private ShardRouting getReplica() {
+        return clusterState.getRoutingTable().index(INDEX_NAME).shard(0).replicaShards().get(0);
+    }
+
+    @Test
+    public void testRetryFailedResetForAllocationCommands() {
+        final int retries = MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.get(Settings.EMPTY);
+        clusterState = strategy.reroute(clusterState, "initial allocation");
+        clusterState = startShardsAndReroute(strategy, clusterState, getPrimary());
+
+        // Exhaust all replica allocation attempts with shard failures
+        for (int i = 0; i < retries; i++) {
+            List<FailedShard> failedShards = Collections.singletonList(
+                new FailedShard(getReplica(), "failing-shard::attempt-" + i,
+                    new ElasticsearchException("simulated"), randomBoolean()));
+            clusterState = strategy.applyFailedShards(clusterState, failedShards, List.of());
+            clusterState = strategy.reroute(clusterState, "allocation retry attempt-" + i);
+        }
+        assertThat("replica should not be assigned", getReplica().state(), equalTo(ShardRoutingState.UNASSIGNED));
+        assertThat("reroute should be a no-op", strategy.reroute(clusterState, "test"), sameInstance(clusterState));
+
+        // Now allocate replica with retry_failed flag set
+        AllocationService.CommandsResult result = strategy.reroute(clusterState,
+            new AllocationCommands(new AllocateReplicaAllocationCommand(INDEX_NAME, 0,
+                getPrimary().currentNodeId().equals("node1") ? "node2" : "node1")),
+            false, true);
+        clusterState = result.getClusterState();
+
+        assertEquals(ShardRoutingState.INITIALIZING, getReplica().state());
+        clusterState = startShardsAndReroute(strategy, clusterState, getReplica());
+        assertEquals(ShardRoutingState.STARTED, getReplica().state());
+        assertFalse(clusterState.getRoutingNodes().hasUnassignedShards());
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commit messages for details

These are older patches missing from es-backports, motivated by recent flaky tests.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)