### PR TITLE
Replace link to backup documentation in release notes to fix sphinx linkcheck

### DIFF
--- a/docs/appendices/release-notes/1.0.0.rst
+++ b/docs/appendices/release-notes/1.0.0.rst
@@ -20,7 +20,7 @@ Released on 2016/12/05.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.0.1.rst
+++ b/docs/appendices/release-notes/1.0.1.rst
@@ -22,7 +22,7 @@ Released on 2016/12/12.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.0.2.rst
+++ b/docs/appendices/release-notes/1.0.2.rst
@@ -23,7 +23,7 @@ Released on 2017/01/09.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.0.3.rst
+++ b/docs/appendices/release-notes/1.0.3.rst
@@ -23,7 +23,7 @@ Released on 2017/02/10.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.0.4.rst
+++ b/docs/appendices/release-notes/1.0.4.rst
@@ -23,7 +23,7 @@ Released on 2017/02/24.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.0.5.rst
+++ b/docs/appendices/release-notes/1.0.5.rst
@@ -23,7 +23,7 @@ Released on 2017/03/14.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.0.6.rst
+++ b/docs/appendices/release-notes/1.0.6.rst
@@ -23,7 +23,7 @@ Released on 2017/04/03.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.1.1.rst
+++ b/docs/appendices/release-notes/1.1.1.rst
@@ -21,7 +21,7 @@ Released on 2017/03/27.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.1.2.rst
+++ b/docs/appendices/release-notes/1.1.2.rst
@@ -23,7 +23,7 @@ Released on 2017/04/10.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.1.3.rst
+++ b/docs/appendices/release-notes/1.1.3.rst
@@ -23,7 +23,7 @@ Released on 2017/05/09.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.1.4.rst
+++ b/docs/appendices/release-notes/1.1.4.rst
@@ -23,7 +23,7 @@ Released on 2017/06/02.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.1.5.rst
+++ b/docs/appendices/release-notes/1.1.5.rst
@@ -23,7 +23,7 @@ Released on 2017/06/12.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/1.1.6.rst
+++ b/docs/appendices/release-notes/1.1.6.rst
@@ -23,7 +23,7 @@ Released on 2017/06/23.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.0.4.rst
+++ b/docs/appendices/release-notes/2.0.4.rst
@@ -28,7 +28,7 @@ Released on 2017/07/06.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.0.5.rst
+++ b/docs/appendices/release-notes/2.0.5.rst
@@ -28,7 +28,7 @@ Released on 2017/07/11.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.0.6.rst
+++ b/docs/appendices/release-notes/2.0.6.rst
@@ -28,7 +28,7 @@ Released on 2017/07/19.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.0.7.rst
+++ b/docs/appendices/release-notes/2.0.7.rst
@@ -28,7 +28,7 @@ Released on 2017/08/08.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.0.rst
+++ b/docs/appendices/release-notes/2.1.0.rst
@@ -23,7 +23,7 @@ Released on 2017/07/11.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.1.rst
+++ b/docs/appendices/release-notes/2.1.1.rst
@@ -25,7 +25,7 @@ Released on 2017/08/04.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.10.rst
+++ b/docs/appendices/release-notes/2.1.10.rst
@@ -25,7 +25,7 @@ Released on 2017/11/13.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.2.rst
+++ b/docs/appendices/release-notes/2.1.2.rst
@@ -25,7 +25,7 @@ Released on 2017/08/08.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.3.rst
+++ b/docs/appendices/release-notes/2.1.3.rst
@@ -25,7 +25,7 @@ Released on 2017/08/11.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.4.rst
+++ b/docs/appendices/release-notes/2.1.4.rst
@@ -25,7 +25,7 @@ Released on 2017/08/14.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.5.rst
+++ b/docs/appendices/release-notes/2.1.5.rst
@@ -25,7 +25,7 @@ Released on 2017/08/14.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.6.rst
+++ b/docs/appendices/release-notes/2.1.6.rst
@@ -25,7 +25,7 @@ Released on 2017/08/29.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.7.rst
+++ b/docs/appendices/release-notes/2.1.7.rst
@@ -25,7 +25,7 @@ Released on 2017/09/14.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.8.rst
+++ b/docs/appendices/release-notes/2.1.8.rst
@@ -25,7 +25,7 @@ Released on 2017/10/12.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.1.9.rst
+++ b/docs/appendices/release-notes/2.1.9.rst
@@ -25,7 +25,7 @@ Released on 2017/11/08.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.0.rst
+++ b/docs/appendices/release-notes/2.2.0.rst
@@ -20,7 +20,7 @@ Released on 2017/09/19.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.1.rst
+++ b/docs/appendices/release-notes/2.2.1.rst
@@ -22,7 +22,7 @@ Released on 2017/10/23.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.2.rst
+++ b/docs/appendices/release-notes/2.2.2.rst
@@ -22,7 +22,7 @@ Released on 2017/11/08.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.3.rst
+++ b/docs/appendices/release-notes/2.2.3.rst
@@ -22,7 +22,7 @@ Released on 2017/11/13.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.4.rst
+++ b/docs/appendices/release-notes/2.2.4.rst
@@ -22,7 +22,7 @@ Released on 2017/11/27.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.5.rst
+++ b/docs/appendices/release-notes/2.2.5.rst
@@ -22,7 +22,7 @@ Released on 2017/12/14.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.6.rst
+++ b/docs/appendices/release-notes/2.2.6.rst
@@ -22,7 +22,7 @@ Released on 2018/01/17.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.2.7.rst
+++ b/docs/appendices/release-notes/2.2.7.rst
@@ -22,7 +22,7 @@ Released on 2018/01/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.0.rst
+++ b/docs/appendices/release-notes/2.3.0.rst
@@ -20,7 +20,7 @@ Released on 2017/12/22.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.1.rst
+++ b/docs/appendices/release-notes/2.3.1.rst
@@ -21,7 +21,7 @@ Released on 2018/01/22.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.10.rst
+++ b/docs/appendices/release-notes/2.3.10.rst
@@ -21,7 +21,7 @@ Released on 2018/05/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 Changelog
 =========

--- a/docs/appendices/release-notes/2.3.11.rst
+++ b/docs/appendices/release-notes/2.3.11.rst
@@ -21,7 +21,7 @@ Released on 2018/05/28.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 Changelog
 =========

--- a/docs/appendices/release-notes/2.3.2.rst
+++ b/docs/appendices/release-notes/2.3.2.rst
@@ -21,7 +21,7 @@ Released on 2018/01/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.3.rst
+++ b/docs/appendices/release-notes/2.3.3.rst
@@ -21,7 +21,7 @@ Released on 2018/02/15.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.4.rst
+++ b/docs/appendices/release-notes/2.3.4.rst
@@ -21,7 +21,7 @@ Released on 2018/03/06.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.5.rst
+++ b/docs/appendices/release-notes/2.3.5.rst
@@ -21,7 +21,7 @@ Released on 2018/03/20.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.6.rst
+++ b/docs/appendices/release-notes/2.3.6.rst
@@ -21,7 +21,7 @@ Released on 2018/04/04.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.7.rst
+++ b/docs/appendices/release-notes/2.3.7.rst
@@ -21,7 +21,7 @@ Released on 2018/05/03.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.8.rst
+++ b/docs/appendices/release-notes/2.3.8.rst
@@ -21,7 +21,7 @@ Released on 2018/05/16.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/2.3.9.rst
+++ b/docs/appendices/release-notes/2.3.9.rst
@@ -21,7 +21,7 @@ Released on 2018/05/17.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -34,7 +34,7 @@ Released on 2018/05/16.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. rubric:: Table of contents
 
@@ -302,7 +302,7 @@ Other Changes
   ``sys.nodes`` table.
 
 .. _admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
-.. _backup: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _backup: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _full cluster restart: https://crate.io/docs/crate/guide/en/latest/admin/full-restart-upgrade.html
 .. _HTTP Authorization header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated

--- a/docs/appendices/release-notes/3.0.1.rst
+++ b/docs/appendices/release-notes/3.0.1.rst
@@ -35,7 +35,7 @@ Released on 2018/05/30.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/3.0.2.rst
+++ b/docs/appendices/release-notes/3.0.2.rst
@@ -35,7 +35,7 @@ Released on 2018/06/12.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/3.0.3.rst
+++ b/docs/appendices/release-notes/3.0.3.rst
@@ -37,7 +37,7 @@ Released on 2018/06/29.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/3.0.4.rst
+++ b/docs/appendices/release-notes/3.0.4.rst
@@ -37,7 +37,7 @@ Released on 2018/07/23.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/3.0.5.rst
+++ b/docs/appendices/release-notes/3.0.5.rst
@@ -37,7 +37,7 @@ Released on 2018/07/30.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/3.0.6.rst
+++ b/docs/appendices/release-notes/3.0.6.rst
@@ -37,7 +37,7 @@ Released on 2018/08/28.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/3.0.7.rst
+++ b/docs/appendices/release-notes/3.0.7.rst
@@ -37,7 +37,7 @@ Released on 2018/09/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/3.1.0.rst
+++ b/docs/appendices/release-notes/3.1.0.rst
@@ -32,7 +32,7 @@ Released on 2018/08/28.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.1.1.rst
+++ b/docs/appendices/release-notes/3.1.1.rst
@@ -32,7 +32,7 @@ Released on 2018/09/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.1.2.rst
+++ b/docs/appendices/release-notes/3.1.2.rst
@@ -30,7 +30,7 @@ Released on 2018/10/18.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.1.3.rst
+++ b/docs/appendices/release-notes/3.1.3.rst
@@ -30,7 +30,7 @@ Released on 2018/11/19.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.1.4.rst
+++ b/docs/appendices/release-notes/3.1.4.rst
@@ -30,7 +30,7 @@ Released on 2018/12/19.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.1.5.rst
+++ b/docs/appendices/release-notes/3.1.5.rst
@@ -30,7 +30,7 @@ Released on 2019/01/14.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.1.6.rst
+++ b/docs/appendices/release-notes/3.1.6.rst
@@ -30,7 +30,7 @@ Released on 2019/02/05.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.0.rst
+++ b/docs/appendices/release-notes/3.2.0.rst
@@ -34,7 +34,7 @@ Released on 2018/12/19.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.1.rst
+++ b/docs/appendices/release-notes/3.2.1.rst
@@ -35,7 +35,7 @@ Released on 2019/01/14.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.2.rst
+++ b/docs/appendices/release-notes/3.2.2.rst
@@ -35,7 +35,7 @@ Released on 2019/01/22.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.3.rst
+++ b/docs/appendices/release-notes/3.2.3.rst
@@ -35,7 +35,7 @@ Released on 2019/02/07.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.4.rst
+++ b/docs/appendices/release-notes/3.2.4.rst
@@ -35,7 +35,7 @@ Released on 2019/02/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.5.rst
+++ b/docs/appendices/release-notes/3.2.5.rst
@@ -35,7 +35,7 @@ Released on 2019/03/11.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.6.rst
+++ b/docs/appendices/release-notes/3.2.6.rst
@@ -35,7 +35,7 @@ Released on 2019/03/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.7.rst
+++ b/docs/appendices/release-notes/3.2.7.rst
@@ -35,7 +35,7 @@ Released on 2019/04/09.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.2.8.rst
+++ b/docs/appendices/release-notes/3.2.8.rst
@@ -35,7 +35,7 @@ Released on 2019/04/16.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.3.0.rst
+++ b/docs/appendices/release-notes/3.3.0.rst
@@ -34,7 +34,7 @@ Released on 2019/03/27.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.3.1.rst
+++ b/docs/appendices/release-notes/3.3.1.rst
@@ -35,7 +35,7 @@ Released on 2019/04/09.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.3.2.rst
+++ b/docs/appendices/release-notes/3.3.2.rst
@@ -35,7 +35,7 @@ Released on 2019/04/17.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.3.3.rst
+++ b/docs/appendices/release-notes/3.3.3.rst
@@ -35,7 +35,7 @@ Released on 2019/05/23.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.3.4.rst
+++ b/docs/appendices/release-notes/3.3.4.rst
@@ -35,7 +35,7 @@ Released on 2019/06/19.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.3.5.rst
+++ b/docs/appendices/release-notes/3.3.5.rst
@@ -35,7 +35,7 @@ Released on 2019/07/08.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/3.3.6.rst
+++ b/docs/appendices/release-notes/3.3.6.rst
@@ -35,7 +35,7 @@ Released on 2019/09/27.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -32,7 +32,7 @@ Released on 2019/06/25.
     Before upgrading, you should `back up your data`_.
 
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.1.rst
+++ b/docs/appendices/release-notes/4.0.1.rst
@@ -29,7 +29,7 @@ Released on 2019/07/08.
     Before upgrading, you should `back up your data`_.
 
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.10.rst
+++ b/docs/appendices/release-notes/4.0.10.rst
@@ -35,7 +35,7 @@ Released on 2019/12/10.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.11.rst
+++ b/docs/appendices/release-notes/4.0.11.rst
@@ -35,7 +35,7 @@ Released on 2020/01/15.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.12.rst
+++ b/docs/appendices/release-notes/4.0.12.rst
@@ -35,7 +35,7 @@ Released on 2020-01-30.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.2.rst
+++ b/docs/appendices/release-notes/4.0.2.rst
@@ -29,7 +29,7 @@ Released on 2019/07/12.
     Before upgrading, you should `back up your data`_.
 
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.3.rst
+++ b/docs/appendices/release-notes/4.0.3.rst
@@ -33,7 +33,7 @@ Released on 2019/08/06.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.4.rst
+++ b/docs/appendices/release-notes/4.0.4.rst
@@ -34,7 +34,7 @@ Released on 2019/08/21.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.5.rst
+++ b/docs/appendices/release-notes/4.0.5.rst
@@ -34,7 +34,7 @@ Released on 2019/09/19.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.6.rst
+++ b/docs/appendices/release-notes/4.0.6.rst
@@ -34,7 +34,7 @@ Released on 2019/10/03.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.7.rst
+++ b/docs/appendices/release-notes/4.0.7.rst
@@ -34,7 +34,7 @@ Released on 2019/10/24.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.8.rst
+++ b/docs/appendices/release-notes/4.0.8.rst
@@ -34,7 +34,7 @@ Released on 2019/11/07.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.0.9.rst
+++ b/docs/appendices/release-notes/4.0.9.rst
@@ -34,7 +34,7 @@ Released on 2019/11/25.
 
 .. _rolling upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
 .. _full restart upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
 

--- a/docs/appendices/release-notes/4.1.0.rst
+++ b/docs/appendices/release-notes/4.1.0.rst
@@ -18,7 +18,7 @@ Released on 2020/01/15.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.1.rst
+++ b/docs/appendices/release-notes/4.1.1.rst
@@ -18,7 +18,7 @@ Released on 2020-01-30.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.2.rst
+++ b/docs/appendices/release-notes/4.1.2.rst
@@ -18,7 +18,7 @@ Released on 2020-02-14.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.3.rst
+++ b/docs/appendices/release-notes/4.1.3.rst
@@ -18,7 +18,7 @@ Released on 2020-03-05.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.4.rst
+++ b/docs/appendices/release-notes/4.1.4.rst
@@ -18,7 +18,7 @@ Released on 2020-03-20.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.5.rst
+++ b/docs/appendices/release-notes/4.1.5.rst
@@ -18,7 +18,7 @@ Released on 2020-04-24.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.6.rst
+++ b/docs/appendices/release-notes/4.1.6.rst
@@ -18,7 +18,7 @@ Released on 2020-06-08.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.7.rst
+++ b/docs/appendices/release-notes/4.1.7.rst
@@ -18,7 +18,7 @@ Released on 2020-06-24.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.1.8.rst
+++ b/docs/appendices/release-notes/4.1.8.rst
@@ -18,7 +18,7 @@ Released on 2020-07-07.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 .. rubric:: Table of Contents

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -18,7 +18,7 @@ Released on 2020-07-07.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.2.1.rst
+++ b/docs/appendices/release-notes/4.2.1.rst
@@ -18,7 +18,7 @@ Released on 2020-07-14.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.2.2.rst
+++ b/docs/appendices/release-notes/4.2.2.rst
@@ -18,7 +18,7 @@ Released on 2020-07-28.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.2.3.rst
+++ b/docs/appendices/release-notes/4.2.3.rst
@@ -18,7 +18,7 @@ Released on 2020-08-18.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.2.4.rst
+++ b/docs/appendices/release-notes/4.2.4.rst
@@ -18,7 +18,7 @@ Released on 2020-08-26.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.2.5.rst
+++ b/docs/appendices/release-notes/4.2.5.rst
@@ -18,7 +18,7 @@ Released on 2020-09-22.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.2.6.rst
+++ b/docs/appendices/release-notes/4.2.6.rst
@@ -18,7 +18,7 @@ Released on 2020-10-08.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.2.7.rst
+++ b/docs/appendices/release-notes/4.2.7.rst
@@ -18,7 +18,7 @@ Released on 2020-10-15.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.3.0.rst
+++ b/docs/appendices/release-notes/4.3.0.rst
@@ -18,7 +18,7 @@ Released on 2020-10-16.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/4.3.1.rst
+++ b/docs/appendices/release-notes/4.3.1.rst
@@ -18,7 +18,7 @@ Released on 2020-10-29.
 
     Before upgrading, you should `back up your data`_.
 
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -17,7 +17,7 @@ Unreleased Changes
     experimenting with unreleased changes.
 
 .. _the master branch: https://github.com/crate/crate
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
 .. DEVELOPER README
 .. ================


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Our sphinx interlink checks are failing on the URL https://crate.io/a/backing-up-and-restoring-cratedb/
which is returning occasional 403s for reasons we're not totally sure about.

In the meantime, this PR changes this URL to a suitable equivalent in our own
documentation, to (hopefully) get the interlink test to pass.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
