### PR TITLE
Ensure pg_proc.oid and pg_type.typreceive can be joined

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -79,6 +79,12 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that resulted in records in ``pg_catalog.pg_proc`` which
+  wouldn't be joined with ``pg_catalog.pg_type``. Clients like ``npgsql`` use
+  this information and without it the users received an error like ``The CLR
+  array type System.Int32[] isn't supported by Npgsql or your PostgreSQL`` if
+  using array types.
+
 - Fixed an issue that could lead to stuck ``INSERT INTO .. RETURNING`` queries.
 
 - Fixed a regression introduced in CrateDB >= ``4.3`` which prevents using

--- a/server/src/main/java/io/crate/metadata/pgcatalog/OidHash.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/OidHash.java
@@ -69,14 +69,6 @@ public final class OidHash {
         return oid(Type.CONSTRAINT.toString() + relationName + constraintName + constraintType);
     }
 
-    public static int regprocOid(FunctionName name) {
-        return oid(Type.PROC.toString() + name.schema() + name.name());
-    }
-
-    public static int regprocOid(String name) {
-        return oid(Type.PROC.toString() + "null" + name);
-    }
-
     public static int functionOid(Signature sig) {
         FunctionName name = sig.getName();
         return oid(Type.PROC.toString() + name.schema() + name.name() + argTypesToStr(sig.getArgumentTypes()));

--- a/server/src/main/java/io/crate/types/Regproc.java
+++ b/server/src/main/java/io/crate/types/Regproc.java
@@ -22,6 +22,7 @@
 
 package io.crate.types;
 
+import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.OidHash;
 
 import javax.annotation.Nonnull;
@@ -33,7 +34,10 @@ public class Regproc {
     private final String name;
 
     public static Regproc of(@Nonnull String name) {
-        return new Regproc(OidHash.regprocOid(name), name);
+        return new Regproc(
+            OidHash.functionOid(Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature())),
+            name
+        );
     }
 
     public static Regproc of(int functionOid, @Nonnull String name) {
@@ -48,6 +52,10 @@ public class Regproc {
     private Regproc(int functionOid, String name) {
         this.oid = functionOid;
         this.name = name;
+    }
+
+    public Signature asDummySignature() {
+        return Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature());
     }
 
     public int oid() {

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -226,4 +226,36 @@ public class PgCatalogITest extends SQLTransportIntegrationTest {
                                                      "integer| trunc\n" +
                                                      "integer| trunc\n"));
     }
+
+    @Test
+    public void test_npgsql_type_lookup_returns_array_typtype_and_elemtypoid() throws Exception {
+        execute("""
+            select pg_proc.oid from pg_proc
+            inner join pg_type on typreceive = pg_proc.oid
+            where proname = 'array_recv' and typname = '_int4'
+        """);
+        assertThat(printedTable(response.rows()), is(
+            "556695454\n"
+        ));
+
+        execute("""
+            SELECT typ.oid, typname, typrelid, typnotnull, relkind, typelem AS elemoid,
+                CASE WHEN proc.proname='array_recv' THEN 'a' ELSE typ.typtype END AS typtype,
+                CASE
+                    WHEN proc.proname='array_recv' THEN typ.typelem
+                    WHEN typ.typtype='r' THEN rngsubtype
+                    WHEN typ.typtype='d' THEN typ.typbasetype
+                END AS elemtypoid
+            FROM pg_type AS typ
+            LEFT JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
+            LEFT JOIN pg_proc AS proc ON proc.oid = typ.typreceive
+            LEFT JOIN pg_range ON (pg_range.rngtypid = typ.oid)
+            where typname in ('_int2', '_int4')
+            order by 1, 3, 4, 5
+        """);
+        assertThat(printedTable(response.rows()), is(
+            "1005| _int2| 0| false| NULL| 21| a| 21\n" +
+            "1007| _int4| 0| false| NULL| 23| a| 23\n"
+        ));
+    }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/RegprocTypeTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres.types;
 
+import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.types.Regproc;
 import io.netty.buffer.ByteBuf;
@@ -42,19 +43,16 @@ public class RegprocTypeTest extends BasePGTypeTest<Regproc> {
 
     @Test
     public void test_write_binary_value_writes_only_oid() {
-        var regproc = Regproc.of(
-            OidHash.regprocOid("test"),
-            String.valueOf(OidHash.regprocOid("test"))
-        );
+        var regproc = Regproc.of(1234, "1234");
         assertBytesWritten(
             regproc,
-            new byte[]{0, 0, 0, 4, -110, -89, 1, 103},
+            new byte[]{0, 0, 0, 4,0, 0, 4, -46},
             RegprocType.INSTANCE.typeLen() + INT32_BYTE_SIZE);
     }
 
     @Test
     public void test_read_binary_value_reads_only_oid() {
-        var oid = OidHash.regprocOid("func");
+        var oid = 1234;
         var regproc = Regproc.of(oid, String.valueOf(oid));
         assertBytesReadBinary(
             ByteBuffer.allocate(4).putInt(regproc.oid()).array(),

--- a/server/src/test/java/io/crate/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegprocTypeTest.java
@@ -22,25 +22,27 @@
 
 package io.crate.types;
 
-import io.crate.metadata.pgcatalog.OidHash;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.junit.Test;
+import static io.crate.types.DataTypes.REGPROC;
+import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.util.Set;
 
-import static io.crate.types.DataTypes.REGPROC;
-import static org.hamcrest.Matchers.is;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import io.crate.metadata.pgcatalog.OidHash;
 
 public class RegprocTypeTest extends ESTestCase {
 
     @Test
     public void test_implicit_cast_regproc_to_integer() {
+        Regproc proc = Regproc.of("func");
         assertThat(
-            DataTypes.INTEGER.implicitCast(Regproc.of("func")),
-            is(OidHash.regprocOid("func")));
+            DataTypes.INTEGER.implicitCast(proc),
+            is(OidHash.functionOid(proc.asDummySignature())));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes a regression which led in npgsql to an error like this:

    The CLR array type System.Int32[] isn't supported by Npgsql or your PostgreSQL. If you wish to map it to an
    PostgreSQL composite type array you need to register it before usage, please refer to the documentation.

The reason for that error is that npgsql looks up type information via
the following query:

    SELECT ns.nspname, typ_and_elem_type.*,
      CASE
          WHEN typtype IN ('b', 'e', 'p') THEN 0           -- First base types, enums, pseudo-types
          WHEN typtype = 'r' THEN 1                        -- Ranges after
          WHEN typtype = 'c' THEN 2                        -- Composites after
          WHEN typtype = 'd' AND elemtyptype <> 'a' THEN 3 -- Domains over non-arrays after
          WHEN typtype = 'a' THEN 4                        -- Arrays before
          WHEN typtype = 'd' AND elemtyptype = 'a' THEN 5  -- Domains over arrays last
        END AS ord
    FROM (
        -- Arrays have typtype=b - this subquery identifies them by their typreceive and converts their typtype to a
        -- We first do this for the type (innerest-most subquery), and then for its element type
        -- This also returns the array element, range subtype and domain base type as elemtypoid
        SELECT
            typ.oid, typ.typnamespace, typ.typname, typ.typtype, typ.typrelid, typ.typnotnull, typ.relkind,
            elemtyp.oid AS elemtypoid, elemtyp.typname AS elemtypname, elemcls.relkind AS elemrelkind,
            CASE WHEN elemproc.proname='array_recv' THEN 'a' ELSE elemtyp.typtype END AS elemtyptype
        FROM (
            SELECT typ.oid, typnamespace, typname, typrelid, typnotnull, relkind, typelem AS elemoid,
                CASE WHEN proc.proname='array_recv' THEN 'a' ELSE typ.typtype END AS typtype,
                CASE
                    WHEN proc.proname='array_recv' THEN typ.typelem
                    WHEN typ.typtype='r' THEN rngsubtype
                    WHEN typ.typtype='d' THEN typ.typbasetype
                END AS elemtypoid
            FROM pg_type AS typ
            LEFT JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
            LEFT JOIN pg_proc AS proc ON proc.oid = typ.typreceive
            LEFT JOIN pg_range ON (pg_range.rngtypid = typ.oid)
        ) AS typ
        LEFT JOIN pg_type AS elemtyp ON elemtyp.oid = elemtypoid
        LEFT JOIN pg_class AS elemcls ON (elemcls.oid = elemtyp.typrelid)
        LEFT JOIN pg_proc AS elemproc ON elemproc.oid = elemtyp.typreceive
    ) AS typ_and_elem_type
    JOIN pg_namespace AS ns ON (ns.oid = typnamespace)
    WHERE
        typtype IN ('b', 'r', 'e', 'd') OR -- Base, range, enum, domain
        (typtype = 'c' AND relkind='c') OR -- User-defined free-standing composites (not table composites) by default
        (typtype = 'p' AND typname IN ('record', 'void')) OR -- Some special supported pseudo-types
        (typtype = 'a' AND (  -- Array of...
            elemtyptype IN ('b', 'r', 'e', 'd') OR -- Array of base, range, enum, domain
            (elemtyptype = 'p' AND elemtypname IN ('record', 'void')) OR -- Arrays of special supported pseudo-types
            (elemtyptype = 'c' AND elemrelkind='c') -- Array of user-defined free-standing composites (not table composites) by default
        ))
    ORDER BY ord;

The join `LEFT JOIN pg_proc AS proc ON proc.oid = typ.typreceive` didn't
match anymore after ae507cc46432064a019e3dc56b5a44d402d1d3b8 because the
function to generate the oid for `pg_proc` was changed without changing
the corresponding `pg_type` related entries.


Fixes https://github.com/crate/crate/issues/10776


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
