### PR TITLE
bp: Check again on-going snapshots/restores of indices before closing

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
@@ -100,7 +100,7 @@ public class MetadataDeleteIndexService {
         Set<Index> snapshottingIndices = SnapshotsService.snapshottingIndices(currentState, indicesToDelete);
         if (snapshottingIndices.isEmpty() == false) {
             throw new SnapshotInProgressException("Cannot delete indices that are being snapshotted: " + snapshottingIndices +
-                                                  ". Try again after snapshot finishes or cancel the currently running snapshot.");
+                ". Try again after snapshot finishes or cancel the currently running snapshot.");
         }
 
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -88,6 +88,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
@@ -864,30 +865,26 @@ public class RestoreService implements ClusterStateApplier {
     }
 
     /**
-     * Check if any of the indices to be closed are currently being restored from a snapshot and fail closing if such an index
-     * is found as closing an index that is being restored makes the index unusable (it cannot be recovered).
+     * Returns the indices that are currently being restored and that are contained in the indices-to-check set.
      */
-    public static void checkIndexClosing(ClusterState currentState, Set<IndexMetadata> indices) {
-        RestoreInProgress restore = currentState.custom(RestoreInProgress.TYPE);
-        if (restore != null) {
-            Set<Index> indicesToFail = null;
-            for (RestoreInProgress.Entry entry : restore) {
-                for (ObjectObjectCursor<ShardId, RestoreInProgress.ShardRestoreStatus> shard : entry.shards()) {
-                    if (!shard.value.state().completed()) {
-                        IndexMetadata indexMetadata = currentState.metadata().index(shard.key.getIndex());
-                        if (indexMetadata != null && indices.contains(indexMetadata)) {
-                            if (indicesToFail == null) {
-                                indicesToFail = new HashSet<>();
-                            }
-                            indicesToFail.add(shard.key.getIndex());
-                        }
-                    }
+    public static Set<Index> restoringIndices(final ClusterState currentState, final Set<Index> indicesToCheck) {
+        final RestoreInProgress restore = currentState.custom(RestoreInProgress.TYPE);
+        if (restore == null) {
+            return emptySet();
+        }
+
+        final Set<Index> indices = new HashSet<>();
+        for (RestoreInProgress.Entry entry : restore) {
+            for (ObjectObjectCursor<ShardId, RestoreInProgress.ShardRestoreStatus> shard : entry.shards()) {
+                Index index = shard.key.getIndex();
+                if (indicesToCheck.contains(index)
+                    && shard.value.state().completed() == false
+                    && currentState.getMetadata().index(index) != null) {
+                    indices.add(index);
                 }
             }
-            if (indicesToFail != null) {
-                throw new IllegalArgumentException("Cannot close indices that are being restored: " + indicesToFail);
-            }
         }
+        return indices;
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/elastic/elasticsearch/commit/a5d9939ac119d7f836408341a562e7bbeeac1e98

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)