### PR TITLE
Set SSL client auth value depending on HBA settings

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,6 +81,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause browsers to prompt for a client certificate
+  if ``SSL`` is enabled on the server side, even if no cert authentication
+  method is configured.
+
 - Fixed a regression introduced Crate ``4.1`` resulting in duplicated recovery
   file chunk responses sent.
   This causes log entries of `Transport handler not found ...`.

--- a/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/SslConfiguration.java
+++ b/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/SslConfiguration.java
@@ -41,9 +41,9 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.elasticsearch.common.settings.Settings;
 
+import io.crate.auth.AuthSettings;
 import io.crate.common.Optionals;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
-import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -190,7 +190,7 @@ public final class SslConfiguration {
                 .forServer(privateKey, keyStoreCertChain)
                 .ciphers(List.of(sslContext.createSSLEngine().getEnabledCipherSuites()))
                 .applicationProtocolConfig(ApplicationProtocolConfig.DISABLED)
-                .clientAuth(ClientAuth.OPTIONAL)
+                .clientAuth(AuthSettings.resolveClientAuth(settings))
                 .trustManager(concat(keyStoreRootCerts, trustStoreRootCerts))
                 .sessionCacheSize(0)
                 .sessionTimeout(0)

--- a/server/src/test/java/io/crate/auth/AuthSettingsTest.java
+++ b/server/src/test/java/io/crate/auth/AuthSettingsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.auth;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import io.netty.handler.ssl.ClientAuth;
+
+public class AuthSettingsTest {
+
+
+    @Test
+    public void test_cliet_auth_is_none_if_no_hba_entry_has_client_cert_method() throws Exception {
+        Settings settings = Settings.builder()
+            .put("auth.host_based.config.1.method", "trust")
+            .put("auth.host_based.config.1.ssl", "on")
+            .put("auth.host_based.config.2.method", "password")
+            .put("auth.host_based.config.2.ssl", "password")
+            .build();
+
+        assertThat(AuthSettings.resolveClientAuth(settings), is(ClientAuth.NONE));
+    }
+
+    @Test
+    public void test_client_auth_is_required_if_all_hba_entries_have_cert_method() throws Exception {
+        Settings settings = Settings.builder()
+            .put("auth.host_based.config.1.method", "cert")
+            .put("auth.host_based.config.2.method", "cert")
+            .build();
+
+        assertThat(AuthSettings.resolveClientAuth(settings), is(ClientAuth.REQUIRE));
+    }
+
+    @Test
+    public void test_client_auth_is_optional_if_one_hba_entry_is_client_cert_trust() throws Exception {
+        Settings settings = Settings.builder()
+            .put("auth.host_based.config.1.method", "cert")
+            .put("auth.host_based.config.2.method", "password")
+            .build();
+        assertThat(AuthSettings.resolveClientAuth(settings), is(ClientAuth.OPTIONAL));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This should address https://github.com/crate/crate/issues/10736

If no HBA entry has `method = cert` then we'll set `ClientAuth` to
`NONE` to prevent browsers from showing a client certificate dialog.

---

We talked about treating this as a fix, but looking at the diff I think this is rather a behavior change. I'd tend to treat it as feature/improvement. Haven't added a changes entry yet because of that. What do you think?


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)