### PR TITLE
Documentation: Upgrade to Sphinx 3.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,6 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -m pip install -r blackbox/requirements.txt
 
-          # We default to Sphinx 1.8 in blackbox/requirements.txt because that's what the crate-docs-theme needs. 
-          # However, we want Sphinx 3.x here because its link checker is much more capable.
-          python -m pip install sphinx==3.3.1
-
       - name: Run linkcheck
         run: |
           sphinx-build -n -W --keep-going -q -c docs/ -b linkcheck -E docs/ docs/out/html

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -3,24 +3,20 @@
 
 crash>=0.25.0
 crate
-crate-docs-theme
 asyncpg>=0.20.1
 cr8>=0.19.1
 tqdm==4.24.0
-sphinx-csv-filter>=0.2.0
 pycodestyle==2.4.0
 zc.customdoctests==1.0.1
 minio>=5.0.0
 
-# packages for local dev
-
-sphinx-autobuild==0.7.1
-
-# the next section should mirror the RTD environment
-
-alabaster>=0.7,<0.8,!=0.7.5
-setuptools<41
-sphinx==1.8.5
-
 # used for dns-discovery tests
 dnslib
+
+# Documentation
+sphinx==3.3.1
+sphinx-csv-filter>=0.2.0
+crate-docs-theme>=0.12.0
+
+# Documentation: local development
+sphinx-autobuild==0.7.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme>=0.7
+crate-docs-theme>=0.12.0
 sphinx-csv-filter
 Pygments==2.3.1


### PR DESCRIPTION
Hi there,

following up on https://github.com/crate/crate-docs-theme/issues/232, I verified that building the documentation works on `sphinx==3.3.1`, when explicitly pulling in `crate-docs-theme==0.11.0`.

This PR still needs https://github.com/crate/crate-docs-theme/pull/233, which relaxes the constraint of `crate-docs-theme` to be installable with Sphinx 3.x.

With kind regards,
Andreas.
