### PR TITLE
Add 4.3.2 to fromId to fix IndexShardTests.testMinimumCompatVersion

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -229,6 +229,8 @@ public class Version implements Comparable<Version>, ToXContentFragment {
                 return V_4_3_0;
             case ES_V_7_3_1_ID:
                 return V_4_3_1;
+            case ES_V_7_3_2_ID:
+                return V_4_3_2;
 
             case ES_V_7_4_0_ID:
                 return V_4_4_0;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Missed this when adding the 4.3.2 release
We should follow up on this and handle unknown patch versions in a
better way like it is done here

https://github.com/elastic/elasticsearch/commit/0df08dd4587c8f9774dad348f7795c677d24fb4b#diff-dbb9c323ecfad4a779336fe48a6dae8c1c30547e8e166e1e695ce0422ab90c93R200


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)