### PR TITLE
Retroactively fix typos within "ALTER CLUSTER DECOMMISSION"

### DIFF
--- a/docs/appendices/release-notes/3.3.0.rst
+++ b/docs/appendices/release-notes/3.3.0.rst
@@ -60,7 +60,7 @@ This setting was already being ignored, and setting the value to ``false``
 had no effect.
 
 The node decommission using the ``USR2`` :ref:`signals <cli-crate-signals>` has
-now been deprecated in favour of the :ref:`ALTER CLUSTER DECOMISSION
+now been deprecated in favour of the :ref:`ALTER CLUSTER DECOMMISSION
 <alter_cluster_decommission>` statement.
 
 The ``CREATE INGEST`` and ``DROP INGEST`` rules have been marked
@@ -146,7 +146,7 @@ Deprecations
   This setting was already being ignored, setting the value to ``false`` has no effect.
 
 - The node decommission using the ``USR2`` :ref:`signal <cli-crate-signals>`
-  has been deprecated in favour of the :ref:`ALTER CLUSTER DECOMISSION
+  has been deprecated in favour of the :ref:`ALTER CLUSTER DECOMMISSION
   <alter_cluster_decommission>` statement.
 
 - Marked ``CREATE INGEST`` and ``DROP INGEST`` as deprecated.

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -246,7 +246,7 @@ Removed Functionality
   ``html_strip``.
 
 - Removed the deprecated ``USR2`` signal handling. Use :ref:`ALTER CLUSTER
-  DECOMISSION <alter_cluster_decommission>` instead. Be aware that the
+  DECOMMISSION <alter_cluster_decommission>` instead. Be aware that the
   behavior of sending ``USR2`` signals to a CrateDB process is now undefined
   and up to the JVM. In some cases it may still terminate the instance but
   without clean shutdown.


### PR DESCRIPTION
Hi there,

in order to research a bit about the graceful shutdown feature, I wrongly typed "decomission" into the search field at [1] and actually found two occurrences where this had a typo in the documentation (release notes).

By blindly reusing that statements when searching within other artefacts, I obviously haven't been successful. This should get things straight that others will also not trip into this.

With kind regards,
Andreas.

[1] https://crate.io/search/
