### PR TITLE
Print the query symbol on GET logical plans

### DIFF
--- a/docs/sql/statements/refresh.rst
+++ b/docs/sql/statements/refresh.rst
@@ -66,11 +66,11 @@ These kind of filters will result in a primary key lookup. You can use the
     CREATE OK, 1 row affected  (... sec)
 
     cr> EXPLAIN SELECT * FROM pk_demo WHERE id = 1;
-    +------------------------------------+
-    | EXPLAIN                            |
-    +------------------------------------+
-    | Get[doc.pk_demo | id | DocKeys{1}] |
-    +------------------------------------+
+    +-----------------------------------------------+
+    | EXPLAIN                                       |
+    +-----------------------------------------------+
+    | Get[doc.pk_demo | id | DocKeys{1} | (id = 1)] |
+    +-----------------------------------------------+
     EXPLAIN 1 row in set (... sec)
 
 

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -282,6 +282,8 @@ public class Get implements LogicalPlan {
             .text(Lists2.joinOn(", ", outputs, Symbol::toString))
             .text(" | ")
             .text(docKeys.toString())
+            .text(" | ")
+            .text(query.toString())
             .text("]");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.integrationtests;
 
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import io.crate.common.collections.Lists2;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.testing.DataTypeTesting;
@@ -28,7 +30,6 @@ import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -51,9 +52,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import com.carrotsearch.randomizedtesting.RandomizedContext;
-import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
@@ -1818,7 +1816,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("refresh table doc.test");
         execute("explain select id from doc.test where id = '1' and region_level_1 = '2' and marker_type = '3' and is_auto = false;");
         assertThat(printedTable(response.rows()), is(
-            "Get[doc.test | id | DocKeys{'1', '2', '3', false}]\n"
+            "Get[doc.test | id | DocKeys{'1', '2', '3', false} | ((((id = '1') AND (region_level_1 = '2')) AND (marker_type = '3')) AND (is_auto = false))]\n"
         ));
         execute("select id from doc.test where id = '1' and region_level_1 = '2' and marker_type = '3' and is_auto = false;");
         assertThat(printedTable(response.rows()), is(

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -350,7 +350,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = plan("select name from users u where id = 1");
         assertThat(plan, isPlan(
             "Rename[name] AS u\n" +
-            "  └ Get[doc.users | name | DocKeys{1::bigint}]"));
+            "  └ Get[doc.users | name | DocKeys{1::bigint} | (id = 1::bigint)]"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -417,7 +417,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "Rename[id, name] AS u\n" +
             "  └ OrderBy[id ASC name ASC]\n" +
             "    └ OrderBy[id ASC name ASC]\n" +
-            "      └ Get[doc.users | id, name | DocKeys{1::bigint}]";
+            "      └ Get[doc.users | id, name | DocKeys{1::bigint} | (id = 1::bigint)]";
         assertThat(plan, isPlan(expectedPlan));
     }
 }


### PR DESCRIPTION
Add the query symbol to the print output of the GET operators so
`explain` statements will show it.

Follow up of #10708.