### PR TITLE
Adjust HEAP recommendation to 25% inside the shipped crate.yml

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -13,8 +13,8 @@
 ################################ Quick Settings ##############################
 
 # Recommended memory settings:
-# - set the environment variable CRATE_HEAP_SIZE to half of your memory
-#   (e.g. 26G, but not more than ~30G to benefit from CompressedOops).
+# - set the environment variable CRATE_HEAP_SIZE to 25% of your memory
+#   (e.g. 16G, but not more than ~30G to benefit from CompressedOops).
 #   Depending on the OS update '/etc/default/crate' or '/etc/sysconfig/crate'
 #
 #   See https://crate.io/docs/crate/howtos/en/latest/performance/memory.html


### PR DESCRIPTION
The "use-half-size" memory for Java HEAP recommendation was changed
to a 25% recommendation some time ago, but we missed changing it
also inside the shipped config comments.
See https://crate.io/docs/crate/howtos/en/latest/performance/memory.html
for reasoning.
