### PR TITLE
Added dense_rank window function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ None
 Changes
 =======
 
+- Added support for the ``dense_rank`` window function, which is available as an
+  enterprise feature.
+
 - Added support for the ``rank`` window function, which is available as an
   enterprise feature.
 

--- a/docs/editions.rst
+++ b/docs/editions.rst
@@ -76,6 +76,8 @@ Enterprise features
 
   - :ref:`window-function-rank`
 
+  - :ref:`window-function-dense_rank`
+
 
 .. _node-limitations:
 

--- a/docs/general/builtins/window-functions.rst
+++ b/docs/general/builtins/window-functions.rst
@@ -658,6 +658,59 @@ Example::
     +-----------------+---------------+--------+-------------+
     SELECT 6 rows in set (... sec)
 
+
+.. _window-function-dense_rank:
+
+``dense_rank()``
+----------------
+
+.. NOTE::
+
+    The ``dense_rank`` window function is an :ref:`enterprise feature
+    <enterprise-features>`.
+
+Synopsis
+........
+
+::
+
+    dense_rank()
+
+Returns the rank of every row within a partition of a result set, similar to
+``rank``. However, unlike ``rank``, ``dense_rank`` always returns sequential
+rank values.
+
+Within each partition, the rank of the first row is ``1``. Subsequent tied
+rows are given the same rank.
+
+Example::
+
+    cr> SELECT
+    ...   name,
+    ...   department_id,
+    ...   salary,
+    ...   DENSE_RANK() OVER (ORDER BY salary desc) as salary_rank
+    ... FROM (VALUES
+    ...      ('Bobson Dugnutt', 1, 2000),
+    ...      ('Todd Bonzalez', 2, 2500),
+    ...      ('Jess Brewer', 1, 2500),
+    ...      ('Safwan Buchanan', 1, 1900),
+    ...      ('Hal Dodd', 1, 2500),
+    ...      ('Gillian Hawes', 2, 2000))
+    ... as t (name, department_id, salary);
+    +-----------------+---------------+--------+-------------+
+    | name            | department_id | salary | salary_rank |
+    +-----------------+---------------+--------+-------------+
+    | Todd Bonzalez   |             2 |   2500 |           1 |
+    | Jess Brewer     |             1 |   2500 |           1 |
+    | Hal Dodd        |             1 |   2500 |           1 |
+    | Bobson Dugnutt  |             1 |   2000 |           2 |
+    | Gillian Hawes   |             2 |   2000 |           2 |
+    | Safwan Buchanan |             1 |   1900 |           3 |
+    +-----------------+---------------+--------+-------------+
+    SELECT 6 rows in set (... sec)
+
+
 Aggregate Window Functions
 ==========================
 

--- a/enterprise/functions/src/test/java/io/crate/window/RankFunctionsIntegrationTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/RankFunctionsIntegrationTest.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-public class RankFunctionIntegrationTest extends SQLTransportIntegrationTest {
+public class RankFunctionsIntegrationTest extends SQLTransportIntegrationTest {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -44,16 +44,17 @@ public class RankFunctionIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testGeneralPurposeWindowFunctionsWithStandaloneValues() {
         execute("select col1, col2, " +
-                "rank() OVER(partition by col2 order by col1) " +
+                "rank() OVER (partition by col2 order by col1), " +
+                "dense_rank() OVER (partition by col2 order by col1)" +
                 "from unnest(['A', 'B', 'C', 'A', 'B', 'C', 'A'], [True, True, False, True, False, True, False]) " +
                 "order by col2, col1");
-        assertThat(printedTable(response.rows()), is("A| false| 1\n" +
-                                                     "B| false| 2\n" +
-                                                     "C| false| 3\n" +
-                                                     "A| true| 1\n" +
-                                                     "A| true| 1\n" +
-                                                     "B| true| 3\n" +
-                                                     "C| true| 4\n"));
+        assertThat(printedTable(response.rows()), is("A| false| 1| 1\n" +
+                                                     "B| false| 2| 2\n" +
+                                                     "C| false| 3| 3\n" +
+                                                     "A| true| 1| 1\n" +
+                                                     "A| true| 1| 1\n" +
+                                                     "B| true| 3| 2\n" +
+                                                     "C| true| 4| 3\n"));
     }
 
 }

--- a/enterprise/functions/src/test/java/io/crate/window/RankFunctionsTest.java
+++ b/enterprise/functions/src/test/java/io/crate/window/RankFunctionsTest.java
@@ -32,9 +32,9 @@ import java.util.List;
 import static org.hamcrest.Matchers.contains;
 
 
-public class RankFunctionTest extends AbstractWindowFunctionTest {
+public class RankFunctionsTest extends AbstractWindowFunctionTest {
 
-    public RankFunctionTest() {
+    public RankFunctionsTest() {
         super(new EnterpriseFunctionsModule());
     }
 
@@ -101,6 +101,79 @@ public class RankFunctionTest extends AbstractWindowFunctionTest {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3};
         assertEvaluate(
             "rank() over(partition by y > 0 order by x)",
+            contains(expected),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {3, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 0},
+            new Object[] {3, 0});
+    }
+
+    @Test
+    public void testDenseRankWithEmptyOver() throws Throwable {
+        assertEvaluate(
+            "dense_rank() over()",
+            contains(new Object[] {1, 1, 1, 1, 1}),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+
+    @Test
+    public void testDenseRankWithOrderByClause() throws Throwable {
+        assertEvaluate(
+            "dense_rank() over(order by x)",
+            contains(new Object[] {1, 1, 1, 2, 2}),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void testDenseRankUseSymbolMultipleTimes() throws Throwable {
+        assertEvaluate(
+            "dense_rank() over(order by y, x)",
+            contains(new Object[] {1, 2, 2, 3, 3}),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void testDenseRankOverPartitionedWindow() throws Throwable {
+        Object[] expected = new Object[]{1, 1, 1, 1, 1, 1};
+        assertEvaluate(
+            "dense_rank() over(partition by y > 0)",
+            contains(expected),
+            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {3, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 0},
+            new Object[] {3, 0});
+    }
+
+    @Test
+    public void testDenseRankOverPartitionedOrderedWindow() throws Throwable {
+        Object[] expected = new Object[]{1, 2, 3, 1, 2, 3};
+        assertEvaluate(
+            "dense_rank() over(partition by y > 0 order by x)",
             contains(expected),
             List.of(new ColumnIdent("x"), new ColumnIdent("y")),
             new Object[] {1, 1},


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This PR adds ``dense_rank`` to our supported enterprise window functions. It's similar in function to ``rank``, but the rank is not calculated based on the proceeding peer ranks, so the ranks in ``dense_rank`` are sequential. This should address #10508 

I've based it against #10770 because it builds on that, for the sake of clarity. I'll rebase it against master when it is merged.

@mfussenegger Maybe im being a bit finickity but switching the behaviour of the rank function based on the boolean argument ``dense`` strikes me as a little... inelegant? Would an enum be better here? If we wanted to bundle other rank functions like ``PERCENT_RANK`` and ``ROW_NUMBER`` into it, I suppose an enum would make more sense?

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
