### PR TITLE
Set shardId on blob requests

### DIFF
--- a/server/src/main/java/io/crate/blob/BlobService.java
+++ b/server/src/main/java/io/crate/blob/BlobService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.transport.TransportService;
 
@@ -78,7 +79,10 @@ public class BlobService extends AbstractLifecycleComponent {
 
     public RemoteDigestBlob newBlob(String index, String digest) {
         assert client != null : "client for remote digest blob must not be null";
-        return new RemoteDigestBlob(client, index, digest);
+        ShardId shardId = clusterService.operationRouting()
+            .indexShards(clusterService.state(), index, digest, null)
+            .shardId();
+        return new RemoteDigestBlob(client, shardId, digest);
     }
 
     @Override

--- a/server/src/main/java/io/crate/blob/BlobTransferRequest.java
+++ b/server/src/main/java/io/crate/blob/BlobTransferRequest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -48,8 +49,8 @@ public abstract class BlobTransferRequest<T extends ReplicationRequest<T>>
         return last;
     }
 
-    public BlobTransferRequest(String index, UUID transferId, BytesReference content, boolean last) {
-        this.index = index;
+    public BlobTransferRequest(ShardId shardId, UUID transferId, BytesReference content, boolean last) {
+        super(shardId);
         this.transferId = transferId;
         this.content = content;
         this.last = last;

--- a/server/src/main/java/io/crate/blob/DeleteBlobRequest.java
+++ b/server/src/main/java/io/crate/blob/DeleteBlobRequest.java
@@ -25,6 +25,7 @@ import io.crate.common.Hex;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -32,9 +33,9 @@ public class DeleteBlobRequest extends ReplicationRequest<DeleteBlobRequest> {
 
     private byte[] digest;
 
-    public DeleteBlobRequest(String index, byte[] digest) {
+    public DeleteBlobRequest(ShardId shardId, byte[] digest) {
+        super(shardId);
         this.digest = digest;
-        this.index = index;
     }
 
     public DeleteBlobRequest() {

--- a/server/src/main/java/io/crate/blob/PutChunkRequest.java
+++ b/server/src/main/java/io/crate/blob/PutChunkRequest.java
@@ -25,6 +25,7 @@ import io.crate.common.Hex;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -34,9 +35,9 @@ public class PutChunkRequest extends BlobTransferRequest<PutChunkRequest> implem
     private byte[] digest;
     private long currentPos;
 
-    public PutChunkRequest(String index, byte[] digest, UUID transferId,
+    public PutChunkRequest(ShardId shardId, byte[] digest, UUID transferId,
                            BytesReference content, long currentPos, boolean last) {
-        super(index, transferId, content, last);
+        super(shardId, transferId, content, last);
         this.digest = digest;
         this.currentPos = currentPos;
     }

--- a/server/src/main/java/io/crate/blob/StartBlobRequest.java
+++ b/server/src/main/java/io/crate/blob/StartBlobRequest.java
@@ -25,6 +25,7 @@ import io.crate.common.Hex;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -33,8 +34,8 @@ public class StartBlobRequest extends BlobTransferRequest<StartBlobRequest> {
 
     private byte[] digest;
 
-    public StartBlobRequest(String index, byte[] digest, BytesReference content, boolean last) {
-        super(index, UUID.randomUUID(), content, last);
+    public StartBlobRequest(ShardId shardId, byte[] digest, BytesReference content, boolean last) {
+        super(shardId, UUID.randomUUID(), content, last);
         this.digest = digest;
     }
 

--- a/server/src/main/java/io/crate/blob/TransportDeleteBlobAction.java
+++ b/server/src/main/java/io/crate/blob/TransportDeleteBlobAction.java
@@ -27,9 +27,7 @@ import io.crate.blob.v2.BlobShard;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -92,14 +90,6 @@ public class TransportDeleteBlobAction extends TransportReplicationAction<Delete
         BlobShard blobShard = blobIndicesService.blobShardSafe(request.shardId());
         blobShard.delete(request.id());
         return new ReplicaResult();
-    }
-
-    @Override
-    protected void resolveRequest(IndexMetadata indexMetadata, DeleteBlobRequest request) {
-        ShardIterator shardIterator = clusterService.operationRouting()
-            .indexShards(clusterService.state(), request.index(), request.id(), null);
-        request.setShardId(shardIterator.shardId());
-        super.resolveRequest(indexMetadata, request);
     }
 
     @Override

--- a/server/src/main/java/io/crate/blob/TransportPutChunkAction.java
+++ b/server/src/main/java/io/crate/blob/TransportPutChunkAction.java
@@ -24,9 +24,7 @@ package io.crate.blob;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -67,14 +65,6 @@ public class TransportPutChunkAction extends TransportReplicationAction<PutChunk
     @Override
     protected PutChunkResponse newResponseInstance(StreamInput in) throws IOException {
         return new PutChunkResponse(in);
-    }
-
-    @Override
-    protected void resolveRequest(IndexMetadata indexMetadata, PutChunkRequest request) {
-        ShardIterator shardIterator = clusterService.operationRouting().indexShards(
-            clusterService.state(), request.index(), null, request.digest());
-        request.setShardId(shardIterator.shardId());
-        super.resolveRequest(indexMetadata, request);
     }
 
     @Override

--- a/server/src/main/java/io/crate/blob/TransportStartBlobAction.java
+++ b/server/src/main/java/io/crate/blob/TransportStartBlobAction.java
@@ -24,13 +24,10 @@ package io.crate.blob;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -43,8 +40,7 @@ public class TransportStartBlobAction extends TransportReplicationAction<StartBl
     private final BlobTransferTarget transferTarget;
 
     @Inject
-    public TransportStartBlobAction(Settings settings,
-                                    TransportService transportService,
+    public TransportStartBlobAction(TransportService transportService,
                                     ClusterService clusterService,
                                     IndicesService indicesService,
                                     ThreadPool threadPool,
@@ -94,16 +90,8 @@ public class TransportStartBlobAction extends TransportReplicationAction<StartBl
     }
 
     @Override
-    protected void resolveRequest(IndexMetadata indexMetadata, StartBlobRequest request) {
-        ShardIterator shardIterator = clusterService.operationRouting().indexShards(
-            clusterService.state(), request.index(), request.id(), null);
-        request.setShardId(shardIterator.shardId());
-        super.resolveRequest(indexMetadata, request);
-    }
-
-    @Override
     protected boolean resolveIndex() {
-        return true;
+        return false;
     }
 }
 

--- a/server/src/test/java/io/crate/blob/DeleteBlobRequestTest.java
+++ b/server/src/test/java/io/crate/blob/DeleteBlobRequestTest.java
@@ -22,9 +22,12 @@
 package io.crate.blob;
 
 import io.crate.common.Hex;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
+
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.is;
 
@@ -33,7 +36,10 @@ public class DeleteBlobRequestTest extends ESTestCase {
     @Test
     public void testDeleteBlobRequestStreaming() throws Exception {
         byte[] digest = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
-        DeleteBlobRequest request = new DeleteBlobRequest("foo", digest);
+        DeleteBlobRequest request = new DeleteBlobRequest(
+            new ShardId("foo", UUID.randomUUID().toString(), 1),
+            digest
+        );
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
 


### PR DESCRIPTION
Resolve the shardId upfront of creating any blob request instead
of using the deprecated `resolveRequest()` method which resolves
the shardId during transport execution.

This is needed as recent ES changes removes usages of
`resolveRequest()` inside the replication logic.
See https://github.com/elastic/elasticsearch/commit/3ad8aa6d465.