### PR TITLE
Optimize fetch performance for sequential value retrieval

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
@@ -338,7 +339,7 @@ final class DocValuesGroupByOptimizedIterator {
                     continue;
                 }
                 for (int i = 0; i < keyExpressions.size(); i++) {
-                    keyExpressions.get(i).setNextReader(leaf);
+                    keyExpressions.get(i).setNextReader(new ReaderContext(leaf));
                 }
                 for (int i = 0; i < aggregators.size(); i++) {
                     aggregators.get(i).loadDocValues(leaf.reader());

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -37,6 +37,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
@@ -294,7 +295,7 @@ final class GroupByOptimizedIterator {
                 continue;
             }
             for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
-                expressions.get(i).setNextReader(leaf);
+                expressions.get(i).setNextReader(new ReaderContext(leaf));
             }
             SortedSetDocValues values = DocValues.getSortedSet(leaf.reader(), keyColumnName);
             try (ObjectArray<Object[]> statesByOrd = bigArrays.newObjectArray(values.getValueCount())) {

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -26,6 +26,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.exceptions.Exceptions;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
@@ -155,7 +156,7 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
             currentDocIdSetIt = scorer.iterator();
             for (LuceneCollectorExpression<?> expression : expressions) {
                 expression.setScorer(currentScorer);
-                expression.setNextReader(currentLeaf);
+                expression.setNextReader(new ReaderContext(currentLeaf));
             }
             return true;
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/ScoreDocRowFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/ScoreDocRowFunction.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.collect.collectors;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.OrderByCollectorExpression;
@@ -85,7 +86,7 @@ class ScoreDocRowFunction implements Function<ScoreDoc, Row> {
         int subDoc = fieldDoc.doc - subReaderContext.docBase;
         for (LuceneCollectorExpression<?> expression : expressions) {
             try {
-                expression.setNextReader(subReaderContext);
+                expression.setNextReader(new ReaderContext(subReaderContext));
                 expression.setNextDocId(subDoc);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
@@ -23,11 +23,14 @@
 package io.crate.execution.engine.fetch;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import com.carrotsearch.hppc.IntContainer;
 import com.carrotsearch.hppc.cursors.IntCursor;
 
+import io.netty.util.collection.IntObjectHashMap;
+import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 
@@ -38,6 +41,7 @@ import io.crate.execution.engine.distribution.StreamBucket;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 
 class FetchCollector {
 
@@ -67,7 +71,7 @@ class FetchCollector {
 
     }
 
-    private void setNextDocId(LeafReaderContext readerContext, int doc) throws IOException {
+    private void setNextDocId(ReaderContext readerContext, int doc) throws IOException {
         for (LuceneCollectorExpression<?> e : collectorExpressions) {
             e.setNextReader(readerContext);
             e.setNextDocId(doc);
@@ -75,19 +79,26 @@ class FetchCollector {
     }
 
     public StreamBucket collect(IntContainer docIds) {
+        if (docIds.size() >= 10) {
+            // If the doc ids are in sequential order we can leverage
+            // the merge instances of the stored fields readers that
+            // are optimized for sequential access.
+            int[] ids = docIds.toArray();
+            Arrays.sort(ids);
+            if (isSequential(ids)) {
+                return collectSequential(ids);
+            }
+        }
         StreamBucket.Builder builder = new StreamBucket.Builder(streamers, ramAccounting);
         try (var borrowed = fetchTask.searcher(readerId)) {
             var searcher = borrowed.item();
             List<LeafReaderContext> leaves = searcher.getTopReaderContext().leaves();
             for (IntCursor cursor : docIds) {
                 int docId = cursor.value;
-                int readerIndex = ReaderUtil.subIndex(docId, leaves);
-                if (readerIndex == -1) {
-                    throw new IllegalStateException("jobId=" + fetchTask.jobId() + " docId " + docId + " doesn't fit to leaves of searcher " + readerId + " fetchTask=" + fetchTask);
-                }
+                int readerIndex = readerIndex(docId, leaves);
                 LeafReaderContext subReaderContext = leaves.get(readerIndex);
                 try {
-                    setNextDocId(subReaderContext, docId - subReaderContext.docBase);
+                    setNextDocId(new ReaderContext(subReaderContext), docId - subReaderContext.docBase);
                 } catch (IOException e) {
                     Exceptions.rethrowRuntimeException(e);
                 }
@@ -95,5 +106,65 @@ class FetchCollector {
             }
         }
         return builder.build();
+    }
+
+    private StreamBucket collectSequential(int[] docIds) {
+        StreamBucket.Builder builder = new StreamBucket.Builder(streamers, ramAccounting);
+        try (var borrowed = fetchTask.searcher(readerId)) {
+            var searcher = borrowed.item();
+            List<LeafReaderContext> leaves = searcher.getTopReaderContext().leaves();
+            var storedFieldsReaders = new IntObjectHashMap<StoredFieldsReader>(leaves.size());
+            for (int docId : docIds) {
+                int readerIndex = readerIndex(docId, leaves);
+                LeafReaderContext subReaderContext = leaves.get(readerIndex);
+                try {
+                    var storedFieldReader = storedFieldsReaders.get(readerIndex);
+                    if (storedFieldReader == null) {
+                        storedFieldReader = sequentialStoredFieldReader(subReaderContext);
+                        storedFieldsReaders.put(readerIndex, storedFieldReader);
+                    }
+                    setNextDocId(new ReaderContext(subReaderContext, storedFieldReader::visitDocument), docId - subReaderContext.docBase);
+                } catch (IOException e) {
+                    Exceptions.rethrowRuntimeException(e);
+                }
+                builder.add(row);
+            }
+        }
+        return builder.build();
+    }
+
+    private int readerIndex(int docId, List<LeafReaderContext> leaves) {
+        int readerIndex = ReaderUtil.subIndex(docId, leaves);
+        if (readerIndex == -1) {
+            throw new IllegalStateException("jobId=" + fetchTask.jobId() + " docId " + docId + " doesn't fit to leaves of searcher " + readerId + " fetchTask=" + fetchTask);
+        }
+        return readerIndex;
+    }
+
+    static boolean isSequential(int[] docIds) {
+        // checks if doc ids are in sequential order using the following conditions:
+        // (last element - first element) = (number of elements in between first and last)
+        // [3,4,5,6,7] -> 7 - 3 == 4
+        if (docIds.length == 0) {
+            return false;
+        }
+        int last = docIds[docIds.length - 1];
+        int first = docIds[0];
+        return last - first == docIds.length - 1;
+    }
+
+    static StoredFieldsReader sequentialStoredFieldReader(LeafReaderContext context) {
+        // If the document access is sequential, the field reader from the merge instance can be used
+        // to provide a significant speed up. However, accessing the merge CompressingStoredFieldsReader is expensive
+        // because the underlying inputData is cloned.
+        if (context.reader() instanceof SequentialStoredFieldsLeafReader) {
+            try {
+                SequentialStoredFieldsLeafReader reader = (SequentialStoredFieldsLeafReader) context.reader();
+                return reader.getSequentialStoredFieldsReader();
+            } catch (IOException e) {
+                throw Exceptions.toRuntimeException(e);
+            }
+        }
+        throw new RuntimeException("Sequential StoredFieldReader not available");
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/fetch/ReaderContext.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/ReaderContext.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.fetch;
+
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.elasticsearch.common.CheckedBiConsumer;
+
+import java.io.IOException;
+
+public class ReaderContext {
+
+    private final LeafReaderContext leafReaderContext;
+    private final CheckedBiConsumer<Integer,StoredFieldVisitor, IOException> storedFieldsReader;
+
+    public ReaderContext(LeafReaderContext leafReaderContext,
+                         CheckedBiConsumer<Integer, StoredFieldVisitor, IOException> storedFieldsReader) {
+        this.leafReaderContext = leafReaderContext;
+        this.storedFieldsReader = storedFieldsReader;
+    }
+
+    public ReaderContext(LeafReaderContext leafReaderContext) {
+        this(leafReaderContext, leafReaderContext.reader()::document);
+    }
+
+    public void visitDocument(int docId, StoredFieldVisitor visitor) throws IOException {
+        storedFieldsReader.accept(docId, visitor);
+    }
+
+    public LeafReader reader() {
+        return leafReaderContext.reader();
+    }
+
+    public int docBase() {
+        return leafReaderContext.docBase;
+    }
+
+}

--- a/server/src/main/java/io/crate/execution/engine/sort/InputFieldComparator.java
+++ b/server/src/main/java/io/crate/execution/engine/sort/InputFieldComparator.java
@@ -23,6 +23,7 @@
 package io.crate.execution.engine.sort;
 
 import io.crate.data.Input;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.FieldComparator;
@@ -62,7 +63,7 @@ class InputFieldComparator extends FieldComparator<Object> implements LeafFieldC
     @Override
     public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
         for (int i = 0; i < collectorExpressions.size(); i++) {
-            collectorExpressions.get(i).setNextReader(context);
+            collectorExpressions.get(i).setNextReader(new ReaderContext(context));
         }
         return this;
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
@@ -22,8 +22,8 @@
 package io.crate.expression.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -67,7 +67,7 @@ public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = FieldData.toString(DocValues.getSortedNumeric(context.reader(), columnName));
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/ByteColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/ByteColumnReference.java
@@ -22,8 +22,8 @@
 package io.crate.expression.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class ByteColumnReference extends LuceneCollectorExpression<Byte> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/BytesRefColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/BytesRefColumnReference.java
@@ -24,8 +24,8 @@ package io.crate.expression.reference.doc.lucene;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
@@ -64,7 +64,7 @@ public class BytesRefColumnReference extends LuceneCollectorExpression<String> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = FieldData.toString(DocValues.getSortedSet(context.reader(), columnName));
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -21,18 +21,19 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.types.DataType;
-import org.apache.lucene.index.LeafReaderContext;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 public class DocCollectorExpression extends LuceneCollectorExpression<Map<String, Object>> {
 
     private SourceLookup sourceLookup;
-    private LeafReaderContext context;
+    private ReaderContext context;
 
     public DocCollectorExpression() {
         super();
@@ -43,13 +44,14 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
         sourceLookup = context.sourceLookup();
     }
 
+
     @Override
     public void setNextDocId(int doc) {
         sourceLookup.setSegmentAndDocument(context, doc);
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(ReaderContext context) throws IOException {
         this.context = context;
     }
 
@@ -72,7 +74,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
         private final DataType<?> returnType;
         private final List<String> path;
         private SourceLookup sourceLookup;
-        private LeafReaderContext context;
+        private ReaderContext context;
 
         ChildDocCollectorExpression(DataType<?> returnType, List<String> path) {
             this.returnType = returnType;
@@ -85,7 +87,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
         }
 
         @Override
-        public void setNextReader(LeafReaderContext context) {
+        public void setNextReader(ReaderContext context) throws IOException {
             this.context = context;
         }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
@@ -24,8 +24,8 @@ package io.crate.expression.reference.doc.lucene;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
@@ -67,7 +67,7 @@ public class DoubleColumnReference extends LuceneCollectorExpression<Double> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         SortedNumericDocValues raw = DocValues.getSortedNumeric(context.reader(), columnName);
         values = FieldData.sortableLongBitsToDoubles(raw);

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/FetchIdCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/FetchIdCollectorExpression.java
@@ -22,7 +22,7 @@
 package io.crate.expression.reference.doc.lucene;
 
 import io.crate.execution.engine.fetch.FetchId;
-import org.apache.lucene.index.LeafReaderContext;
+import io.crate.execution.engine.fetch.ReaderContext;
 
 import java.io.IOException;
 
@@ -49,8 +49,8 @@ public class FetchIdCollectorExpression extends LuceneCollectorExpression<Long> 
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
-        docBase = context.docBase;
+        docBase = context.docBase();
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatColumnReference.java
@@ -24,8 +24,8 @@ package io.crate.expression.reference.doc.lucene;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.NumericUtils;
 
@@ -67,7 +67,7 @@ public class FloatColumnReference extends LuceneCollectorExpression<Float> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/GeoPointColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/GeoPointColumnReference.java
@@ -24,9 +24,9 @@ package io.crate.expression.reference.doc.lucene;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.Point;
@@ -74,7 +74,7 @@ public class GeoPointColumnReference extends LuceneCollectorExpression<Point> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
@@ -21,9 +21,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.doc.DocSysColumns;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fieldvisitor.IDVisitor;
 
 import java.io.IOException;
@@ -32,7 +31,7 @@ import java.io.UncheckedIOException;
 public final class IdCollectorExpression extends LuceneCollectorExpression<String> {
 
     private final IDVisitor visitor = new IDVisitor(DocSysColumns.ID.name());
-    private LeafReader reader;
+    private ReaderContext context;
     private int docId;
 
     public IdCollectorExpression() {
@@ -47,7 +46,7 @@ public final class IdCollectorExpression extends LuceneCollectorExpression<Strin
     public String value() {
         try {
             visitor.setCanStop(false);
-            reader.document(docId, visitor);
+            context.visitDocument(docId, visitor);
             return visitor.getId();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -55,7 +54,7 @@ public final class IdCollectorExpression extends LuceneCollectorExpression<Strin
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
-        reader = context.reader();
+    public void setNextReader(ReaderContext context) throws IOException {
+        this.context = context;
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
@@ -22,8 +22,8 @@
 package io.crate.expression.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 
 import java.io.IOException;
@@ -64,7 +64,7 @@ public class IntegerColumnReference extends LuceneCollectorExpression<Integer> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
@@ -23,8 +23,8 @@ package io.crate.expression.reference.doc.lucene;
 
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.search.DocValueFormat;
@@ -66,7 +66,7 @@ public class IpColumnReference extends LuceneCollectorExpression<String> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         values = context.reader().getSortedSetDocValues(columnName);
         if (values == null) {
             values = DocValues.emptySortedSet();

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LongColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LongColumnReference.java
@@ -22,8 +22,8 @@
 package io.crate.expression.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 
 import java.io.IOException;
@@ -64,7 +64,7 @@ public class LongColumnReference extends LuceneCollectorExpression<Long> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneCollectorExpression.java
@@ -22,7 +22,7 @@
 package io.crate.expression.reference.doc.lucene;
 
 import io.crate.data.Input;
-import org.apache.lucene.index.LeafReaderContext;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.search.Scorable;
 
 import java.io.IOException;
@@ -42,7 +42,7 @@ public abstract class LuceneCollectorExpression<ReturnType> implements Input<Ret
     public void setNextDocId(int doc) {
     }
 
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
     }
 
     public void setScorer(Scorable scorer) {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.lucene.index.LeafReaderContext;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.search.Scorable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
@@ -250,7 +250,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
             inner.setNextDocId(doc);
         }
 
-        public void setNextReader(final LeafReaderContext context) throws IOException {
+        public void setNextReader(ReaderContext context) throws IOException {
             inner.setNextReader(context);
         }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/PrimaryTermCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/PrimaryTermCollectorExpression.java
@@ -22,8 +22,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.doc.DocSysColumns;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 
 import java.io.IOException;
@@ -35,9 +35,9 @@ public class PrimaryTermCollectorExpression extends LuceneCollectorExpression<Lo
     private int doc;
 
     @Override
-    public void setNextReader(LeafReaderContext reader) {
+    public void setNextReader(ReaderContext context) throws IOException {
         try {
-            primaryTerms = reader.reader().getNumericDocValues(DocSysColumns.PRIMARY_TERM.name());
+            primaryTerms = context.reader().getNumericDocValues(DocSysColumns.PRIMARY_TERM.name());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import org.apache.lucene.index.LeafReaderContext;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.elasticsearch.common.compress.CompressorFactory;
 
 import java.io.IOException;
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class RawCollectorExpression extends LuceneCollectorExpression<String> {
 
     private SourceLookup sourceLookup;
-    private LeafReaderContext context;
+    private ReaderContext context;
 
     @Override
     public void startCollect(CollectorContext context) {
@@ -42,7 +42,7 @@ public class RawCollectorExpression extends LuceneCollectorExpression<String> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         this.context = context;
     }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SeqNoCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SeqNoCollectorExpression.java
@@ -22,8 +22,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.doc.DocSysColumns;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 
 import java.io.IOException;
@@ -35,9 +35,9 @@ public class SeqNoCollectorExpression extends LuceneCollectorExpression<Long> {
     private int doc;
 
     @Override
-    public void setNextReader(LeafReaderContext reader) {
+    public void setNextReader(ReaderContext context) throws IOException {
         try {
-            seqNumbers = reader.reader().getNumericDocValues(DocSysColumns.SEQ_NO.name());
+            seqNumbers = context.reader().getNumericDocValues(DocSysColumns.SEQ_NO.name());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/ShortColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/ShortColumnReference.java
@@ -22,8 +22,8 @@
 package io.crate.expression.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 
 import java.io.IOException;
@@ -64,7 +64,7 @@ public class ShortColumnReference extends LuceneCollectorExpression<Short> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) throws IOException {
+    public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/VersionCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/VersionCollectorExpression.java
@@ -22,8 +22,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.doc.DocSysColumns;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 
 import java.io.IOException;
@@ -35,9 +35,9 @@ public class VersionCollectorExpression extends LuceneCollectorExpression<Long> 
     private int docId;
 
     @Override
-    public void setNextReader(LeafReaderContext reader) {
+    public void setNextReader(ReaderContext context) throws IOException {
         try {
-            versions = reader.reader().getNumericDocValues(DocSysColumns.VERSION.name());
+            versions = context.reader().getNumericDocValues(DocSysColumns.VERSION.name());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -23,6 +23,7 @@
 package io.crate.lucene;
 
 import io.crate.data.Input;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.InputCondition;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.symbol.Function;
@@ -126,7 +127,7 @@ class GenericFunctionQuery extends Query {
 
     private FilteredTwoPhaseIterator getTwoPhaseIterator(final LeafReaderContext context) throws IOException {
         for (LuceneCollectorExpression expression : expressions) {
-            expression.setNextReader(context);
+            expression.setNextReader(new ReaderContext(context));
         }
         return new FilteredTwoPhaseIterator(context.reader(), condition, expressions);
     }

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -32,6 +32,7 @@ import io.crate.data.RowN;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.engine.collect.DocInputFactory;
 import io.crate.execution.engine.fetch.FetchId;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
@@ -239,7 +240,7 @@ public final class ReservoirSampler {
             int subDoc = docId - leafContext.docBase;
             for (LuceneCollectorExpression<?> expression : expressions) {
                 try {
-                    expression.setNextReader(leafContext);
+                    expression.setNextReader(new ReaderContext(leafContext));
                     expression.setNextDocId(subDoc);
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);

--- a/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReader.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReader.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.lucene.index;
 
+import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.index.shard.ShardId;
@@ -27,7 +28,7 @@ import org.elasticsearch.index.shard.ShardId;
  * A {@link org.apache.lucene.index.FilterLeafReader} that exposes
  * Elasticsearch internal per shard / index information like the shard ID.
  */
-public final class ElasticsearchLeafReader extends FilterLeafReader {
+public final class ElasticsearchLeafReader extends SequentialStoredFieldsLeafReader {
 
     private final ShardId shardId;
 
@@ -72,5 +73,10 @@ public final class ElasticsearchLeafReader extends FilterLeafReader {
             }
         }
         return null;
+    }
+
+    @Override
+    protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
+        return reader;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/lucene/index/SequentialStoredFieldsLeafReader.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/index/SequentialStoredFieldsLeafReader.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.index;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.LeafReader;
+
+import java.io.IOException;
+
+/**
+ * A {@link FilterLeafReader} that exposes a {@link StoredFieldsReader}
+ * optimized for sequential access. This class should be used by custom
+ * {@link FilterLeafReader} that are used at search time in order to
+ * leverage sequential access when retrieving stored fields in queries,
+ * aggregations or during the fetch phase.
+ */
+public abstract class SequentialStoredFieldsLeafReader extends FilterLeafReader {
+    /**
+     * <p>Construct a StoredFieldsFilterLeafReader based on the specified base reader.
+     * <p>Note that base reader is closed if this FilterLeafReader is closed.</p>
+     *
+     * @param in specified base reader.
+     */
+    public SequentialStoredFieldsLeafReader(LeafReader in) {
+        super(in);
+    }
+
+    /**
+     * Implementations should return a {@link StoredFieldsReader} that wraps the provided <code>reader</code>
+     * that is optimized for sequential access (adjacent doc ids).
+     */
+    protected abstract StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader);
+
+    /**
+     * Returns a {@link StoredFieldsReader} optimized for sequential access (adjacent doc ids).
+     */
+    public StoredFieldsReader getSequentialStoredFieldsReader() throws IOException {
+        if (in instanceof CodecReader) {
+            CodecReader reader = (CodecReader) in;
+            return doGetSequentialStoredFieldsReader(reader.getFieldsReader().getMergeInstance());
+        } else if (in instanceof SequentialStoredFieldsLeafReader) {
+            SequentialStoredFieldsLeafReader reader = (SequentialStoredFieldsLeafReader) in;
+            return doGetSequentialStoredFieldsReader(reader.getSequentialStoredFieldsReader());
+        } else {
+            throw new IOException("requires a CodecReader or a SequentialStoredFieldsLeafReader, got " + in.getClass());
+        }
+    }
+
+}

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -26,6 +26,7 @@ import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.BytesRefColumnReference;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LongColumnReference;
@@ -45,7 +46,6 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
@@ -245,7 +245,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             List.of(new LuceneCollectorExpression<>() {
 
                 @Override
-                public void setNextReader(LeafReaderContext context) {
+                public void setNextReader(ReaderContext context) throws IOException {
                     onNextReader.run();
                 }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -27,6 +27,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
@@ -42,7 +43,6 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
@@ -109,7 +109,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             List.of(new LuceneCollectorExpression<Object>() {
 
                 @Override
-                public void setNextReader(LeafReaderContext context) throws IOException {
+                public void setNextReader(ReaderContext context) throws IOException {
                     onNextReader.run();
                 }
 

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchCollectorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.fetch;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(RandomizedRunner.class)
+public class FetchCollectorTest {
+
+    @Test
+    public void test_sequential_docs_ids() {
+        int start = randomIntBetween(0, Short.MAX_VALUE);
+        var sequential = new int[10];
+        for (int i = 0; i < 10; i++) {
+            sequential[i] = start;
+            start++;
+        }
+        assertThat(FetchCollector.isSequential(sequential), is(true));
+
+        var random = new int[10];
+        for (int i = 0; i < 10; i++) {
+            random[i] = randomIntBetween(0, Short.MAX_VALUE);
+        }
+        assertThat(FetchCollector.isSequential(random), is(false));
+    }
+}

--- a/server/src/test/java/io/crate/expression/reference/doc/BooleanColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/BooleanColumnReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference.doc;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.BooleanColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -57,7 +58,7 @@ public class BooleanColumnReferenceTest extends DocLevelExpressionsTest {
     public void testBooleanExpression() throws Exception {
         BooleanColumnReference booleanColumn = new BooleanColumnReference(column);
         booleanColumn.startCollect(ctx);
-        booleanColumn.setNextReader(readerContext);
+        booleanColumn.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 20);
         int i = 0;

--- a/server/src/test/java/io/crate/expression/reference/doc/DoubleColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/DoubleColumnReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference.doc;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.DoubleColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -55,7 +56,7 @@ public class DoubleColumnReferenceTest extends DocLevelExpressionsTest {
     public void testFieldCacheExpression() throws Exception {
         DoubleColumnReference doubleColumn = new DoubleColumnReference(column);
         doubleColumn.startCollect(ctx);
-        doubleColumn.setNextReader(readerContext);
+        doubleColumn.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
         double d = 0.5;

--- a/server/src/test/java/io/crate/expression/reference/doc/FloatColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/FloatColumnReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference.doc;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.FloatColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -55,7 +56,7 @@ public class FloatColumnReferenceTest extends DocLevelExpressionsTest {
     public void testFieldCacheExpression() throws Exception {
         FloatColumnReference floatColumn = new FloatColumnReference(column);
         floatColumn.startCollect(ctx);
-        floatColumn.setNextReader(readerContext);
+        floatColumn.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
         float f = -0.5f;

--- a/server/src/test/java/io/crate/expression/reference/doc/IpColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/IpColumnReferenceTest.java
@@ -23,6 +23,7 @@
 package io.crate.expression.reference.doc;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.IpColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -95,7 +96,7 @@ public class IpColumnReferenceTest extends DocLevelExpressionsTest {
     public void testIpExpression() throws Exception {
         IpColumnReference columnReference = new IpColumnReference(IP_COLUMN);
         columnReference.startCollect(ctx);
-        columnReference.setNextReader(readerContext);
+        columnReference.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 21);
         assertThat(topDocs.scoreDocs.length, is(21));
@@ -119,7 +120,7 @@ public class IpColumnReferenceTest extends DocLevelExpressionsTest {
     public void testIpExpressionOnArrayThrowsException() throws Exception {
         IpColumnReference columnReference = new IpColumnReference(IP_ARRAY_COLUMN);
         columnReference.startCollect(ctx);
-        columnReference.setNextReader(readerContext);
+        columnReference.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
 
@@ -136,7 +137,7 @@ public class IpColumnReferenceTest extends DocLevelExpressionsTest {
     public void testNullDocValuesDoNotResultInNPE() throws IOException {
         IpColumnReference ref = new IpColumnReference("missing_column");
         ref.startCollect(ctx);
-        ref.setNextReader(readerContext);
+        ref.setNextReader(new ReaderContext(readerContext));
         ref.setNextDocId(0);
 
         assertThat(ref.value(), Matchers.nullValue());

--- a/server/src/test/java/io/crate/expression/reference/doc/LongColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/LongColumnReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference.doc;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.LongColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -57,7 +58,7 @@ public class LongColumnReferenceTest extends DocLevelExpressionsTest {
     public void testLongExpression() throws Exception {
         LongColumnReference longColumn = new LongColumnReference(column);
         longColumn.startCollect(ctx);
-        longColumn.setNextReader(readerContext);
+        longColumn.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 20);
         long l = Long.MIN_VALUE;

--- a/server/src/test/java/io/crate/expression/reference/doc/ShortColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/ShortColumnReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference.doc;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.ShortColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -57,7 +58,7 @@ public class ShortColumnReferenceTest extends DocLevelExpressionsTest {
     public void testShortExpression() throws Exception {
         ShortColumnReference shortColumn = new ShortColumnReference(column);
         shortColumn.startCollect(ctx);
-        shortColumn.setNextReader(readerContext);
+        shortColumn.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 20);
         short i = -10;

--- a/server/src/test/java/io/crate/expression/reference/doc/StringColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/StringColumnReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference.doc;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.BytesRefColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -60,7 +61,7 @@ public class StringColumnReferenceTest extends DocLevelExpressionsTest {
     public void testFieldCacheExpression() throws Exception {
         BytesRefColumnReference bytesRefColumn = new BytesRefColumnReference(column);
         bytesRefColumn.startCollect(ctx);
-        bytesRefColumn.setNextReader(readerContext);
+        bytesRefColumn.setNextReader(new ReaderContext(readerContext));
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 20);
         int i = 0;

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -148,6 +148,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
+import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver;
 import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndSeqNo;
@@ -5963,6 +5964,28 @@ public class InternalEngineTests extends EngineTestCase {
                     getter.join();
                 }
                 assertThat(refreshCount.get(), lessThanOrEqualTo(refreshCountBeforeGet + 1));
+            }
+        }
+    }
+
+    @Test
+    public void testProducesStoredFieldsReader() throws Exception {
+        // Make sure that the engine produces a SequentialStoredFieldsLeafReader.
+        // This is required for optimizations on SourceLookup to work, which is in-turn useful for runtime fields.
+        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField("test"),
+                                                new BytesArray("{}".getBytes(Charset.defaultCharset())), null);
+        Engine.Index operation = randomBoolean() ?
+            appendOnlyPrimary(doc, false, 1)
+            : appendOnlyReplica(doc, false, 1, randomIntBetween(0, 5));
+        engine.index(operation);
+        engine.refresh("test");
+        try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
+            IndexReader reader = searcher.getIndexReader();
+            assertThat(reader.leaves().size(), Matchers.greaterThanOrEqualTo(1));
+            for (LeafReaderContext context: reader.leaves()) {
+                assertThat(context.reader(), Matchers.instanceOf(SequentialStoredFieldsLeafReader.class));
+                SequentialStoredFieldsLeafReader lf = (SequentialStoredFieldsLeafReader) context.reader();
+                assertNotNull(lf.getSequentialStoredFieldsReader());
             }
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The fetch performance can be optimized for the case where the retrival is in sequential order by leveraging the merge instances of stored fields readers that are optimized for sequential access. 

```
Q: SELECT * FROM uservisits LIMIT 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       43.509 ±    9.050 |     34.549 |     42.470 |     46.479 |    255.659 |
|   V2    |        9.481 ±    6.594 |      7.322 |      8.460 |      9.279 |    197.222 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 128.43%                           - 133.56%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 128.43%
The test has statistical significance

Q: select * from articles inner join colors on articles.id = colors.id order by articles.id limit 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       57.408 ±   34.947 |     47.715 |     51.859 |     54.174 |    525.007 |
|   V2    |       47.619 ±   28.969 |     39.616 |     42.811 |     45.897 |    440.282 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  18.64%                           -  19.12%
There is a 99.76% probability that the observed difference is not random, and the best estimate of that difference is 18.64%
The test has statistical significance
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
