### PR TITLE
Increase SQL request timeout on Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Run tests on ${{ matrix.os }}
         uses: eskatos/gradle-command-action@v1
+        env:
+          CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
         with:
           arguments: :server:test -Dtests.crate.run-windows-incompatible=${{ matrix.os == 'ubuntu-latest' }}
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

On windows the tests sometimes run into a timeout.
It looks like the default of 5 seconds is too short.

On Azure pipelines we also used to have a 20 second timeout.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)