### PR TITLE
Optimize ReaderContext creation for LuceneCollectorExpressions

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -294,8 +294,9 @@ final class GroupByOptimizedIterator {
             if (scorer == null) {
                 continue;
             }
+            var readerContext = new ReaderContext(leaf);
             for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
-                expressions.get(i).setNextReader(new ReaderContext(leaf));
+                expressions.get(i).setNextReader(readerContext);
             }
             SortedSetDocValues values = DocValues.getSortedSet(leaf.reader(), keyColumnName);
             try (ObjectArray<Object[]> statesByOrd = bigArrays.newObjectArray(values.getValueCount())) {

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -154,9 +154,10 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
             currentScorer = scorer;
             currentLeaf = leaf;
             currentDocIdSetIt = scorer.iterator();
+            var readerContext = new ReaderContext(currentLeaf);
             for (LuceneCollectorExpression<?> expression : expressions) {
                 expression.setScorer(currentScorer);
-                expression.setNextReader(new ReaderContext(currentLeaf));
+                expression.setNextReader(readerContext);
             }
             return true;
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/ScoreDocRowFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/ScoreDocRowFunction.java
@@ -84,9 +84,10 @@ class ScoreDocRowFunction implements Function<ScoreDoc, Row> {
         int readerIndex = ReaderUtil.subIndex(fieldDoc.doc, leaves);
         LeafReaderContext subReaderContext = leaves.get(readerIndex);
         int subDoc = fieldDoc.doc - subReaderContext.docBase;
+        var readerContext = new ReaderContext(subReaderContext);
         for (LuceneCollectorExpression<?> expression : expressions) {
             try {
-                expression.setNextReader(new ReaderContext(subReaderContext));
+                expression.setNextReader(readerContext);
                 expression.setNextDocId(subDoc);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -238,9 +238,10 @@ public final class ReservoirSampler {
             int readerIndex = ReaderUtil.subIndex(docId, leaves);
             LeafReaderContext leafContext = leaves.get(readerIndex);
             int subDoc = docId - leafContext.docBase;
+            var readerContext = new ReaderContext(leafContext);
             for (LuceneCollectorExpression<?> expression : expressions) {
                 try {
-                    expression.setNextReader(new ReaderContext(leafContext));
+                    expression.setNextReader(readerContext);
                     expression.setNextDocId(subDoc);
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/10862 based on https://github.com/crate/crate/pull/10862#issuecomment-747598659.

Sequential doc retrieval:

```
Q: SELECT * FROM uservisits LIMIT 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        8.927 ±    7.309 |      7.098 |      7.982 |      8.478 |    218.877 |
|   V2    |        8.760 ±    7.120 |      6.609 |      7.838 |      8.352 |    210.473 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.89%                           -   1.82%
There is a 39.48% probability that the observed difference is not random, and the best estimate of that difference is 1.89%
The test has no statistical significance
```

Random doc retrieval:

```
Q: select * from uservisits where "searchWord" = 'hardnose' order by "visitDate" desc
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       64.798 ±   46.650 |     55.149 |     60.915 |     63.605 |   1094.213 |
|   V2    |       59.777 ±   36.961 |     51.145 |     55.056 |     57.617 |    842.318 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   8.06%                           -  10.10%
There is a 94.05% probability that the observed difference is not random, and the best estimate of that difference is 8.06%
The test has no statistical significance
```



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
