### PR TITLE
Add scalar function split_part

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,8 @@ None
 Changes
 =======
 
+- Added support for the ``split_part`` scalar function
+
 - Improved the performance of queries on the ``sys.health`` table.
 
 - Added support for the ``dense_rank`` window function, which is available as an

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -663,6 +663,36 @@ Returns: ``text``
    +--------+
    SELECT 1 row in set (... sec)
 
+
+``split_part(text, text, integer)``
+-----------------------------------
+
+Splits a string into parts using a delimiter and returns the part at the given index.
+The first part is addressed by index ``1``.
+
+Special Cases:
+
+* Returns the empty string if the index is greater than the number of parts.
+* If any of the arguments is ``NULL``, the result is ``NULL``.
+* If the delimiter is the empty string, the input string is considered as consisting of exactly one part.
+
+Returns: ``text``
+
+Synopsis::
+
+    split_part(string, delimiter, index)
+
+Example::
+
+   cr> select split_part('ab--cdef--gh', '--', 2) AS part;
+   +------+
+   | part |
+   +------+
+   | cdef |
+   +------+
+   SELECT 1 row in set (... sec)
+
+
 Date and time functions
 =======================
 

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -68,6 +68,7 @@ import io.crate.expression.scalar.string.StringCaseFunction;
 import io.crate.expression.scalar.string.StringLeftRightFunction;
 import io.crate.expression.scalar.string.StringPaddingFunction;
 import io.crate.expression.scalar.string.StringRepeatFunction;
+import io.crate.expression.scalar.string.StringSplitPartFunction;
 import io.crate.expression.scalar.string.TranslateFunction;
 import io.crate.expression.scalar.string.TrimFunctions;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
@@ -144,6 +145,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         AsciiFunction.register(this);
         EncodeDecodeFunction.register(this);
         StringRepeatFunction.register(this);
+        StringSplitPartFunction.register(this);
         ChrFunction.register(this);
 
         TranslateFunction.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+/**
+ * String split_part(String text, String delimiter, Integer index)
+ * <p>
+ * Splits a text on delimiter and returns the and returns the part at index (1 for the first part)
+ */
+public final class StringSplitPartFunction extends Scalar<String, Object> {
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                "split_part",
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
+            StringSplitPartFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    public StringSplitPartFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
+        assert args.length == 3 : "split_part takes exactly three arguments";
+        var text = (String) args[0].value();
+        var delimiter = (String) args[1].value();
+        var indexB = (Integer) args[2].value();
+        if (text == null || delimiter == null || indexB == null) {
+            return null;
+        }
+        int index = indexB;
+        if (index < 1) {
+            throw new IllegalArgumentException("index in split_part must be greater than zero");
+        }
+
+        // special case for empty delimiter
+        if (delimiter.isEmpty()) {
+            if (index == 1) {
+                return text;
+            } else {
+                return "";
+            }
+        }
+
+        int startIndex = 0;
+        for (int i = 1; i < index; i++) {
+            int pos = text.indexOf(delimiter, startIndex);
+            if (pos < 0) {
+                return "";
+            }
+            startIndex = pos + delimiter.length();
+        }
+        int endIndex = text.indexOf(delimiter, startIndex);
+        if (endIndex < 0) {
+            endIndex = text.length();
+        }
+        return text.substring(startIndex, endIndex);
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/string/StringSplitPartFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringSplitPartFunctionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import org.junit.Test;
+
+public class StringSplitPartFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void split_part_mid() {
+        assertEvaluate("split_part('abc~@~def~@~ghi', '~@~', 2)", "def");
+    }
+
+    @Test
+    public void split_part_first() {
+        assertEvaluate("split_part('abc~@~def~@~ghi', '~@~', 1)", "abc");
+    }
+
+    @Test
+    public void split_part_last() {
+        assertEvaluate("split_part('abc~@~def~@~ghi', '~@~', 3)", "ghi");
+    }
+
+    @Test
+    public void split_part_index_smaller_one_throws_exception() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("index in split_part must be greater than zero");
+        assertEvaluate("split_part('abc~@~def~@~ghi', '~@~', 0)", "");
+    }
+
+    @Test
+    public void split_part_index_greater_index() {
+        assertEvaluate("split_part('abc~@~def~@~ghi', '~@~', 4)", "");
+    }
+
+    @Test
+    public void text_is_null() {
+        assertEvaluate("split_part(NULL, ',', 3)", null);
+    }
+
+    @Test
+    public void delimiter_is_null() {
+        assertEvaluate("split_part('abcdefg', NULL, 3)", null);
+    }
+
+    @Test
+    public void field_is_null() {
+        assertEvaluate("split_part('a,bc,de,fg', ',', NULL)", null);
+    }
+
+    @Test
+    public void delimiter_is_empty_first() {
+        assertEvaluate("split_part('abcdefg', '', 1)", "abcdefg");
+    }
+
+    @Test
+    public void delimiter_is_empty_second() {
+        assertEvaluate("split_part('abcdefg', '', 2)", "");
+    }
+
+    @Test
+    public void repeating_delimiter_mid() {
+        assertEvaluate("split_part('+++++++++++a+++b', '+++', 4)", "++a");
+    }
+
+    @Test
+    public void repeating_delimiter_last() {
+        assertEvaluate("split_part('+++++++++++a+++b', '+++', 5)", "b");
+    }
+
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This PR adds support for the `split_part` scalar function (Splits a string into parts using a delimiter and returns the part at the
given index, should be compatible with respective PostgreSQL function https://www.postgresql.org/docs/13/functions-string.html).

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)

Note: I am not sure how to update the `sql_features` table. Does this refer to https://github.com/crate/crate/blob/master/server/src/main/resources/sql_features.tsv ? I would appreciate some help with that. 


