### PR TITLE
Add jmx shard relate information to node info

### DIFF
--- a/docs/admin/monitoring.rst
+++ b/docs/admin/monitoring.rst
@@ -165,25 +165,89 @@ NodeStatus can be accessed using the JMX MBean object name
 
    Defines if the node is able to process SQL statements.
 
-NodeInfo MBean
---------------
+.. _node_info_mxbean:
 
-The ``NodeInfo`` JMX MBean exposes information about the current node;
+NodeInfo MXBean
+---------------
 
-NodeInfo can be accessed using the JMX MBean object name
+The ``NodeInfo`` JMX MXBean exposes information about the current node.
+
+NodeInfo can be accessed using the JMX MXBean object name
 ``io.crate.monitoring:type=NodeInfo`` and the following attributes:
 
- - ``ClusterStateVersion``
++-------------------------+---------------------------------------------------+
+| Name                    | Description                                       |
++=========================+===================================================+
+| ``NodeId``              | Provides the unique identifier of the node in the |
+|                         | cluster.                                          |
++-------------------------+---------------------------------------------------+
+| ``NodeName``            | Provides the human friendly name of the node.     |
++-------------------------+---------------------------------------------------+
+| ``ClusterStateVersion`` | Provides the version of the current applied       |
+|                         | cluster state.                                    |
++-------------------------+---------------------------------------------------+
+| ``ShardStats``          | Statistics about the number of shards located on  |
+|                         | the node.                                         |
++-------------------------+---------------------------------------------------+
+| ``ShardInfo``           | Detailed information about the shards located on  |
+|                         | the node.                                         |
++-------------------------+---------------------------------------------------+
 
-   Provides the version of the current applied cluster state
+``ShardStats`` returns a `CompositeData`_ object containing statistics about
+the number of shards located on the node with the following attributes:
 
- - ``NodeId``
++-------------------+---------------------------------------------------------+
+| Name              | Description                                             |
++===================+=========================================================+
+| ``Total``         | The number of shards located on the node.               |
++-------------------+---------------------------------------------------------+
+| ``Primaries``     | The number of primary shards located on the node.       |
++-------------------+---------------------------------------------------------+
+| ``Replicas``      | The number of replica shards located on the node.       |
++-------------------+---------------------------------------------------------+
+| ``Unassigned``    | The number of unassigned shards in the cluster. If the  |
+|                   | node is the elected master node in the cluster, this    |
+|                   | will show the total number of unassigned shards in the  |
+|                   | cluster, otherwise 0.                                   |
++-------------------+---------------------------------------------------------+
 
-   Provides the unique identifier of the node in the cluster
+``ShardInfo`` returns an Array of `CompositeData`_ objects containing detailed
+information about the shards located on the node with the following attributes:
 
- - ``NodeName``
-
-   Provides the human friendly name of the node
++--------------------+--------------------------------------------------------+
+| Name               | Description                                            |
++====================+========================================================+
+| ``Id``             | The shard id. This shard id is managed by the system,  |
+|                    | ranging from 0 up to the number of configured shards   |
+|                    | of the table.                                          |
++--------------------+--------------------------------------------------------+
+| ``Table``          | The name of the table this shard belongs to.           |
++--------------------+--------------------------------------------------------+
+| ``PartitionIdent`` | The partition ident of a partitioned table. Empty for  |
+|                    | non-partitioned tables.                                |
++--------------------+--------------------------------------------------------+
+| ``RoutingState``   | The current state of the shard in the routing table.   |
+|                    | Possible states are:                                   |
+|                    |                                                        |
+|                    | * UNASSIGNED                                           |
+|                    | * INITIALIZING                                         |
+|                    | * STARTED                                              |
+|                    | * RELOCATING                                           |
++--------------------+--------------------------------------------------------+
+| ``State``          | The current state of the shard. Possible states are:   |
+|                    |                                                        |
+|                    | * CREATED                                              |
+|                    | * RECOVERING                                           |
+|                    | * POST_RECOVERY                                        |
+|                    | * STARTED                                              |
+|                    | * RELOCATED                                            |
+|                    | * CLOSED                                               |
+|                    | * INITIALIZING                                         |
+|                    | * UNASSIGNED                                           |
++--------------------+--------------------------------------------------------+
+| ``Size``           | The estimated cumulated size in bytes of all files of  |
+|                    | this shard.                                            |
++--------------------+--------------------------------------------------------+
 
 Connections MBean
 -----------------

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,10 @@ None
 Changes
 =======
 
+- Added information about the shards located on the node to the
+  :ref:`NodeInfo MXBean <node_info_mxbean>` which is available as an
+  enterprise feature.
+
 - Added the ``to_char`` scalar function for timestamp, interval and numeric types.
 
 - Added support for the ``split_part`` scalar function

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeInfoMXBean.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeInfoMXBean.java
@@ -18,20 +18,27 @@
 
 package io.crate.beans;
 
+import java.util.List;
+
 /**
- * The {@link NodeInfoMBean| interface is required to define a standard MBean,
- * such as a standard MBean is composed of an MBean interface and a class.
+ * The {@link NodeInfoMXBean | interface is required to define a standard MXBean,
+ * such as a standard MXBean is composed of an MXBean interface and a class.
  *
  * This interface lists the methods for all exposed attributes.
  *
- * @see <a href="https://docs.oracle.com/javase/tutorial/jmx/mbeans/standard.html">
- *     https://docs.oracle.com/javase/tutorial/jmx/mbeans/standard.html</a>
+ * @see <a href="https://docs.oracle.com/javase/tutorial/jmx/mbeans/mxbeans.html">
+ *     https://docs.oracle.com/javase/tutorial/jmx/mbeans/mxbeans.html</a>
  */
-public interface NodeInfoMBean {
+public interface NodeInfoMXBean {
 
     String getNodeId();
 
     String getNodeName();
 
     long getClusterStateVersion();
+
+    ShardStats getShardStats();
+
+    List<ShardInfo> getShardInfo();
+
 }

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ShardInfo.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ShardInfo.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.beans;
+
+import java.beans.ConstructorProperties;
+
+public class ShardInfo {
+    final int shardId;
+    final String routingState;
+    final String state;
+    final String table;
+    final String partitionIdent;
+    final long size;
+
+    @ConstructorProperties({"shardId", "table", "partitionIdent", "routingState", "state", "size"})
+    public ShardInfo(int shardId, String table, String partitionIdent, String routingState, String state, long size) {
+        this.shardId = shardId;
+        this.routingState = routingState;
+        this.state = state;
+        this.table = table;
+        this.partitionIdent = partitionIdent;
+        this.size = size;
+    }
+
+    public int getShardId() {
+        return shardId;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String getPartitionIdent() {
+        return partitionIdent;
+    }
+
+    public String getRoutingState() {
+        return routingState;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public long getSize() {
+        return size;
+    }
+}

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ShardStats.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ShardStats.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.beans;
+
+import java.beans.ConstructorProperties;
+
+public class ShardStats {
+
+    private final int total;
+
+    private final int primaries;
+
+    private final int replicas;
+
+    private final int unassigned;
+
+    @ConstructorProperties({"name", "total", "primaries", "replicas", "unassigned"})
+    public ShardStats(int total, int primaries, int replicas, int unassigned) {
+        this.total = total;
+        this.primaries = primaries;
+        this.replicas = replicas;
+        this.unassigned = unassigned;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public int getPrimaries() {
+        return primaries;
+    }
+
+    public int getReplicas() {
+        return replicas;
+    }
+
+    public int getUnassigned() {
+        return unassigned;
+    }
+
+}

--- a/enterprise/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
+++ b/enterprise/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
@@ -18,19 +18,255 @@
 
 package io.crate.beans;
 
-import io.crate.testing.DiscoveryNodes;
-import org.junit.Test;
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.crate.common.collections.Tuple;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.index.shard.ShardId;
 
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static io.crate.testing.MoreMatchers.withFeature;
+import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class NodeInfoTest {
 
+    ClusterState.Builder clusterState;
+
+    @Before
+    public void setup() {
+        var tableName = "test";
+        var indexRoutingTableBuilder = IndexRoutingTable
+            .builder(new Index(tableName, UUID.randomUUID().toString()))
+            .addShard(TestShardRouting.newShardRouting(tableName,
+                                                       1,
+                                                       "node_1",
+                                                       true,
+                                                       ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(tableName,
+                                                       2,
+                                                       "node_1",
+                                                       false,
+                                                       ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(tableName,
+                                                       3,
+                                                       "node_1",
+                                                       false,
+                                                       ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(tableName,
+                                                       4,
+                                                       null,
+                                                       false,
+                                                       ShardRoutingState.UNASSIGNED));
+
+        var routingTable = RoutingTable.builder().add(indexRoutingTableBuilder).build();
+        var meta = IndexMetadata.builder(tableName).numberOfShards(1).numberOfReplicas(2);
+        this.clusterState = ClusterState.builder(new ClusterName("crate")).version(1L).routingTable(routingTable)
+            .metadata(Metadata.builder().put(meta));
+    }
+
     @Test
-    public void testNodeInfo() {
-        NodeInfo nodeInfo = new NodeInfo(() -> DiscoveryNodes.newNode("testNode", "testNodeId"), () -> 1L);
-        assertThat(nodeInfo.getNodeId(), is("testNodeId"));
-        assertThat(nodeInfo.getNodeName(), is("testNode"));
+    public void test_local_node_is_master_all_shards_locally() {
+        var nodes = DiscoveryNodes
+            .builder()
+            .add(discoveryNode("node_1"))
+            .masterNodeId("node_1")
+            .localNodeId("node_1")
+            .build();
+
+        var nodeInfo = new NodeInfo(() -> clusterState.nodes(nodes).build(), this::shardStateAndSizeProvider);
+
+        assertThat(nodeInfo.getNodeId(), is("node_1"));
+        assertThat(nodeInfo.getNodeName(), is("node_1"));
+
         assertThat(nodeInfo.getClusterStateVersion(), is(1L));
+        ShardStats shardStats = nodeInfo.getShardStats();
+        assertThat(shardStats.getPrimaries(), is(1));
+        assertThat(shardStats.getTotal(), is(3));
+        assertThat(shardStats.getReplicas(), is(2));
+        // Unassigned shards are counted on the master node
+        assertThat(shardStats.getUnassigned(), is(1));
+
+        assertThat(nodeInfo.getShardInfo(),
+                   containsInAnyOrder(
+                       isShardInfo(1, "test", "", "STARTED", "STARTED", 100),
+                       isShardInfo(2, "test", "", "STARTED", "STARTED", 100),
+                       isShardInfo(3, "test", "", "STARTED", "STARTED", 100)
+                   )
+        );
+    }
+
+    @Test
+    public void test_local_node_is_data_node_no_shards_locally() {
+        var nodes = DiscoveryNodes
+            .builder()
+            .add(discoveryNode("node_1"))
+            .add(discoveryNode("node_2"))
+            .masterNodeId("node_1")
+            .localNodeId("node_2")
+            .build();
+
+        var nodeInfo = new NodeInfo(() -> clusterState.nodes(nodes).build(), this::shardStateAndSizeProvider);
+
+        assertThat(nodeInfo.getNodeId(), is("node_2"));
+        assertThat(nodeInfo.getNodeName(), is("node_2"));
+        var shardStats = nodeInfo.getShardStats();
+        assertThat(shardStats.getPrimaries(), is(0));
+        assertThat(shardStats.getTotal(), is(0));
+        assertThat(shardStats.getReplicas(), is(0));
+        assertThat(shardStats.getUnassigned(), is(0));
+    }
+
+    @Test
+    public void test_local_node_is_master_node_no_shards_locally() {
+        var nodes = DiscoveryNodes
+            .builder()
+            .add(discoveryNode("node_1"))
+            .add(discoveryNode("node_2"))
+            .masterNodeId("node_2")
+            .localNodeId("node_2")
+            .build();
+
+        var nodeInfo = new NodeInfo(() -> clusterState.nodes(nodes).build(), this::shardStateAndSizeProvider);
+
+        assertThat(nodeInfo.getNodeId(), is("node_2"));
+        assertThat(nodeInfo.getNodeName(), is("node_2"));
+        var shardStats = nodeInfo.getShardStats();
+        assertThat(shardStats.getPrimaries(), is(0));
+        assertThat(shardStats.getTotal(), is(0));
+        assertThat(shardStats.getReplicas(), is(0));
+        // Unassigned shards are only counted on the master node
+        assertThat(shardStats.getUnassigned(), is(1));
+
+        assertThat(nodeInfo.getShardInfo().isEmpty(), is(true));
+    }
+
+    @Test
+    public void test_local_node_is_data_node_all_shards_locally() {
+        var nodes = DiscoveryNodes
+            .builder()
+            .add(discoveryNode("node_1"))
+            .add(discoveryNode("node_2"))
+            .masterNodeId("node_2")
+            .localNodeId("node_1")
+            .build();
+
+        var nodeInfo = new NodeInfo(() -> clusterState.nodes(nodes).build(), this::shardStateAndSizeProvider);
+        var shardStats = nodeInfo.getShardStats();
+        assertThat(shardStats.getPrimaries(), is(1));
+        assertThat(shardStats.getTotal(), is(3));
+        assertThat(shardStats.getReplicas(), is(2));
+        // Unassigned shards are not counted on a data node
+        assertThat(shardStats.getUnassigned(), is(0));
+
+        assertThat(nodeInfo.getShardInfo(),
+                   containsInAnyOrder(
+                       isShardInfo(1, "test", "", "STARTED", "STARTED", 100),
+                       isShardInfo(2, "test", "", "STARTED", "STARTED", 100),
+                       isShardInfo(3, "test", "", "STARTED", "STARTED", 100)
+                   )
+        );
+    }
+
+    @Test
+    public void test_partitioned_tables() {
+        var tableName = ".partitioned.test.p1";
+        var indexRoutingTableBuilder = IndexRoutingTable
+            .builder(new Index(tableName, UUID.randomUUID().toString()))
+            .addShard(TestShardRouting.newShardRouting(tableName,
+                                                       1,
+                                                       "node_1",
+                                                       true,
+                                                       ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(tableName,
+                                                       2,
+                                                       "node_1",
+                                                       false,
+                                                       ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(tableName,
+                                                       3,
+                                                       "node_1",
+                                                       false,
+                                                       ShardRoutingState.STARTED));
+
+
+        var routingTable = RoutingTable.builder().add(indexRoutingTableBuilder).build();
+        var meta = IndexMetadata.builder(tableName).numberOfShards(1).numberOfReplicas(2);
+        var cs = ClusterState.builder(new ClusterName("crate")).version(1L).routingTable(routingTable)
+            .metadata(Metadata.builder().put(meta));
+
+        var nodes = DiscoveryNodes
+            .builder()
+            .add(discoveryNode("node_1"))
+            .localNodeId("node_1")
+            .masterNodeId("node_1")
+            .build();
+
+        var nodeInfo = new NodeInfo(() -> cs.nodes(nodes).build(), this::shardStateAndSizeProvider);
+        var shardStats = nodeInfo.getShardStats();
+        assertThat(shardStats.getPrimaries(), is(1));
+        assertThat(shardStats.getTotal(), is(3));
+        assertThat(shardStats.getReplicas(), is(2));
+
+        assertThat(nodeInfo.getShardInfo(),
+                   containsInAnyOrder(
+                       isShardInfo(1, "test", "p1", "STARTED", "STARTED", 100),
+                       isShardInfo(2, "test", "p1", "STARTED", "STARTED", 100),
+                       isShardInfo(3, "test", "p1", "STARTED", "STARTED", 100)
+                   )
+        );
+
+    }
+
+    Tuple<IndexShardState, Long> shardStateAndSizeProvider(ShardId shardId) {
+        return new Tuple<>(IndexShardState.STARTED, 100L);
+    }
+
+    DiscoveryNode discoveryNode(String id) {
+        return new DiscoveryNode(id,
+                                 id,
+                                 buildNewFakeTransportAddress(),
+                                 Map.of(),
+                                 Set.of(DiscoveryNode.Role.MASTER, DiscoveryNode.Role.DATA),
+                                 Version.CURRENT);
+    }
+
+    Matcher<ShardInfo> isShardInfo(int shardId, String table, String partitionIdent, String routingState, String state, long size) {
+        return allOf(
+            instanceOf(ShardInfo.class),
+            withFeature(x -> x.shardId, "", is(shardId)),
+            withFeature(x -> x.table, "", is(table)),
+            withFeature(x -> x.routingState, "", is(routingState)),
+            withFeature(x -> x.state, "", is(state)),
+            withFeature(x -> x.partitionIdent, "", is(partitionIdent)),
+            withFeature(x -> x.size, "", is(size))
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds shards specific information to the jmx node info. 


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
