### PR TITLE
ES backports of transport action commits

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -41,7 +41,8 @@ repository. For example::
       server/src/main/java/org/elasticsearch/cluster/routing \
       server/src/main/java/org/elasticsearch/transport \
       server/src/main/java/org/elasticsearch/gateway \
-      server/src/main/java/org/elasticsearch/action/admin/cluster/health
+      server/src/main/java/org/elasticsearch/action/admin/cluster/health \
+      server/src/main/java/org/elasticsearch/action/support/replication
 
 
 Here ``4b16d50cd4b`` is the starting point, it shows any changes since then
@@ -137,6 +138,7 @@ should be crossed out as well.
 - [ ] 39a6deccea9 Prioritise recovery of system index shards (#62640)
 - [ ] 3a9b65733c5 Move stored flag from TextSearchInfo to MappedFieldType (#62717)
 - [ ] e02555ce822 Cleanup Blobstore Repository Metadata Serialization (#62727)
+- [ ] f34246b90b5 Optimize XContentParserUtils.ensureExpectedToken (#62691)
 - [ ] 27ca0a8979d Convert ConstantKeywordFieldMapper to parametrized form (#62688)
 - [ ] ea2dbd93b49 Add field type for version strings (#59773)
 - [ ] db1a137927a Fix cluster health when closing (#61709)
@@ -256,6 +258,7 @@ should be crossed out as well.
 - [ ] 8bcca0c7a1d Preserve old serialization for CompletionFieldMapper (#59550)
 - [ ] 678ae31d1d6 Fix compilation in Eclipse (#59675)
 - [ ] fd88ab13419 Correct type parametrization in geo mappers. (#59583)
+- [ ] aa14860597e Separate coordinating and primary bytes in stats (#59487)
 - [ ] b083bafa786 Make MappedFieldType#meta final (#59383)
 - [ ] dc91a300700 Move getPointReaderOrNull into AggregatorBase (#58769)
 - [ ] b87bb86d88d Adding indexing pressure stats to node stats API (#59247)
@@ -268,6 +271,7 @@ should be crossed out as well.
 - [ ] 5e73d7133c9 Fix node health-check-related test failures (#59277)
 - [ ] 219b7dbd12f Add declarative parameters to FieldMappers (#58663)
 - [ ] 5688e0e4900 Do not release safe commit with CancellableThreads (#59182)
+- [ ] 611fb03f628 Implement rejections in `WriteMemoryLimits` (#58885)
 - [ ] cb6b05d12b9 Fix the timestamp field of a data stream to @timestamp (#59076)
 - [ ] 961db311f0e Sending operations concurrently in peer recovery (#58018)
 - [ ] 31a569a60a2 Remove uid from translog delete operation (#59101)
@@ -275,11 +279,13 @@ should be crossed out as well.
 - [ ] 2e3f3c0fce8 Extract recovery files details to its own class (#59039)
 - [ ] f6cc374e132 Remove IndexShardRoutingTable#primaryAsList (#59044)
 - [ ] 90e72a4194e Avoid flipping translog header version (#58866)
+- [ ] 922c8672cc7 Fix Two Common Zero Len Array Instantiations (#58944)
 - [ ] e592a9a5e72 Add include_data_streams flag for authorization (#58154)
 - [ ] 52ff121fcfc Re-enable support for array-valued geo_shape fields. (#58786)
 - [ ] 673444000e3 Percolator keyword fields should not store norms (#58899)
 - [ ] 001b3fb4406 Add data stream timestamp validation via metadata field mapper (#58582)
 - [ ] 69c7e73b665 Drop rewriting in date_histogram (#57836)
+- [ ] 9a36d6e5bde Count coordinating and primary bytes as write bytes (#58575)
 - [ ] 3944066e992 Move MappedFieldType#getSearchAnalyzer and #getSearchQuoteAnalyzer to TextSearchInfo (#58639)
 - [ ] dcd723a6b19 Enable BWC tests after backport of #58029 (#58815)
 - [ ] ee79ae072ba Week based parsing for ingest date processor (#58597)
@@ -295,6 +301,7 @@ should be crossed out as well.
 - [ ] 83ce7a96915 Move MappedFieldType.similarity() to TextSearchInfo (#58439)
 - [ ] d747c1bf7a8 [DOCS] Fix typo in RoutingNode comment (#58079)
 - [ ] 57316e26af6 Add text search information to MappedFieldType (#58230)
+- [ ] 63922dfcbdb Save Shard ID Serializations in Bulk Requests (#56209)
 - [ ] b8db2da0963 Remove anonymous PublicationContext implementation (#58405)
 - [ ] 3cbe56463ed Make FieldTypeLookup immutable (#58162)
 - [ ] 409306e01db Correct default formatting of binary fields (#58338)
@@ -344,11 +351,13 @@ should be crossed out as well.
 - [ ] 4de4c14b5b9 Save Bounds Checks in BytesReference (#56577)
 - [ ] a01d2bd24b0 [Geo] Refactor Point Field Mappers (#56060)
 - [ ] fa535d08b50 Use CollectionUtils.isEmpty where appropriate (#55910)
+- [ ] 77aa2362bbb Allow a number of broadcast transport actions to resolve data streams (#55726)
 - [ ] 0ae0e700397 Allow cluster health api to resolve data streams (#56413)
 - [ ] e1dbe2606ce Use snapshot information to build searchable snapshot store MetadataSnapshot (#56289)
 - [ ] a95586773fd Improve logging around SniffConnectionStrategy (#56292)
 - [ ] 601617a3fc0 Avoid copying file chunks in peer covery (#56072)
 - [ ] 77ac5d805bb Make sure to use ParseContext.Document#addAll when possible.
+- [ ] 378e36c26d1 Move includeDataStream flag from IndicesOptions to IndexNameExpressionResolver.Context (#56034)
 - [ ] 7a5d18ddc37 Simplify signature of FieldMapper#parseCreateField. (#56066)
 - [ ] bb04fbcd969 For constant_keyword, make sure exists query handles missing values. (#55757)
 - [ ] b2b32d7cf85 Retry failed replication due to transient errors (#55633)
@@ -511,6 +520,7 @@ should be crossed out as well.
 - [ ] fdd413370ef Deleted docs disregarded for if_seq_no check (#50526)
 - [ ] 4c1f1b2acab Declare remaining parsers `final` (#50571)
 - [ ] 77fd51f30ba Remove some Dead Code from Discovery Plugins (#50592)
+- [ ] 671fefaf59e Enhance TransportReplicationAction assertions (#49081)
 - [ ] 424ed93e38b Always use soft-deletes in InternalEngine (#50415)
 - [ ] d02afccd983 Ensure relocating shards establish peer recovery retention leases (#50486)
 - [ ] 50bd5842c3c Fix testCancelRecoveryDuringPhase1 (#50449)
@@ -544,6 +554,7 @@ should be crossed out as well.
 - [ ] 8c2dda90c0f Add int indicating size of transport header (#48884)
 - [ ] fb293adb0f5 Ensure remote strategy settings can be updated (#49772)
 - [ ] de5eb04f050 Silence lint warnings in server project - part 2 (#49728)
+- [ ] 8c165e04a1c Replicate write actions before fsyncing them (#49746)
 - [ ] 944c681680d Make Snapshot Metadata Javadocs Clearer (#49697)
 - [ ] f8e39d2ff18 New setting to prevent automatically importing dangling indices (#49174)
 - [x] 3ad8aa6d465 Remove obsolete resolving logic from TRA (#49685)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -546,7 +546,7 @@ should be crossed out as well.
 - [ ] de5eb04f050 Silence lint warnings in server project - part 2 (#49728)
 - [ ] 944c681680d Make Snapshot Metadata Javadocs Clearer (#49697)
 - [ ] f8e39d2ff18 New setting to prevent automatically importing dangling indices (#49174)
-- [ ] 3ad8aa6d465 Remove obsolete resolving logic from TRA (#49685)
+- [x] 3ad8aa6d465 Remove obsolete resolving logic from TRA (#49685)
 - [x] 602e589235d fix mis typo (#49689)
 - [s] a354c607228 Revert "Remove obsolete resolving logic from TRA (#49647)"
 - [s] 6cca2b04fa0 Remove obsolete resolving logic from TRA (#49647)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -42,7 +42,8 @@ repository. For example::
       server/src/main/java/org/elasticsearch/transport \
       server/src/main/java/org/elasticsearch/gateway \
       server/src/main/java/org/elasticsearch/action/admin/cluster/health \
-      server/src/main/java/org/elasticsearch/action/support/replication
+      server/src/main/java/org/elasticsearch/action/support/replication \
+      server/src/main/java/org/elasticsearch/action/support/master
 
 
 Here ``4b16d50cd4b`` is the starting point, it shows any changes since then
@@ -102,6 +103,7 @@ should be crossed out as well.
 - [ ] 8f8d2d1b4ba [DOCS] Fix dup word in ShardRouting hashcode method. (#63452)
 - [ ] 62857b49d1d Add support for missing value fetchers. (#63515)
 - [ ] 2d1bf0c79ef Dry up TransportMasterNodeAction Usage (#63524)
+- [ ] 4e740c2e4a5 Dry up AcknowledgedResponse Handling (#63335)
 - [ ] dc5dbbbfe29 Flush translog writer before adding new operation (#63505)
 - [ ] 8c56bbc3e6e Add factory methods for common value fetchers. (#63438)
 - [ ] 80268f9bff6 TextSearchInfo should never get null analyzers (#63472)
@@ -331,6 +333,7 @@ should be crossed out as well.
 - [ ] 6477924c262 Store parsed mapping settings in IndexSettings (#57492)
 - [ ] 4d6dc51c729 Header warning logging refactoring (#55941)
 - [ ] 2ef82cd7f95 Fix Local Translog Recovery not Updating Safe Commit in Edge Case (#57350)
+- [ ] 9d07229879d Change cluster info actions to be able to resolve data streams. (#56878)
 - [ ] 99871b18d64 Catch InputCoercionException thrown by Jackson parser (#57287)
 - [ ] 86b64e4c39e Remove unused logic from FieldNamesFieldMapper. (#56834)
 - [ ] 579ce2f99cb Reestablish peer recovery after network errors (#55274)
@@ -493,6 +496,7 @@ should be crossed out as well.
 - [ ] c117c0cf0a2 Password-protected Keystore Feature Branch PR (#51123)
 - [ ] 0c87892b3db Remove sync flush logic in Engine (#51450)
 - [ ] b034d1e2ef8 Remove translog retention policy (#51417)
+- [ ] db480292eeb Fix TransportMasterNodeAction not Retrying NodeClosedException (#51325)
 - [ ] 80cacc617f2 Enable operation-based recoveries for old copies (#51380)
 - [ ] 5132715bc10 Do not wrap soft-deletes reader for segment stats (#51331)
 - [ ] 151148622cb Exclude nested documents in LuceneChangesSnapshot (#51279)
@@ -505,6 +509,7 @@ should be crossed out as well.
 - [ ] 173c3bdac41 Introduce hidden indices (#50452)
 - [ ] 9bb7d21c0b0 Remove the AllFieldMapper from master (#51106)
 - [ ] 09b46c86463 Goodbye and thank you synced flush! (#50882)
+- [ ] 0e0f900d181 Tweak formatter config for long generic lines (#50909)
 - [ ] 7cd4b73b098 Fix compilation for #50813
 - [ ] d94b81e8b0e Remove custom metadata tool (#50813)
 - [ ] e349c5eec09 Track Snapshot Version in RepositoryData (#50930)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -547,9 +547,9 @@ should be crossed out as well.
 - [ ] 944c681680d Make Snapshot Metadata Javadocs Clearer (#49697)
 - [ ] f8e39d2ff18 New setting to prevent automatically importing dangling indices (#49174)
 - [ ] 3ad8aa6d465 Remove obsolete resolving logic from TRA (#49685)
-- [ ] 602e589235d fix mis typo (#49689)
-- [ ] a354c607228 Revert "Remove obsolete resolving logic from TRA (#49647)"
-- [ ] 6cca2b04fa0 Remove obsolete resolving logic from TRA (#49647)
+- [x] 602e589235d fix mis typo (#49689)
+- [s] a354c607228 Revert "Remove obsolete resolving logic from TRA (#49647)"
+- [s] 6cca2b04fa0 Remove obsolete resolving logic from TRA (#49647)
 - [x] 4b16d50cd4b Fix typo when assigning null_value in GeoPointFieldMapper  (#49645)
 
 Below lists deferred patches. In-between patches that we applied or skipped

--- a/server/src/main/java/io/crate/blob/TransportDeleteBlobAction.java
+++ b/server/src/main/java/io/crate/blob/TransportDeleteBlobAction.java
@@ -23,11 +23,9 @@ package io.crate.blob;
 
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.blob.v2.BlobShard;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -48,8 +46,7 @@ public class TransportDeleteBlobAction extends TransportReplicationAction<Delete
                                      IndicesService indicesService,
                                      ThreadPool threadPool,
                                      ShardStateAction shardStateAction,
-                                     BlobIndicesService blobIndicesService,
-                                     IndexNameExpressionResolver indexNameExpressionResolver) {
+                                     BlobIndicesService blobIndicesService) {
         super(
             DeleteBlobAction.NAME,
             transportService,
@@ -57,7 +54,6 @@ public class TransportDeleteBlobAction extends TransportReplicationAction<Delete
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             DeleteBlobRequest::new,
             DeleteBlobRequest::new,
             ThreadPool.Names.WRITE
@@ -90,11 +86,6 @@ public class TransportDeleteBlobAction extends TransportReplicationAction<Delete
         BlobShard blobShard = blobIndicesService.blobShardSafe(request.shardId());
         blobShard.delete(request.id());
         return new ReplicaResult();
-    }
-
-    @Override
-    protected boolean resolveIndex() {
-        return false;
     }
 }
 

--- a/server/src/main/java/io/crate/blob/TransportPutChunkAction.java
+++ b/server/src/main/java/io/crate/blob/TransportPutChunkAction.java
@@ -24,7 +24,6 @@ package io.crate.blob;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -45,8 +44,7 @@ public class TransportPutChunkAction extends TransportReplicationAction<PutChunk
                                    IndicesService indicesService,
                                    ThreadPool threadPool,
                                    ShardStateAction shardStateAction,
-                                   BlobTransferTarget transferTarget,
-                                   IndexNameExpressionResolver indexNameExpressionResolver) {
+                                   BlobTransferTarget transferTarget) {
         super(
             PutChunkAction.NAME,
             transportService,
@@ -54,7 +52,6 @@ public class TransportPutChunkAction extends TransportReplicationAction<PutChunk
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             PutChunkRequest::new,
             PutChunkReplicaRequest::new,
             ThreadPool.Names.WRITE
@@ -93,10 +90,4 @@ public class TransportPutChunkAction extends TransportReplicationAction<PutChunk
         transferTarget.continueTransfer(shardRequest, response);
         return new ReplicaResult();
     }
-
-    @Override
-    protected boolean resolveIndex() {
-        return false;
-    }
 }
-

--- a/server/src/main/java/io/crate/blob/TransportStartBlobAction.java
+++ b/server/src/main/java/io/crate/blob/TransportStartBlobAction.java
@@ -24,7 +24,6 @@ package io.crate.blob;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -45,8 +44,7 @@ public class TransportStartBlobAction extends TransportReplicationAction<StartBl
                                     IndicesService indicesService,
                                     ThreadPool threadPool,
                                     ShardStateAction shardStateAction,
-                                    BlobTransferTarget transferTarget,
-                                    IndexNameExpressionResolver indexNameExpressionResolver) {
+                                    BlobTransferTarget transferTarget) {
         super(
             StartBlobAction.NAME,
             transportService,
@@ -54,7 +52,6 @@ public class TransportStartBlobAction extends TransportReplicationAction<StartBl
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             StartBlobRequest::new,
             StartBlobRequest::new,
             ThreadPool.Names.WRITE
@@ -87,11 +84,6 @@ public class TransportStartBlobAction extends TransportReplicationAction<StartBl
         final StartBlobResponse response = new StartBlobResponse();
         transferTarget.startTransfer(request, response);
         return new ReplicaResult();
-    }
-
-    @Override
-    protected boolean resolveIndex() {
-        return false;
     }
 }
 

--- a/server/src/main/java/io/crate/execution/dml/TransportShardAction.java
+++ b/server/src/main/java/io/crate/execution/dml/TransportShardAction.java
@@ -33,13 +33,11 @@ import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.jobs.kill.KillAllListener;
 import io.crate.execution.jobs.kill.KillableCallable;
 import io.crate.metadata.ColumnIdent;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.MappingUpdatePerformer;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -72,7 +70,6 @@ public abstract class TransportShardAction<Request extends ShardRequest<Request,
 
     protected TransportShardAction(String actionName,
                                    TransportService transportService,
-                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                    ClusterService clusterService,
                                    IndicesService indicesService,
                                    ThreadPool threadPool,
@@ -86,7 +83,6 @@ public abstract class TransportShardAction<Request extends ShardRequest<Request,
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             reader,
             reader,
             ThreadPool.Names.WRITE,
@@ -101,11 +97,6 @@ public abstract class TransportShardAction<Request extends ShardRequest<Request,
     @Override
     protected ShardResponse newResponseInstance(StreamInput in) throws IOException {
         return new ShardResponse(in);
-    }
-
-    @Override
-    protected boolean resolveIndex() {
-        return true;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -28,7 +28,6 @@ import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.TransportShardAction;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -54,7 +53,6 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
 
     @Inject
     public TransportShardDeleteAction(TransportService transportService,
-                                      IndexNameExpressionResolver indexNameExpressionResolver,
                                       ClusterService clusterService,
                                       IndicesService indicesService,
                                       ThreadPool threadPool,
@@ -63,7 +61,6 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
         super(
             ACTION_NAME,
             transportService,
-            indexNameExpressionResolver,
             clusterService,
             indicesService,
             threadPool,

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -45,7 +45,6 @@ import io.crate.metadata.table.Operation;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
@@ -102,12 +101,10 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                                       IndicesService indicesService,
                                       ShardStateAction shardStateAction,
                                       NodeContext nodeCtx,
-                                      Schemas schemas,
-                                      IndexNameExpressionResolver indexNameExpressionResolver) {
+                                      Schemas schemas) {
         super(
             ACTION_NAME,
             transportService,
-            indexNameExpressionResolver,
             clusterService,
             indicesService,
             threadPool,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.cluster.node.stats;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -43,13 +42,11 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
     public TransportNodesStatsAction(ThreadPool threadPool,
                                      ClusterService clusterService,
                                      TransportService transportService,
-                                     NodeService nodeService,
-                                     IndexNameExpressionResolver indexNameExpressionResolver) {
+                                     NodeService nodeService) {
         super(NodesStatsAction.NAME,
               threadPool,
               clusterService,
               transportService,
-              indexNameExpressionResolver,
               NodesStatsRequest::new,
               NodeStatsRequest::new,
               ThreadPool.Names.MANAGEMENT,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -19,12 +19,10 @@
 
 package org.elasticsearch.action.admin.indices.close;
 
-import java.io.IOException;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
-import org.elasticsearch.action.support.replication.ReplicationOperation.Replicas;
+import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
@@ -43,6 +41,8 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
 
 public class TransportVerifyShardBeforeCloseAction extends TransportReplicationAction<
     TransportVerifyShardBeforeCloseAction.ShardRequest, TransportVerifyShardBeforeCloseAction.ShardRequest, ReplicationResponse> {
@@ -136,8 +136,8 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
     }
 
     @Override
-    public Replicas<ShardRequest> newReplicasProxy(long primaryTerm) {
-        return new VerifyShardBeforeCloseActionReplicasProxy(primaryTerm);
+    protected ReplicationOperation.Replicas<ShardRequest> newReplicasProxy() {
+        return new VerifyShardBeforeCloseActionReplicasProxy();
     }
 
     /**
@@ -146,13 +146,9 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
      * or reopened in an unverified state with potential non flushed translog operations.
      */
     class VerifyShardBeforeCloseActionReplicasProxy extends ReplicasProxy {
-
-        public VerifyShardBeforeCloseActionReplicasProxy(long primaryTerm) {
-            super(primaryTerm);
-        }
-
         @Override
-        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener) {
+        public void markShardCopyAsStaleIfNeeded(final ShardId shardId, final String allocationId, final long primaryTerm,
+                                                 final ActionListener<Void> listener) {
             shardStateAction.remoteShardFailed(shardId, allocationId, primaryTerm, true, "mark copy as stale", null, listener);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -56,8 +55,7 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
                                                  final ClusterService clusterService,
                                                  final IndicesService indicesService,
                                                  final ThreadPool threadPool,
-                                                 final ShardStateAction stateAction,
-                                                 final IndexNameExpressionResolver resolver) {
+                                                 final ShardStateAction stateAction) {
         super(
             NAME,
             transportService,
@@ -65,7 +63,6 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
             indicesService,
             threadPool,
             stateAction,
-            resolver,
             ShardRequest::new,
             ShardRequest::new,
             ThreadPool.Names.MANAGEMENT

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
@@ -40,12 +39,11 @@ public class TransportFlushAction extends TransportBroadcastReplicationAction<Fl
     public static final String NAME = "indices:admin/flush";
 
     @Inject
-    public TransportFlushAction(ThreadPool threadPool,
-                                ClusterService clusterService,
+    public TransportFlushAction(ClusterService clusterService,
                                 TransportService transportService,
                                 NodeClient client,
                                 IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(NAME, FlushRequest::new, threadPool, clusterService, transportService, client, indexNameExpressionResolver, TransportShardFlushAction.TYPE);
+        super(NAME, FlushRequest::new, clusterService, transportService, client, indexNameExpressionResolver, TransportShardFlushAction.TYPE);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -19,14 +19,11 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import java.io.IOException;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -34,6 +31,8 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
 
 public class TransportShardFlushAction extends TransportReplicationAction<ShardFlushRequest, ShardFlushRequest, ReplicationResponse> {
 
@@ -45,10 +44,9 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
                                      ClusterService clusterService,
                                      IndicesService indicesService,
                                      ThreadPool threadPool,
-                                     ShardStateAction shardStateAction,
-                                     IndexNameExpressionResolver indexNameExpressionResolver) {
+                                     ShardStateAction shardStateAction) {
         super(NAME, transportService, clusterService, indicesService, threadPool, shardStateAction,
-            indexNameExpressionResolver, ShardFlushRequest::new, ShardFlushRequest::new, ThreadPool.Names.FLUSH);
+              ShardFlushRequest::new, ShardFlushRequest::new, ThreadPool.Names.FLUSH);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportSyncedFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportSyncedFlushAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.admin.indices.flush;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.indices.flush.SyncedFlushService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -37,9 +36,8 @@ public class TransportSyncedFlushAction extends HandledTransportAction<SyncedFlu
     @Inject
     public TransportSyncedFlushAction(ThreadPool threadPool,
                                       TransportService transportService,
-                                      IndexNameExpressionResolver indexNameExpressionResolver,
                                       SyncedFlushService syncedFlushService) {
-        super(SyncedFlushAction.NAME, threadPool, transportService, SyncedFlushRequest::new, indexNameExpressionResolver);
+        super(SyncedFlushAction.NAME, threadPool, transportService, SyncedFlushRequest::new);
         this.syncedFlushService = syncedFlushService;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportSyncedFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportSyncedFlushAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.indices.flush.SyncedFlushService;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
 /**
@@ -40,7 +41,7 @@ public class TransportSyncedFlushAction extends HandledTransportAction<SyncedFlu
     }
 
     @Override
-    protected void doExecute(SyncedFlushRequest request, ActionListener<SyncedFlushResponse> listener) {
+    protected void doExecute(Task task, SyncedFlushRequest request, ActionListener<SyncedFlushResponse> listener) {
         syncedFlushService.attemptSyncedFlush(request.indices(), request.indicesOptions(), listener);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportSyncedFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportSyncedFlushAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.indices.flush.SyncedFlushService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 /**
@@ -34,10 +33,9 @@ public class TransportSyncedFlushAction extends HandledTransportAction<SyncedFlu
     private final SyncedFlushService syncedFlushService;
 
     @Inject
-    public TransportSyncedFlushAction(ThreadPool threadPool,
-                                      TransportService transportService,
+    public TransportSyncedFlushAction(TransportService transportService,
                                       SyncedFlushService syncedFlushService) {
-        super(SyncedFlushAction.NAME, threadPool, transportService, SyncedFlushRequest::new);
+        super(SyncedFlushAction.NAME, transportService, SyncedFlushRequest::new);
         this.syncedFlushService = syncedFlushService;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
@@ -46,14 +46,12 @@ public class TransportForceMergeAction extends TransportBroadcastByNodeAction<Fo
     private final IndicesService indicesService;
 
     @Inject
-    public TransportForceMergeAction(ThreadPool threadPool,
-                                     ClusterService clusterService,
+    public TransportForceMergeAction(ClusterService clusterService,
                                      TransportService transportService,
                                      IndicesService indicesService,
                                      IndexNameExpressionResolver indexNameExpressionResolver) {
         super(
             ForceMergeAction.NAME,
-            threadPool,
             clusterService,
             transportService,
             indexNameExpressionResolver,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -52,14 +52,12 @@ public class TransportRecoveryAction extends TransportBroadcastByNodeAction<Reco
     private final IndicesService indicesService;
 
     @Inject
-    public TransportRecoveryAction(ThreadPool threadPool,
-                                   ClusterService clusterService,
+    public TransportRecoveryAction(ClusterService clusterService,
                                    TransportService transportService,
                                    IndicesService indicesService,
                                    IndexNameExpressionResolver indexNameExpressionResolver) {
         super(
             RecoveryAction.NAME,
-            threadPool,
             clusterService,
             transportService,
             indexNameExpressionResolver,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
@@ -40,15 +39,13 @@ import java.util.List;
 public class TransportRefreshAction extends TransportBroadcastReplicationAction<RefreshRequest, RefreshResponse, BasicReplicationRequest, ReplicationResponse> {
 
     @Inject
-    public TransportRefreshAction(ThreadPool threadPool,
-                                  ClusterService clusterService,
+    public TransportRefreshAction(ClusterService clusterService,
                                   TransportService transportService,
                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                   NodeClient client) {
         super(
             RefreshAction.NAME,
             RefreshRequest::new,
-            threadPool,
             clusterService,
             transportService,
             client,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.support.replication.BasicReplicationRequest;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -48,10 +47,9 @@ public class TransportShardRefreshAction
                                        ClusterService clusterService,
                                        IndicesService indicesService,
                                        ThreadPool threadPool,
-                                       ShardStateAction shardStateAction,
-                                       IndexNameExpressionResolver indexNameExpressionResolver) {
+                                       ShardStateAction shardStateAction) {
         super(NAME, transportService, clusterService, indicesService, threadPool, shardStateAction,
-                indexNameExpressionResolver, BasicReplicationRequest::new, BasicReplicationRequest::new, ThreadPool.Names.REFRESH);
+                BasicReplicationRequest::new, BasicReplicationRequest::new, ThreadPool.Names.REFRESH);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -49,14 +49,12 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
     private final IndicesService indicesService;
 
     @Inject
-    public TransportIndicesStatsAction(ThreadPool threadPool,
-                                       ClusterService clusterService,
+    public TransportIndicesStatsAction(ClusterService clusterService,
                                        TransportService transportService,
                                        IndicesService indicesService,
                                        IndexNameExpressionResolver indexNameExpressionResolver) {
         super(
             IndicesStatsAction.NAME,
-            threadPool,
             clusterService,
             transportService,
             indexNameExpressionResolver,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
@@ -60,13 +60,12 @@ public class TransportUpgradeAction extends TransportBroadcastByNodeAction<Upgra
     private final TransportUpgradeSettingsAction upgradeSettingsAction;
 
     @Inject
-    public TransportUpgradeAction(ThreadPool threadPool,
-                                  ClusterService clusterService,
+    public TransportUpgradeAction(ClusterService clusterService,
                                   TransportService transportService,
                                   IndicesService indicesService,
                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                   TransportUpgradeSettingsAction upgradeSettingsAction) {
-        super(UpgradeAction.NAME, threadPool, clusterService, transportService, indexNameExpressionResolver, UpgradeRequest::new, ThreadPool.Names.FORCE_MERGE, true);
+        super(UpgradeAction.NAME, clusterService, transportService, indexNameExpressionResolver, UpgradeRequest::new, ThreadPool.Names.FORCE_MERGE, true);
         this.indicesService = indicesService;
         this.upgradeSettingsAction = upgradeSettingsAction;
     }

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -85,8 +85,8 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     }
 
     @Override
-    protected ReplicationOperation.Replicas newReplicasProxy(long primaryTerm) {
-        return new ResyncActionReplicasProxy(primaryTerm);
+    protected ReplicationOperation.Replicas<ResyncReplicationRequest> newReplicasProxy() {
+        return new ResyncActionReplicasProxy();
     }
 
     @Override
@@ -104,9 +104,10 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     }
 
     @Override
-    protected WriteReplicaResult shardOperationOnReplica(ResyncReplicationRequest request, IndexShard replica) throws Exception {
+    protected WriteReplicaResult<ResyncReplicationRequest> shardOperationOnReplica(ResyncReplicationRequest request,
+                                                                                   IndexShard replica) throws Exception {
         Translog.Location location = performOnReplica(request, replica);
-        return new WriteReplicaResult(request, location, null, replica, logger);
+        return new WriteReplicaResult<>(request, location, null, replica, logger);
     }
 
     public static Translog.Location performOnReplica(ResyncReplicationRequest request, IndexShard replica) throws Exception {
@@ -181,12 +182,9 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
      */
     class ResyncActionReplicasProxy extends ReplicasProxy {
 
-        ResyncActionReplicasProxy(long primaryTerm) {
-            super(primaryTerm);
-        }
-
         @Override
-        public void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener) {
+        public void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception,
+                                      ActionListener<Void> listener) {
             shardStateAction.remoteShardFailed(
                 replica.shardId(), replica.allocationId().getId(), primaryTerm, false, message, exception, listener);
         }

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -56,8 +55,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
                                             ClusterService clusterService,
                                             IndicesService indicesService,
                                             ThreadPool threadPool,
-                                            ShardStateAction shardStateAction,
-                                            IndexNameExpressionResolver indexNameExpressionResolver) {
+                                            ShardStateAction shardStateAction) {
         super(
             ACTION_NAME,
             transportService,
@@ -65,7 +63,6 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             ResyncReplicationRequest::new,
             ResyncReplicationRequest::new,
             ThreadPool.Names.WRITE,

--- a/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.support;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -42,18 +41,16 @@ public abstract class HandledTransportAction<Request extends TransportRequest, R
     protected HandledTransportAction(String actionName,
                                      ThreadPool threadPool,
                                      TransportService transportService,
-                                     Writeable.Reader<Request> reader,
-                                     IndexNameExpressionResolver indexNameExpressionResolver) {
-        this(actionName, true, threadPool, transportService, reader, indexNameExpressionResolver);
+                                     Writeable.Reader<Request> reader) {
+        this(actionName, true, threadPool, transportService, reader);
     }
 
     protected HandledTransportAction(String actionName,
                                      boolean canTripCircuitBreaker,
                                      ThreadPool threadPool,
                                      TransportService transportService,
-                                     Writeable.Reader<Request> requestReader,
-                                     IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(actionName, threadPool, indexNameExpressionResolver, transportService.getTaskManager());
+                                     Writeable.Reader<Request> requestReader) {
+        super(actionName, threadPool, transportService.getTaskManager());
         transportService.registerRequestHandler(
             actionName,
             ThreadPool.Names.SAME,

--- a/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -39,18 +39,16 @@ public abstract class HandledTransportAction<Request extends TransportRequest, R
     protected final Logger logger = LogManager.getLogger(getClass());
 
     protected HandledTransportAction(String actionName,
-                                     ThreadPool threadPool,
                                      TransportService transportService,
                                      Writeable.Reader<Request> reader) {
-        this(actionName, true, threadPool, transportService, reader);
+        this(actionName, true, transportService, reader);
     }
 
     protected HandledTransportAction(String actionName,
                                      boolean canTripCircuitBreaker,
-                                     ThreadPool threadPool,
                                      TransportService transportService,
                                      Writeable.Reader<Request> requestReader) {
-        super(actionName, threadPool, transportService.getTaskManager());
+        super(actionName,transportService.getTaskManager());
         transportService.registerRequestHandler(
             actionName,
             ThreadPool.Names.SAME,

--- a/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -34,16 +33,13 @@ public abstract class TransportAction<Request extends TransportRequest, Response
 
     protected final ThreadPool threadPool;
     protected final String actionName;
-    protected final IndexNameExpressionResolver indexNameExpressionResolver;
     protected final TaskManager taskManager;
 
     protected TransportAction(String actionName,
                               ThreadPool threadPool,
-                              IndexNameExpressionResolver indexNameExpressionResolver,
                               TaskManager taskManager) {
         this.threadPool = threadPool;
         this.actionName = actionName;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.taskManager = taskManager;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportResponse;
 
@@ -31,14 +30,11 @@ import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
 
 public abstract class TransportAction<Request extends TransportRequest, Response extends TransportResponse> {
 
-    protected final ThreadPool threadPool;
     protected final String actionName;
     protected final TaskManager taskManager;
 
     protected TransportAction(String actionName,
-                              ThreadPool threadPool,
                               TaskManager taskManager) {
-        this.threadPool = threadPool;
         this.actionName = actionName;
         this.taskManager = taskManager;
     }

--- a/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -90,9 +90,5 @@ public abstract class TransportAction<Request extends TransportRequest, Response
         }
     }
 
-    protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
-        doExecute(request, listener);
-    }
-
-    protected abstract void doExecute(Request request, ActionListener<Response> listener);
+    protected abstract void doExecute(Task task, Request request, ActionListener<Response> listener);
 }

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -211,11 +211,6 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
     protected abstract ClusterBlockException checkRequestBlock(ClusterState state, Request request, String[] concreteIndices);
 
     @Override
-    protected final void doExecute(Request request, ActionListener<Response> listener) {
-        throw new UnsupportedOperationException("the task parameter is required for this operation");
-    }
-
-    @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         new AsyncAction(task, request, listener).start();
     }

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -84,14 +84,13 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
 
     public TransportBroadcastByNodeAction(
             String actionName,
-            ThreadPool threadPool,
             ClusterService clusterService,
             TransportService transportService,
             IndexNameExpressionResolver indexNameExpressionResolver,
             Writeable.Reader<Request> reader,
             String executor,
             boolean canTripCircuitBreaker) {
-        super(actionName, canTripCircuitBreaker, threadPool, transportService, reader);
+        super(actionName, canTripCircuitBreaker, transportService, reader);
 
         this.clusterService = clusterService;
         this.transportService = transportService;

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -78,6 +78,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
 
     private final ClusterService clusterService;
     private final TransportService transportService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     private final String transportNodeBroadcastAction;
 
@@ -90,10 +91,11 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
             Writeable.Reader<Request> reader,
             String executor,
             boolean canTripCircuitBreaker) {
-        super(actionName, canTripCircuitBreaker, threadPool, transportService, reader, indexNameExpressionResolver);
+        super(actionName, canTripCircuitBreaker, threadPool, transportService, reader);
 
         this.clusterService = clusterService;
         this.transportService = transportService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
 
         transportNodeBroadcastAction = actionName + "[n]";
 

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -57,6 +57,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
     protected final TransportService transportService;
     protected final ClusterService clusterService;
+    protected final IndexNameExpressionResolver indexNameExpressionResolver;
 
     private final String executor;
 
@@ -76,9 +77,10 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                                         ThreadPool threadPool,
                                         Writeable.Reader<Request> request,
                                         IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(actionName, canTripCircuitBreaker, threadPool, transportService, request, indexNameExpressionResolver);
+        super(actionName, canTripCircuitBreaker, threadPool, transportService, request);
         this.transportService = transportService;
         this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.executor = executor();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -100,12 +100,6 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
     protected abstract ClusterBlockException checkBlock(Request request, ClusterState state);
 
     @Override
-    protected final void doExecute(final Request request, ActionListener<Response> listener) {
-        logger.warn("attempt to execute a master node operation without task");
-        throw new UnsupportedOperationException("task parameter is required for this operation");
-    }
-
-    @Override
     protected void doExecute(Task task, final Request request, ActionListener<Response> listener) {
         new AsyncSingleAction(task, request, listener).start();
     }

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -55,6 +55,7 @@ import java.util.function.Predicate;
 public abstract class TransportMasterNodeAction<Request extends MasterNodeRequest<Request>, Response extends TransportResponse>
     extends HandledTransportAction<Request, Response> {
 
+    protected final ThreadPool threadPool;
     protected final TransportService transportService;
     protected final ClusterService clusterService;
     protected final IndexNameExpressionResolver indexNameExpressionResolver;
@@ -77,9 +78,10 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                                         ThreadPool threadPool,
                                         Writeable.Reader<Request> request,
                                         IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(actionName, canTripCircuitBreaker, threadPool, transportService, request);
+        super(actionName, canTripCircuitBreaker, transportService, request);
         this.transportService = transportService;
         this.clusterService = clusterService;
+        this.threadPool = threadPool;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.executor = executor();
     }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -51,6 +51,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                                            NodeResponse extends BaseNodeResponse>
     extends HandledTransportAction<NodesRequest, NodesResponse> {
 
+    protected final ThreadPool threadPool;
     protected final ClusterService clusterService;
     protected final TransportService transportService;
     protected final Class<NodeResponse> nodeResponseClass;
@@ -65,7 +66,8 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                                    Writeable.Reader<NodeRequest> nodeRequestReader,
                                    String nodeExecutor,
                                    Class<NodeResponse> nodeResponseClass) {
-        super(actionName, threadPool, transportService, nodesRequestReader);
+        super(actionName, transportService, nodesRequestReader);
+        this.threadPool = threadPool;
         this.clusterService = Objects.requireNonNull(clusterService);
         this.transportService = Objects.requireNonNull(transportService);
         this.nodeResponseClass = Objects.requireNonNull(nodeResponseClass);

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -62,12 +61,11 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                                    ThreadPool threadPool,
                                    ClusterService clusterService,
                                    TransportService transportService,
-                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                    Writeable.Reader<NodesRequest> nodesRequestReader,
                                    Writeable.Reader<NodeRequest> nodeRequestReader,
                                    String nodeExecutor,
                                    Class<NodeResponse> nodeResponseClass) {
-        super(actionName, threadPool, transportService, nodesRequestReader, indexNameExpressionResolver);
+        super(actionName, threadPool, transportService, nodesRequestReader);
         this.clusterService = Objects.requireNonNull(clusterService);
         this.transportService = Objects.requireNonNull(transportService);
         this.nodeResponseClass = Objects.requireNonNull(nodeResponseClass);

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -79,12 +79,6 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
     }
 
     @Override
-    protected final void doExecute(NodesRequest request, ActionListener<NodesResponse> listener) {
-        logger.warn("attempt to execute a transport nodes operation without a task");
-        throw new UnsupportedOperationException("task parameter is required for this operation");
-    }
-
-    @Override
     protected void doExecute(Task task, NodesRequest request, ActionListener<NodesResponse> listener) {
         new AsyncAction(task, request, listener).start();
     }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -72,7 +72,10 @@ public class ReplicationOperation<
     private final Primary<Request, ReplicaRequest, PrimaryResultT> primary;
     private final Replicas<ReplicaRequest> replicasProxy;
     private final AtomicBoolean finished = new AtomicBoolean();
-    protected final ActionListener<PrimaryResultT> resultListener;
+    private final long primaryTerm;
+
+    // exposed for tests
+    final ActionListener<PrimaryResultT> resultListener;
 
     private volatile PrimaryResultT primaryResult = null;
 
@@ -81,13 +84,14 @@ public class ReplicationOperation<
     public ReplicationOperation(Request request, Primary<Request, ReplicaRequest, PrimaryResultT> primary,
                                 ActionListener<PrimaryResultT> listener,
                                 Replicas<ReplicaRequest> replicas,
-                                Logger logger, String opType) {
+                                Logger logger, String opType, long primaryTerm) {
         this.replicasProxy = replicas;
         this.primary = primary;
         this.resultListener = listener;
         this.logger = logger;
         this.request = request;
         this.opType = opType;
+        this.primaryTerm = primaryTerm;
     }
 
     public void execute() throws Exception {
@@ -139,7 +143,7 @@ public class ReplicationOperation<
         // if inSyncAllocationIds contains allocation ids of shards that don't exist in RoutingTable, mark copies as stale
         for (String allocationId : replicationGroup.getUnavailableInSyncShards()) {
             pendingActions.incrementAndGet();
-            replicasProxy.markShardCopyAsStaleIfNeeded(replicaRequest.shardId(), allocationId,
+            replicasProxy.markShardCopyAsStaleIfNeeded(replicaRequest.shardId(), allocationId, primaryTerm,
                 ActionListener.wrap(r -> decPendingAndFinishIfNeeded(), ReplicationOperation.this::onNoLongerPrimary));
         }
     }
@@ -167,42 +171,45 @@ public class ReplicationOperation<
 
         totalShards.incrementAndGet();
         pendingActions.incrementAndGet();
-        replicasProxy.performOn(shard, replicaRequest, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, new ActionListener<ReplicaResponse>() {
-            @Override
-            public void onResponse(ReplicaResponse response) {
-                successfulShards.incrementAndGet();
-                try {
-                    primary.updateLocalCheckpointForShard(shard.allocationId().getId(), response.localCheckpoint());
-                    primary.updateGlobalCheckpointForShard(shard.allocationId().getId(), response.globalCheckpoint());
-                } catch (final AlreadyClosedException e) {
-                    // okay, the index was deleted or this shard was never activated after a relocation; fall through and finish normally
-                } catch (final Exception e) {
-                    // fail the primary but fall through and let the rest of operation processing complete
-                    final String message = String.format(Locale.ROOT, "primary failed updating local checkpoint for replica %s", shard);
-                    primary.failShard(message, e);
+        replicasProxy.performOn(shard, replicaRequest, primaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(ReplicaResponse response) {
+                    successfulShards.incrementAndGet();
+                    try {
+                        primary.updateLocalCheckpointForShard(shard.allocationId().getId(), response.localCheckpoint());
+                        primary.updateGlobalCheckpointForShard(shard.allocationId().getId(), response.globalCheckpoint());
+                    } catch (final AlreadyClosedException e) {
+                        // the index was deleted or this shard was never activated after a relocation; fall through and finish normally
+                    } catch (final Exception e) {
+                        // fail the primary but fall through and let the rest of operation processing complete
+                        final String message = String.format(Locale.ROOT, "primary failed updating local checkpoint for replica %s", shard);
+                        primary.failShard(message, e);
+                    }
+                    decPendingAndFinishIfNeeded();
                 }
-                decPendingAndFinishIfNeeded();
-            }
 
-            @Override
-            public void onFailure(Exception replicaException) {
-                logger.trace(() -> new ParameterizedMessage(
-                    "[{}] failure while performing [{}] on replica {}, request [{}]",
-                    shard.shardId(), opType, shard, replicaRequest), replicaException);
-                // Only report "critical" exceptions - TODO: Reach out to the master node to get the latest shard state then report.
-                if (TransportActions.isShardNotAvailableException(replicaException) == false) {
-                    RestStatus restStatus = ExceptionsHelper.status(replicaException);
-                    shardReplicaFailures.add(new ReplicationResponse.ShardInfo.Failure(
-                        shard.shardId(), shard.currentNodeId(), replicaException, restStatus, false));
+                @Override
+                public void onFailure(Exception replicaException) {
+                    logger.trace(() -> new ParameterizedMessage(
+                        "[{}] failure while performing [{}] on replica {}, request [{}]",
+                        shard.shardId(), opType, shard, replicaRequest), replicaException);
+                    // Only report "critical" exceptions - TODO: Reach out to the master node to get the latest shard state then report.
+                    if (TransportActions.isShardNotAvailableException(replicaException) == false) {
+                        RestStatus restStatus = ExceptionsHelper.status(replicaException);
+                        shardReplicaFailures.add(new ReplicationResponse.ShardInfo.Failure(
+                            shard.shardId(), shard.currentNodeId(), replicaException, restStatus, false));
+                    }
+                    String message = String.format(Locale.ROOT, "failed to perform %s on replica %s", opType, shard);
+                    replicasProxy.failShardIfNeeded(shard, primaryTerm, message, replicaException,
+                        ActionListener.wrap(r -> decPendingAndFinishIfNeeded(), ReplicationOperation.this::onNoLongerPrimary));
                 }
-                String message = String.format(Locale.ROOT, "failed to perform %s on replica %s", opType, shard);
-                replicasProxy.failShardIfNeeded(
-                    shard,
-                    message,
-                    replicaException,
-                    ActionListener.wrap(r -> decPendingAndFinishIfNeeded(), ReplicationOperation.this::onNoLongerPrimary));
-            }
-        });
+
+                @Override
+                public String toString() {
+                    return "[" + replicaRequest + "][" + shard + "]";
+                }
+            });
     }
 
     private void onNoLongerPrimary(Exception failure) {
@@ -378,25 +385,27 @@ public class ReplicationOperation<
          *
          * @param replica                    the shard this request should be executed on
          * @param replicaRequest             the operation to perform
+         * @param primaryTerm                the primary term
          * @param globalCheckpoint           the global checkpoint on the primary
          * @param maxSeqNoOfUpdatesOrDeletes the max seq_no of updates (index operations overwriting Lucene) or deletes on primary
          *                                   after this replication was executed on it.
          * @param listener                   callback for handling the response or failure
          */
-        void performOn(ShardRouting replica, RequestT replicaRequest, long globalCheckpoint,
-                       long maxSeqNoOfUpdatesOrDeletes, ActionListener<ReplicaResponse> listener);
+        void performOn(ShardRouting replica, RequestT replicaRequest,
+                       long primaryTerm, long globalCheckpoint, long maxSeqNoOfUpdatesOrDeletes, ActionListener<ReplicaResponse> listener);
 
         /**
          * Fail the specified shard if needed, removing it from the current set
          * of active shards. Whether a failure is needed is left up to the
          * implementation.
          *
-         * @param replica   shard to fail
-         * @param message   a (short) description of the reason
-         * @param exception the original exception which caused the ReplicationOperation to request the shard to be failed
-         * @param listener  a listener that will be notified when the failing shard has been removed from the in-sync set
+         * @param replica      shard to fail
+         * @param primaryTerm  the primary term
+         * @param message      a (short) description of the reason
+         * @param exception    the original exception which caused the ReplicationOperation to request the shard to be failed
+         * @param listener     a listener that will be notified when the failing shard has been removed from the in-sync set
          */
-        void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener);
+        void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception, ActionListener<Void> listener);
 
         /**
          * Marks shard copy as stale if needed, removing its allocation id from
@@ -405,9 +414,10 @@ public class ReplicationOperation<
          *
          * @param shardId      shard id
          * @param allocationId allocation id to remove from the set of in-sync allocation ids
+         * @param primaryTerm  the primary term
          * @param listener     a listener that will be notified when the failing shard has been removed from the in-sync set
          */
-        void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener);
+        void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, long primaryTerm, ActionListener<Void> listener);
     }
 
     /**
@@ -436,7 +446,7 @@ public class ReplicationOperation<
             this(shardId, msg, null);
         }
 
-        public RetryOnPrimaryException(ShardId shardId, String msg, Throwable cause) {
+        RetryOnPrimaryException(ShardId shardId, String msg, Throwable cause) {
             super(msg, cause);
             setShard(shardId);
         }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -75,7 +75,7 @@ public class ReplicationOperation<
     private final long primaryTerm;
 
     // exposed for tests
-    final ActionListener<PrimaryResultT> resultListener;
+    private final ActionListener<PrimaryResultT> resultListener;
 
     private volatile PrimaryResultT primaryResult = null;
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -19,19 +19,19 @@
 
 package org.elasticsearch.action.support.replication;
 
+import io.crate.common.unit.TimeValue;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.refresh.TransportShardRefreshAction;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportRequest;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -154,7 +154,7 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
      * Used to prevent redirect loops, see also {@link TransportReplicationAction.ReroutePhase#doRun()}
      */
     @SuppressWarnings("unchecked")
-    Request routedBasedOnClusterVersion(long routedBasedOnClusterVersion) {
+    protected Request routedBasedOnClusterVersion(long routedBasedOnClusterVersion) {
         this.routedBasedOnClusterVersion = routedBasedOnClusterVersion;
         return (Request) this;
     }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -57,6 +57,7 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
     private final ActionType<ShardResponse> replicatedBroadcastShardAction;
     private final ClusterService clusterService;
     private final NodeClient client;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     public TransportBroadcastReplicationAction(String name,
                                                Writeable.Reader<Request> reader,
@@ -66,10 +67,11 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
                                                NodeClient client,
                                                IndexNameExpressionResolver indexNameExpressionResolver,
                                                ActionType<ShardResponse> replicatedBroadcastShardAction) {
-        super(name, threadPool, transportService, reader, indexNameExpressionResolver);
+        super(name, threadPool, transportService, reader);
         this.client = client;
         this.replicatedBroadcastShardAction = replicatedBroadcastShardAction;
         this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -73,11 +73,6 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
     }
 
     @Override
-    protected final void doExecute(final Request request, final ActionListener<Response> listener) {
-        throw new UnsupportedOperationException("the task parameter is required for this operation");
-    }
-
-    @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         final ClusterState clusterState = clusterService.state();
         List<ShardId> shards = shards(request, clusterState);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
@@ -61,13 +60,12 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
 
     public TransportBroadcastReplicationAction(String name,
                                                Writeable.Reader<Request> reader,
-                                               ThreadPool threadPool,
                                                ClusterService clusterService,
                                                TransportService transportService,
                                                NodeClient client,
                                                IndexNameExpressionResolver indexNameExpressionResolver,
                                                ActionType<ShardResponse> replicatedBroadcastShardAction) {
-        super(name, threadPool, transportService, reader);
+        super(name, transportService, reader);
         this.client = client;
         this.replicatedBroadcastShardAction = replicatedBroadcastShardAction;
         this.clusterService = clusterService;

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -102,6 +102,7 @@ public abstract class TransportReplicationAction<
 
     protected final Logger logger = LogManager.getLogger(getClass());
 
+    protected final ThreadPool threadPool;
     protected final TransportService transportService;
     protected final ClusterService clusterService;
     protected final ShardStateAction shardStateAction;
@@ -144,7 +145,8 @@ public abstract class TransportReplicationAction<
                                          String executor,
                                          boolean syncGlobalCheckpointAfterOperation,
                                          boolean forceExecutionOnPrimary) {
-        super(actionName, threadPool, transportService.getTaskManager());
+        super(actionName, transportService.getTaskManager());
+        this.threadPool = threadPool;
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.indicesService = indicesService;

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -42,10 +42,8 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.AllocationId;
-import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -105,7 +103,6 @@ public abstract class TransportReplicationAction<
     protected final ClusterService clusterService;
     protected final ShardStateAction shardStateAction;
     protected final IndicesService indicesService;
-    protected final IndexNameExpressionResolver indexNameExpressionResolver;
     protected final TransportRequestOptions transportOptions;
     protected final String executor;
 
@@ -115,19 +112,17 @@ public abstract class TransportReplicationAction<
 
     private final boolean syncGlobalCheckpointAfterOperation;
 
-
     protected TransportReplicationAction(String actionName,
                                          TransportService transportService,
                                          ClusterService clusterService,
                                          IndicesService indicesService,
                                          ThreadPool threadPool,
                                          ShardStateAction shardStateAction,
-                                         IndexNameExpressionResolver indexNameExpressionResolver,
                                          Writeable.Reader<Request> reader,
                                          Writeable.Reader<ReplicaRequest> replicaReader,
                                          String executor) {
         this(actionName, transportService, clusterService, indicesService, threadPool, shardStateAction,
-                indexNameExpressionResolver, reader, replicaReader, executor, false, false);
+                reader, replicaReader, executor, false, false);
     }
 
 
@@ -137,7 +132,6 @@ public abstract class TransportReplicationAction<
                                          IndicesService indicesService,
                                          ThreadPool threadPool,
                                          ShardStateAction shardStateAction,
-                                         IndexNameExpressionResolver indexNameExpressionResolver,
                                          Writeable.Reader<Request> reader,
                                          Writeable.Reader<ReplicaRequest> replicaReader,
                                          String executor,
@@ -149,7 +143,6 @@ public abstract class TransportReplicationAction<
         this.clusterService = clusterService;
         this.indicesService = indicesService;
         this.shardStateAction = shardStateAction;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.executor = executor;
 
         this.transportPrimaryAction = actionName + "[p]";
@@ -238,19 +231,8 @@ public abstract class TransportReplicationAction<
         return null;
     }
 
-    /**
-     * True if provided index should be resolved when resolving request
-     */
-    protected boolean resolveIndex() {
-        return true;
-    }
-
     protected TransportRequestOptions transportOptions() {
         return TransportRequestOptions.EMPTY;
-    }
-
-    private String concreteIndex(final ClusterState state, final ReplicationRequest request) {
-        return resolveIndex() ? indexNameExpressionResolver.concreteSingleIndex(state, request).getName() : request.index();
     }
 
     private ClusterBlockException blockExceptions(final ClusterState state, final String indexName) {
@@ -678,9 +660,7 @@ public abstract class TransportReplicationAction<
         protected void doRun() {
             setPhase(task, "routing");
             final ClusterState state = observer.setAndGetObservedState();
-
-            final String concreteIndex = concreteIndex(state, request);
-            final ClusterBlockException blockException = blockExceptions(state, concreteIndex);
+            final ClusterBlockException blockException = blockExceptions(state, request.shardId().getIndexName());
             if (blockException != null) {
                 if (blockException.retryable()) {
                     logger.trace("cluster is blocked, scheduling a retry", blockException);
@@ -689,25 +669,47 @@ public abstract class TransportReplicationAction<
                     finishAsFailed(blockException);
                 }
             } else {
-                // request does not have a shardId yet, we need to pass the concrete index to
-                // resolve shardId
-                final IndexMetadata indexMetadata = state.metadata().index(concreteIndex);
+                final IndexMetadata indexMetadata = state.metadata().index(request.shardId().getIndex());
                 if (indexMetadata == null) {
-                    retry(new IndexNotFoundException(concreteIndex));
+                    // ensure that the cluster state on the node is at least as high as the node that decided that the index was there
+                    if (state.version() < request.routedBasedOnClusterVersion()) {
+                        logger.trace("failed to find index [{}] for request [{}] despite sender thinking it would be here. " +
+                                "Local cluster state version [{}]] is older than on sending node (version [{}]), scheduling a retry...",
+                            request.shardId().getIndex(), request, state.version(), request.routedBasedOnClusterVersion());
+                        retry(new IndexNotFoundException("failed to find index as current cluster state with version [" + state.version() +
+                            "] is stale (expected at least [" + request.routedBasedOnClusterVersion() + "]",
+                            request.shardId().getIndexName()));
+                        return;
+                    } else {
+                        finishAsFailed(new IndexNotFoundException(request.shardId().getIndex()));
+                        return;
+                    }
+                }
+
+                if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+                    finishAsFailed(new IndexClosedException(indexMetadata.getIndex()));
                     return;
                 }
-                if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
-                    throw new IndexClosedException(indexMetadata.getIndex());
+
+                if (request.waitForActiveShards() == ActiveShardCount.DEFAULT) {
+                    // if the wait for active shard count has not been set in the request,
+                    // resolve it from the index settings
+                    request.waitForActiveShards(indexMetadata.getWaitForActiveShards());
                 }
+                assert request.waitForActiveShards() != ActiveShardCount.DEFAULT :
+                    "request waitForActiveShards must be set in resolveRequest";
 
-                // resolve all derived request fields, so we can route and apply it
-                resolveRequest(indexMetadata, request);
-                assert request.shardId() != null : "request shardId must be set in resolveRequest";
-                assert request
-                        .waitForActiveShards() != ActiveShardCount.DEFAULT : "request waitForActiveShards must be set in resolveRequest";
-
-                final ShardRouting primary = primary(state);
-                if (retryIfUnavailable(state, primary)) {
+                final ShardRouting primary = state.getRoutingTable().shardRoutingTable(request.shardId()).primaryShard();
+                if (primary == null || primary.active() == false) {
+                    logger.trace("primary shard [{}] is not yet active, scheduling a retry: action [{}], request [{}], "
+                        + "cluster state version [{}]", request.shardId(), actionName, request, state.version());
+                    retryBecauseUnavailable(request.shardId(), "primary shard is not active");
+                    return;
+                }
+                if (state.nodes().nodeExists(primary.currentNodeId()) == false) {
+                    logger.trace("primary shard [{}] is assigned to an unknown node [{}], scheduling a retry: action [{}], request [{}], "
+                        + "cluster state version [{}]", request.shardId(), primary.currentNodeId(), actionName, request, state.version());
+                    retryBecauseUnavailable(request.shardId(), "primary shard isn't assigned to a known node.");
                     return;
                 }
                 final DiscoveryNode node = state.nodes().get(primary.currentNodeId());
@@ -749,27 +751,6 @@ public abstract class TransportReplicationAction<
             }
             setPhase(task, "rerouted");
             performAction(node, actionName, false, request);
-        }
-
-        private boolean retryIfUnavailable(ClusterState state, ShardRouting primary) {
-            if (primary == null || primary.active() == false) {
-                logger.trace("primary shard [{}] is not yet active, scheduling a retry: action [{}], request [{}], "
-                    + "cluster state version [{}]", request.shardId(), actionName, request, state.version());
-                retryBecauseUnavailable(request.shardId(), "primary shard is not active");
-                return true;
-            }
-            if (state.nodes().nodeExists(primary.currentNodeId()) == false) {
-                logger.trace("primary shard [{}] is assigned to an unknown node [{}], scheduling a retry: action [{}], request [{}], "
-                    + "cluster state version [{}]", request.shardId(), primary.currentNodeId(), actionName, request, state.version());
-                retryBecauseUnavailable(request.shardId(), "primary shard isn't assigned to a known node.");
-                return true;
-            }
-            return false;
-        }
-
-        private ShardRouting primary(ClusterState state) {
-            IndexShardRoutingTable indexShard = state.getRoutingTable().shardRoutingTable(request.shardId());
-            return indexShard.primaryShard();
         }
 
         private void performAction(final DiscoveryNode node, final String action, final boolean isPrimaryAction,

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -181,11 +181,6 @@ public abstract class TransportReplicationAction<
     }
 
     @Override
-    protected final void doExecute(Request request, ActionListener<Response> listener) {
-        throw new UnsupportedOperationException("the task parameter is required for this operation");
-    }
-
-    @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         new ReroutePhase((ReplicationTask) task, request, listener).run();
     }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -19,12 +19,8 @@
 
 package org.elasticsearch.action.support.replication;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.annotation.Nullable;
-
+import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.SQLExceptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -83,8 +79,10 @@ import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
-import io.crate.common.unit.TimeValue;
-import io.crate.exceptions.SQLExceptions;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Base class for requests that should be executed on a primary copy followed by replica copies.
@@ -185,8 +183,8 @@ public abstract class TransportReplicationAction<
         new ReroutePhase((ReplicationTask) task, request, listener).run();
     }
 
-    protected ReplicationOperation.Replicas<ReplicaRequest> newReplicasProxy(long primaryTerm) {
-        return new ReplicasProxy(primaryTerm);
+    protected ReplicationOperation.Replicas<ReplicaRequest> newReplicasProxy() {
+        return new ReplicasProxy();
     }
 
     protected abstract Response newResponseInstance(StreamInput in) throws IOException;
@@ -448,7 +446,7 @@ public abstract class TransportReplicationAction<
             Request request, ActionListener<PrimaryResult<ReplicaRequest, Response>> listener,
             PrimaryShardReference primaryShardReference) {
             return new ReplicationOperation<>(request, primaryShardReference, listener,
-                    newReplicasProxy(primaryRequest.getPrimaryTerm()), logger, actionName);
+                    newReplicasProxy(), logger, actionName, primaryRequest.getPrimaryTerm());
         }
     }
 
@@ -1046,16 +1044,11 @@ public abstract class TransportReplicationAction<
      */
     protected class ReplicasProxy implements ReplicationOperation.Replicas<ReplicaRequest> {
 
-        protected final long primaryTerm;
-
-        public ReplicasProxy(long primaryTerm) {
-            this.primaryTerm = primaryTerm;
-        }
-
         @Override
         public void performOn(
                 final ShardRouting replica,
                 final ReplicaRequest request,
+                final long primaryTerm,
                 final long globalCheckpoint,
                 final long maxSeqNoOfUpdatesOrDeletes,
                 final ActionListener<ReplicationOperation.ReplicaResponse> listener) {
@@ -1072,7 +1065,8 @@ public abstract class TransportReplicationAction<
         }
 
         @Override
-        public void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener) {
+        public void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception,
+                                      ActionListener<Void> listener) {
             // This does not need to fail the shard. The idea is that this
             // is a non-write operation (something like a refresh or a global
             // checkpoint sync) and therefore the replica should still be
@@ -1081,7 +1075,7 @@ public abstract class TransportReplicationAction<
         }
 
         @Override
-        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener) {
+        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, long primaryTerm, ActionListener<Void> listener) {
             // This does not need to make the shard stale. The idea is that this
             // is a non-write operation (something like a refresh or a global
             // checkpoint sync) and therefore the replica should still be

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -106,6 +106,7 @@ public abstract class TransportReplicationAction<
     protected final ClusterService clusterService;
     protected final ShardStateAction shardStateAction;
     protected final IndicesService indicesService;
+    protected final IndexNameExpressionResolver indexNameExpressionResolver;
     protected final TransportRequestOptions transportOptions;
     protected final String executor;
 
@@ -143,11 +144,12 @@ public abstract class TransportReplicationAction<
                                          String executor,
                                          boolean syncGlobalCheckpointAfterOperation,
                                          boolean forceExecutionOnPrimary) {
-        super(actionName, threadPool, indexNameExpressionResolver, transportService.getTaskManager());
+        super(actionName, threadPool, transportService.getTaskManager());
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.indicesService = indicesService;
         this.shardStateAction = shardStateAction;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.executor = executor;
 
         this.transportPrimaryAction = actionName + "[p]";

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import javax.annotation.Nullable;
@@ -61,7 +60,6 @@ public abstract class TransportWriteAction<
                                    IndicesService indicesService,
                                    ThreadPool threadPool,
                                    ShardStateAction shardStateAction,
-                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                    Writeable.Reader<Request> reader,
                                    Writeable.Reader<ReplicaRequest> replicaReader,
                                    String executor,
@@ -73,7 +71,6 @@ public abstract class TransportWriteAction<
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             reader,
             replicaReader,
             executor,

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -109,8 +109,8 @@ public abstract class TransportWriteAction<
     }
 
     @Override
-    protected ReplicationOperation.Replicas newReplicasProxy(long primaryTerm) {
-        return new WriteActionReplicasProxy(primaryTerm);
+    protected ReplicationOperation.Replicas<ReplicaRequest> newReplicasProxy() {
+        return new WriteActionReplicasProxy();
     }
 
     /**
@@ -346,12 +346,9 @@ public abstract class TransportWriteAction<
      */
     class WriteActionReplicasProxy extends ReplicasProxy {
 
-        WriteActionReplicasProxy(long primaryTerm) {
-            super(primaryTerm);
-        }
-
         @Override
-        public void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener) {
+        public void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception,
+                                      ActionListener<Void> listener) {
             if (TransportActions.isShardNotAvailableException(exception) == false) {
                 logger.warn(new ParameterizedMessage("[{}] {}", replica.shardId(), message), exception);
             }
@@ -360,7 +357,7 @@ public abstract class TransportWriteAction<
         }
 
         @Override
-        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener) {
+        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, long primaryTerm, ActionListener<Void> listener) {
             shardStateAction.remoteShardFailed(shardId, allocationId, primaryTerm, true, "mark copy as stale", null, listener);
         }
     }

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
@@ -19,11 +19,6 @@
 
 package org.elasticsearch.gateway;
 
-import java.io.IOException;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodeRequest;
@@ -32,7 +27,6 @@ import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -42,6 +36,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.List;
 
 public class TransportNodesListGatewayMetaState extends TransportNodesAction<TransportNodesListGatewayMetaState.Request,
                                                                              TransportNodesListGatewayMetaState.NodesGatewayMetaState,
@@ -57,9 +55,8 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
     public TransportNodesListGatewayMetaState(ThreadPool threadPool,
                                               ClusterService clusterService,
                                               TransportService transportService,
-                                              IndexNameExpressionResolver indexNameExpressionResolver,
                                               GatewayMetaState metaState) {
-        super(ACTION_NAME, threadPool, clusterService, transportService, indexNameExpressionResolver,
+        super(ACTION_NAME, threadPool, clusterService, transportService,
             Request::new, NodeRequest::new, ThreadPool.Names.GENERIC, NodeGatewayMetaState.class);
         this.metaState = metaState;
     }

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -30,7 +30,6 @@ import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -76,7 +75,6 @@ public class TransportNodesListGatewayStartedShards extends
                                                   ThreadPool threadPool,
                                                   ClusterService clusterService,
                                                   TransportService transportService,
-                                                  IndexNameExpressionResolver indexNameExpressionResolver,
                                                   NodeEnvironment env,
                                                   IndicesService indicesService,
                                                   NamedXContentRegistry namedXContentRegistry) {
@@ -85,7 +83,6 @@ public class TransportNodesListGatewayStartedShards extends
             threadPool,
             clusterService,
             transportService,
-            indexNameExpressionResolver,
             Request::new,
             NodeRequest::new,
             ThreadPool.Names.FETCH_SHARD_STARTED,

--- a/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -57,8 +56,7 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
             final ClusterService clusterService,
             final IndicesService indicesService,
             final ThreadPool threadPool,
-            final ShardStateAction shardStateAction,
-            final IndexNameExpressionResolver indexNameExpressionResolver) {
+            final ShardStateAction shardStateAction) {
         super(
                 ACTION_NAME,
                 transportService,
@@ -66,7 +64,6 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
                 indicesService,
                 threadPool,
                 shardStateAction,
-                indexNameExpressionResolver,
                 Request::new,
                 Request::new,
                 ThreadPool.Names.MANAGEMENT);

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -34,7 +34,6 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.ReplicationTask;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -76,8 +75,7 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
             final ClusterService clusterService,
             final IndicesService indicesService,
             final ThreadPool threadPool,
-            final ShardStateAction shardStateAction,
-            final IndexNameExpressionResolver indexNameExpressionResolver) {
+            final ShardStateAction shardStateAction) {
         super(
             ACTION_NAME,
             transportService,
@@ -85,7 +83,6 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             Request::new,
             Request::new,
             ThreadPool.Names.MANAGEMENT);

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -35,7 +35,6 @@ import org.elasticsearch.action.support.replication.ReplicationTask;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -74,8 +73,7 @@ public class RetentionLeaseSyncAction extends
             final ClusterService clusterService,
             final IndicesService indicesService,
             final ThreadPool threadPool,
-            final ShardStateAction shardStateAction,
-            final IndexNameExpressionResolver indexNameExpressionResolver) {
+            final ShardStateAction shardStateAction) {
         super(
             ACTION_NAME,
             transportService,
@@ -83,7 +81,6 @@ public class RetentionLeaseSyncAction extends
             indicesService,
             threadPool,
             shardStateAction,
-            indexNameExpressionResolver,
             RetentionLeaseSyncAction.Request::new,
             RetentionLeaseSyncAction.Request::new,
             ThreadPool.Names.MANAGEMENT,

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -19,12 +19,7 @@
 
 package org.elasticsearch.indices.store;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import io.crate.common.unit.TimeValue;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -37,7 +32,6 @@ import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -61,7 +55,11 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import io.crate.common.unit.TimeValue;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class TransportNodesListShardStoreMetadata extends TransportNodesAction<TransportNodesListShardStoreMetadata.Request,
     TransportNodesListShardStoreMetadata.NodesStoreFilesMetadata,
@@ -83,9 +81,8 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<T
                                                 TransportService transportService,
                                                 IndicesService indicesService,
                                                 NodeEnvironment nodeEnv,
-                                                IndexNameExpressionResolver indexNameExpressionResolver,
                                                 NamedXContentRegistry namedXContentRegistry) {
-        super(ACTION_NAME, threadPool, clusterService, transportService, indexNameExpressionResolver,
+        super(ACTION_NAME, threadPool, clusterService, transportService,
             Request::new, NodeRequest::new, ThreadPool.Names.FETCH_SHARD_STORE, NodeStoreFilesMetadata.class);
         this.settings = settings;
         this.indicesService = indicesService;

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -611,7 +611,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         DiscoveryNode node = connection.getNode();
 
         TimeoutResponseHandler<T> responseHandler = new TimeoutResponseHandler<>(handler);
-        // TODO we can probably fold this entire request ID dance into connection.sendReqeust but it will be a bigger refactoring
+        // TODO we can probably fold this entire request ID dance into connection.sendRequest but it will be a bigger refactoring
         final long requestId = responseHandlers.add(new Transport.ResponseContext<>(responseHandler, connection, action));
         final TimeoutHandler timeoutHandler;
         if (options.timeout() != null) {

--- a/server/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
@@ -30,7 +30,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -77,7 +76,6 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
         transportShardDeleteAction = new TransportShardDeleteAction(
             MockTransportService.createNewService(
                 Settings.EMPTY, Version.CURRENT, THREAD_POOL, clusterService.getClusterSettings()),
-            mock(IndexNameExpressionResolver.class),
             mock(ClusterService.class),
             indicesService,
             mock(ThreadPool.class),

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.dml.upsert;
 
+import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
@@ -44,11 +45,9 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
@@ -109,10 +108,9 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                                                  IndicesService indicesService,
                                                  ShardStateAction shardStateAction,
                                                  NodeContext nodeCtx,
-                                                 Schemas schemas,
-                                                 IndexNameExpressionResolver indexNameExpressionResolver) {
+                                                 Schemas schemas) {
             super(threadPool, clusterService, transportService, schemaUpdateClient,
-                tasksService, indicesService, shardStateAction, nodeCtx, schemas, indexNameExpressionResolver);
+                tasksService, indicesService, shardStateAction, nodeCtx, schemas);
         }
 
         @Override
@@ -163,8 +161,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             indicesService,
             mock(ShardStateAction.class),
             createNodeContext(),
-            schemas,
-            mock(IndexNameExpressionResolver.class)
+            schemas
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -19,11 +19,10 @@
  * software solely pursuant to the terms of the relevant commercial
  * agreement.
  */
-package org.elasticsearch.indices.close;
+package org.elasticsearch.action.admin.indices.close;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.close.TransportVerifyShardBeforeCloseAction;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.replication.ReplicationOperation;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -291,7 +291,7 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
         TransportVerifyShardBeforeCloseAction.ShardRequest request =
             new TransportVerifyShardBeforeCloseAction.ShardRequest(shardId, false, clusterBlock);
         ReplicationOperation.Replicas<TransportVerifyShardBeforeCloseAction.ShardRequest> proxy =
-            action.newReplicasProxy(primaryTerm);
+            action.newReplicasProxy();
         ReplicationOperation<TransportVerifyShardBeforeCloseAction.ShardRequest,
             TransportVerifyShardBeforeCloseAction.ShardRequest, PrimaryResult> operation = new ReplicationOperation<>(
             request,
@@ -299,7 +299,8 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
             listener,
             proxy,
             logger,
-            "test"
+            "test",
+            primaryTerm
         );
         operation.execute();
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -156,8 +155,8 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
             mock(
                 IndicesService.class),
             mock(ThreadPool.class),
-            shardStateAction,
-            mock(IndexNameExpressionResolver.class));
+            shardStateAction
+        );
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -18,41 +18,7 @@
  */
 package org.elasticsearch.action.support.replication;
 
-import static java.util.Collections.emptyMap;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
-import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
-import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
-import static org.elasticsearch.test.ClusterServiceUtils.setState;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
+import io.crate.common.unit.TimeValue;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -65,7 +31,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -100,7 +65,40 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.crate.common.unit.TimeValue;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
+import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
+import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+import static org.elasticsearch.test.ClusterServiceUtils.setState;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -440,7 +438,6 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                 mockIndicesService(shardId, executedOnPrimary, primary, replica),
                 threadPool,
                 shardStateAction,
-                new IndexNameExpressionResolver(),
                 Request::new,
                 Request::new,
                 ThreadPool.Names.SAME

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.gateway.WriteStateException;
 import org.elasticsearch.index.Index;
@@ -103,8 +102,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
             clusterService,
             indicesService,
             threadPool,
-            shardStateAction,
-            new IndexNameExpressionResolver()
+            shardStateAction
         );
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final RetentionLeaseBackgroundSyncAction.Request request =
@@ -140,8 +138,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
             clusterService,
             indicesService,
             threadPool,
-            shardStateAction,
-            new IndexNameExpressionResolver()
+            shardStateAction
         );
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final RetentionLeaseBackgroundSyncAction.Request request =
@@ -178,8 +175,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
             clusterService,
             indicesService,
             threadPool,
-            shardStateAction,
-            new IndexNameExpressionResolver()
+            shardStateAction
         );
 
         assertNull(action.indexBlockLevel());

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
@@ -17,21 +17,11 @@
 
 package org.elasticsearch.index.seqno;
 
-import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import io.crate.common.io.IOUtils;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.support.ActionTestUtils;
-import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.WriteStateException;
@@ -46,9 +36,14 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
-import io.crate.common.io.IOUtils;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class RetentionLeaseSyncActionTests extends ESTestCase {
 
@@ -104,9 +99,9 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
             clusterService,
             indicesService,
             threadPool,
-            shardStateAction,
-            new IndexNameExpressionResolver());
-        final RetentionLeases retentionLeases = mock(RetentionLeases.class);
+            shardStateAction
+        );
+       final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final RetentionLeaseSyncAction.Request request = new RetentionLeaseSyncAction.Request(indexShard.shardId(), retentionLeases);
 
         action.shardOperationOnPrimary(request, indexShard,
@@ -142,8 +137,7 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
             clusterService,
             indicesService,
             threadPool,
-            shardStateAction,
-            new IndexNameExpressionResolver()
+            shardStateAction
         );
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final RetentionLeaseSyncAction.Request request = new RetentionLeaseSyncAction.Request(indexShard.shardId(), retentionLeases);
@@ -181,8 +175,8 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
             clusterService,
             indicesService,
             threadPool,
-            shardStateAction,
-            new IndexNameExpressionResolver());
+            shardStateAction
+        );
 
         assertNull(action.indexBlockLevel());
     }


### PR DESCRIPTION
See commits.
The first 5 backport commits are older once we missed and such were missing at the es-backports.rst.
The last backport requires a change in our insert-from-values error handling as a cluster block exception is now thrown instead of an IndexClosedException because no index name resolving is happening at this point anymore (which was raising the IndexClosedException).