### PR TITLE
Set netty leak detection to paranoid in blackbox tests

### DIFF
--- a/blackbox/test_dns_discovery.py
+++ b/blackbox/test_dns_discovery.py
@@ -53,22 +53,23 @@ _test._srv.crate.internal.    600   IN   SRV   1 10 {port} 127.0.0.1.'''.format(
         self.nodes = nodes = []
         for i in range(self.num_nodes):
             settings = {
-                         'node.name': f'node-{i}',
-                         'cluster.name': 'crate-dns-discovery',
-                         'psql.port': 0,
-                         'transport.tcp.port': transport_ports[i],
-                         "discovery.seed_providers": "srv",
-                         "discovery.srv.query": "_test._srv.crate.internal.",
-                         "discovery.srv.resolver": "127.0.0.1:" + str(dns_port)
-                     }
-            if i is 0:
+                'node.name': f'node-{i}',
+                'cluster.name': 'crate-dns-discovery',
+                'psql.port': 0,
+                'transport.tcp.port': transport_ports[i],
+                "discovery.seed_providers": "srv",
+                "discovery.srv.query": "_test._srv.crate.internal.",
+                "discovery.srv.resolver": "127.0.0.1:" + str(dns_port)
+            }
+            if i == 0:
                 settings['cluster.initial_master_nodes'] = f'node-{i}'
             node = CrateNode(
                 crate_dir=crate_path(),
                 version=(4, 0, 0),
                 settings=settings,
                 env={
-                    'CRATE_HEAP_SIZE': '256M'
+                    'CRATE_HEAP_SIZE': '256M',
+                    'CRATE_JAVA_OPTS': '-Dio.netty.leakDetection.level=paranoid',
                 }
             )
             node.start()

--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -95,7 +95,10 @@ class ConnectingCrateLayer(CrateNode):
 
 crate = ConnectingCrateLayer(
     crate_dir=crate_path(),
-    env={'JAVA_HOME': os.environ.get('JAVA_HOME', '')},
+    env={
+        'JAVA_HOME': os.environ.get('JAVA_HOME', ''),
+        'CRATE_JAVA_OPTS': '-Dio.netty.leakDetection.level=paranoid',
+    },
     settings=CRATE_SETTINGS,
     version=(4, 0, 0)
 )

--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -39,6 +39,7 @@ JMX_OPTS = '''
      -Dcom.sun.management.jmxremote.port={}
      -Dcom.sun.management.jmxremote.ssl=false
      -Dcom.sun.management.jmxremote.authenticate=false
+     -Dio.netty.leakDetection.level=paranoid
 '''
 
 

--- a/blackbox/test_ssl.py
+++ b/blackbox/test_ssl.py
@@ -10,6 +10,7 @@ from cr8.run_crate import CrateNode
 
 env = os.environ.copy()
 env['CRATE_HEAP_SIZE'] = '256M'
+env['CRATE_JAVA_OPTS'] = '-Dio.netty.leakDetection.level=paranoid'
 crate = CrateNode(
     crate_dir=crate_path(),
     settings={


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Might help detect leaks

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)