### PR TITLE
Use postgres compatible formatter for to_char with interval types

### DIFF
--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -1251,17 +1251,18 @@ containing any of the following symbols:
     +-----------------------------------------+
     SELECT 1 row in set (... sec)
 
-For ``interval`` expressions, the formatting string is discard and the interval
-is returned in a standard form:
+For ``interval`` expressions, the formatting string accepts the same tokens as
+``timestamp`` expressions. The function then uses the timestamp of the specified
+interval added to the timestamp of ``0000/01/01 00:00:00``:
 
 ::
 
-    cr> select to_char(interval '1-2 3 4:5:6', '') as interval;
-    +------------------------------------------------------------+
-    | interval                                                   |
-    +------------------------------------------------------------+
-    | 1 year, 2 months, 3 days, 4 hours, 5 minutes and 6 seconds |
-    +------------------------------------------------------------+
+    cr> select to_char(interval '1 year 3 weeks 200 minutes', 'YYYY MM DD HH12:MI:SS') as interval;
+    +---------------------+
+    | interval            |
+    +---------------------+
+    | 0001 01 22 03:20:00 |
+    +---------------------+
     SELECT 1 row in set (... sec)
 
 For ``numeric`` expressions, the syntax follows that of the `Java DecimalFormat`_.

--- a/server/src/main/java/io/crate/expression/scalar/formatting/DateTimeFormatter.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/DateTimeFormatter.java
@@ -301,17 +301,17 @@ public class DateTimeFormatter {
                 String s = String.valueOf(datetime.getYear());
                 yield s.substring(0, 1) + "," + s.substring(1);
             }
-            case YEAR_YYYY -> datetime.getYear();
+            case YEAR_YYYY -> padStart(String.valueOf(datetime.getYear()), 4, '0');
             case YEAR_YYY -> {
-                String s = String.valueOf(datetime.getYear());
+                String s = padStart(String.valueOf(datetime.getYear()), 4, '0');
                 yield s.substring(s.length() - 3);
             }
             case YEAR_YY -> {
-                String s = String.valueOf(datetime.getYear());
+                String s = padStart(String.valueOf(datetime.getYear()), 4, '0');
                 yield s.substring(s.length() - 2);
             }
             case YEAR_Y -> {
-                String s = String.valueOf(datetime.getYear());
+                String s = padStart(String.valueOf(datetime.getYear()), 4, '0');
                 yield s.substring(s.length() - 1);
             }
             case ISO_YEAR_YYY -> String.valueOf(datetime.get(IsoFields.WEEK_BASED_YEAR));

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
@@ -54,7 +54,7 @@ public class ToCharFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateInterval() {
-        assertEvaluate("to_char(INTERVAL '1-2 3 4:5:6', 'HH24:M:SS')", "1 year, 2 months, 3 days, 4 hours, 5 minutes and 6 seconds");
+        assertEvaluate("to_char(INTERVAL '1 year 2 months 3 weeks 5 hours 6 minutes 7 seconds', 'YYYY MM DD HH12:MI:SS')", "0001 03 22 05:06:07");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, `to_char` would ignore the string formatting field and just output the standard string rendering of the interval. This PR instead uses the postgres syntax compatible parser by adding the interval to the date 0000/01/01 00:00:00, which brings it into agreement with the behaviour with postgresql.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
