### PR TITLE
Fix changing of "cluster.info.update.interval" global setting

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -83,4 +83,5 @@ Changes
 Fixes
 =====
 
-None
+- Fixed a regression introduced in CrateDB ``4.0`` preventing the global setting
+  ``cluster.info.update.interval`` to be changed.

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -103,7 +103,7 @@ public class InternalClusterInfoService implements ClusterInfoService, LocalNode
         this.enabled = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
         //clusterSettings.addSettingsUpdateConsumer(INTERNAL_CLUSTER_INFO_TIMEOUT_SETTING, this::setFetchTimeout);
-        //clusterSettings.addSettingsUpdateConsumer(INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING, this::setUpdateFrequency);
+        clusterSettings.addSettingsUpdateConsumer(INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING, this::setUpdateFrequency);
         clusterSettings.addSettingsUpdateConsumer(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING, this::setEnabled);
 
         // Add InternalClusterInfoService to listen for Master changes

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.bootstrap.BootstrapSettings;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.coordination.ClusterBootstrapService;
@@ -209,6 +210,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
         DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING,
         SameShardAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING,
+        InternalClusterInfoService.INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING,
         DestructiveOperations.REQUIRES_NAME_SETTING,
         NoMasterBlockService.NO_MASTER_BLOCK_SETTING,
         DiscoverySettings.PUBLISH_TIMEOUT_SETTING,

--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -21,12 +21,13 @@
 
 package io.crate.integrationtests;
 
-import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
-import static org.hamcrest.Matchers.is;
-
-import java.util.List;
-import java.util.Map;
-
+import io.crate.common.unit.TimeValue;
+import io.crate.execution.engine.collect.stats.JobsLogService;
+import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
+import io.crate.settings.CrateSetting;
+import io.crate.udc.service.UDCService;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.MemorySizeValue;
@@ -36,10 +37,12 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
-import io.crate.execution.engine.collect.stats.JobsLogService;
-import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
-import io.crate.settings.CrateSetting;
-import io.crate.udc.service.UDCService;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
+import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope
 public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
@@ -53,7 +56,7 @@ public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
 
     @After
     public void resetSettings() throws Exception {
-        execute("reset global stats, bulk, indices");
+        execute("reset global stats, bulk, indices, cluster");
     }
 
     @Test
@@ -181,6 +184,20 @@ public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
         assertSettingsValue(
             INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(),
             "100kb");
+    }
+
+    /**
+     * There was a regression introduced with v4.0.0 which prevents to set this setting as it was not included
+     * at {@link org.elasticsearch.common.settings.ClusterSettings#BUILT_IN_CLUSTER_SETTINGS}.
+     * Additionally the new setting was not applied internally to the cluster service due to missing update consumer.
+     */
+    @Test
+    public void test_set_cluster_info_update_interval() throws Exception {
+        execute("set global transient \"cluster.info.update.interval\" = '45s'");
+        var clusterService = internalCluster().getInstance(ClusterInfoService.class);
+        Field f1 = clusterService.getClass().getDeclaredField("updateFrequency");
+        f1.setAccessible(true);
+        assertThat(f1.get(clusterService), is(TimeValue.timeValueSeconds(45)));
     }
 
     private void assertSettingsDefault(CrateSetting<?> crateSetting) {


### PR DESCRIPTION
Fixes a regression introduced in CrateDB `4.0` which prevents to
change the "cluster.info.update.interval" setting as it was removed
from the allowed cluster settings list.