### PR TITLE
Add an empty pg_catalog.pg_am table

### DIFF
--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -81,6 +81,7 @@ number of replicas.
     | information_schema | table_partitions        | BASE TABLE |             NULL | NULL               |
     | information_schema | tables                  | BASE TABLE |             NULL | NULL               |
     | information_schema | views                   | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_am                   | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_attrdef              | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_attribute            | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_class                | BASE TABLE |             NULL | NULL               |
@@ -116,7 +117,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 49 rows in set (... sec)
+    SELECT 50 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -146,6 +146,7 @@ following tables:
  - `pg_range`_
  - `pg_enum`_
  - `pg_roles`_
+ - `pg_am`_
 
 
 .. _postgres_pg_type:
@@ -416,6 +417,7 @@ either because of the table is empty or by a not matching where clause.
 .. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html
 .. _pg_enum: https://www.postgresql.org/docs/10/catalog-pg-enum.html
 .. _pgjdbc: https://github.com/pgjdbc/pgjdbc
+.. _pg_am: https://www.postgresql.org/docs/10/catalog-pg-am.html
 .. _pg_range: https://www.postgresql.org/docs/10/catalog-pg-range.html
 .. _pg_roles: https://www.postgresql.org/docs/10/view-pg-roles.html
 .. _pgsql_pg_attrdef: https://www.postgresql.org/docs/10/static/catalog-pg-attrdef.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAmTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAmTable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.types.DataTypes;
+
+public final class PgAmTable {
+
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_am");
+
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(IDENT)
+            .add("oid", DataTypes.INTEGER, ignored -> null)
+            .add("amname", DataTypes.STRING, ignored -> null)
+            .add("amhandler", DataTypes.REGPROC, ignored -> null)
+            .add("amtype", DataTypes.BYTE, ignored -> null)
+            .build();
+    }
+}

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -68,7 +68,8 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgProcTable.IDENT.name(), PgProcTable.create()),
             Map.entry(PgRangeTable.IDENT.name(), PgRangeTable.create()),
             Map.entry(PgEnumTable.IDENT.name(), PgEnumTable.create()),
-            Map.entry(PgRolesTable.IDENT.name(), PgRolesTable.create())
+            Map.entry(PgRolesTable.IDENT.name(), PgRolesTable.create()),
+            Map.entry(PgAmTable.IDENT.name(), PgAmTable.create())
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -123,6 +123,11 @@ public class PgCatalogTableDefinitions {
             PgRolesTable.create().expressions(),
             false
         ));
+        tableDefinitions.put(PgAmTable.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgAmTable.create().expressions(),
+            false
+        ));
         Iterable<NamedSessionSetting> sessionSettings =
             () -> sessionSettingRegistry.settings().entrySet().stream()
                 .map(s -> new NamedSessionSetting(s.getKey(), s.getValue()))

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -61,7 +61,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(43L, response.rowCount());
+        assertEquals(44L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| character_sets| information_schema| BASE TABLE| NULL\n" +
@@ -75,6 +75,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| table_partitions| information_schema| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| tables| information_schema| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| views| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_am| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_attrdef| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_attribute| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_class| pg_catalog| BASE TABLE| NULL\n" +
@@ -187,13 +188,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(43L, response.rowCount());
+        assertEquals(44L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(44L, response.rowCount());
+        assertEquals(45L, response.rowCount());
     }
 
     @Test
@@ -523,7 +524,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(828, response.rowCount());
+        assertEquals(832, response.rowCount());
     }
 
     @Test
@@ -767,7 +768,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(46L, response.rows()[0][0]);
+        assertEquals(47L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -99,7 +99,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(43L, response.rowCount());
+        assertEquals(44L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `pg_catalog.pg_am` table exposes the index-access methods that are available in PostgreSQL.

They don't map one-to-one to CrateDB, so this adds an empty table.

Closes https://github.com/crate/crate/issues/10217

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)