### PR TITLE
Treat client cert as one auth candidate in addition to auth headers

### DIFF
--- a/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
+++ b/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
@@ -45,6 +45,7 @@ import java.security.cert.Certificate;
 import java.util.EnumSet;
 
 import static io.crate.protocols.http.HttpAuthUpstreamHandler.WWW_AUTHENTICATE_REALM_MESSAGE;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -157,9 +158,11 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         when(session.getPeerCertificates()).thenReturn(new Certificate[] { ssc.cert() });
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
-        String userName = HttpAuthUpstreamHandler.credentialsFromRequest(request, session, Settings.EMPTY).v1();
+        var credentials = HttpAuthUpstreamHandler.credentialsFromRequest(request, session, Settings.EMPTY);
 
-        assertThat(userName, is("localhost"));
+        assertThat(credentials, contains(
+            new UserWithPassword("localhost", null)
+        ));
     }
 
     @Test

--- a/server/src/main/java/io/crate/protocols/http/Headers.java
+++ b/server/src/main/java/io/crate/protocols/http/Headers.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpVersion;
-import io.crate.common.collections.Tuple;
 import org.elasticsearch.common.settings.SecureString;
 
 import javax.annotation.Nullable;
@@ -39,8 +38,6 @@ import java.util.regex.Pattern;
 public final class Headers {
 
     private static final Pattern USER_AGENT_BROWSER_PATTERN = Pattern.compile("(Mozilla|Chrome|Safari|Opera|Android|AppleWebKit)+?[/\\s][\\d.]+");
-    private static final SecureString EMPTY_PASSWORD = new SecureString(new char[] {});
-    private static final Tuple<String, SecureString> EMPTY_CREDENTIALS_TUPLE = new Tuple<>("", EMPTY_PASSWORD);
 
     static boolean isBrowser(@Nullable String headerValue) {
         if (headerValue == null) {
@@ -67,12 +64,13 @@ public final class Headers {
         }
     }
 
-    public static Tuple<String, SecureString> extractCredentialsFromHttpBasicAuthHeader(String authHeaderValue) {
+    @Nullable
+    public static UserWithPassword extractCredentialsFromHttpBasicAuthHeader(String authHeaderValue) {
         if (authHeaderValue == null || authHeaderValue.isEmpty()) {
-            return EMPTY_CREDENTIALS_TUPLE;
+            return null;
         }
         String username;
-        SecureString password = EMPTY_PASSWORD;
+        SecureString password = null;
         String valueWithoutBasePrefix = authHeaderValue.substring(6);
         String decodedCreds = new String(Base64.getDecoder().decode(valueWithoutBasePrefix), StandardCharsets.UTF_8);
 
@@ -86,6 +84,6 @@ public final class Headers {
                 password = new SecureString(passwdStr.toCharArray());
             }
         }
-        return new Tuple<>(username, password);
+        return new UserWithPassword(username, password);
     }
 }

--- a/server/src/main/java/io/crate/protocols/http/UserWithPassword.java
+++ b/server/src/main/java/io/crate/protocols/http/UserWithPassword.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.http;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.settings.SecureString;
+
+public final class UserWithPassword {
+
+    private final String userName;
+    private final SecureString password;
+
+    public UserWithPassword(String userName, @Nullable SecureString password) {
+        this.userName = userName;
+        this.password = password;
+    }
+
+    public String userName() {
+        return userName;
+    }
+
+    public SecureString password() {
+        return password;
+    }
+
+    @Override
+    public String toString() {
+        return "UserWithPassword{" + userName + "}";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((password == null) ? 0 : password.hashCode());
+        result = prime * result + userName.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        UserWithPassword other = (UserWithPassword) obj;
+        return userName.equals(other.userName()) && Objects.equals(password, other.password);
+    }
+}

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -301,11 +301,11 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
     }
 
     User userFromAuthHeader(@Nullable String authHeaderValue) {
-        String username = Headers.extractCredentialsFromHttpBasicAuthHeader(authHeaderValue).v1();
+        var userWithPassword = Headers.extractCredentialsFromHttpBasicAuthHeader(authHeaderValue);
         // Fallback to trusted user from configuration
-        if (username == null || username.isEmpty()) {
-            username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
-        }
+        String username = userWithPassword == null || userWithPassword.userName().isEmpty()
+            ? AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings)
+            : userWithPassword.userName();
         return userLookup.findUser(username);
     }
 

--- a/server/src/test/java/io/crate/protocols/http/HeadersTest.java
+++ b/server/src/test/java/io/crate/protocols/http/HeadersTest.java
@@ -50,28 +50,28 @@ public class HeadersTest {
 
     @Test
     public void testExtractUsernamePasswordFromHttpBasicAuthHeader() {
-        Tuple<String, SecureString> creds = extractCredentialsFromHttpBasicAuthHeader("");
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is(""));
+        UserWithPassword creds = extractCredentialsFromHttpBasicAuthHeader("");
+        assertThat(creds.userName(), is(""));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader(null);
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is(""));
+        assertThat(creds.userName(), is(""));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOkV4Y2FsaWJ1cg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is("Excalibur"));
+        assertThat(creds.userName(), is("Arthur"));
+        assertThat(creds.password().toString(), is("Excalibur"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOjp0ZXN0OnBhc3N3b3JkOg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is(":test:password:"));
+        assertThat(creds.userName(), is("Arthur"));
+        assertThat(creds.password().toString(), is(":test:password:"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is(""));
+        assertThat(creds.userName(), is("Arthur"));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic OnBhc3N3b3Jk");
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is("password"));
+        assertThat(creds.userName(), is(""));
+        assertThat(creds.password().toString(), is("password"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)