### PR TITLE
Added the ``delimiter`` option for copy fromm CSV files.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ None
 Changes
 =======
 
+- Added the ``delimiter`` option for :ref:`copy_from` CSV files. The option is
+  used to specify the character that separates columns within a row.
+
 - Added the ``empty_string_as_null`` option for :ref:`copy_from` CSV files.
   If the option is enabled, all column's values represented by an empty string,
   including a quoted empty string, are set to ``NULL``.

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -334,6 +334,15 @@ execution.
 The option is only supported when using the ``CSV`` format,
 otherwise, it will be ignored.
 
+``delimiter``
+'''''''''''''
+
+Specifies a single one-byte character that separates columns within each line
+of the file. The default delimiter is ``,``.
+
+The option is only supported when using the ``CSV`` format, otherwise, it will
+be ignored.
+
 ``format``
 ''''''''''
 

--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -22,6 +22,7 @@
 
 package io.crate.analyze;
 
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import io.crate.metadata.settings.Validators;
 import org.elasticsearch.common.settings.Setting;
 
@@ -54,6 +55,19 @@ public final class CopyStatementSettings {
         "empty_string_as_null",
         false,
         Setting.Property.Dynamic);
+
+    public static final Setting<Character> CSV_COLUMN_SEPARATOR = new Setting<>(
+        "delimiter",
+        String.valueOf(CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+        value -> {
+            if (value.length() != 1) {
+                throw new IllegalArgumentException(
+                    "Invalid CSV fields delimiter: " + value + ". The delimiter must be a single character.");
+            }
+            return value.charAt(0);
+        },
+        Setting.Property.Dynamic
+    );
 
     public static final Map<String, Setting<?>> OUTPUT_SETTINGS = Map.of(
         COMPRESSION_SETTING.getKey(), COMPRESSION_SETTING,

--- a/server/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
+++ b/server/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
@@ -46,7 +46,12 @@ public class CSVLineParser {
         if (properties.emptyStringAsNull()) {
             mapper.enable(CsvParser.Feature.EMPTY_STRING_AS_NULL);
         }
-        csvReader = mapper.readerWithTypedSchemaFor(String.class);
+        var csvSchema = mapper
+            .typedSchemaFor(String.class)
+            .withColumnSeparator(properties.columnSeparator());
+        csvReader = mapper
+            .readerWithTypedSchemaFor(String.class)
+            .with(csvSchema);
     }
 
     public void parseHeader(String header) throws IOException {

--- a/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
@@ -23,6 +23,7 @@
 package io.crate.execution.dsl.phases;
 
 
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import io.crate.analyze.CopyFromParserProperties;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
@@ -54,7 +55,7 @@ public class FileUriCollectPhaseTest {
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true),
+            new CopyFromParserProperties(true, '|'),
             FileUriCollectPhase.InputFormat.CSV
         );
 
@@ -74,6 +75,9 @@ public class FileUriCollectPhaseTest {
         // parser properties option serialization implemented in crate >= 4.4.0
         assertThat(expected.parserProperties().emptyStringAsNull(), is(true));
         assertThat(actual.parserProperties().emptyStringAsNull(), is(false));
+
+        assertThat(actual.parserProperties().columnSeparator(), is(CsvSchema.DEFAULT_COLUMN_SEPARATOR));
+
         assertThat(expected.inputFormat(), is(actual.inputFormat()));
         assertThat(expected.compression(), is(actual.compression()));
         assertThat(expected.sharedStorage(), is(actual.sharedStorage()));
@@ -91,7 +95,7 @@ public class FileUriCollectPhaseTest {
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true),
+            new CopyFromParserProperties(true, '|'),
             FileUriCollectPhase.InputFormat.CSV
         );
 
@@ -104,6 +108,7 @@ public class FileUriCollectPhaseTest {
         var actual = new FileUriCollectPhase(input);
 
         assertThat(expected.parserProperties().emptyStringAsNull(), is(true));
+        assertThat(actual.parserProperties().columnSeparator(), is('|'));
         assertThat(expected, is(actual));
     }
 }

--- a/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
+++ b/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
@@ -1,5 +1,6 @@
 package io.crate.operation.collect.files;
 
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import io.crate.analyze.CopyFromParserProperties;
 import org.junit.Before;
 import org.junit.Test;
@@ -96,13 +97,28 @@ public class CSVLineParserTest {
     @Test
     public void test_quoted_and_unquoted_empty_string_converted_to_null_empty_string_as_null_is_set() throws IOException {
         String header = "Code,Country,City\n";
-        csvParser = new CSVLineParser(new CopyFromParserProperties(true));
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, CsvSchema.DEFAULT_COLUMN_SEPARATOR)
+        );
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,,\"\"\n");
 
         assertThat(
             new String(result, StandardCharsets.UTF_8),
             is("{\"Code\":\"GER\",\"Country\":null,\"City\":null}")
+        );
+    }
+
+    @Test
+    public void test_parse_csv_with_configured_delimiter_parses_lines_correctly() throws IOException {
+        String header = "Code|Country|City\n";
+        csvParser = new CSVLineParser(new CopyFromParserProperties(true, '|'));
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER|Germany|Berlin\n");
+
+        assertThat(
+            new String(result, StandardCharsets.UTF_8),
+            is("{\"Code\":\"GER\",\"Country\":\"Germany\",\"City\":\"Berlin\"}")
         );
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The option is used to specify the character that separates
columns within a row.

Related to https://github.com/crate/crate/issues/7260

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
