### PR TITLE
Improve the experience when working on the documentation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
           agent { label 'medium' }
           steps {
             sh 'cd ./blackbox/ && ./bootstrap.sh'
-            sh './blackbox/.venv/bin/sphinx-build -n -W -c docs/ -b html -E docs/ docs/out/html'
+            sh './blackbox/.venv/bin/sphinx-build -n -W -c docs/ -b html -E docs/ docs/_out/html'
             sh 'find ./blackbox/*/src/ -type f -name "*.py" | xargs ./blackbox/.venv/bin/pycodestyle'
           }
         }

--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -6,10 +6,8 @@ DOCS_DIR=$DIR/../docs
 PATH=$DIR/.venv/bin:$PATH
 
 if [ "$1" == "dev" ]; then
-    sphinx-autobuild -n -W -E $DOCS_DIR $DOCS_DIR/_out/html
+    exec sphinx-autobuild -n -W $DOCS_DIR $DOCS_DIR/_out/html
 else
-    printf "\033[1mCleaning output folder ...\033[0m\n"
-    rm -rf $DIR/docs/_out
     printf "\033[1;44mBuilding server docs ...\033[0m\n"
-    sphinx-build -n -W -b html -E $DOCS_DIR $DOCS_DIR/_out/html
+    sphinx-build -n -W -b html $DOCS_DIR $DOCS_DIR/_out/html
 fi

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -19,4 +19,4 @@ sphinx-csv-filter>=0.2.0
 crate-docs-theme>=0.12.0
 
 # Documentation: local development
-sphinx-autobuild==0.7.1
+sphinx-autobuild>=2020.9.1


### PR DESCRIPTION
Hi there,

these updates significantly improve some of the bits wrapping up Sphinx into build steps, with and without being invoked from gradle.

- Reuse saved Sphinx environment to prevent always reading all files.
- Don't clean output folder on each invocation.
- Replace the wrapper shell with the "sphinx-autobuild" process to make it receive SIGINT from gradle. Otherwise, it will keep running in the background even after `CTRL+C`ing the gradle process.
- Use most recent "sphinx-autobuild" package.
- Adjust output folder when running on Jenkins.

With kind regards,
Andreas.
