### PR TITLE
Improvement: Make ``ITEST_FILE_NAME_FILTER`` documentation more visible

### DIFF
--- a/devs/docs/tests.rst
+++ b/devs/docs/tests.rst
@@ -6,12 +6,17 @@ Run tests in a single module using multiple forks::
 
     $ ./gradlew --parallel -PtestForks=2 :sql:test
 
-Run the doc-tests::
+Run the all of `doctests`_::
 
     $ ./gradlew itest
-      (export ITEST_FILE_NAME_FILTER=<file-name>
-       if you want to only run the test of a particular file.
-       Clear the env var to test all files.)
+
+Run the doctests for a specific file (e.g., ``filename.rst``):
+
+    $ ITEST_FILE_NAME_FILTER=filename.rst ./gradlew itest
+
+You can also ``export`` ``ITEST_FILE_NAME_FILTER`` to your shell environment
+(e.g., export ITEST_FILE_NAME_FILTER=filename.rst``) if you want to set the
+value for the remainder of your terminal session.
 
 Filter tests::
 
@@ -39,3 +44,5 @@ Use ``@TestLogging(["<packageName1>:<logLevel1>", ...])`` on your test class or
 test method to enable more detailed logging. For example::
 
     @TestLogging("io.crate:DEBUG,io.crate.planner.consumer.NestedLoopConsumer:TRACE")
+
+.. _doctests: https://github.com/crate/crate/blob/master/blackbox/test_docs.py

--- a/devs/docs/write_docs.rst
+++ b/devs/docs/write_docs.rst
@@ -13,11 +13,83 @@ particular line width if you do not want to do this by hand.
 To work on the docs locally, you will need `Python`_ 3 in addition to `Java`_
 (required for the `doctests`_). Make sure that ``python3`` is on your ``$PATH``.
 
+.. contents::
+
+
+Build the docs with Gradle (including doctests)
+===============================================
+
+We have a `Gradle`_ `build script`_ that can also be used to build and, more
+importantly, test the docs.
+
+To bootstrap Gradle on your system, you can navigate to the home directory
+of this repository and run::
+
+    $ ./gradlew
+
+
+Run the Sphinx dev server
+-------------------------
+
+Run the Gradle ``developDocs`` task::
+
+    $ ./gradlew :blackbox:developDocs
+
+This invokes the running of a script which watches the file system and
+rebuilds the docs when changes are detected. When a change is detected, it
+will automatically refresh the browser tab for you.
+
+Once the web server is running, you can view your local copy of the docs by
+visiting http://127.0.0.1:8000 in a web browser.
+
+
+Build the docs
+--------------
+
+You can build the docs without starting the web server. You may want to do
+this if you want to test the docs without previewing your changes.
+
+To do this, run the Gradle ``buildDocs`` task::
+
+    $ ./gradlew :blackbox:buildDocs
+
+The build output is located in `/docs/_out/html`.
+
+
+Run the doctests
+----------------
+
+Many of the code examples in the documentation are executable and function as
+`doctests`_.
+
+You can run the doctests with the Gradle ``itest`` task::
+
+    $ ./gradlew :blackbox:itest
+
+**Note**: Your network connection should be up and running, or some of the tests
+will fail.
+
+You can run the doctests for a specific file (e.g., ``filename.rst``):
+
+    $ ITEST_FILE_NAME_FILTER=filename.rst ./gradlew itest
+
+You can also ``export`` ``ITEST_FILE_NAME_FILTER`` to your shell environment
+(e.g., export ITEST_FILE_NAME_FILTER=filename.rst``) if you want to set the
+value for the remainder of your terminal session.
+
+
+Reset the docs build
+--------------------
+
+To clean or reset the docs build, run the Gradle ``cleanDocs`` task::
+
+    $ ./gradlew :blackbox:cleanDocs
+
 
 Build the docs with Sphinx
 ==========================
 
-You can use Sphinx to build the docs without setting up your Java environment
+You can use Sphinx to build the docs *without* setting up your Java environment
 or running the `doctests`_.
 
 From the root directory of this repository, change into the ``blackbox``
@@ -41,10 +113,11 @@ browser tab for you.
 Once the web server is running, you can view your local copy of the docs by
 visiting http://127.0.0.1:8000 in a web browser.
 
-*Note*: The CrateDB docs include many `doctests`_ to test code snippets in the
+**Note**: The CrateDB docs include many `doctests`_ to test code snippets in the
 documentation. The method described above is useful for previewing quick
 changes. However, to properly test the documentation, you must follow the
-instructions in the section, `Build the docs with Gradle (including full doctests)`_.
+instructions in the section, `Build the docs with Gradle (including full
+doctests)`_.
 
 
 Troubleshoot
@@ -63,67 +136,8 @@ Then, rerun the bootstrap script::
     $ ./bootstrap.sh
 
 
-Build the docs with Gradle (including full doctests)
-====================================================
-
-We have a `Gradle`_ `build script`_ that can also be used to build and,
-more importantly, test the docs. 
-
-To bootstrap Gradle on your system, you can navigate to the home directory
-of this repository and run::
-
-    $ ./gradlew
-
-
-Run the Sphinx dev server
--------------------------
-
-Run the Gradle `developDocs` task::
-
-    $ ./gradlew :blackbox:developDocs
-
-This invokes the running of a script which watches the file system and
-rebuilds the docs when changes are detected. When a change is detected, it
-will automatically refresh the browser tab for you.
-
-Once the web server is running, you can view your local copy of the docs by
-visiting http://127.0.0.1:8000 in a web browser.
-
-
-Build the docs
---------------
-
-You can build the docs without starting the web server. You may want to do
-this if you want to test the docs without previewing your changes.
-
-To do this, run the Gradle `buildDocs` task::
-
-    $ ./gradlew :blackbox:buildDocs
-
-The build output is located in `/docs/_out/html`.
-
-
-Run the doctests
-----------------
-
-Many of the code examples in the documentation are executable and function as
-`doctests`_.
-
-You can run the doctests with the Gradle `itest` task::
-
-    $ ./gradlew :blackbox:itest
-
-*Note*: Your network connection should be up and running, or some of the tests
-will fail.
-
-
-Reset the docs build
---------------------
-
-To clean or reset the docs build, run the Gradle `cleanDocs` task::
-
-    $ ./gradlew :blackbox:cleanDocs
-
+Continuous Integration and Deployment (CI/CD)
+=============================================
 
 `Read the Docs`_ automatically builds and deploys the docs directly from Git,
 and there is nothing you need to do to get the live docs to update. We do,
@@ -133,11 +147,11 @@ docs web cache (we have a Jenkins job for this purpose).
 
 
 .. _build script: https://github.com/crate/crate/blob/master/blackbox/build.gradle
-.. _doctests: http://www.sphinx-doc.org/en/stable/ext/doctest.html
+.. _doctests: https://github.com/crate/crate/blob/master/blackbox/test_docs.py
 .. _Gradle: https://gradle.org
 .. _Java: http://www.java.com
-.. _Python: http://www.python.org
 .. _Python virtual environment: https://docs.python.org/3/tutorial/venv.html
+.. _Python: http://www.python.org
 .. _Read the Docs: http://readthedocs.org
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _script: https://github.com/crate/crate/blob/master/blackbox/bin/sphinx


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change does the following:

- Lifts the mention of `ITEST_FILE_NAME_FILTER` into its own example in
  `tests.rst`
- Adds a mention of `ITEST_FILE_NAME_FILTER` to `write_docs.rst`
- Links to the `test_docs.py` file (and fixes link list ordering where
  appropriate)
- Re-orders the sections in `write_docs.rst` to prioritize the Gradle workflow
  (and in turn, promote the execution of the docstests during development)
- Adds a new header for CI/CD information to split this off from the build
  workflow content
- Adds a TOC to `write_docs.rst` to aid navigation
- Fixes some RST literal syntax

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
