### PR TITLE
Improve more links within the documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,10 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -m pip install -r blackbox/requirements.txt
 
+          # We default to Sphinx 1.8 in blackbox/requirements.txt because that's what the crate-docs-theme needs. 
+          # However, we want Sphinx 3.x here because its link checker is much more capable.
+          python -m pip install sphinx==3.3.1
+
       - name: Run linkcheck
         run: |
-          sphinx-build -n -W -c docs/ -b linkcheck -E docs/ docs/out/html
+          sphinx-build -n -W --keep-going -q -c docs/ -b linkcheck -E docs/ docs/out/html

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -244,8 +244,8 @@ The table schema is as follows:
 | Column Name | Description                                     | Return Type |
 +=============+=================================================+=============+
 | ``name``    | The node name within a cluster. The system will | ``TEXT``    |
-|             | choose a random name. You can specify the node  |             |
-|             | name via your own custom `configuration`_.      |             |
+|             | choose a random name. You can also customize    |             |
+|             | the node name, see :ref:`conf-node-settings`.   |             |
 +-------------+-------------------------------------------------+-------------+
 
 ``hostname``
@@ -276,8 +276,8 @@ The table schema is as follows:
 | Column Name           | Description                                     | Return Type |
 +=======================+=================================================+=============+
 | ``port``              | The specified ports for both HTTP and binary    | ``OBJECT``  |
-|                       | transport interfaces. You can specify the ports |             |
-|                       | via your own custom `configuration`_.           |             |
+|                       | transport interfaces. You can also customize    |             |
+|                       | the ports setting, see :ref:`conf_ports`.       |             |
 +-----------------------+-------------------------------------------------+-------------+
 | ``port['http']``      | CrateDB's HTTP port.                            | ``INTEGER`` |
 +-----------------------+-------------------------------------------------+-------------+
@@ -337,7 +337,7 @@ The table schema is as follows:
 +-----------------------------+------------------------------------------------+-------------+
 | ``heap['max']``             | Maximum available heap memory. You can specify | ``BIGINT``  |
 |                             | the max heap memory CrateDB should use in the  |             |
-|                             | `configuration`_.                              |             |
+|                             | :ref:`config`.                                 |             |
 +-----------------------------+------------------------------------------------+-------------+
 | ``heap['free']``            | Currently available heap memory in bytes.      | ``BIGINT``  |
 +-----------------------------+------------------------------------------------+-------------+
@@ -2245,5 +2245,4 @@ been analyzed.
     Not all data types support creating statistics. So some columns may not
     show up in the table.
 
-.. _configuration: ../configuration.html
 .. _Enterprise Edition: https://crate.io/products/cratedb-editions/

--- a/docs/appendices/release-notes/3.2.0.rst
+++ b/docs/appendices/release-notes/3.2.0.rst
@@ -52,7 +52,7 @@ Logging Configuration Changes
 -----------------------------
 
 The default logging configuration for CrateDB in ``log4j2.properties`` has been
-changed. If you have customised this `logging configuration <conf-logging-log4j>`_, 
+changed. If you have customised this :ref:`logging configuration <conf-logging-log4j>`, 
 you should replace the ``$marker`` entry with ``[%node_name] %marker``.
 
 Deprecated Settings and Features
@@ -79,7 +79,7 @@ Breaking Changes
 ----------------
 
 - The ``*`` of ``SELECT *`` statements in the query clause of 
-  `view definitions <views>`_
+  :ref:`view definitions <views>`
   is no longer expanded at view creation time but lazy whenever a view is
   evaluated. That means columns added to a table after the views initial
   creation will show up in queries on the view. It is generally recommended to
@@ -92,62 +92,62 @@ New Features
 ~~~~~~~~~~~~
 
 - Added support for executing existing aggregation functions as 
-  `window functions <window-functions>`_ using the 
-  `OVER <over>`_ clause.
+  :ref:`window functions <window-functions>` using the 
+  :ref:`OVER <over>` clause.
 
 - Added support for CrateDB license management enabling users to 
-  `trial <enterprise_trial>`_ the
-  enterprise features, set a production enterprise license or continue
+  trial the :ref:`enterprise-features`,
+  set a production enterprise license or continue
   using the community edition. Additionally, a new 
-  `SET LICENSE <ref-set-license>`_ statement
+  :ref:`SET LICENSE <ref-set-license>` statement
   has been added for license registration, and the ``license.ident`` setting
   has become ``@deprecated``.
 
 SQL Improvements
 ~~~~~~~~~~~~~~~~
 
-- Added the `REPLACE <scalar-replace>`_ scalar function replacing
+- Added the :ref:`REPLACE <scalar-replace>` scalar function replacing
   substrings in a string with another string.
 
 - Added the 
-  `GENERATE_SERIES(start, stop [, step ]) <table-functions-generate-series>`_ 
+  :ref:`GENERATE_SERIES(start, stop [, step ]) <table-functions-generate-series>` 
   table function which can generate a series of numbers.
 
-- Implemented the `ARRAY_UPPER <scalar-array-upper>`_, 
-  `ARRAY_LENGTH <scalar-array-length>`_ and 
-  `ARRAY_LOWER <_scalar-array-lower>`_ scalars
+- Implemented the :ref:`ARRAY_UPPER <scalar-array-upper>`, 
+  :ref:`ARRAY_LENGTH <scalar-array-length>` and 
+  :ref:`ARRAY_LOWER <scalar-array-lower>` scalars
   that return the upper and respectively lower bound of a given array
   dimension.
 
 - Added support for the 
-  `ARRAY(subquery) <_sql_expressions_array_subquery>`_ expression,
+  :ref:`ARRAY(subquery) <sql_expressions_array_subquery>` expression,
   which can turn the result from a subquery into an array.
 
-- The `= ANY <sql_dql_any_array>`_ operator now also supports 
+- The :ref:`= ANY <sql_dql_any_array>` operator now also supports 
   operations on object arrays or
   nested arrays. This enables queries like ``WHERE ['foo', 'bar'] =
   ANY(object_array(string_array))``.
 
-- Added support for `SHOW parameter_name | ALL <ref-show>`_ to retrieve
+- Added support for :ref:`SHOW parameter_name | ALL <ref-show>` to retrieve
   one or all session setting value(s).
 
-- Added support for `INITCAP(string) <scalar-initcap>`_ which
+- Added support for :ref:`INITCAP(string) <scalar-initcap>` which
   capitalizes the first letter of every word while turning all others into
   lowercase.
 
 - Added the scalar expression 
-  `CURRENT_DATABASE <scalar_current_database>`_ which returns the
+  :ref:`CURRENT_DATABASE <scalar_current_database>` which returns the
   current database.
 
-- Functions like `CURRENT_SCHEMA <scalar_current_schema>`_ and 
-  `CURRENT_USER <current_user>`_ which depend on the
+- Functions like :ref:`CURRENT_SCHEMA <scalar_current_schema>` and 
+  :ref:`CURRENT_USER <current_user>` which depend on the
   active session can now be used as 
-  `generated columns <sql-ddl-generated-columns>`_.
+  :ref:`generated columns <sql-ddl-generated-columns>`.
 
-- Added support for using `table functions <ref-table-functions>`_ in the 
+- Added support for using :ref:`table functions <ref-table-functions>` in the 
   select list of a query.
 
-- `geo_shape <geo_shape_data_type>`_ columns can now be casted to ``object``
+- :ref:`geo_shape <geo_shape_data_type>` columns can now be casted to ``object``
   with ``cast`` in addition to ``try_cast``.
 
 - Improved the handling of function expressions inside subscripts used on
@@ -166,11 +166,11 @@ SQL Improvements
 PostgreSQL Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Added the `pg_catalog.pg_database <postgres_pg_catalog>`_ table.
+- Added the :ref:`pg_catalog.pg_database <postgres_pg_catalog>` table.
 
 - Added ``pg_class``, ``pg_namespace``, ``pg_attribute``, ``pg_attrdef``,
   ``pg_index`` and ``pg_constraint`` tables to the 
-  `pg_catalog <postgres_pg_catalog>`_ schema for
+  :ref:`pg_catalog <postgres_pg_catalog>` schema for
   improved compatibility with PostgreSQL.
 
 - Improved the compatibility with PostgreSQL clients that use the ``text`` type
@@ -180,33 +180,33 @@ PostgreSQL Compatibility
 
 - Added some type aliases for improved compatibility with PostgreSQL.
 
-- Expand the `search_path <conf-session-search-path>`_ setting to 
+- Expand the :ref:`search_path <conf-session-search-path>` setting to 
   accept a list of schemas that will be
   searched when a relation (table, view or user defined function) is referenced
   without specifying a schema. The system 
-  `pg_catalog <postgres_pg_catalog>`_ schema is implicitly
+  :ref:`pg_catalog <postgres_pg_catalog>` schema is implicitly
   included as the first one in the path.
 
 Database Administration
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 - Added support for changing the number of shards on an existing table or
-  partition using the `ALTER TABLE SET <alter_table_set_reset>`_ 
+  partition using the :ref:`ALTER TABLE SET <alter_table_set_reset>` 
   statement.
 
-- Improved resiliency of the `ALTER TABLE RENAME <alter_table_rename>`_
+- Improved resiliency of the :ref:`ALTER TABLE RENAME <alter_table_rename>`
   operation by making it an atomic operation.
 
-- Added an `ALTER CLUSTER SWAP TABLE <alter_cluster_swap_table>`_
+- Added an :ref:`ALTER CLUSTER SWAP TABLE <alter_cluster_swap_table>`
   statement that can be used to switch the names of two tables.
 
-- Added a `ALTER CLUSTER GC DANGLING ARTIFACTS <alter_cluster_gc_dangling_artifacts>`_
+- Added a :ref:`ALTER CLUSTER GC DANGLING ARTIFACTS <alter_cluster_gc_dangling_artifacts>`
   statement that can be used to
   clean up internal structures that weren't properly cleaned up due to cluster
   failures during operations which create such temporary artifacts.
 
 - Added support for per-table 
-  `shard allocation filtering <ddl_shard_allocation>`_.
+  :ref:`shard allocation filtering <ddl_shard_allocation>`.
 
 Admin UI Upgrade to 1.11.3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -237,16 +237,16 @@ Other
 - Upgraded to Elasticsearch 6.5.1, which includes changes to the default logging
   configuration.
 
-- Added a `remove_duplicates <analyzers_remove_duplicates>`_ token 
+- Added a :ref:`remove_duplicates <analyzers_remove_duplicates>` token 
   filter.
 
-- Added a `char_group <analyzers_char_group>`_ tokenizer.
+- Added a :ref:`char_group <analyzers_char_group>` tokenizer.
 
 - Renamed the ``delimited_payload_filter`` token filter to
-  `delimited_payload <delimited_payload-tokenfilter>`_. The old name 
+  :ref:`delimited_payload <delimited_payload-tokenfilter>`. The old name 
   can still be used, but is deprecated.
 
 For further information on CrateDB 3.2.0 see our
-`announcement blogpost <blogpost>`_.
+`announcement blogpost <blogpost_>`__.
 
 .. _blogpost: https://crate.io/a/cratedb-3-2-stable-available-now/

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -58,9 +58,9 @@ system capable of automatically maintaining an optimal level of fault
 tolerance even in situations of network partitions.
 This eliminates the need of the easily miss configured ``minimum_master_nodes``
 setting.
-Additionally a rare resiliency failure, recorded as `Repeated cluster
+Additionally a rare resiliency failure, recorded as :ref:`Repeated cluster
 partitions can cause cluster state updates to be lost
-<resiliency_cluster_partitions_cause_lost_cluster_updates>`_
+<resiliency_cluster_partitions_cause_lost_cluster_updates>`
 can no longer occur.
 
 Due to this some discovery settings are added, renamed and removed.
@@ -315,7 +315,7 @@ SQL Standard and PostgreSQL compatibility improvements
   :ref:`pg_catalog.pg_type <postgres_pg_type>` for improved PostgreSQL
   compatibility.
 
-- Added the `pg_catalog.pg_settings <pgsql_pg_settings>`_ table.
+- Added the :ref:`pg_catalog.pg_settings <postgres_pg_catalog>` table.
 
 - Added support for :ref:`sql_escape_string_literals`.
 
@@ -378,11 +378,11 @@ Performance and resiliency improvements
   :ref:`_primary_term <sql_administration_system_columns_primary_term>`, the
   following resiliency issues were fixed:
 
-   - `Version Number Representing Ambiguous Row Versions
-     <resiliency_ambiguous_row_versions>`_
+   - :ref:`Version Number Representing Ambiguous Row Versions
+     <resiliency_ambiguous_row_versions>`
 
-   - `Replicas can fall out of sync when a primary shard fails
-     <resiliency_replicas_fall_out_of_sync>`_
+   - :ref:`Replicas can fall out of sync when a primary shard fails
+     <resiliency_replicas_fall_out_of_sync>`
 
 - Predicates like ``abs(x) = 1`` which require a scalar function evaluation and
   cannot operate on table indices directly are now candidates for the query

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -150,13 +150,13 @@ SQL Standard and PostgreSQL compatibility improvements
   :ref:`server_version <conf-session-server_version>` read-only session
   settings.
 
-- Added the `pg_catalog.pg_proc <postgres_pg_catalog>`_ table.
+- Added the :ref:`pg_catalog.pg_proc <postgres_pg_catalog>` table.
 
-- Added the `pg_catalog.pg_range <postgres_pg_catalog>`_ table.
+- Added the :ref:`pg_catalog.pg_range <postgres_pg_catalog>` table.
 
-- Added the `pg_catalog.pg_enum <postgres_pg_catalog>`_ table.
+- Added the :ref:`pg_catalog.pg_enum <postgres_pg_catalog>` table.
 
-- Added the `information_schema.character_sets <character_sets>`_ table.
+- Added the :ref:`information_schema.character_sets <character_sets>` table.
 
 - Added :ref:`postgres_pg_type` columns: ``typbyval``, ``typcategory``,
   ``typowner``, ``typisdefined``, ``typrelid``, ``typndims``,

--- a/docs/concepts/resiliency.rst
+++ b/docs/concepts/resiliency.rst
@@ -1,3 +1,5 @@
+.. _concepts_resiliency:
+
 ==========
 Resiliency
 ==========
@@ -6,7 +8,7 @@ Distributed systems are tricky. All sorts of things can go wrong that are
 beyond your control. The network can go away, disks can fail, hosts can be
 terminated unexpectedly. CrateDB tries very hard to cope with these sorts of
 issues while maintaining :doc:`availability <shared-nothing>`,
-`consistency <consistency>`_, and `durability <durability>`_.
+:ref:`consistency <consistency>`, and :ref:`durability <durability>`.
 
 However, as with any distributed system, sometimes, *rarely*, things can go
 wrong.
@@ -51,8 +53,8 @@ Code that expects the behavior of an `ACID
 <https://en.wikipedia.org/wiki/ACID>`_ compliant database like MySQL may not
 always work as expected with CrateDB.
 
-CrateDB does not support ACID transactions, but instead has `atomic operations
-<concepts_atomic_document_level>`_ and :doc:`eventual consistency
+CrateDB does not support ACID transactions, but instead has :ref:`atomic operations
+<concepts_atomic_document_level>` and :doc:`eventual consistency
 <shared-nothing>` at the row level. Eventual consistency is the trade-off that
 CrateDB makes in exchange for high-availability that can tolerate most hardware
 and network failures. So you may observe data from different cluster nodes
@@ -61,7 +63,7 @@ time they will become consistent.
 
 For example, you know a row has been written as soon as you get the ``INSERT
 OK`` message. But that row might not be read back by a subsequent ``SELECT`` on
-a different node until after a `table refresh <sql_ref_refresh>`_ (which
+a different node until after a :ref:`table refresh <sql_ref_refresh>` (which
 typically occurs within one second).
 
 Your applications should be designed to work this storage and consistency model.
@@ -90,13 +92,13 @@ Here are some considerations:
    failures like a zone going down.
 
 -  If data durability or read performance is a concern, you can increase the
-   number of `table replicas <concepts_data_storage>`_.
+   number of :ref:`table replicas <concepts_data_storage>`.
    More table replicas means a smaller chance of permanent data loss due to
    hardware failures, in exchange for the use of more disk space and more
    intra-cluster network traffic.
 
--  If disaster recovery is important, you can `take regular snapshots
-   <snapshot-restore>`_ and store those snapshots in cold storage. This
+-  If disaster recovery is important, you can :ref:`take regular snapshots
+   <snapshot-restore>` and store those snapshots in cold storage. This
    safeguards data that has already been successfully written and replicated
    across the cluster.
 

--- a/docs/concepts/storage-consistency.rst
+++ b/docs/concepts/storage-consistency.rst
@@ -166,9 +166,8 @@ translog.
 .. CAUTION::
 
    Some outage conditions can affect these consistency claims. See the
-   `resiliency documentation`_ for details.
+   :ref:`resiliency documentation <concepts_resiliency>` for details.
 
-.. _resiliency documentation: /docs/scale/resilience/
 
 .. _storage_consistency_cluster_meta_data:
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -2400,8 +2400,8 @@ return the default schema, which is ``doc``.
 Returns: ``text``
 
 The default schema can be set when using the `JDBC client
-<https://crate.io/docs/jdbc/en/latest/connect.html>`_ and `HTTP clients
-<http_default_schema>`_ such as `CrateDB PDO`_.
+<https://crate.io/docs/jdbc/en/latest/connect.html>`_ and :ref:`HTTP clients
+<http_default_schema>` such as `CrateDB PDO`_.
 
 .. NOTE::
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -40,7 +40,7 @@ or collections.
 * `bigint <numeric types_>`_
 * `real <numeric types_>`_
 * `double precision <numeric types_>`_
-* `text <data-type-text>`_
+* `text <data-type-text_>`_
 * `ip`_
 * `timestamp with time zone <timestamp with time zone_>`_
 * `timestamp without time zone <timestamp without time zone_>`_
@@ -159,8 +159,8 @@ will be truncated to ``n`` characters without raising an error.
     SELECT 1 row in set (... sec)
 
 ``character varying`` and ``varchar`` without the length specifier are
-aliases for the `text <data-type-text>`_ data type. See ` type aliases
-<data-type-aliases>`_.
+aliases for the :ref:`text <data-type-text>` data type,
+see also :ref:`type aliases <data-type-aliases>`.
 
 .. hide:
 


### PR DESCRIPTION
### Summary of the changes / Why this improves CrateDB
When using Sphinx 3.3.1, the linkchecker became even more capable and reported many more broken links. For example, URLs derived from ad hoc inline links as well as `:ref:`-based links within reStructuredText became visible. Every offending link has been mitigated within this PR, so `echo $?` returns `0`.

Also, by using the `--keep-going` option, the linkcheck report now includes **all** broken links instead of just one as before and `-q` reduces all noise about the good/non-broken links. This tremendously helps when aiming to mitigate all errors coming from this within a single shot.

This is a followup to #10828 and also might finally help with the linkcheck step still failing occasionally, like [1].

[1] https://github.com/crate/crate/runs/1459941156#step:5:1264