### PR TITLE
Fix flaky testDisablingAllocationFiltering

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -204,7 +204,7 @@ public class FilteringAllocationIT extends SQLTransportIntegrationTest {
         execute("alter table test set( \"routing.allocation.exclude._name\" = ?)", new Object[]{node_0});
         // Force re-allocation, ensure shards are moved. CrateDB does not support `reroute` without concrete commands
         // while ES (hidden, official documentation does not) supports this.
-        client().admin().cluster().prepareReroute().get();
+        client().admin().cluster().prepareReroute().execute().actionGet(20, TimeUnit.SECONDS);
         ensureGreen(tableName);
 
         logger.info("--> verify all shards are allocated on node_1 now");

--- a/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -203,6 +203,7 @@ public class FilteringAllocationIT extends SQLTransportIntegrationTest {
 
         if (closed) {
             execute("alter table test open");
+            ensureGreen(tableName);
         }
         execute("alter table test set( \"routing.allocation.exclude._name\" = ?)", new Object[]{node_0});
         // Force re-allocation, ensure shards are moved. CrateDB does not support `reroute` without concrete commands


### PR DESCRIPTION
Fix flakiness of the test as new shard allocation may not have happen yet.
Force re-allocation using the ES API by executing an empty `reroute` command.
(Same happen on the original commit)

Also the name of node_1 is not a constant name (could be `node_t1` instead
of `node_1`), use resolved name instead.
This change does not exists at the original ES commit as it no real effect
currently anyhow because the current default of `max_concurrent_recoveries`
is not smaller than the used 2 shards.

See https://github.com/crate/crate/pull/10797/checks?check_run_id=1443820573#step:4:1376 for a failing scenario which should be fixed by this commit.