### PR TITLE
Backport more gatway changes from ES

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -65,6 +65,7 @@ import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.gateway.IncrementalClusterStateWriter;
 import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.indices.IndexingMemoryController;
@@ -219,6 +220,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         GatewayService.RECOVER_AFTER_MASTER_NODES_SETTING,
         GatewayService.RECOVER_AFTER_NODES_SETTING,
         GatewayService.RECOVER_AFTER_TIME_SETTING,
+        IncrementalClusterStateWriter.SLOW_WRITE_LOGGING_THRESHOLD,
         NetworkModule.HTTP_DEFAULT_TYPE_SETTING,
         NetworkModule.TRANSPORT_DEFAULT_TYPE_SETTING,
         NetworkModule.HTTP_TYPE_SETTING,

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -92,8 +92,10 @@ public class GatewayMetaState {
         }
 
         final IncrementalClusterStateWriter incrementalClusterStateWriter
-            = new IncrementalClusterStateWriter(metaStateService, manifestClusterStateTuple.v1(),
-                prepareInitialClusterState(transportService, clusterService, manifestClusterStateTuple.v2()));
+            = new IncrementalClusterStateWriter(settings, clusterService.getClusterSettings(), metaStateService,
+                manifestClusterStateTuple.v1(),
+                prepareInitialClusterState(transportService, clusterService, manifestClusterStateTuple.v2()),
+                transportService.getThreadPool()::relativeTimeInMillis);
         if (DiscoveryNode.isMasterNode(settings) == false) {
             if (DiscoveryNode.isDataNode(settings)) {
                 // Master-eligible nodes persist index metadata for all indices regardless of whether they hold any shards or not. It's

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -29,6 +29,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.coordination.CoordinationState.PersistedState;
 import org.elasticsearch.cluster.coordination.InMemoryPersistedState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -36,8 +37,6 @@ import org.elasticsearch.cluster.metadata.Manifest;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.RoutingNode;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import io.crate.common.collections.Tuple;
@@ -48,63 +47,53 @@ import org.elasticsearch.plugins.MetadataUpgrader;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 /**
- * This class is responsible for storing/retrieving metadata to/from disk.
- * When instance of this class is created, constructor ensures that this version is compatible with state stored on disk and performs
- * state upgrade if necessary. Also it checks that atomic move is supported on the filesystem level, because it's a must for metadata
- * store algorithm.
- * Please note that the state being loaded when constructing the instance of this class is NOT the state that will be used as a
- * {@link ClusterState#metadata()}. Instead when node is starting up, it calls {@link #getMetadata()} method and if this node is
- * elected as master, it requests metadata from other master eligible nodes. After that, master node performs re-conciliation on the
- * gathered results, re-creates {@link ClusterState} and broadcasts this state to other nodes in the cluster.
+ * Loads (and maybe upgrades) cluster metadata at startup, and persistently stores cluster metadata for future restarts.
+ *
+ * When started, ensures that this version is compatible with the state stored on disk, and performs a state upgrade if necessary. Note that
+ * the state being loaded when constructing the instance of this class is not necessarily the state that will be used as {@link
+ * ClusterState#metadata()} because it might be stale or incomplete. Master-eligible nodes must perform an election to find a complete and
+ * non-stale state, and master-ineligible nodes receive the real cluster state from the elected master after joining the cluster.
  */
-public class GatewayMetaState implements PersistedState {
-    protected static final Logger LOGGER = LogManager.getLogger(GatewayMetaState.class);
+public class GatewayMetaState {
+    private static final Logger LOGGER = LogManager.getLogger(GatewayMetaState.class);
 
-    private final MetaStateService metaStateService;
-    private final Settings settings;
-
-    // On master-eligible Zen2 nodes, we use this very object for the PersistedState (so that the state is actually persisted); on other
-    // nodes we use an InMemoryPersistedState instead and persist using a cluster applier if needed. In all cases it's an error to try and
-    // use this object as a PersistedState before calling start(). TODO stop implementing PersistedState at the top level.
+    // Set by calling start()
     private final SetOnce<PersistedState> persistedState = new SetOnce<>();
 
-    // on master-eligible nodes we call updateClusterState under the Coordinator's mutex; on master-ineligible data nodes we call
-    // updateClusterState on the (unique) cluster applier thread; on other nodes we never call updateClusterState. In all cases there's no
-    // need to synchronize access to these variables.
-    protected Manifest previousManifest;
-    protected ClusterState previousClusterState;
-    protected boolean incrementalWrite;
-
-    public GatewayMetaState(Settings settings, MetaStateService metaStateService) {
-        this.settings = settings;
-        this.metaStateService = metaStateService;
+    public PersistedState getPersistedState() {
+        final PersistedState persistedState = this.persistedState.get();
+        assert persistedState != null : "not started";
+        return persistedState;
     }
 
-    public void start(TransportService transportService, ClusterService clusterService,
-                      MetadataIndexUpgradeService metadataIndexUpgradeService, MetadataUpgrader metadataUpgrader) {
-        assert previousClusterState == null : "should only start once, but already have " + previousClusterState;
+    public Metadata getMetadata() {
+        return getPersistedState().getLastAcceptedState().metadata();
+    }
+
+    public void start(Settings settings, TransportService transportService, ClusterService clusterService,
+                      MetaStateService metaStateService, MetadataIndexUpgradeService metadataIndexUpgradeService,
+                      MetadataUpgrader metadataUpgrader) {
+        assert persistedState.get() == null : "should only start once, but already have " + persistedState.get();
+
+        final Tuple<Manifest, ClusterState> manifestClusterStateTuple;
         try {
-            upgradeMetadata(metadataIndexUpgradeService, metadataUpgrader);
-            initializeClusterState(ClusterName.CLUSTER_NAME_SETTING.get(settings));
+            upgradeMetadata(settings, metaStateService, metadataIndexUpgradeService, metadataUpgrader);
+            manifestClusterStateTuple = loadStateAndManifest(ClusterName.CLUSTER_NAME_SETTING.get(settings), metaStateService);
         } catch (IOException e) {
             throw new ElasticsearchException("failed to load metadata", e);
         }
-        incrementalWrite = false;
 
-        applyClusterStateUpdaters(transportService, clusterService);
+        final IncrementalClusterStateWriter incrementalClusterStateWriter
+            = new IncrementalClusterStateWriter(metaStateService, manifestClusterStateTuple.v1(),
+                prepareInitialClusterState(transportService, clusterService, manifestClusterStateTuple.v2()));
         if (DiscoveryNode.isMasterNode(settings) == false) {
             if (DiscoveryNode.isDataNode(settings)) {
                 // Master-eligible nodes persist index metadata for all indices regardless of whether they hold any shards or not. It's
@@ -121,43 +110,36 @@ public class GatewayMetaState implements PersistedState {
                 // state on master-ineligible data nodes is mostly ignored - it's only there to support dangling index imports, which is
                 // inherently unsafe anyway. Thus we can safely delay metadata writes on master-ineligible data nodes until applying the
                 // cluster state, which is what this does:
-                clusterService.addLowPriorityApplier(this::applyClusterState);
+                clusterService.addLowPriorityApplier(new GatewayClusterApplier(incrementalClusterStateWriter));
             }
-            persistedState.set(new InMemoryPersistedState(getCurrentTerm(), getLastAcceptedState()));
+
+            // Master-ineligible nodes do not need to persist the cluster state when accepting it because they are not in the voting
+            // configuration, so it's ok if they have a stale or incomplete cluster state when restarted. We track the latest cluster state
+            // in memory instead.
+            persistedState.set(new InMemoryPersistedState(manifestClusterStateTuple.v1().getCurrentTerm(), manifestClusterStateTuple.v2()));
         } else {
-            persistedState.set(this);
+            // Master-ineligible nodes must persist the cluster state when accepting it because they must reload the (complete, fresh)
+            // last-accepted cluster state when restarted.
+            persistedState.set(new GatewayPersistedState(incrementalClusterStateWriter));
         }
     }
 
-    private void initializeClusterState(ClusterName clusterName) throws IOException {
-        long startNS = System.nanoTime();
-        Tuple<Manifest, Metadata> manifestAndMetadata = metaStateService.loadFullState();
-        previousManifest = manifestAndMetadata.v1();
-
-        final Metadata metadata = manifestAndMetadata.v2();
-
-        previousClusterState = ClusterState.builder(clusterName)
-                .version(previousManifest.getClusterStateVersion())
-                .metadata(metadata).build();
-
-        LOGGER.debug("took {} to load state", TimeValue.timeValueMillis(TimeValue.nsecToMSec(System.nanoTime() - startNS)));
-    }
-
-    protected void applyClusterStateUpdaters(TransportService transportService, ClusterService clusterService) {
-        assert previousClusterState.nodes().getLocalNode() == null : "applyClusterStateUpdaters must only be called once";
+    // exposed so it can be overridden by tests
+    ClusterState prepareInitialClusterState(TransportService transportService, ClusterService clusterService, ClusterState clusterState) {
+        assert clusterState.nodes().getLocalNode() == null : "prepareInitialClusterState must only be called once";
         assert transportService.getLocalNode() != null : "transport service is not yet started";
-
-        previousClusterState = Function.<ClusterState>identity()
+        return Function.<ClusterState>identity()
             .andThen(ClusterStateUpdaters::addStateNotRecoveredBlock)
             .andThen(state -> ClusterStateUpdaters.setLocalNode(state, transportService.getLocalNode()))
             .andThen(state -> ClusterStateUpdaters.upgradeAndArchiveUnknownOrInvalidSettings(state, clusterService.getClusterSettings()))
             .andThen(ClusterStateUpdaters::recoverClusterBlocks)
-            .apply(previousClusterState);
+            .apply(clusterState);
     }
 
-    protected void upgradeMetadata(MetadataIndexUpgradeService metadataIndexUpgradeService, MetadataUpgrader metadataUpgrader)
-            throws IOException {
-        if (isMasterOrDataNode()) {
+    // exposed so it can be overridden by tests
+    void upgradeMetadata(Settings settings, MetaStateService metaStateService, MetadataIndexUpgradeService metadataIndexUpgradeService,
+                         MetadataUpgrader metadataUpgrader) throws IOException {
+        if (isMasterOrDataNode(settings)) {
             try {
                 final Tuple<Manifest, Metadata> metaStateAndData = metaStateService.loadFullState();
                 final Manifest manifest = metaStateAndData.v1();
@@ -170,7 +152,8 @@ public class GatewayMetaState implements PersistedState {
                 // if there is manifest file, it means metadata is properly persisted to all data paths
                 // if there is no manifest file (upgrade from 6.x to 7.x) metadata might be missing on some data paths,
                 // but anyway we will re-write it as soon as we receive first ClusterState
-                final AtomicClusterStateWriter writer = new AtomicClusterStateWriter(metaStateService, manifest);
+                final IncrementalClusterStateWriter.AtomicClusterStateWriter writer
+                    = new IncrementalClusterStateWriter.AtomicClusterStateWriter(metaStateService, manifest);
                 final Metadata upgradedMetadata = upgradeMetadata(metadata, metadataIndexUpgradeService, metadataUpgrader);
 
                 final long globalStateGeneration;
@@ -198,231 +181,23 @@ public class GatewayMetaState implements PersistedState {
         }
     }
 
-    private boolean isMasterOrDataNode() {
+    private static Tuple<Manifest,ClusterState> loadStateAndManifest(ClusterName clusterName,
+                                                                     MetaStateService metaStateService) throws IOException {
+        final long startNS = System.nanoTime();
+        final Tuple<Manifest, Metadata> manifestAndMetadata = metaStateService.loadFullState();
+        final Manifest manifest = manifestAndMetadata.v1();
+
+        final ClusterState clusterState = ClusterState.builder(clusterName)
+            .version(manifest.getClusterStateVersion())
+            .metadata(manifestAndMetadata.v2()).build();
+
+        LOGGER.debug("took {} to load state", TimeValue.timeValueMillis(TimeValue.nsecToMSec(System.nanoTime() - startNS)));
+
+        return Tuple.tuple(manifest, clusterState);
+    }
+
+    private static boolean isMasterOrDataNode(Settings settings) {
         return DiscoveryNode.isMasterNode(settings) || DiscoveryNode.isDataNode(settings);
-    }
-
-    public PersistedState getPersistedState() {
-        final PersistedState persistedState = this.persistedState.get();
-        assert persistedState != null : "not started";
-        return persistedState;
-    }
-
-    public Metadata getMetadata() {
-        return previousClusterState.metadata();
-    }
-
-    private void applyClusterState(ClusterChangedEvent event) {
-        assert isMasterOrDataNode();
-
-        if (event.state().blocks().disableStatePersistence()) {
-            incrementalWrite = false;
-            return;
-        }
-
-        try {
-            // Hack: This is to ensure that non-master-eligible Zen2 nodes always store a current term
-            // that's higher than the last accepted term.
-            // TODO: can we get rid of this hack?
-            if (event.state().term() > getCurrentTerm()) {
-                innerSetCurrentTerm(event.state().term());
-            }
-
-            updateClusterState(event.state(), event.previousState());
-            incrementalWrite = true;
-        } catch (WriteStateException e) {
-            LOGGER.warn("Exception occurred when storing new meta data", e);
-        }
-    }
-
-    @Override
-    public long getCurrentTerm() {
-        return previousManifest.getCurrentTerm();
-    }
-
-    @Override
-    public ClusterState getLastAcceptedState() {
-        assert previousClusterState.nodes().getLocalNode() != null : "Cluster state is not fully built yet";
-        return previousClusterState;
-    }
-
-    @Override
-    public void setCurrentTerm(long currentTerm) {
-        try {
-            innerSetCurrentTerm(currentTerm);
-        } catch (WriteStateException e) {
-            LOGGER.error(new ParameterizedMessage("Failed to set current term to {}", currentTerm), e);
-            e.rethrowAsErrorOrUncheckedException();
-        }
-    }
-
-    private void innerSetCurrentTerm(long currentTerm) throws WriteStateException {
-        Manifest manifest = new Manifest(currentTerm, previousManifest.getClusterStateVersion(), previousManifest.getGlobalGeneration(),
-            new HashMap<>(previousManifest.getIndexGenerations()));
-        metaStateService.writeManifestAndCleanup("current term changed", manifest);
-        previousManifest = manifest;
-    }
-
-    @Override
-    public void setLastAcceptedState(ClusterState clusterState) {
-        try {
-            incrementalWrite = previousClusterState.term() == clusterState.term();
-            updateClusterState(clusterState, previousClusterState);
-        } catch (WriteStateException e) {
-            LOGGER.error(new ParameterizedMessage("Failed to set last accepted state with version {}", clusterState.version()), e);
-            e.rethrowAsErrorOrUncheckedException();
-        }
-    }
-
-    /**
-     * This class is used to write changed global {@link Metadata}, {@link IndexMetadata} and {@link Manifest} to disk.
-     * This class delegates <code>write*</code> calls to corresponding write calls in {@link MetaStateService} and
-     * additionally it keeps track of cleanup actions to be performed if transaction succeeds or fails.
-     */
-    static class AtomicClusterStateWriter {
-        private static final String FINISHED_MSG = "AtomicClusterStateWriter is finished";
-        private final List<Runnable> commitCleanupActions;
-        private final List<Runnable> rollbackCleanupActions;
-        private final Manifest previousManifest;
-        private final MetaStateService metaStateService;
-        private boolean finished;
-
-        AtomicClusterStateWriter(MetaStateService metaStateService, Manifest previousManifest) {
-            this.metaStateService = metaStateService;
-            assert previousManifest != null;
-            this.previousManifest = previousManifest;
-            this.commitCleanupActions = new ArrayList<>();
-            this.rollbackCleanupActions = new ArrayList<>();
-            this.finished = false;
-        }
-
-        long writeGlobalState(String reason, Metadata metadata) throws WriteStateException {
-            assert finished == false : FINISHED_MSG;
-            try {
-                rollbackCleanupActions.add(() -> metaStateService.cleanupGlobalState(previousManifest.getGlobalGeneration()));
-                long generation = metaStateService.writeGlobalState(reason, metadata);
-                commitCleanupActions.add(() -> metaStateService.cleanupGlobalState(generation));
-                return generation;
-            } catch (WriteStateException e) {
-                rollback();
-                throw e;
-            }
-        }
-
-        long writeIndex(String reason, IndexMetadata metadata) throws WriteStateException {
-            assert finished == false : FINISHED_MSG;
-            try {
-                Index index = metadata.getIndex();
-                Long previousGeneration = previousManifest.getIndexGenerations().get(index);
-                if (previousGeneration != null) {
-                    // we prefer not to clean-up index metadata in case of rollback,
-                    // if it's not referenced by previous manifest file
-                    // not to break dangling indices functionality
-                    rollbackCleanupActions.add(() -> metaStateService.cleanupIndex(index, previousGeneration));
-                }
-                long generation = metaStateService.writeIndex(reason, metadata);
-                commitCleanupActions.add(() -> metaStateService.cleanupIndex(index, generation));
-                return generation;
-            } catch (WriteStateException e) {
-                rollback();
-                throw e;
-            }
-        }
-
-        void writeManifestAndCleanup(String reason, Manifest manifest) throws WriteStateException {
-            assert finished == false : FINISHED_MSG;
-            try {
-                metaStateService.writeManifestAndCleanup(reason, manifest);
-                commitCleanupActions.forEach(Runnable::run);
-                finished = true;
-            } catch (WriteStateException e) {
-                // if Manifest write results in dirty WriteStateException it's not safe to remove
-                // new metadata files, because if Manifest was actually written to disk and its deletion
-                // fails it will reference these new metadata files.
-                // In the future, we might decide to add more fine grained check to understand if after
-                // WriteStateException Manifest deletion has actually failed.
-                if (e.isDirty() == false) {
-                    rollback();
-                }
-                throw e;
-            }
-        }
-
-        void rollback() {
-            rollbackCleanupActions.forEach(Runnable::run);
-            finished = true;
-        }
-    }
-
-    /**
-     * Updates manifest and meta data on disk.
-     *
-     * @param newState new {@link ClusterState}
-     * @param previousState previous {@link ClusterState}
-     *
-     * @throws WriteStateException if exception occurs. See also {@link WriteStateException#isDirty()}.
-     */
-    private void updateClusterState(ClusterState newState, ClusterState previousState)
-            throws WriteStateException {
-        Metadata newMetadata = newState.metadata();
-
-        final AtomicClusterStateWriter writer = new AtomicClusterStateWriter(metaStateService, previousManifest);
-        long globalStateGeneration = writeGlobalState(writer, newMetadata);
-        Map<Index, Long> indexGenerations = writeIndicesMetadata(writer, newState, previousState);
-        Manifest manifest = new Manifest(previousManifest.getCurrentTerm(), newState.version(), globalStateGeneration, indexGenerations);
-        writeManifest(writer, manifest);
-
-        previousManifest = manifest;
-        previousClusterState = newState;
-    }
-
-    private void writeManifest(AtomicClusterStateWriter writer, Manifest manifest) throws WriteStateException {
-        if (manifest.equals(previousManifest) == false) {
-            writer.writeManifestAndCleanup("changed", manifest);
-        }
-    }
-
-    private Map<Index, Long> writeIndicesMetadata(AtomicClusterStateWriter writer, ClusterState newState, ClusterState previousState)
-            throws WriteStateException {
-        Map<Index, Long> previouslyWrittenIndices = previousManifest.getIndexGenerations();
-        Set<Index> relevantIndices = getRelevantIndices(newState, previousState, previouslyWrittenIndices.keySet());
-
-        Map<Index, Long> newIndices = new HashMap<>();
-
-        Metadata previousMetadata = incrementalWrite ? previousState.metadata() : null;
-        Iterable<IndexMetadataAction> actions = resolveIndexMetadataActions(previouslyWrittenIndices, relevantIndices, previousMetadata,
-                newState.metadata());
-
-        for (IndexMetadataAction action : actions) {
-            long generation = action.execute(writer);
-            newIndices.put(action.getIndex(), generation);
-        }
-
-        return newIndices;
-    }
-
-    private long writeGlobalState(AtomicClusterStateWriter writer, Metadata newMetadata)
-            throws WriteStateException {
-        if (incrementalWrite == false || Metadata.isGlobalStateEquals(previousClusterState.metadata(), newMetadata) == false) {
-            return writer.writeGlobalState("changed", newMetadata);
-        }
-        return previousManifest.getGlobalGeneration();
-    }
-
-    public static Set<Index> getRelevantIndices(ClusterState state, ClusterState previousState, Set<Index> previouslyWrittenIndices) {
-        Set<Index> relevantIndices;
-        if (isDataOnlyNode(state)) {
-            relevantIndices = getRelevantIndicesOnDataOnlyNode(state, previousState, previouslyWrittenIndices);
-        } else if (state.nodes().getLocalNode().isMasterNode()) {
-            relevantIndices = getRelevantIndicesForMasterEligibleNode(state);
-        } else {
-            relevantIndices = Collections.emptySet();
-        }
-        return relevantIndices;
-    }
-
-    private static boolean isDataOnlyNode(ClusterState state) {
-        return state.nodes().getLocalNode().isMasterNode() == false && state.nodes().getLocalNode().isDataNode();
     }
 
     /**
@@ -480,160 +255,81 @@ public class GatewayMetaState implements PersistedState {
         return false;
     }
 
-    /**
-     * Returns list of {@link IndexMetadataAction} for each relevant index.
-     * For each relevant index there are 3 options:
-     * <ol>
-     * <li>
-     * {@link KeepPreviousGeneration} - index metadata is already stored to disk and index metadata version is not changed, no
-     * action is required.
-     * </li>
-     * <li>
-     * {@link WriteNewIndexMetadata} - there is no index metadata on disk and index metadata for this index should be written.
-     * </li>
-     * <li>
-     * {@link WriteChangedIndexMetadata} - index metadata is already on disk, but index metadata version has changed. Updated
-     * index metadata should be written to disk.
-     * </li>
-     * </ol>
-     *
-     * @param previouslyWrittenIndices A list of indices for which the state was already written before
-     * @param relevantIndices          The list of indices for which state should potentially be written
-     * @param previousMetadata         The last meta data we know of
-     * @param newMetadata              The new metadata
-     * @return list of {@link IndexMetadataAction} for each relevant index.
-     */
-    public static List<IndexMetadataAction> resolveIndexMetadataActions(Map<Index, Long> previouslyWrittenIndices,
-                                                                        Set<Index> relevantIndices,
-                                                                        Metadata previousMetadata,
-                                                                        Metadata newMetadata) {
-        List<IndexMetadataAction> actions = new ArrayList<>();
-        for (Index index : relevantIndices) {
-            IndexMetadata newIndexMetadata = newMetadata.getIndexSafe(index);
-            IndexMetadata previousIndexMetadata = previousMetadata == null ? null : previousMetadata.index(index);
 
-            if (previouslyWrittenIndices.containsKey(index) == false || previousIndexMetadata == null) {
-                actions.add(new WriteNewIndexMetadata(newIndexMetadata));
-            } else if (previousIndexMetadata.getVersion() != newIndexMetadata.getVersion()) {
-                actions.add(new WriteChangedIndexMetadata(previousIndexMetadata, newIndexMetadata));
-            } else {
-                actions.add(new KeepPreviousGeneration(index, previouslyWrittenIndices.get(index)));
+    private static class GatewayClusterApplier implements ClusterStateApplier {
+
+        private final IncrementalClusterStateWriter incrementalClusterStateWriter;
+
+        private GatewayClusterApplier(IncrementalClusterStateWriter incrementalClusterStateWriter) {
+            this.incrementalClusterStateWriter = incrementalClusterStateWriter;
+        }
+
+        @Override
+        public void applyClusterState(ClusterChangedEvent event) {
+            if (event.state().blocks().disableStatePersistence()) {
+                incrementalClusterStateWriter.setIncrementalWrite(false);
+                return;
+            }
+
+            try {
+                // Hack: This is to ensure that non-master-eligible Zen2 nodes always store a current term
+                // that's higher than the last accepted term.
+                // TODO: can we get rid of this hack?
+                if (event.state().term() > incrementalClusterStateWriter.getPreviousManifest().getCurrentTerm()) {
+                    incrementalClusterStateWriter.setCurrentTerm(event.state().term());
+                }
+
+                incrementalClusterStateWriter.updateClusterState(event.state(), event.previousState());
+                incrementalClusterStateWriter.setIncrementalWrite(true);
+            } catch (WriteStateException e) {
+                LOGGER.warn("Exception occurred when storing new meta data", e);
             }
         }
-        return actions;
+
     }
 
-    private static Set<Index> getRelevantIndicesOnDataOnlyNode(ClusterState state, ClusterState previousState, Set<Index>
-            previouslyWrittenIndices) {
-        RoutingNode newRoutingNode = state.getRoutingNodes().node(state.nodes().getLocalNodeId());
-        if (newRoutingNode == null) {
-            throw new IllegalStateException("cluster state does not contain this node - cannot write index meta state");
+    private static class GatewayPersistedState implements PersistedState {
+
+        private final IncrementalClusterStateWriter incrementalClusterStateWriter;
+
+        GatewayPersistedState(IncrementalClusterStateWriter incrementalClusterStateWriter) {
+            this.incrementalClusterStateWriter = incrementalClusterStateWriter;
         }
-        Set<Index> indices = new HashSet<>();
-        for (ShardRouting routing : newRoutingNode) {
-            indices.add(routing.index());
+
+        @Override
+        public long getCurrentTerm() {
+            return incrementalClusterStateWriter.getPreviousManifest().getCurrentTerm();
         }
-        // we have to check the meta data also: closed indices will not appear in the routing table, but we must still write the state if
-        // we have it written on disk previously
-        for (IndexMetadata indexMetadata : state.metadata()) {
-            boolean isOrWasClosed = indexMetadata.getState().equals(IndexMetadata.State.CLOSE);
-            // if the index is open we might still have to write the state if it just transitioned from closed to open
-            // so we have to check for that as well.
-            IndexMetadata previousMetadata = previousState.metadata().index(indexMetadata.getIndex());
-            if (previousMetadata != null) {
-                isOrWasClosed = isOrWasClosed || previousMetadata.getState().equals(IndexMetadata.State.CLOSE);
+
+        @Override
+        public ClusterState getLastAcceptedState() {
+            final ClusterState previousClusterState = incrementalClusterStateWriter.getPreviousClusterState();
+            assert previousClusterState.nodes().getLocalNode() != null : "Cluster state is not fully built yet";
+            return previousClusterState;
+        }
+
+        @Override
+        public void setCurrentTerm(long currentTerm) {
+            try {
+                incrementalClusterStateWriter.setCurrentTerm(currentTerm);
+            } catch (WriteStateException e) {
+                LOGGER.error(new ParameterizedMessage("Failed to set current term to {}", currentTerm), e);
+                e.rethrowAsErrorOrUncheckedException();
             }
-            if (previouslyWrittenIndices.contains(indexMetadata.getIndex()) && isOrWasClosed) {
-                indices.add(indexMetadata.getIndex());
+        }
+
+        @Override
+        public void setLastAcceptedState(ClusterState clusterState) {
+            try {
+                final ClusterState previousClusterState = incrementalClusterStateWriter.getPreviousClusterState();
+                incrementalClusterStateWriter.setIncrementalWrite(previousClusterState.term() == clusterState.term());
+                incrementalClusterStateWriter.updateClusterState(clusterState, previousClusterState);
+            } catch (WriteStateException e) {
+                LOGGER.error(new ParameterizedMessage("Failed to set last accepted state with version {}", clusterState.version()), e);
+                e.rethrowAsErrorOrUncheckedException();
             }
         }
-        return indices;
+
     }
 
-    private static Set<Index> getRelevantIndicesForMasterEligibleNode(ClusterState state) {
-        Set<Index> relevantIndices = new HashSet<>();
-        // we have to iterate over the metadata to make sure we also capture closed indices
-        for (IndexMetadata indexMetadata : state.metadata()) {
-            relevantIndices.add(indexMetadata.getIndex());
-        }
-        return relevantIndices;
-    }
-
-    /**
-     * Action to perform with index metadata.
-     */
-    public interface IndexMetadataAction {
-        /**
-         * @return index for index metadata.
-         */
-        Index getIndex();
-
-        /**
-         * Executes this action using provided {@link AtomicClusterStateWriter}.
-         *
-         * @return new index metadata state generation, to be used in manifest file.
-         * @throws WriteStateException if exception occurs.
-         */
-        long execute(AtomicClusterStateWriter writer) throws WriteStateException;
-    }
-
-    public static class KeepPreviousGeneration implements IndexMetadataAction {
-        private final Index index;
-        private final long generation;
-
-        KeepPreviousGeneration(Index index, long generation) {
-            this.index = index;
-            this.generation = generation;
-        }
-
-        @Override
-        public Index getIndex() {
-            return index;
-        }
-
-        @Override
-        public long execute(AtomicClusterStateWriter writer) {
-            return generation;
-        }
-    }
-
-    public static class WriteNewIndexMetadata implements IndexMetadataAction {
-        private final IndexMetadata indexMetadata;
-
-        WriteNewIndexMetadata(IndexMetadata indexMetadata) {
-            this.indexMetadata = indexMetadata;
-        }
-
-        @Override
-        public Index getIndex() {
-            return indexMetadata.getIndex();
-        }
-
-        @Override
-        public long execute(AtomicClusterStateWriter writer) throws WriteStateException {
-            return writer.writeIndex("freshly created", indexMetadata);
-        }
-    }
-
-    public static class WriteChangedIndexMetadata implements IndexMetadataAction {
-        private final IndexMetadata newIndexMetadata;
-        private final IndexMetadata oldIndexMetadata;
-
-        WriteChangedIndexMetadata(IndexMetadata oldIndexMetadata, IndexMetadata newIndexMetadata) {
-            this.oldIndexMetadata = oldIndexMetadata;
-            this.newIndexMetadata = newIndexMetadata;
-        }
-
-        @Override
-        public Index getIndex() {
-            return newIndexMetadata.getIndex();
-        }
-
-        @Override
-        public long execute(AtomicClusterStateWriter writer) throws WriteStateException {
-            return writer.writeIndex(
-                    "version changed from [" + oldIndexMetadata.getVersion() + "] to [" + newIndexMetadata.getVersion() + "]",
-                    newIndexMetadata);
-        }
-    }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
+++ b/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Manifest;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.index.Index;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tracks the metadata written to disk, allowing updated metadata to be written incrementally (i.e. only writing out the changed metadata).
+ */
+class IncrementalClusterStateWriter {
+
+    private final MetaStateService metaStateService;
+
+    // On master-eligible nodes we call updateClusterState under the Coordinator's mutex; on master-ineligible data nodes we call
+    // updateClusterState on the (unique) cluster applier thread; on other nodes we never call updateClusterState. In all cases there's
+    // no need to synchronize access to these fields.
+    private Manifest previousManifest;
+    private ClusterState previousClusterState;
+    private boolean incrementalWrite;
+
+    IncrementalClusterStateWriter(MetaStateService metaStateService, Manifest manifest, ClusterState clusterState) {
+        this.metaStateService = metaStateService;
+        this.previousManifest = manifest;
+        this.previousClusterState = clusterState;
+        this.incrementalWrite = false;
+    }
+
+    void setCurrentTerm(long currentTerm) throws WriteStateException {
+        Manifest manifest = new Manifest(currentTerm, previousManifest.getClusterStateVersion(), previousManifest.getGlobalGeneration(),
+            new HashMap<>(previousManifest.getIndexGenerations()));
+        metaStateService.writeManifestAndCleanup("current term changed", manifest);
+        previousManifest = manifest;
+    }
+
+    Manifest getPreviousManifest() {
+        return previousManifest;
+    }
+
+    ClusterState getPreviousClusterState() {
+        return previousClusterState;
+    }
+
+    void setIncrementalWrite(boolean incrementalWrite) {
+        this.incrementalWrite = incrementalWrite;
+    }
+
+    /**
+     * Updates manifest and meta data on disk.
+     *
+     * @param newState new {@link ClusterState}
+     * @param previousState previous {@link ClusterState}
+     *
+     * @throws WriteStateException if exception occurs. See also {@link WriteStateException#isDirty()}.
+     */
+    void updateClusterState(ClusterState newState, ClusterState previousState) throws WriteStateException {
+        Metadata newMetadata = newState.metadata();
+
+        final AtomicClusterStateWriter writer = new AtomicClusterStateWriter(metaStateService, previousManifest);
+        long globalStateGeneration = writeGlobalState(writer, newMetadata);
+        Map<Index, Long> indexGenerations = writeIndicesMetadata(writer, newState, previousState);
+        Manifest manifest = new Manifest(previousManifest.getCurrentTerm(), newState.version(), globalStateGeneration, indexGenerations);
+        writeManifest(writer, manifest);
+
+        previousManifest = manifest;
+        previousClusterState = newState;
+    }
+
+    private void writeManifest(AtomicClusterStateWriter writer, Manifest manifest) throws WriteStateException {
+        if (manifest.equals(previousManifest) == false) {
+            writer.writeManifestAndCleanup("changed", manifest);
+        }
+    }
+
+    private Map<Index, Long> writeIndicesMetadata(AtomicClusterStateWriter writer, ClusterState newState, ClusterState previousState)
+        throws WriteStateException {
+        Map<Index, Long> previouslyWrittenIndices = previousManifest.getIndexGenerations();
+        Set<Index> relevantIndices = getRelevantIndices(newState, previousState, previouslyWrittenIndices.keySet());
+
+        Map<Index, Long> newIndices = new HashMap<>();
+
+        Metadata previousMetadata = incrementalWrite ? previousState.metadata() : null;
+        Iterable<IndexMetadataAction> actions = resolveIndexMetadataActions(previouslyWrittenIndices, relevantIndices, previousMetadata,
+            newState.metadata());
+
+        for (IndexMetadataAction action : actions) {
+            long generation = action.execute(writer);
+            newIndices.put(action.getIndex(), generation);
+        }
+
+        return newIndices;
+    }
+
+    private long writeGlobalState(AtomicClusterStateWriter writer, Metadata newMetadata) throws WriteStateException {
+        if (incrementalWrite == false || Metadata.isGlobalStateEquals(previousClusterState.metadata(), newMetadata) == false) {
+            return writer.writeGlobalState("changed", newMetadata);
+        }
+        return previousManifest.getGlobalGeneration();
+    }
+
+
+    /**
+     * Returns list of {@link IndexMetadataAction} for each relevant index.
+     * For each relevant index there are 3 options:
+     * <ol>
+     * <li>
+     * {@link KeepPreviousGeneration} - index metadata is already stored to disk and index metadata version is not changed, no
+     * action is required.
+     * </li>
+     * <li>
+     * {@link WriteNewIndexMetadata} - there is no index metadata on disk and index metadata for this index should be written.
+     * </li>
+     * <li>
+     * {@link WriteChangedIndexMetadata} - index metadata is already on disk, but index metadata version has changed. Updated
+     * index metadata should be written to disk.
+     * </li>
+     * </ol>
+     *
+     * @param previouslyWrittenIndices A list of indices for which the state was already written before
+     * @param relevantIndices          The list of indices for which state should potentially be written
+     * @param previousMetadata         The last meta data we know of
+     * @param newMetadata              The new metadata
+     * @return list of {@link IndexMetadataAction} for each relevant index.
+     */
+    // exposed for tests
+    static List<IndexMetadataAction> resolveIndexMetadataActions(Map<Index, Long> previouslyWrittenIndices,
+                                                                 Set<Index> relevantIndices,
+                                                                 Metadata previousMetadata,
+                                                                 Metadata newMetadata) {
+        List<IndexMetadataAction> actions = new ArrayList<>();
+        for (Index index : relevantIndices) {
+            IndexMetadata newIndexMetadata = newMetadata.getIndexSafe(index);
+            IndexMetadata previousIndexMetadata = previousMetadata == null ? null : previousMetadata.index(index);
+
+            if (previouslyWrittenIndices.containsKey(index) == false || previousIndexMetadata == null) {
+                actions.add(new WriteNewIndexMetadata(newIndexMetadata));
+            } else if (previousIndexMetadata.getVersion() != newIndexMetadata.getVersion()) {
+                actions.add(new WriteChangedIndexMetadata(previousIndexMetadata, newIndexMetadata));
+            } else {
+                actions.add(new KeepPreviousGeneration(index, previouslyWrittenIndices.get(index)));
+            }
+        }
+        return actions;
+    }
+
+    private static Set<Index> getRelevantIndicesOnDataOnlyNode(ClusterState state, ClusterState previousState, Set<Index>
+        previouslyWrittenIndices) {
+        RoutingNode newRoutingNode = state.getRoutingNodes().node(state.nodes().getLocalNodeId());
+        if (newRoutingNode == null) {
+            throw new IllegalStateException("cluster state does not contain this node - cannot write index meta state");
+        }
+        Set<Index> indices = new HashSet<>();
+        for (ShardRouting routing : newRoutingNode) {
+            indices.add(routing.index());
+        }
+        // we have to check the meta data also: closed indices will not appear in the routing table, but we must still write the state if
+        // we have it written on disk previously
+        for (IndexMetadata indexMetadata : state.metadata()) {
+            boolean isOrWasClosed = indexMetadata.getState().equals(IndexMetadata.State.CLOSE);
+            // if the index is open we might still have to write the state if it just transitioned from closed to open
+            // so we have to check for that as well.
+            IndexMetadata previousMetadata = previousState.metadata().index(indexMetadata.getIndex());
+            if (previousMetadata != null) {
+                isOrWasClosed = isOrWasClosed || previousMetadata.getState().equals(IndexMetadata.State.CLOSE);
+            }
+            if (previouslyWrittenIndices.contains(indexMetadata.getIndex()) && isOrWasClosed) {
+                indices.add(indexMetadata.getIndex());
+            }
+        }
+        return indices;
+    }
+
+    private static Set<Index> getRelevantIndicesForMasterEligibleNode(ClusterState state) {
+        Set<Index> relevantIndices = new HashSet<>();
+        // we have to iterate over the metadata to make sure we also capture closed indices
+        for (IndexMetadata indexMetadata : state.metadata()) {
+            relevantIndices.add(indexMetadata.getIndex());
+        }
+        return relevantIndices;
+    }
+
+    // exposed for tests
+    static Set<Index> getRelevantIndices(ClusterState state, ClusterState previousState, Set<Index> previouslyWrittenIndices) {
+        Set<Index> relevantIndices;
+        if (isDataOnlyNode(state)) {
+            relevantIndices = getRelevantIndicesOnDataOnlyNode(state, previousState, previouslyWrittenIndices);
+        } else if (state.nodes().getLocalNode().isMasterNode()) {
+            relevantIndices = getRelevantIndicesForMasterEligibleNode(state);
+        } else {
+            relevantIndices = Collections.emptySet();
+        }
+        return relevantIndices;
+    }
+
+    private static boolean isDataOnlyNode(ClusterState state) {
+        return state.nodes().getLocalNode().isMasterNode() == false && state.nodes().getLocalNode().isDataNode();
+    }
+
+    /**
+     * Action to perform with index metadata.
+     */
+    interface IndexMetadataAction {
+        /**
+         * @return index for index metadata.
+         */
+        Index getIndex();
+
+        /**
+         * Executes this action using provided {@link AtomicClusterStateWriter}.
+         *
+         * @return new index metadata state generation, to be used in manifest file.
+         * @throws WriteStateException if exception occurs.
+         */
+        long execute(AtomicClusterStateWriter writer) throws WriteStateException;
+    }
+
+    /**
+     * This class is used to write changed global {@link Metadata}, {@link IndexMetadata} and {@link Manifest} to disk.
+     * This class delegates <code>write*</code> calls to corresponding write calls in {@link MetaStateService} and
+     * additionally it keeps track of cleanup actions to be performed if transaction succeeds or fails.
+     */
+    static class AtomicClusterStateWriter {
+        private static final String FINISHED_MSG = "AtomicClusterStateWriter is finished";
+        private final List<Runnable> commitCleanupActions;
+        private final List<Runnable> rollbackCleanupActions;
+        private final Manifest previousManifest;
+        private final MetaStateService metaStateService;
+        private boolean finished;
+
+        AtomicClusterStateWriter(MetaStateService metaStateService, Manifest previousManifest) {
+            this.metaStateService = metaStateService;
+            assert previousManifest != null;
+            this.previousManifest = previousManifest;
+            this.commitCleanupActions = new ArrayList<>();
+            this.rollbackCleanupActions = new ArrayList<>();
+            this.finished = false;
+        }
+
+        long writeGlobalState(String reason, Metadata metadata) throws WriteStateException {
+            assert finished == false : FINISHED_MSG;
+            try {
+                rollbackCleanupActions.add(() -> metaStateService.cleanupGlobalState(previousManifest.getGlobalGeneration()));
+                long generation = metaStateService.writeGlobalState(reason, metadata);
+                commitCleanupActions.add(() -> metaStateService.cleanupGlobalState(generation));
+                return generation;
+            } catch (WriteStateException e) {
+                rollback();
+                throw e;
+            }
+        }
+
+        long writeIndex(String reason, IndexMetadata metadata) throws WriteStateException {
+            assert finished == false : FINISHED_MSG;
+            try {
+                Index index = metadata.getIndex();
+                Long previousGeneration = previousManifest.getIndexGenerations().get(index);
+                if (previousGeneration != null) {
+                    // we prefer not to clean-up index metadata in case of rollback,
+                    // if it's not referenced by previous manifest file
+                    // not to break dangling indices functionality
+                    rollbackCleanupActions.add(() -> metaStateService.cleanupIndex(index, previousGeneration));
+                }
+                long generation = metaStateService.writeIndex(reason, metadata);
+                commitCleanupActions.add(() -> metaStateService.cleanupIndex(index, generation));
+                return generation;
+            } catch (WriteStateException e) {
+                rollback();
+                throw e;
+            }
+        }
+
+        void writeManifestAndCleanup(String reason, Manifest manifest) throws WriteStateException {
+            assert finished == false : FINISHED_MSG;
+            try {
+                metaStateService.writeManifestAndCleanup(reason, manifest);
+                commitCleanupActions.forEach(Runnable::run);
+                finished = true;
+            } catch (WriteStateException e) {
+                // If the Manifest write results in a dirty WriteStateException it's not safe to roll back, removing the new metadata files,
+                // because if the Manifest was actually written to disk and its deletion fails it will reference these new metadata files.
+                // On master-eligible nodes a dirty WriteStateException here is fatal to the node since we no longer really have any idea
+                // what the state on disk is and the only sensible response is to start again from scratch.
+                if (e.isDirty() == false) {
+                    rollback();
+                }
+                throw e;
+            }
+        }
+
+        void rollback() {
+            rollbackCleanupActions.forEach(Runnable::run);
+            finished = true;
+        }
+    }
+
+    static class KeepPreviousGeneration implements IndexMetadataAction {
+        private final Index index;
+        private final long generation;
+
+        KeepPreviousGeneration(Index index, long generation) {
+            this.index = index;
+            this.generation = generation;
+        }
+
+        @Override
+        public Index getIndex() {
+            return index;
+        }
+
+        @Override
+        public long execute(AtomicClusterStateWriter writer) {
+            return generation;
+        }
+    }
+
+    static class WriteNewIndexMetadata implements IndexMetadataAction {
+        private final IndexMetadata indexMetadata;
+
+        WriteNewIndexMetadata(IndexMetadata indexMetadata) {
+            this.indexMetadata = indexMetadata;
+        }
+
+        @Override
+        public Index getIndex() {
+            return indexMetadata.getIndex();
+        }
+
+        @Override
+        public long execute(AtomicClusterStateWriter writer) throws WriteStateException {
+            return writer.writeIndex("freshly created", indexMetadata);
+        }
+    }
+
+    static class WriteChangedIndexMetadata implements IndexMetadataAction {
+        private final IndexMetadata newIndexMetadata;
+        private final IndexMetadata oldIndexMetadata;
+
+        WriteChangedIndexMetadata(IndexMetadata oldIndexMetadata, IndexMetadata newIndexMetadata) {
+            this.oldIndexMetadata = oldIndexMetadata;
+            this.newIndexMetadata = newIndexMetadata;
+        }
+
+        @Override
+        public Index getIndex() {
+            return newIndexMetadata.getIndex();
+        }
+
+        @Override
+        public long execute(AtomicClusterStateWriter writer) throws WriteStateException {
+            return writer.writeIndex(
+                    "version changed from [" + oldIndexMetadata.getVersion() + "] to [" + newIndexMetadata.getVersion() + "]",
+                    newIndexMetadata);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -473,7 +473,7 @@ public class Node implements Closeable {
                 localNodeFactory,
                 settingsModule.getClusterSettings()
             );
-            final GatewayMetaState gatewayMetaState = new GatewayMetaState(settings, metaStateService);
+            final GatewayMetaState gatewayMetaState = new GatewayMetaState();
             final HttpServerTransport httpServerTransport = newHttpTransport(networkModule);
 
 
@@ -689,8 +689,14 @@ public class Node implements Closeable {
 
         // Load (and maybe upgrade) the metadata stored on disk
         final GatewayMetaState gatewayMetaState = injector.getInstance(GatewayMetaState.class);
-        gatewayMetaState.start(transportService, clusterService,
-            injector.getInstance(MetadataIndexUpgradeService.class), injector.getInstance(MetadataUpgrader.class));
+        gatewayMetaState.start(
+            settings(),
+            transportService,
+            clusterService,
+            injector.getInstance(MetaStateService.class),
+            injector.getInstance(MetadataIndexUpgradeService.class),
+            injector.getInstance(MetadataUpgrader.class)
+        );
         // we load the global state here (the persistent part of the cluster state stored on disk) to
         // pass it to the bootstrap checks to allow plugins to enforce certain preconditions based on the recovered state.
         final Metadata onDiskMetadata = gatewayMetaState.getPersistedState().getLastAcceptedState().metadata();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -173,6 +173,7 @@ public class CoordinatorTests extends ESTestCase {
         nodeEnvironments.clear();
     }
 
+
     @Before
     public void resetPortCounterBeforeEachTest() {
         resetPortCounter();
@@ -1780,9 +1781,8 @@ public class CoordinatorTests extends ESTestCase {
                     if (rarely()) {
                         nodeEnvironment = newNodeEnvironment();
                         nodeEnvironments.add(nodeEnvironment);
-                        MockGatewayMetaState gatewayMetaState = new MockGatewayMetaState(
-                            Settings.EMPTY, nodeEnvironment, xContentRegistry(), localNode);
-                        gatewayMetaState.start();
+                        final MockGatewayMetaState gatewayMetaState = new MockGatewayMetaState(localNode);
+                        gatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry());
                         delegate = gatewayMetaState.getPersistedState();
                     } else {
                         nodeEnvironment = null;
@@ -1812,10 +1812,9 @@ public class CoordinatorTests extends ESTestCase {
                                 new Manifest(updatedTerm, manifest.getClusterStateVersion(), manifest.getGlobalGeneration(),
                                     manifest.getIndexGenerations()));
                         }
-                        MockGatewayMetaState mockGatewayMetaState = new MockGatewayMetaState(
-                            Settings.EMPTY, nodeEnvironment, xContentRegistry(), newLocalNode);
-                        mockGatewayMetaState.start();
-                        delegate = mockGatewayMetaState.getPersistedState();
+                        final MockGatewayMetaState gatewayMetaState = new MockGatewayMetaState(newLocalNode);
+                        gatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry());
+                        delegate = gatewayMetaState.getPersistedState();
                     } else {
                         nodeEnvironment = null;
                         BytesStreamOutput outStream = new BytesStreamOutput();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -61,6 +61,7 @@ import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationComm
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -650,7 +651,6 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
     }
 
     @Test
-    @Ignore("Likely a backport missing. Will follow up on this")
     public void testConflictingCommandsInSingleRequest() {
         AllocationService allocation = createAllocationService(Settings.builder()
             .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")
@@ -666,6 +666,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                     .build()
                 ).numberOfShards(1).numberOfReplicas(1)
                 .putInSyncAllocationIds(0, Collections.singleton("randomAllocID"))
@@ -674,6 +675,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                     .build()
                 ).numberOfShards(1).numberOfReplicas(1)
                 .putInSyncAllocationIds(0, Collections.singleton("randomAllocID"))
@@ -682,6 +684,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                     .build()
                 ).numberOfShards(1).numberOfReplicas(1)
                 .putInSyncAllocationIds(0, Collections.singleton("randomAllocID"))

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.CoordinationMetadata;
+import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
+import org.elasticsearch.cluster.coordination.CoordinationState;
+import org.elasticsearch.cluster.coordination.InMemoryPersistedState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Manifest;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+public class GatewayMetaStatePersistedStateTests extends ESTestCase {
+    private NodeEnvironment nodeEnvironment;
+    private ClusterName clusterName;
+    private Settings settings;
+    private DiscoveryNode localNode;
+
+    @Override
+    public void setUp() throws Exception {
+        nodeEnvironment = newNodeEnvironment();
+        localNode = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Collections.emptyMap(),
+                Sets.newHashSet(DiscoveryNode.Role.MASTER), Version.CURRENT);
+        clusterName = new ClusterName(randomAlphaOfLength(10));
+        settings = Settings.builder().put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName.value()).build();
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        nodeEnvironment.close();
+        super.tearDown();
+    }
+
+    private CoordinationState.PersistedState newGatewayPersistedState() {
+        final MockGatewayMetaState gateway = new MockGatewayMetaState(localNode);
+        gateway.start(settings, nodeEnvironment, xContentRegistry());
+        final CoordinationState.PersistedState persistedState = gateway.getPersistedState();
+        assertThat(persistedState, not(instanceOf(InMemoryPersistedState.class)));
+        return persistedState;
+    }
+
+    private CoordinationState.PersistedState maybeNew(CoordinationState.PersistedState persistedState) {
+        if (randomBoolean()) {
+            return newGatewayPersistedState();
+        }
+        return persistedState;
+    }
+
+    public void testInitialState() {
+        CoordinationState.PersistedState gateway = newGatewayPersistedState();
+        ClusterState state = gateway.getLastAcceptedState();
+        assertThat(state.getClusterName(), equalTo(clusterName));
+        assertTrue(Metadata.isGlobalStateEquals(state.metadata(), Metadata.EMPTY_METADATA));
+        assertThat(state.getVersion(), equalTo(Manifest.empty().getClusterStateVersion()));
+        assertThat(state.getNodes().getLocalNode(), equalTo(localNode));
+
+        long currentTerm = gateway.getCurrentTerm();
+        assertThat(currentTerm, equalTo(Manifest.empty().getCurrentTerm()));
+    }
+
+    public void testSetCurrentTerm() {
+        CoordinationState.PersistedState gateway = newGatewayPersistedState();
+
+        for (int i = 0; i < randomIntBetween(1, 5); i++) {
+            final long currentTerm = randomNonNegativeLong();
+            gateway.setCurrentTerm(currentTerm);
+            gateway = maybeNew(gateway);
+            assertThat(gateway.getCurrentTerm(), equalTo(currentTerm));
+        }
+    }
+
+    private ClusterState createClusterState(long version, Metadata metadata) {
+        return ClusterState.builder(clusterName).
+                nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).build()).
+                version(version).
+                metadata(metadata).
+                build();
+    }
+
+    private CoordinationMetadata createCoordinationMetadata(long term) {
+        CoordinationMetadata.Builder builder = CoordinationMetadata.builder();
+        builder.term(term);
+        builder.lastAcceptedConfiguration(
+                new CoordinationMetadata.VotingConfiguration(
+                        Sets.newHashSet(generateRandomStringArray(10, 10, false))));
+        builder.lastCommittedConfiguration(
+                new CoordinationMetadata.VotingConfiguration(
+                        Sets.newHashSet(generateRandomStringArray(10, 10, false))));
+        for (int i = 0; i < randomIntBetween(0, 5); i++) {
+            builder.addVotingConfigExclusion(new VotingConfigExclusion(randomAlphaOfLength(10), randomAlphaOfLength(10)));
+        }
+
+        return builder.build();
+    }
+
+    private IndexMetadata createIndexMetadata(String indexName, int numberOfShards, long version) {
+        return IndexMetadata.builder(indexName).settings(
+                Settings.builder()
+                        .put(IndexMetadata.SETTING_INDEX_UUID, indexName)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                        .build()
+        ).version(version).build();
+    }
+
+    private void assertClusterStateEqual(ClusterState expected, ClusterState actual) {
+        assertThat(actual.version(), equalTo(expected.version()));
+        assertTrue(Metadata.isGlobalStateEquals(actual.metadata(), expected.metadata()));
+        for (IndexMetadata indexMetadata : expected.metadata()) {
+            assertThat(actual.metadata().index(indexMetadata.getIndex()), equalTo(indexMetadata));
+        }
+    }
+
+    public void testSetLastAcceptedState() {
+        CoordinationState.PersistedState gateway = newGatewayPersistedState();
+        final long term = randomNonNegativeLong();
+
+        for (int i = 0; i < randomIntBetween(1, 5); i++) {
+            final long version = randomNonNegativeLong();
+            final String indexName = randomAlphaOfLength(10);
+            final IndexMetadata indexMetadata = createIndexMetadata(indexName, randomIntBetween(1,5), randomNonNegativeLong());
+            final Metadata metadata = Metadata.builder().
+                    persistentSettings(Settings.builder().put(randomAlphaOfLength(10), randomAlphaOfLength(10)).build()).
+                    coordinationMetadata(createCoordinationMetadata(term)).
+                    put(indexMetadata, false).
+                    build();
+            ClusterState state = createClusterState(version, metadata);
+
+            gateway.setLastAcceptedState(state);
+            gateway = maybeNew(gateway);
+
+            ClusterState lastAcceptedState = gateway.getLastAcceptedState();
+            assertClusterStateEqual(state, lastAcceptedState);
+        }
+    }
+
+    public void testSetLastAcceptedStateTermChanged() {
+        CoordinationState.PersistedState gateway = newGatewayPersistedState();
+
+        final String indexName = randomAlphaOfLength(10);
+        final int numberOfShards = randomIntBetween(1, 5);
+        final long version = randomNonNegativeLong();
+        final long term = randomNonNegativeLong();
+        final IndexMetadata indexMetadata = createIndexMetadata(indexName, numberOfShards, version);
+        final ClusterState state = createClusterState(randomNonNegativeLong(),
+                Metadata.builder().coordinationMetadata(createCoordinationMetadata(term)).put(indexMetadata, false).build());
+        gateway.setLastAcceptedState(state);
+
+        gateway = maybeNew(gateway);
+        final long newTerm = randomValueOtherThan(term, ESTestCase::randomNonNegativeLong);
+        final int newNumberOfShards = randomValueOtherThan(numberOfShards, () -> randomIntBetween(1,5));
+        final IndexMetadata newIndexMetadata = createIndexMetadata(indexName, newNumberOfShards, version);
+        final ClusterState newClusterState = createClusterState(randomNonNegativeLong(),
+                Metadata.builder().coordinationMetadata(createCoordinationMetadata(newTerm)).put(newIndexMetadata, false).build());
+        gateway.setLastAcceptedState(newClusterState);
+
+        gateway = maybeNew(gateway);
+        assertThat(gateway.getLastAcceptedState().metadata().index(indexName), equalTo(newIndexMetadata));
+    }
+
+    public void testCurrentTermAndTermAreDifferent() {
+        CoordinationState.PersistedState gateway = newGatewayPersistedState();
+
+        long currentTerm = randomNonNegativeLong();
+        long term  = randomValueOtherThan(currentTerm, ESTestCase::randomNonNegativeLong);
+
+        gateway.setCurrentTerm(currentTerm);
+        gateway.setLastAcceptedState(createClusterState(randomNonNegativeLong(),
+                Metadata.builder().coordinationMetadata(CoordinationMetadata.builder().term(term).build()).build()));
+
+        gateway = maybeNew(gateway);
+        assertThat(gateway.getCurrentTerm(), equalTo(currentTerm));
+        assertThat(gateway.getLastAcceptedState().coordinationMetadata().term(), equalTo(term));
+    }
+
+    public void testMarkAcceptedConfigAsCommitted() {
+        CoordinationState.PersistedState gateway = newGatewayPersistedState();
+
+        //generate random coordinationMetadata with different lastAcceptedConfiguration and lastCommittedConfiguration
+        CoordinationMetadata coordinationMetadata;
+        do {
+            coordinationMetadata = createCoordinationMetadata(randomNonNegativeLong());
+        } while (coordinationMetadata.getLastAcceptedConfiguration().equals(coordinationMetadata.getLastCommittedConfiguration()));
+
+        ClusterState state = createClusterState(randomNonNegativeLong(),
+                Metadata.builder().coordinationMetadata(coordinationMetadata)
+                    .clusterUUID(randomAlphaOfLength(10)).build());
+        gateway.setLastAcceptedState(state);
+
+        gateway = maybeNew(gateway);
+        assertThat(gateway.getLastAcceptedState().getLastAcceptedConfiguration(),
+                not(equalTo(gateway.getLastAcceptedState().getLastCommittedConfiguration())));
+        gateway.markLastAcceptedStateAsCommitted();
+
+        CoordinationMetadata expectedCoordinationMetadata = CoordinationMetadata.builder(coordinationMetadata)
+                .lastCommittedConfiguration(coordinationMetadata.getLastAcceptedConfiguration()).build();
+        ClusterState expectedClusterState =
+                ClusterState.builder(state).metadata(Metadata.builder().coordinationMetadata(expectedCoordinationMetadata)
+                    .clusterUUID(state.metadata().clusterUUID()).clusterUUIDCommitted(true).build()).build();
+
+        gateway = maybeNew(gateway);
+        assertClusterStateEqual(expectedClusterState, gateway.getLastAcceptedState());
+        gateway.markLastAcceptedStateAsCommitted();
+
+        gateway = maybeNew(gateway);
+        assertClusterStateEqual(expectedClusterState, gateway.getLastAcceptedState());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.MetadataUpgrader;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TestCustomMetadata;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class GatewayMetaStateTests extends ESTestCase {
+
+    public void testAddCustomMetadataOnUpgrade() throws Exception {
+        Metadata metadata = randomMetadata();
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
+            Collections.singletonList(customs -> {
+                customs.put(CustomMetadata1.TYPE, new CustomMetadata1("modified_data1"));
+                return customs;
+            }),
+            Collections.emptyList()
+        );
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade != metadata);
+        assertFalse(Metadata.isGlobalStateEquals(upgrade, metadata));
+        assertNotNull(upgrade.custom(CustomMetadata1.TYPE));
+        assertThat(((TestCustomMetadata) upgrade.custom(CustomMetadata1.TYPE)).getData(), equalTo("modified_data1"));
+    }
+
+    public void testRemoveCustomMetadataOnUpgrade() throws Exception {
+        Metadata metadata = randomMetadata(new CustomMetadata1("data"));
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
+            Collections.singletonList(customs -> {
+                customs.remove(CustomMetadata1.TYPE);
+                return customs;
+            }),
+            Collections.emptyList()
+        );
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade != metadata);
+        assertFalse(Metadata.isGlobalStateEquals(upgrade, metadata));
+        assertNull(upgrade.custom(CustomMetadata1.TYPE));
+    }
+
+    public void testUpdateCustomMetadataOnUpgrade() throws Exception {
+        Metadata metadata = randomMetadata(new CustomMetadata1("data"));
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
+            Collections.singletonList(customs -> {
+                customs.put(CustomMetadata1.TYPE, new CustomMetadata1("modified_data1"));
+                return customs;
+            }),
+            Collections.emptyList()
+        );
+
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade != metadata);
+        assertFalse(Metadata.isGlobalStateEquals(upgrade, metadata));
+        assertNotNull(upgrade.custom(CustomMetadata1.TYPE));
+        assertThat(((TestCustomMetadata) upgrade.custom(CustomMetadata1.TYPE)).getData(), equalTo("modified_data1"));
+    }
+
+
+    public void testUpdateTemplateMetadataOnUpgrade() throws Exception {
+        Metadata metadata = randomMetadata();
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
+            Collections.emptyList(),
+            Collections.singletonList(
+                templates -> {
+                    templates.put("added_test_template", IndexTemplateMetadata.builder("added_test_template")
+                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false))).build());
+                    return templates;
+                }
+            ));
+
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade != metadata);
+        assertFalse(Metadata.isGlobalStateEquals(upgrade, metadata));
+        assertTrue(upgrade.templates().containsKey("added_test_template"));
+    }
+
+    public void testNoMetadataUpgrade() throws Exception {
+        Metadata metadata = randomMetadata(new CustomMetadata1("data"));
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(Collections.emptyList(), Collections.emptyList());
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade == metadata);
+        assertTrue(Metadata.isGlobalStateEquals(upgrade, metadata));
+        for (IndexMetadata indexMetadata : upgrade) {
+            assertTrue(metadata.hasIndexMetadata(indexMetadata));
+        }
+    }
+
+    public void testCustomMetadataValidation() throws Exception {
+        Metadata metadata = randomMetadata(new CustomMetadata1("data"));
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(Collections.singletonList(
+            customs -> {
+                throw new IllegalStateException("custom meta data too old");
+            }
+        ), Collections.emptyList());
+        try {
+            GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), equalTo("custom meta data too old"));
+        }
+    }
+
+    public void testMultipleCustomMetadataUpgrade() throws Exception {
+        final Metadata metadata;
+        switch (randomIntBetween(0, 2)) {
+            case 0:
+                metadata = randomMetadata(new CustomMetadata1("data1"), new CustomMetadata2("data2"));
+                break;
+            case 1:
+                metadata = randomMetadata(randomBoolean() ? new CustomMetadata1("data1") : new CustomMetadata2("data2"));
+                break;
+            case 2:
+                metadata = randomMetadata();
+                break;
+            default:
+                throw new IllegalStateException("should never happen");
+        }
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
+            Arrays.asList(
+                customs -> {
+                    customs.put(CustomMetadata1.TYPE, new CustomMetadata1("modified_data1"));
+                    return customs;
+                },
+                customs -> {
+                    customs.put(CustomMetadata2.TYPE, new CustomMetadata1("modified_data2"));
+                    return customs;
+                }
+            ), Collections.emptyList());
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade != metadata);
+        assertFalse(Metadata.isGlobalStateEquals(upgrade, metadata));
+        assertNotNull(upgrade.custom(CustomMetadata1.TYPE));
+        assertThat(((TestCustomMetadata) upgrade.custom(CustomMetadata1.TYPE)).getData(), equalTo("modified_data1"));
+        assertNotNull(upgrade.custom(CustomMetadata2.TYPE));
+        assertThat(((TestCustomMetadata) upgrade.custom(CustomMetadata2.TYPE)).getData(), equalTo("modified_data2"));
+        for (IndexMetadata indexMetadata : upgrade) {
+            assertTrue(metadata.hasIndexMetadata(indexMetadata));
+        }
+    }
+
+    public void testIndexMetadataUpgrade() throws Exception {
+        Metadata metadata = randomMetadata();
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(Collections.emptyList(), Collections.emptyList());
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(true), metadataUpgrader);
+        assertTrue(upgrade != metadata);
+        assertTrue(Metadata.isGlobalStateEquals(upgrade, metadata));
+        for (IndexMetadata indexMetadata : upgrade) {
+            assertFalse(metadata.hasIndexMetadata(indexMetadata));
+        }
+    }
+
+    public void testCustomMetadataNoChange() throws Exception {
+        Metadata metadata = randomMetadata(new CustomMetadata1("data"));
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(Collections.singletonList(HashMap::new),
+            Collections.singletonList(HashMap::new));
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade == metadata);
+        assertTrue(Metadata.isGlobalStateEquals(upgrade, metadata));
+        for (IndexMetadata indexMetadata : upgrade) {
+            assertTrue(metadata.hasIndexMetadata(indexMetadata));
+        }
+    }
+
+    public void testIndexTemplateValidation() throws Exception {
+        Metadata metadata = randomMetadata();
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
+            Collections.emptyList(),
+            Collections.singletonList(
+                customs -> {
+                    throw new IllegalStateException("template is incompatible");
+                }));
+        String message = expectThrows(IllegalStateException.class,
+            () -> GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader)).getMessage();
+        assertThat(message, equalTo("template is incompatible"));
+    }
+
+
+    public void testMultipleIndexTemplateUpgrade() throws Exception {
+        final Metadata metadata;
+        switch (randomIntBetween(0, 2)) {
+            case 0:
+                metadata = randomMetadataWithIndexTemplates("template1", "template2");
+                break;
+            case 1:
+                metadata = randomMetadataWithIndexTemplates(randomBoolean() ? "template1" : "template2");
+                break;
+            case 2:
+                metadata = randomMetadata();
+                break;
+            default:
+                throw new IllegalStateException("should never happen");
+        }
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
+            Collections.emptyList(),
+            Arrays.asList(
+                indexTemplateMetadatas -> {
+                    indexTemplateMetadatas.put("template1", IndexTemplateMetadata.builder("template1")
+                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
+                        .settings(Settings.builder().put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 20).build())
+                        .build());
+                    return indexTemplateMetadatas;
+
+                },
+                indexTemplateMetadatas -> {
+                    indexTemplateMetadatas.put("template2", IndexTemplateMetadata.builder("template2")
+                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
+                        .settings(Settings.builder().put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10).build()).build());
+                    return indexTemplateMetadatas;
+
+                }
+            ));
+        Metadata upgrade = GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertTrue(upgrade != metadata);
+        assertFalse(Metadata.isGlobalStateEquals(upgrade, metadata));
+        assertNotNull(upgrade.templates().get("template1"));
+        assertThat(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(upgrade.templates().get("template1").settings()), equalTo(20));
+        assertNotNull(upgrade.templates().get("template2"));
+        assertThat(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(upgrade.templates().get("template2").settings()), equalTo(10));
+        for (IndexMetadata indexMetadata : upgrade) {
+            assertTrue(metadata.hasIndexMetadata(indexMetadata));
+        }
+    }
+
+    private static class MockMetadataIndexUpgradeService extends MetadataIndexUpgradeService {
+        private final boolean upgrade;
+
+        MockMetadataIndexUpgradeService(boolean upgrade) {
+            super(Settings.EMPTY, null, null, null, null);
+            this.upgrade = upgrade;
+        }
+
+        @Override
+        public IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata, Version minimumIndexCompatibilityVersion) {
+            return upgrade ? IndexMetadata.builder(indexMetadata).build() : indexMetadata;
+        }
+    }
+
+    private static class CustomMetadata1 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_1";
+
+        protected CustomMetadata1(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class CustomMetadata2 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_2";
+
+        protected CustomMetadata2(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    private static Metadata randomMetadata(TestCustomMetadata... customMetadatas) {
+        Metadata.Builder builder = Metadata.builder();
+        for (TestCustomMetadata customMetadata : customMetadatas) {
+            builder.putCustom(customMetadata.getWriteableName(), customMetadata);
+        }
+        for (int i = 0; i < randomIntBetween(1, 5); i++) {
+            builder.put(
+                IndexMetadata.builder(randomAlphaOfLength(10))
+                    .settings(settings(Version.CURRENT))
+                    .numberOfReplicas(randomIntBetween(0, 3))
+                    .numberOfShards(randomIntBetween(1, 5))
+            );
+        }
+        return builder.build();
+    }
+
+    private static Metadata randomMetadataWithIndexTemplates(String... templates) {
+        Metadata.Builder builder = Metadata.builder();
+        for (String template : templates) {
+            IndexTemplateMetadata templateMetadata = IndexTemplateMetadata.builder(template)
+                .settings(settings(Version.CURRENT)
+                    .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), randomIntBetween(0, 3))
+                    .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), randomIntBetween(1, 5)))
+                .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
+                .build();
+            builder.put(templateMetadata);
+        }
+        for (int i = 0; i < randomIntBetween(1, 5); i++) {
+            builder.put(
+                IndexMetadata.builder(randomAlphaOfLength(10))
+                    .settings(settings(Version.CURRENT))
+                    .numberOfReplicas(randomIntBetween(0, 3))
+                    .numberOfShards(randomIntBetween(1, 5))
+            );
+        }
+        return builder.build();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -18,9 +18,13 @@
  */
 package org.elasticsearch.gateway;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MockDirectoryWrapper;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -32,13 +36,16 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
-import org.junit.Ignore;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -52,15 +59,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
@@ -271,13 +281,19 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 
         assertThat(actions, hasSize(3));
 
+        boolean keptPreviousGeneration = false;
+        boolean wroteNewIndex = false;
+        boolean wroteChangedIndex = false;
+
         for (IncrementalClusterStateWriter.IndexMetadataAction action : actions) {
             if (action instanceof IncrementalClusterStateWriter.KeepPreviousGeneration) {
                 assertThat(action.getIndex(), equalTo(notChangedIndex.getIndex()));
                 IncrementalClusterStateWriter.AtomicClusterStateWriter writer
                     = mock(IncrementalClusterStateWriter.AtomicClusterStateWriter.class);
                 assertThat(action.execute(writer), equalTo(3L));
-                verifyZeroInteractions(writer);
+                verify(writer, times(1)).incrementIndicesSkipped();
+                verifyNoMoreInteractions(writer);
+                keptPreviousGeneration = true;
             }
             if (action instanceof IncrementalClusterStateWriter.WriteNewIndexMetadata) {
                 assertThat(action.getIndex(), equalTo(newIndex.getIndex()));
@@ -285,6 +301,8 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
                     = mock(IncrementalClusterStateWriter.AtomicClusterStateWriter.class);
                 when(writer.writeIndex("freshly created", newIndex)).thenReturn(0L);
                 assertThat(action.execute(writer), equalTo(0L));
+                verify(writer, times(1)).incrementIndicesWritten();
+                wroteNewIndex = true;
             }
             if (action instanceof IncrementalClusterStateWriter.WriteChangedIndexMetadata) {
                 assertThat(action.getIndex(), equalTo(newVersionChangedIndex.getIndex()));
@@ -294,10 +312,16 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
                 assertThat(action.execute(writer), equalTo(3L));
                 ArgumentCaptor<String> reason = ArgumentCaptor.forClass(String.class);
                 verify(writer).writeIndex(reason.capture(), eq(newVersionChangedIndex));
+                verify(writer, times(1)).incrementIndicesWritten();
                 assertThat(reason.getValue(), containsString(Long.toString(versionChangedIndex.getVersion())));
                 assertThat(reason.getValue(), containsString(Long.toString(newVersionChangedIndex.getVersion())));
+                wroteChangedIndex = true;
             }
         }
+
+        assertTrue(keptPreviousGeneration);
+        assertTrue(wroteNewIndex);
+        assertTrue(wroteChangedIndex);
     }
 
     private static class MetaStateServiceWithFailures extends MetaStateService {
@@ -446,5 +470,85 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 
             assertTrue(possibleMetadata.stream().anyMatch(md -> metadataEquals(md, loadedMetadata)));
         }
+    }
+
+    @TestLogging(value = "org.elasticsearch.gateway:WARN")
+    public void testSlowLogging() throws WriteStateException, IllegalAccessException {
+        final long slowWriteLoggingThresholdMillis;
+        final Settings settings;
+        if (randomBoolean()) {
+            slowWriteLoggingThresholdMillis = IncrementalClusterStateWriter.SLOW_WRITE_LOGGING_THRESHOLD.get(Settings.EMPTY).millis();
+            settings = Settings.EMPTY;
+        } else {
+            slowWriteLoggingThresholdMillis = randomLongBetween(2, 100000);
+            settings = Settings.builder()
+                .put(IncrementalClusterStateWriter.SLOW_WRITE_LOGGING_THRESHOLD.getKey(), slowWriteLoggingThresholdMillis + "ms")
+                .build();
+        }
+
+        final DiscoveryNode localNode = newNode("node");
+        final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId())).build();
+
+        final long startTimeMillis = randomLongBetween(0L, Long.MAX_VALUE - slowWriteLoggingThresholdMillis * 10);
+        final AtomicLong currentTime = new AtomicLong(startTimeMillis);
+        final AtomicLong writeDurationMillis = new AtomicLong(slowWriteLoggingThresholdMillis);
+
+        final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final IncrementalClusterStateWriter incrementalClusterStateWriter
+            = new IncrementalClusterStateWriter(settings, clusterSettings, mock(MetaStateService.class),
+            new Manifest(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), Collections.emptyMap()),
+            clusterState, () -> currentTime.getAndAdd(writeDurationMillis.get()));
+
+        assertExpectedLogs(clusterState, incrementalClusterStateWriter, new MockLogAppender.SeenEventExpectation(
+            "should see warning at threshold",
+            IncrementalClusterStateWriter.class.getCanonicalName(),
+            Level.WARN,
+            "writing cluster state took [*] which is above the warn threshold of [*]; " +
+                "wrote metadata for [0] indices and skipped [0] unchanged indices"));
+
+        writeDurationMillis.set(randomLongBetween(slowWriteLoggingThresholdMillis, slowWriteLoggingThresholdMillis * 2));
+        assertExpectedLogs(clusterState, incrementalClusterStateWriter, new MockLogAppender.SeenEventExpectation(
+            "should see warning above threshold",
+            IncrementalClusterStateWriter.class.getCanonicalName(),
+            Level.WARN,
+            "writing cluster state took [*] which is above the warn threshold of [*]; " +
+                "wrote metadata for [0] indices and skipped [0] unchanged indices"));
+
+        writeDurationMillis.set(randomLongBetween(1, slowWriteLoggingThresholdMillis - 1));
+        assertExpectedLogs(clusterState, incrementalClusterStateWriter, new MockLogAppender.UnseenEventExpectation(
+            "should not see warning below threshold",
+            IncrementalClusterStateWriter.class.getCanonicalName(),
+            Level.WARN,
+            "*"));
+
+        clusterSettings.applySettings(Settings.builder()
+            .put(IncrementalClusterStateWriter.SLOW_WRITE_LOGGING_THRESHOLD.getKey(), writeDurationMillis.get() + "ms")
+            .build());
+        assertExpectedLogs(clusterState, incrementalClusterStateWriter, new MockLogAppender.SeenEventExpectation(
+            "should see warning at reduced threshold",
+            IncrementalClusterStateWriter.class.getCanonicalName(),
+            Level.WARN,
+            "writing cluster state took [*] which is above the warn threshold of [*]; " +
+                "wrote metadata for [0] indices and skipped [0] unchanged indices"));
+
+        assertThat(currentTime.get(), lessThan(startTimeMillis + 10 * slowWriteLoggingThresholdMillis)); // ensure no overflow
+    }
+
+    private void assertExpectedLogs(ClusterState clusterState, IncrementalClusterStateWriter incrementalClusterStateWriter,
+                                    MockLogAppender.LoggingExpectation expectation) throws IllegalAccessException, WriteStateException {
+        MockLogAppender mockAppender = new MockLogAppender();
+        mockAppender.start();
+        mockAppender.addExpectation(expectation);
+        Logger classLogger = LogManager.getLogger(IncrementalClusterStateWriter.class);
+        Loggers.addAppender(classLogger, mockAppender);
+
+        try {
+            incrementalClusterStateWriter.updateClusterState(clusterState, clusterState);
+        } finally {
+            Loggers.removeAppender(classLogger, mockAppender);
+            mockAppender.stop();
+        }
+        mockAppender.assertAllExpectationsMatched();
     }
 }

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gateway;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MockDirectoryWrapper;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Manifest;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.crate.common.collections.Tuple;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
+
+    private ClusterState noIndexClusterState(boolean masterEligible) {
+        Metadata metadata = Metadata.builder().build();
+        RoutingTable routingTable = RoutingTable.builder().build();
+
+        return ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTable)
+            .nodes(generateDiscoveryNodes(masterEligible))
+            .build();
+    }
+
+    private ClusterState clusterStateWithUnassignedIndex(IndexMetadata indexMetadata, boolean masterEligible) {
+        Metadata metadata = Metadata.builder()
+            .put(indexMetadata, false)
+            .build();
+
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(metadata.index("test"))
+            .build();
+
+        return ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTable)
+            .nodes(generateDiscoveryNodes(masterEligible))
+            .build();
+    }
+
+    private ClusterState clusterStateWithAssignedIndex(IndexMetadata indexMetadata, boolean masterEligible) {
+        AllocationService strategy = createAllocationService(Settings.builder()
+            .put("cluster.routing.allocation.node_concurrent_recoveries", 100)
+            .put(ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.getKey(), "always")
+            .put("cluster.routing.allocation.cluster_concurrent_rebalance", 100)
+            .put("cluster.routing.allocation.node_initial_primaries_recoveries", 100)
+            .build());
+
+        ClusterState oldClusterState = clusterStateWithUnassignedIndex(indexMetadata, masterEligible);
+        RoutingTable routingTable = strategy.reroute(oldClusterState, "reroute").routingTable();
+
+        Metadata metadataNewClusterState = Metadata.builder()
+            .put(oldClusterState.metadata().index("test"), false)
+            .build();
+
+        return ClusterState.builder(oldClusterState).routingTable(routingTable)
+            .metadata(metadataNewClusterState).version(oldClusterState.getVersion() + 1).build();
+    }
+
+    private ClusterState clusterStateWithClosedIndex(IndexMetadata indexMetadata, boolean masterEligible) {
+        ClusterState oldClusterState = clusterStateWithAssignedIndex(indexMetadata, masterEligible);
+
+        Metadata metadataNewClusterState = Metadata.builder()
+            .put(
+                IndexMetadata.builder("test").settings(settings(Version.CURRENT)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, indexMetadata.getIndexUUID())
+                )
+                .state(IndexMetadata.State.CLOSE)
+                .numberOfShards(5)
+                .numberOfReplicas(2)
+            )
+            .version(oldClusterState.metadata().version() + 1)
+            .build();
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(metadataNewClusterState.index("test"))
+            .build();
+
+        return ClusterState.builder(oldClusterState).routingTable(routingTable)
+            .metadata(metadataNewClusterState).version(oldClusterState.getVersion() + 1).build();
+    }
+
+    private ClusterState clusterStateWithJustOpenedIndex(IndexMetadata indexMetadata, boolean masterEligible) {
+        ClusterState oldClusterState = clusterStateWithClosedIndex(indexMetadata, masterEligible);
+
+        Metadata metadataNewClusterState = Metadata.builder()
+            .put(
+                IndexMetadata.builder("test").settings(settings(Version.CURRENT)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, indexMetadata.getIndexUUID())
+                )
+                .state(IndexMetadata.State.OPEN)
+                .numberOfShards(5)
+                .numberOfReplicas(2))
+            .version(oldClusterState.metadata().version() + 1)
+            .build();
+
+        return ClusterState.builder(oldClusterState)
+            .metadata(metadataNewClusterState).version(oldClusterState.getVersion() + 1).build();
+    }
+
+    private DiscoveryNodes.Builder generateDiscoveryNodes(boolean masterEligible) {
+        Set<DiscoveryNode.Role> dataOnlyRoles = Collections.singleton(DiscoveryNode.Role.DATA);
+        return DiscoveryNodes.builder().add(newNode("node1", masterEligible ? MASTER_DATA_ROLES : dataOnlyRoles))
+            .add(newNode("master_node", MASTER_DATA_ROLES)).localNodeId("node1").masterNodeId(masterEligible ? "node1" : "master_node");
+    }
+
+    private Set<Index> randomPrevWrittenIndices(IndexMetadata indexMetadata) {
+        if (randomBoolean()) {
+            return Collections.singleton(indexMetadata.getIndex());
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    private IndexMetadata createIndexMetadata(String name) {
+        return IndexMetadata.builder(name).
+            settings(settings(Version.CURRENT)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+            )
+            .numberOfShards(5)
+            .numberOfReplicas(2)
+            .build();
+    }
+
+    public void testGetRelevantIndicesWithUnassignedShardsOnMasterEligibleNode() {
+        IndexMetadata indexMetadata = createIndexMetadata("test");
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
+            clusterStateWithUnassignedIndex(indexMetadata, true),
+            noIndexClusterState(true),
+            randomPrevWrittenIndices(indexMetadata));
+        assertThat(indices.size(), equalTo(1));
+    }
+
+    public void testGetRelevantIndicesWithUnassignedShardsOnDataOnlyNode() {
+        IndexMetadata indexMetadata = createIndexMetadata("test");
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
+            clusterStateWithUnassignedIndex(indexMetadata, false),
+            noIndexClusterState(false),
+            randomPrevWrittenIndices(indexMetadata));
+        assertThat(indices.size(), equalTo(0));
+    }
+
+    public void testGetRelevantIndicesWithAssignedShards() {
+        IndexMetadata indexMetadata = createIndexMetadata("test");
+        boolean masterEligible = randomBoolean();
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
+            clusterStateWithAssignedIndex(indexMetadata, masterEligible),
+            clusterStateWithUnassignedIndex(indexMetadata, masterEligible),
+            randomPrevWrittenIndices(indexMetadata));
+        assertThat(indices.size(), equalTo(1));
+    }
+
+    public void testGetRelevantIndicesForClosedPrevWrittenIndexOnDataOnlyNode() {
+        IndexMetadata indexMetadata = createIndexMetadata("test");
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
+            clusterStateWithClosedIndex(indexMetadata, false),
+            clusterStateWithAssignedIndex(indexMetadata, false),
+            Collections.singleton(indexMetadata.getIndex()));
+        assertThat(indices.size(), equalTo(1));
+    }
+
+    public void testGetRelevantIndicesForClosedPrevNotWrittenIndexOnDataOnlyNode() {
+        IndexMetadata indexMetadata = createIndexMetadata("test");
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
+            clusterStateWithJustOpenedIndex(indexMetadata, false),
+            clusterStateWithClosedIndex(indexMetadata, false),
+            Collections.emptySet());
+        assertThat(indices.size(), equalTo(0));
+    }
+
+    public void testGetRelevantIndicesForWasClosedPrevWrittenIndexOnDataOnlyNode() {
+        IndexMetadata indexMetadata = createIndexMetadata("test");
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
+            clusterStateWithJustOpenedIndex(indexMetadata, false),
+            clusterStateWithClosedIndex(indexMetadata, false),
+            Collections.singleton(indexMetadata.getIndex()));
+        assertThat(indices.size(), equalTo(1));
+    }
+
+    @Test
+    public void testResolveStatesToBeWritten() throws WriteStateException {
+        Map<Index, Long> indices = new HashMap<>();
+        Set<Index> relevantIndices = new HashSet<>();
+
+        IndexMetadata removedIndex = createIndexMetadata("removed_index");
+        indices.put(removedIndex.getIndex(), 1L);
+
+        IndexMetadata versionChangedIndex = createIndexMetadata("version_changed_index");
+        indices.put(versionChangedIndex.getIndex(), 2L);
+        relevantIndices.add(versionChangedIndex.getIndex());
+
+        IndexMetadata notChangedIndex = createIndexMetadata("not_changed_index");
+        indices.put(notChangedIndex.getIndex(), 3L);
+        relevantIndices.add(notChangedIndex.getIndex());
+
+        IndexMetadata newIndex = createIndexMetadata("new_index");
+        relevantIndices.add(newIndex.getIndex());
+
+        Metadata oldMetadata = Metadata.builder()
+            .put(removedIndex, false)
+            .put(versionChangedIndex, false)
+            .put(notChangedIndex, false)
+            .build();
+
+        Metadata newMetadata = Metadata.builder()
+            .put(versionChangedIndex, true)
+            .put(notChangedIndex, false)
+            .put(newIndex, false)
+            .build();
+
+        IndexMetadata newVersionChangedIndex = newMetadata.index(versionChangedIndex.getIndex());
+
+        List<IncrementalClusterStateWriter.IndexMetadataAction> actions =
+            IncrementalClusterStateWriter.resolveIndexMetadataActions(indices, relevantIndices, oldMetadata, newMetadata);
+
+        assertThat(actions, hasSize(3));
+
+        for (IncrementalClusterStateWriter.IndexMetadataAction action : actions) {
+            if (action instanceof IncrementalClusterStateWriter.KeepPreviousGeneration) {
+                assertThat(action.getIndex(), equalTo(notChangedIndex.getIndex()));
+                IncrementalClusterStateWriter.AtomicClusterStateWriter writer
+                    = mock(IncrementalClusterStateWriter.AtomicClusterStateWriter.class);
+                assertThat(action.execute(writer), equalTo(3L));
+                verifyZeroInteractions(writer);
+            }
+            if (action instanceof IncrementalClusterStateWriter.WriteNewIndexMetadata) {
+                assertThat(action.getIndex(), equalTo(newIndex.getIndex()));
+                IncrementalClusterStateWriter.AtomicClusterStateWriter writer
+                    = mock(IncrementalClusterStateWriter.AtomicClusterStateWriter.class);
+                when(writer.writeIndex("freshly created", newIndex)).thenReturn(0L);
+                assertThat(action.execute(writer), equalTo(0L));
+            }
+            if (action instanceof IncrementalClusterStateWriter.WriteChangedIndexMetadata) {
+                assertThat(action.getIndex(), equalTo(newVersionChangedIndex.getIndex()));
+                IncrementalClusterStateWriter.AtomicClusterStateWriter writer
+                    = mock(IncrementalClusterStateWriter.AtomicClusterStateWriter.class);
+                when(writer.writeIndex(anyString(), eq(newVersionChangedIndex))).thenReturn(3L);
+                assertThat(action.execute(writer), equalTo(3L));
+                ArgumentCaptor<String> reason = ArgumentCaptor.forClass(String.class);
+                verify(writer).writeIndex(reason.capture(), eq(newVersionChangedIndex));
+                assertThat(reason.getValue(), containsString(Long.toString(versionChangedIndex.getVersion())));
+                assertThat(reason.getValue(), containsString(Long.toString(newVersionChangedIndex.getVersion())));
+            }
+        }
+    }
+
+    private static class MetaStateServiceWithFailures extends MetaStateService {
+        private final int invertedFailRate;
+        private boolean failRandomly;
+
+        private <T> MetadataStateFormat<T> wrap(MetadataStateFormat<T> format) {
+            return new MetadataStateFormat<T>(format.getPrefix()) {
+                @Override
+                public void toXContent(XContentBuilder builder, T state) throws IOException {
+                    format.toXContent(builder, state);
+                }
+
+                @Override
+                public T fromXContent(XContentParser parser) throws IOException {
+                    return format.fromXContent(parser);
+                }
+
+                @Override
+                protected Directory newDirectory(Path dir) {
+                    MockDirectoryWrapper mock = newMockFSDirectory(dir);
+                    if (failRandomly) {
+                        MockDirectoryWrapper.Failure fail = new MockDirectoryWrapper.Failure() {
+                            @Override
+                            public void eval(MockDirectoryWrapper dir) throws IOException {
+                                int r = randomIntBetween(0, invertedFailRate);
+                                if (r == 0) {
+                                    throw new MockDirectoryWrapper.FakeIOException();
+                                }
+                            }
+                        };
+                        mock.failOn(fail);
+                    }
+                    closeAfterSuite(mock);
+                    return mock;
+                }
+            };
+        }
+
+        MetaStateServiceWithFailures(int invertedFailRate, NodeEnvironment nodeEnv, NamedXContentRegistry namedXContentRegistry) {
+            super(nodeEnv, namedXContentRegistry);
+            META_DATA_FORMAT = wrap(Metadata.FORMAT);
+            INDEX_META_DATA_FORMAT = wrap(IndexMetadata.FORMAT);
+            MANIFEST_FORMAT = wrap(Manifest.FORMAT);
+            failRandomly = false;
+            this.invertedFailRate = invertedFailRate;
+        }
+
+        void failRandomly() {
+            failRandomly = true;
+        }
+
+        void noFailures() {
+            failRandomly = false;
+        }
+    }
+
+    private boolean metadataEquals(Metadata md1, Metadata md2) {
+        boolean equals = Metadata.isGlobalStateEquals(md1, md2);
+
+        for (IndexMetadata imd : md1) {
+            IndexMetadata imd2 = md2.index(imd.getIndex());
+            equals = equals && imd.equals(imd2);
+        }
+
+        for (IndexMetadata imd : md2) {
+            IndexMetadata imd2 = md1.index(imd.getIndex());
+            equals = equals && imd.equals(imd2);
+        }
+        return equals;
+    }
+
+    private static Metadata randomMetadataForTx() {
+        int settingNo = randomIntBetween(0, 10);
+        Metadata.Builder builder = Metadata.builder()
+            .persistentSettings(Settings.builder().put("setting" + settingNo, randomAlphaOfLength(5)).build());
+        int numOfIndices = randomIntBetween(0, 3);
+
+        for (int i = 0; i < numOfIndices; i++) {
+            int indexNo = randomIntBetween(0, 50);
+            IndexMetadata indexMetadata = IndexMetadata.builder("index" + indexNo).settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "index" + indexNo)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .build()
+            ).build();
+            builder.put(indexMetadata, false);
+        }
+        return builder.build();
+    }
+
+    public void testAtomicityWithFailures() throws IOException {
+        try (NodeEnvironment env = newNodeEnvironment()) {
+            MetaStateServiceWithFailures metaStateService =
+                new MetaStateServiceWithFailures(randomIntBetween(100, 1000), env, xContentRegistry());
+
+            // We only guarantee atomicity of writes, if there is initial Manifest file
+            Manifest manifest = Manifest.empty();
+            Metadata metadata = Metadata.EMPTY_METADATA;
+            metaStateService.writeManifestAndCleanup("startup", Manifest.empty());
+            long currentTerm = randomNonNegativeLong();
+            long clusterStateVersion = randomNonNegativeLong();
+
+            metaStateService.failRandomly();
+            Set<Metadata> possibleMetadata = new HashSet<>();
+            possibleMetadata.add(metadata);
+
+            for (int i = 0; i < randomIntBetween(1, 5); i++) {
+                IncrementalClusterStateWriter.AtomicClusterStateWriter writer =
+                    new IncrementalClusterStateWriter.AtomicClusterStateWriter(metaStateService, manifest);
+                metadata = randomMetadataForTx();
+                Map<Index, Long> indexGenerations = new HashMap<>();
+
+                try {
+                    long globalGeneration = writer.writeGlobalState("global", metadata);
+
+                    for (IndexMetadata indexMetadata : metadata) {
+                        long generation = writer.writeIndex("index", indexMetadata);
+                        indexGenerations.put(indexMetadata.getIndex(), generation);
+                    }
+
+                    Manifest newManifest = new Manifest(currentTerm, clusterStateVersion, globalGeneration, indexGenerations);
+                    writer.writeManifestAndCleanup("manifest", newManifest);
+                    possibleMetadata.clear();
+                    possibleMetadata.add(metadata);
+                    manifest = newManifest;
+                } catch (WriteStateException e) {
+                    if (e.isDirty()) {
+                        possibleMetadata.add(metadata);
+                        /*
+                         * If dirty WriteStateException occurred, it's only safe to proceed if there is subsequent
+                         * successful write of metadata and Manifest. We prefer to break here, not to over complicate test logic.
+                         * See also MetadataStateFormat#testFailRandomlyAndReadAnyState, that does not break.
+                         */
+                        break;
+                    }
+                }
+            }
+
+            metaStateService.noFailures();
+
+            Tuple<Manifest, Metadata> manifestAndMetadata = metaStateService.loadFullState();
+            Metadata loadedMetadata = manifestAndMetadata.v2();
+
+            assertTrue(possibleMetadata.stream().anyMatch(md -> metadataEquals(md, loadedMetadata)));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
@@ -23,11 +23,16 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.MetadataUpgrader;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link GatewayMetaState} constructor accepts a lot of arguments.
@@ -57,6 +62,12 @@ public class MockGatewayMetaState extends GatewayMetaState {
     }
 
     public void start(Settings settings, NodeEnvironment nodeEnvironment, NamedXContentRegistry xContentRegistry) {
-        start(settings, null, null, new MetaStateService(nodeEnvironment, xContentRegistry), null, null);
+        final TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
+        final ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings())
+            .thenReturn(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+        start(settings, transportService, clusterService, new MetaStateService(nodeEnvironment, xContentRegistry),
+            null, null);
     }
 }

--- a/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.gateway;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.plugins.MetadataUpgrader;
 import org.elasticsearch.transport.TransportService;
 
@@ -40,24 +40,23 @@ import org.elasticsearch.transport.TransportService;
 public class MockGatewayMetaState extends GatewayMetaState {
     private final DiscoveryNode localNode;
 
-    public MockGatewayMetaState(Settings settings, NodeEnvironment nodeEnvironment,
-                                NamedXContentRegistry xContentRegistry, DiscoveryNode localNode) {
-        super(settings, new MetaStateService(nodeEnvironment, xContentRegistry));
+    public MockGatewayMetaState(DiscoveryNode localNode) {
         this.localNode = localNode;
     }
 
     @Override
-    protected void upgradeMetadata(MetadataIndexUpgradeService metadataIndexUpgradeService, MetadataUpgrader metadataUpgrader) {
+    void upgradeMetadata(Settings settings, MetaStateService metaStateService, MetadataIndexUpgradeService metadataIndexUpgradeService,
+                         MetadataUpgrader metadataUpgrader) {
         // Metadata upgrade is tested in GatewayMetaStateTests, we override this method to NOP to make mocking easier
     }
 
     @Override
-    public void applyClusterStateUpdaters(TransportService transportService, ClusterService clusterService) {
+    ClusterState prepareInitialClusterState(TransportService transportService, ClusterService clusterService, ClusterState clusterState) {
         // Just set localNode here, not to mess with ClusterService and IndicesService mocking
-        previousClusterState = ClusterStateUpdaters.setLocalNode(previousClusterState, localNode);
+        return ClusterStateUpdaters.setLocalNode(clusterState, localNode);
     }
 
-    public void start() {
-        start(null, null, null, null);
+    public void start(Settings settings, NodeEnvironment nodeEnvironment, NamedXContentRegistry xContentRegistry) {
+        start(settings, null, null, new MetaStateService(nodeEnvironment, xContentRegistry), null, null);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Addressing gaps in our backports

See commits for details.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)