### PR TITLE
Add a type aware source parser

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import io.crate.metadata.Reference;
+
 public class CollectorContext {
 
     private final int readerId;
@@ -44,5 +46,12 @@ public class CollectorContext {
             sourceLookup = new SourceLookup();
         }
         return sourceLookup;
+    }
+
+    public SourceLookup sourceLookup(Reference ref) {
+        if (sourceLookup == null) {
+            sourceLookup = new SourceLookup();
+        }
+        return sourceLookup.registerRef(ref);
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -96,7 +96,7 @@ public final class SourceLookup {
     }
 
     public SourceLookup registerRef(Reference ref) {
-        sourceParser.register(ref);
+        sourceParser.register(ref.column(), ref.valueType());
         return this;
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -24,7 +24,6 @@ package io.crate.expression.reference.doc.lucene;
 
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.lucene.index.LeafReader;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DoubleType;
+import io.crate.types.FloatType;
+import io.crate.types.IntegerType;
+import io.crate.types.LongType;
+import io.crate.types.ObjectType;
+import io.crate.types.ShortType;
+import io.crate.types.StringType;
+
+public final class SourceParser {
+
+    static Object parseValue(Map<ColumnIdent, DataType<?>> typesByColumn, XContentParser parser, DataType<?> type) throws IOException {
+        return switch (type.id()) {
+            case ArrayType.ID -> parseArray(parser, type);
+            case ObjectType.ID -> parseObject(parser, type);
+            case ShortType.ID -> parser.shortValue(true);
+            case IntegerType.ID -> parser.intValue();
+            case LongType.ID -> parser.longValue();
+            case FloatType.ID -> parser.floatValue();
+            case DoubleType.ID -> parser.doubleValue();
+            case StringType.ID -> parser.text();
+            default -> {
+                throw new UnsupportedOperationException("parseValue not implemented for " + type);
+            }
+        };
+    }
+
+    static Object parseObject(XContentParser parser, DataType<?> type) {
+        throw new UnsupportedOperationException("parseValue not implemented for object");
+    }
+
+    static Object parseArray(XContentParser parser, DataType<?> type) {
+        throw new UnsupportedOperationException("parseValue not implemented for array");
+    }
+
+    public static Map<ColumnIdent, Object> parse(BytesReference bytes, Map<ColumnIdent, DataType<?>> typesByColumn) {
+        try (InputStream inputStream = XContentHelper.getUncompressedInputStream(bytes)) {
+            XContentParser parser = XContentType.JSON.xContent().createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                inputStream
+            );
+            Token token = parser.currentToken();
+            if (token == null) {
+                token = parser.nextToken();
+            }
+            if (token == XContentParser.Token.START_OBJECT) {
+                token = parser.nextToken();
+            }
+            HashMap<ColumnIdent, Object> result = new HashMap<>();
+            for (; token == XContentParser.Token.FIELD_NAME; token = parser.nextToken()) {
+                String fieldName = parser.currentName();
+                parser.nextToken();
+
+                ColumnIdent column = new ColumnIdent(fieldName);
+                if (token == XContentParser.Token.VALUE_NULL) {
+                    result.put(column, null);
+                } else {
+                    var type = typesByColumn.get(column);
+                    if (type == null) {
+                        continue;
+                    }
+                    Object value = parseValue(typesByColumn, parser, type);
+                    result.put(column, value);
+                }
+            }
+            return result;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -24,18 +24,25 @@ package io.crate.expression.reference.doc.lucene;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocSysColumns;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DoubleType;
@@ -48,10 +55,27 @@ import io.crate.types.StringType;
 
 public final class SourceParser {
 
-    static Object parseValue(Map<ColumnIdent, DataType<?>> typesByColumn, XContentParser parser, DataType<?> type) throws IOException {
-        return switch (type.id()) {
-            case ArrayType.ID -> parseArray(parser, type);
-            case ObjectType.ID -> parseObject(parser, type);
+    private final Map<ColumnIdent, ParseInfo> parseInfoByColumn = new HashMap<>();
+    private Object[] result;
+
+    public SourceParser() {
+    }
+
+    static class ParseInfo {
+
+        final DataType<?> type;
+        final int index;
+
+        public ParseInfo(DataType<?> type, int index) {
+            this.type = type;
+            this.index = index;
+        }
+    }
+
+    Object parseValue(XContentParser parser, ParseInfo parseInfo, ColumnIdent column) throws IOException {
+        return switch (parseInfo.type.id()) {
+            case ArrayType.ID -> parseArray(parser, parseInfo, column);
+            case ObjectType.ID -> parseObject(parser, parseInfo, column);
             case ShortType.ID -> parser.shortValue(true);
             case IntegerType.ID -> parser.intValue();
             case LongType.ID -> parser.longValue();
@@ -59,20 +83,95 @@ public final class SourceParser {
             case DoubleType.ID -> parser.doubleValue();
             case StringType.ID -> parser.text();
             default -> {
-                throw new UnsupportedOperationException("parseValue not implemented for " + type);
+                throw new UnsupportedOperationException("parseValue not implemented for " + parseInfo.type);
             }
         };
     }
 
-    static Object parseObject(XContentParser parser, DataType<?> type) {
-        throw new UnsupportedOperationException("parseValue not implemented for object");
+    Object parseObject(XContentParser parser, ParseInfo parseInfo, ColumnIdent column) throws IOException {
+        Token token = parser.currentToken();
+        if (token == XContentParser.Token.START_OBJECT) {
+            token = parser.nextToken();
+        }
+        assert parseInfo.type instanceof ObjectType
+            : "type passed to parseObject must be an ObjectType. Got=" + parseInfo.type;
+        ObjectType objectType = (ObjectType) parseInfo.type;
+        HashMap<String, Object> result = new HashMap<>();
+        for (; token == XContentParser.Token.FIELD_NAME; token = parser.nextToken()) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            var childColumn = column.append(fieldName);
+            if (token == XContentParser.Token.VALUE_NULL) {
+                result.put(fieldName, null);
+            } else {
+                var childType = objectType.innerType(fieldName);
+                // Object value = parseValue(typesByColumn, parser, childType, childColumn);
+                // result.put(fieldName, value);
+            }
+        }
+        return result;
     }
 
-    static Object parseArray(XContentParser parser, DataType<?> type) {
-        throw new UnsupportedOperationException("parseValue not implemented for array");
+    Object parseArray(XContentParser parser, ParseInfo parseInfo, ColumnIdent column) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        if (token == XContentParser.Token.FIELD_NAME) {
+            token = parser.nextToken();
+        }
+        if (token == XContentParser.Token.START_ARRAY) {
+            token = parser.nextToken();
+        } else {
+            throw new XContentParseException(
+                parser.getTokenLocation(),
+                "Failed to parse list:  expecting "
+                + XContentParser.Token.START_ARRAY + " but got " + token);
+        }
+        assert parseInfo.type instanceof ArrayType
+            : "type passed to parseArray must be an ArrayType. Got=" + parseInfo.type;
+        DataType<?> innerType = ((ArrayType<?>) parseInfo.type).innerType();
+        ArrayList<Object> list = new ArrayList<>();
+        for (; token != null && token != XContentParser.Token.END_ARRAY; token = parser.nextToken()) {
+            if (token == XContentParser.Token.VALUE_NULL) {
+                list.add(null);
+            } else {
+                //list.add(parseValue(parser, innerType, column));
+            }
+        }
+        return list;
     }
 
-    public static Map<ColumnIdent, Object> parse(BytesReference bytes, Map<ColumnIdent, DataType<?>> typesByColumn) {
+    public void register(Reference ref) {
+        ColumnIdent docColumn = ref.column();
+        assert docColumn.name().equals(DocSysColumns.DOC.name()) : "All columns registered for sourceParser must start with _doc";
+        ColumnIdent column = docColumn.shiftRight();
+
+        if (column.isTopLevel()) {
+            ParseInfo parseInfo = parseInfoByColumn.get(column);
+            if (parseInfo != null) {
+                return;
+            }
+            parseInfo = new ParseInfo(ref.valueType(), parseInfoByColumn.size());
+            parseInfoByColumn.put(column, parseInfo);
+        } else {
+        }
+    }
+
+    public Object get(ColumnIdent column) {
+        ParseInfo parseInfo = parseInfoByColumn.get(column.shiftRight());
+        return parseInfo == null
+            ? null
+            : result[parseInfo.index];
+    }
+
+    public void reset() {
+        result = null;
+    }
+
+    public boolean parsed() {
+        return result != null;
+    }
+
+    public void parse(BytesReference bytes) {
         try (InputStream inputStream = XContentHelper.getUncompressedInputStream(bytes)) {
             XContentParser parser = XContentType.JSON.xContent().createParser(
                 NamedXContentRegistry.EMPTY,
@@ -86,24 +185,25 @@ public final class SourceParser {
             if (token == XContentParser.Token.START_OBJECT) {
                 token = parser.nextToken();
             }
-            HashMap<ColumnIdent, Object> result = new HashMap<>();
+            result = new Object[parseInfoByColumn.size()];
             for (; token == XContentParser.Token.FIELD_NAME; token = parser.nextToken()) {
                 String fieldName = parser.currentName();
-                parser.nextToken();
-
                 ColumnIdent column = new ColumnIdent(fieldName);
+                parser.nextToken();
                 if (token == XContentParser.Token.VALUE_NULL) {
-                    result.put(column, null);
+                    // result[index] value defaults to null, nothing to do
                 } else {
-                    var type = typesByColumn.get(column);
-                    if (type == null) {
+                    ParseInfo parseInfo = parseInfoByColumn.get(column);
+                    if (parseInfo == null) {
+                        parser.skipChildren();
                         continue;
                     }
-                    Object value = parseValue(typesByColumn, parser, type);
-                    result.put(column, value);
+                    Object value = parseValue(parser, parseInfo, column);
+                    if (parseInfo.index >= 0) {
+                        result[parseInfo.index] = value;
+                    }
                 }
             }
-            return result;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -104,7 +104,7 @@ public class XContentHelper {
         }
     }
 
-    private static InputStream getUncompressedInputStream(BytesReference bytes) throws IOException {
+    public static InputStream getUncompressedInputStream(BytesReference bytes) throws IOException {
         Compressor compressor = CompressorFactory.compressor(bytes);
         if (compressor == null) {
             return bytes.streamInput();

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
@@ -37,27 +37,4 @@ import static org.junit.Assert.assertThat;
 
 public class SourceLookupTest {
 
-    @Test
-    public void testExtractValueFromNestedObject() {
-        Map<String, Map<String, Integer>> map = singletonMap("x", singletonMap("y", 10));
-        Object o = SourceLookup.extractValue(map, Arrays.asList("x", "y"), 0);
-        assertThat(o, is(10));
-    }
-
-    @Test
-    public void testExtractValueFromNestedObjectWithinList() {
-        Map<String, List<Map<String, Map<String, Integer>>>> m = singletonMap("x", Arrays.asList(
-            singletonMap("y", singletonMap("z", 10)),
-            singletonMap("y", singletonMap("z", 20))
-        ));
-        Object o = SourceLookup.extractValue(m, Arrays.asList("x", "y", "z"), 0);
-        assertThat((Collection<Integer>) o, contains(is(10), is(20)));
-    }
-
-    @Test
-    public void testExtractValueFromNestedObjectWithListAsLeaf() {
-        Map<String, List<Integer>> m = singletonMap("x", Arrays.asList(10, 20));
-        Object o = SourceLookup.extractValue(m, singletonList("x"), 0);
-        assertThat((Collection<Integer>) o, contains(is(10), is(20)));
-    }
 }

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.DataTypes;
+
+public class SourceParserTest {
+
+    @Test
+    public void test_extract_single_value_from_json_with_multiple_columns() throws Exception {
+        SourceParser sourceParser = new SourceParser();
+        var ref = TestingHelpers.createReference(
+            new ColumnIdent("_doc", List.of("x")),
+            DataTypes.INTEGER
+        );
+        sourceParser.register(ref);
+        sourceParser.parse(new BytesArray("""
+            {"x": 10, "y": 20}
+        """));
+
+        assertThat(sourceParser.get(ref.column()), is(10));
+        assertThat(sourceParser.get(new ColumnIdent("_doc", List.of("y"))), Matchers.nullValue());
+    }
+}

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -25,6 +25,7 @@ package io.crate.expression.reference.doc.lucene;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.elasticsearch.common.bytes.BytesArray;
@@ -71,9 +72,9 @@ public class SourceParserTest {
         var column = new ColumnIdent("_doc", List.of("x"));
         sourceParser.register(column, DataTypes.INTEGER_ARRAY);
         sourceParser.parse(new BytesArray("""
-            {"x": [10, 11, 12], "y": 20}
+            {"x": [10, null, 11, 12], "y": 20}
         """));
-        assertThat(sourceParser.get(column), is(List.of(10, 11, 12)));
+        assertThat(sourceParser.get(column), is(Arrays.asList(10, null, 11, 12)));
         assertThat(sourceParser.get(new ColumnIdent("_doc", List.of("y"))), Matchers.nullValue());
     }
 
@@ -83,9 +84,9 @@ public class SourceParserTest {
         var column = new ColumnIdent("_doc", List.of("obj_arr", "x"));
         sourceParser.register(column, DataTypes.INTEGER);
         sourceParser.parse(new BytesArray("""
-            {"obj_arr": [{"x": 10}, {"x": 11}, {"x": 12}], "y": 20}
+            {"obj_arr": [{"x": 10}, {"x": 11}, {"x": 12}, {"x": null}], "y": 20}
         """));
-        assertThat(sourceParser.get(column), is(List.of(10, 11, 12)));
+        assertThat(sourceParser.get(column), is(Arrays.asList(10, 11, 12, null)));
         assertThat(sourceParser.get(new ColumnIdent("_doc", List.of("y"))), Matchers.nullValue());
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This removes the `returnType.implicitCast` call from the
ChildDocCollectorExpression which can be expensive for large objects or
arrays because `implicitCast` will copy the whole structure.

It instead integrates a type aware parser, so that we parse the values
with the correct type in the first place and don't need to correct the
values in a second pass.

Additionally it now doesn't create a map for *all* columns, but only for the
requested columns. This should reduce memory consumption if only a subset of
the columns is selected.


## TODO

- [ ] Finish up implementation
- [ ] Run benchmarks


First preliminary benchmark run:

```
# Results (server side duration in ms)
V1: 4.4.0-4fb81d93bacbffc21778276edea3da4b7b4239f9
V2: 4.4.0-e64219069edb83beeb5ab98e9593707321eeca61

Q: select x1788, x1200 from wide limit 100
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       89.488 ±  119.231 |     37.622 |     62.851 |     74.069 |    613.183 |
|   V2    |       63.212 ±   68.912 |     33.244 |     55.737 |     62.840 |    669.379 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  34.42%                           -  12.00%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 34.42%
The test has statistical significance

Q: select x1788, x1200 from wide limit 1500
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      514.525 ±   36.784 |    455.159 |    508.245 |    528.915 |    654.462 |
|   V2    |      468.725 ±   27.986 |    421.204 |    464.198 |    483.735 |    605.532 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   9.32%                           -   9.06%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 9.32%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |   59     5.02     3.06 |    0     0.00     0.00 |     2147      611 |  4816.61      57289
 V2 |  169     3.34     3.02 |    0     0.00     0.00 |     2147      518 |  4266.86     182686

V1 top allocation frames
  HashMap.newNode(...):23209091297
  HashMap.resize():10829875620
  Integer.valueOf(int):8642338199
  ArrayUtil.growExact(...):5468656181
  BufferRecycler.balloc(int):3329073792
V2 top allocation frames
  HashMap.newNode(...):54664007378
  SourceParser.parse(...):45524741036
  HashMap.resize():25451518322
  ArrayUtil.growExact(...):22362736059
  BufferRecycler.balloc(int):13291542200
```

Looks like it's worth to continue with this.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
