### PR TITLE
Fix flaky testSeqNoCASLinearizability

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
@@ -65,12 +65,12 @@ public abstract class AbstractDisruptionTestCase extends SQLTransportIntegration
     static final TimeValue DISRUPTION_HEALING_OVERHEAD = TimeValue.timeValueSeconds(40);
 
     protected static final Settings DEFAULT_SETTINGS = Settings.builder()
-        .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "1s") // for hitting simulated network failures quickly
+        .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "5s") // for hitting simulated network failures quickly
         .put(LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING.getKey(), 1) // for hitting simulated network failures quickly
-        .put(FollowersChecker.FOLLOWER_CHECK_TIMEOUT_SETTING.getKey(), "1s") // for hitting simulated network failures quickly
+        .put(FollowersChecker.FOLLOWER_CHECK_TIMEOUT_SETTING.getKey(), "5s") // for hitting simulated network failures quickly
         .put(FollowersChecker.FOLLOWER_CHECK_RETRY_COUNT_SETTING.getKey(), 1) // for hitting simulated network failures quickly
         .put(JoinHelper.JOIN_TIMEOUT_SETTING.getKey(), "10s") // still long to induce failures but not too long so test won't time out
-        .put(Coordinator.PUBLISH_TIMEOUT_SETTING.getKey(), "1s") // <-- for hitting simulated network failures quickly
+        .put(Coordinator.PUBLISH_TIMEOUT_SETTING.getKey(), "5s") // <-- for hitting simulated network failures quickly
         .put(TransportSettings.CONNECT_TIMEOUT.getKey(), "10s") // Network delay disruption waits for the min between this
         // value and the time of disruption and does not recover immediately
         // when disruption is stopped. We should make sure we recover faster


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://github.com/elastic/elasticsearch/commit/8332ad44e34171adf54f676d0e0ca57a3bd10267

We haven't caught up with the patches that introduce Lucene storage for
the metadata, but it looks as if increasing the timeout still helps
fixing some flakyness.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)