### PR TITLE
Added ``rank`` window function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ None
 Changes
 =======
 
+- Added support for the ``rank`` window function, which is available as an
+  enterprise feature.
+
 - Added the ``delimiter`` option for :ref:`copy_from` CSV files. The option is
   used to specify the character that separates columns within a row.
 

--- a/docs/editions.rst
+++ b/docs/editions.rst
@@ -74,6 +74,8 @@ Enterprise features
 
   - :ref:`window-function-nthvalue`
 
+  - :ref:`window-function-rank`
+
 
 .. _node-limitations:
 

--- a/docs/general/builtins/window-functions.rst
+++ b/docs/general/builtins/window-functions.rst
@@ -607,6 +607,57 @@ Example::
    +---------+------+--------+-------------+
    SELECT 5 rows in set (... sec)
 
+
+.. _window-function-rank:
+
+``rank()``
+----------
+
+.. NOTE::
+
+    The ``rank`` window function is an :ref:`enterprise feature
+    <enterprise-features>`.
+
+Synopsis
+........
+
+::
+
+    rank()
+
+Returns the rank of every row within a partition of a result set.
+
+Within each partition, the rank of the first row is ``1``. Subsequent tied
+rows are given the same rank, and the potential rank of the next row
+is incremented. Because of this, ranks may not be sequential.
+
+Example::
+
+    cr> SELECT
+    ...   name,
+    ...   department_id,
+    ...   salary,
+    ...   RANK() OVER (ORDER BY salary desc) as salary_rank
+    ... FROM (VALUES
+    ...      ('Bobson Dugnutt', 1, 2000),
+    ...      ('Todd Bonzalez', 2, 2500),
+    ...      ('Jess Brewer', 1, 2500),
+    ...      ('Safwan Buchanan', 1, 1900),
+    ...      ('Hal Dodd', 1, 2500),
+    ...      ('Gillian Hawes', 2, 2000))
+    ... as t (name, department_id, salary);
+    +-----------------+---------------+--------+-------------+
+    | name            | department_id | salary | salary_rank |
+    +-----------------+---------------+--------+-------------+
+    | Todd Bonzalez   |             2 |   2500 |           1 |
+    | Jess Brewer     |             1 |   2500 |           1 |
+    | Hal Dodd        |             1 |   2500 |           1 |
+    | Bobson Dugnutt  |             1 |   2000 |           4 |
+    | Gillian Hawes   |             2 |   2000 |           4 |
+    | Safwan Buchanan |             1 |   1900 |           6 |
+    +-----------------+---------------+--------+-------------+
+    SELECT 6 rows in set (... sec)
+
 Aggregate Window Functions
 ==========================
 

--- a/enterprise/functions/src/main/java/io/crate/module/EnterpriseFunctionsModule.java
+++ b/enterprise/functions/src/main/java/io/crate/module/EnterpriseFunctionsModule.java
@@ -23,6 +23,7 @@ import io.crate.expression.AbstractFunctionModule;
 import io.crate.operation.aggregation.HyperLogLogDistinctAggregation;
 import io.crate.window.NthValueFunctions;
 import io.crate.window.OffsetValueFunctions;
+import io.crate.window.RankFunctions;
 
 public class EnterpriseFunctionsModule extends AbstractFunctionModule<AggregationFunction> {
 
@@ -31,5 +32,6 @@ public class EnterpriseFunctionsModule extends AbstractFunctionModule<Aggregatio
         HyperLogLogDistinctAggregation.register(this);
         NthValueFunctions.register(this);
         OffsetValueFunctions.register(this);
+        RankFunctions.register(this);
     }
 }

--- a/enterprise/functions/src/main/java/io/crate/window/RankFunctions.java
+++ b/enterprise/functions/src/main/java/io/crate/window/RankFunctions.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.window;
+
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.execution.engine.window.WindowFrameState;
+import io.crate.execution.engine.window.WindowFunction;
+import io.crate.metadata.functions.Signature;
+import io.crate.module.EnterpriseFunctionsModule;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+
+
+public class RankFunctions implements WindowFunction {
+
+    private static final String RANK_NAME = "rank";
+
+    private final Signature signature;
+    private final Signature boundSignature;
+    private int seenLastUpperBound;
+    private int rank;
+
+    private RankFunctions(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public Object execute(int idxInPartition,
+                          WindowFrameState currentFrame,
+                          List<? extends CollectExpression<Row, ?>> expressions,
+                          Input... args) {
+        if (idxInPartition == 0) {
+            rank = 1;
+            seenLastUpperBound = currentFrame.upperBoundExclusive();
+        }
+
+        if (currentFrame.upperBoundExclusive() != seenLastUpperBound) {
+            rank = seenLastUpperBound + 1;
+            seenLastUpperBound = currentFrame.upperBoundExclusive();
+        }
+
+        return rank;
+
+    }
+
+    public static void register(EnterpriseFunctionsModule module) {
+        module.register(
+            Signature.window(
+                RANK_NAME,
+                DataTypes.INTEGER.getTypeSignature()
+                ),
+            RankFunctions::new
+        );
+    }
+}

--- a/enterprise/functions/src/test/java/io/crate/window/RankFunctionIntegrationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/RankFunctionIntegrationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.window;
+
+import io.crate.integrationtests.SQLTransportIntegrationTest;
+import org.elasticsearch.plugins.Plugin;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.Matchers.is;
+
+public class RankFunctionIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(EnterpriseFunctionsProxyTestPlugin.class);
+        return plugins;
+    }
+
+    @Test
+    public void testGeneralPurposeWindowFunctionsWithStandaloneValues() {
+        execute("select col1, col2, " +
+                "rank() OVER(partition by col2 order by col1) " +
+                "from unnest(['A', 'B', 'C', 'A', 'B', 'C', 'A'], [True, True, False, True, False, True, False]) " +
+                "order by col2, col1");
+        assertThat(printedTable(response.rows()), is("A| false| 1\n" +
+                                                     "B| false| 2\n" +
+                                                     "C| false| 3\n" +
+                                                     "A| true| 1\n" +
+                                                     "A| true| 1\n" +
+                                                     "B| true| 3\n" +
+                                                     "C| true| 4\n"));
+    }
+
+}

--- a/enterprise/functions/src/test/java/io/crate/window/RankFunctionTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/RankFunctionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.window;
+
+import io.crate.execution.engine.window.AbstractWindowFunctionTest;
+import io.crate.metadata.ColumnIdent;
+import io.crate.module.EnterpriseFunctionsModule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+
+
+public class RankFunctionTest extends AbstractWindowFunctionTest {
+
+    public RankFunctionTest() {
+        super(new EnterpriseFunctionsModule());
+    }
+
+    @Test
+    public void testRankWithEmptyOver() throws Throwable {
+        assertEvaluate(
+            "rank() over()",
+            contains(new Object[] {1, 1, 1, 1, 1}),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+
+    @Test
+    public void testRankWithOrderByClause() throws Throwable {
+        assertEvaluate(
+            "rank() over(order by x)",
+            contains(new Object[] {1, 1, 1, 4, 4}),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void testRankUseSymbolMultipleTimes() throws Throwable {
+        assertEvaluate(
+            "rank() over(order by y, x)",
+            contains(new Object[] {1, 2, 2, 4, 4}),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void testRankOverPartitionedWindow() throws Throwable {
+        Object[] expected = new Object[]{1, 1, 1, 1, 1, 1};
+        assertEvaluate(
+            "rank() over(partition by y > 0)",
+            contains(expected),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {3, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 0},
+            new Object[] {3, 0});
+    }
+
+    @Test
+    public void testRankOverPartitionedOrderedWindow() throws Throwable {
+        Object[] expected = new Object[]{1, 2, 3, 1, 2, 3};
+        assertEvaluate(
+            "rank() over(partition by y > 0 order by x)",
+            contains(expected),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {3, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 0},
+            new Object[] {3, 0});
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This PR adds the window function ``rank`` as described in #10507 

I've implemented it as a map, rather than just tracking the last viewed row as the latter behaviour would return behaviour like this:

```
 cr> SELECT
    ...   col1,
    ...   RANK() OVER () as rank
    ... FROM (VALUES
    ...      ('A'),
    ...      ('A'),
    ...      ('B'),
    ...      ('C'),
    ...      ('A'),
    ...      ('D'))
    ... as t (col1);
    +------+------+
    | col1 | rank |
    +------+------+
    | A    |    1 |
    | A    |    1 |
    | B    |    3 |
    | C    |    4 |
    | A    |    5 |
    | D    |    6 |
    +------+------+
    SELECT 6 rows in set (... sec)
```

Which i'm not sure is entirely accurate, but I will verify the postgres behaviour before requesting a review.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
