### PR TITLE
Fix output names of COPY TO statements

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -89,6 +89,12 @@ Changes
 Fixes
 =====
 
+- Fixed an issue resulting in the full generated expression as the column name
+  inside data exported by ``COPY TO`` statements.
+
+- Fixed an issue resulting double-quoted column names inside data exported by
+  ``COPY TO`` statements.
+
 - Fixed a memory leak in the DNS discovery seed provider. The memory leak
   occurred if you configured ``discovery.seed_providers=srv``.
 

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -364,4 +364,22 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         expectedException.expectMessage("node_filters argument 'name' must be a String, not 20 (Integer)");
         analyze("COPY users FROM '/' WITH (node_filters={name=20})");
     }
+
+    @Test
+    public void test_copy_to_using_upper_case_columns_does_not_result_in_quoted_col_names() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("CREATE TABLE doc.upper (\"Name\" varchar)")
+            .build();
+        BoundCopyTo analysis = analyze("COPY doc.upper (\"Name\") TO DIRECTORY '/dummy'");
+        assertThat(analysis.outputNames(), contains("Name"));
+    }
+
+    @Test
+    public void test_copy_to_using_generated_columns_does_not_result_in_full_expression() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("CREATE TABLE doc.generated_copy (i as 1 + 1)")
+            .build();
+        BoundCopyTo analysis = analyze("COPY doc.generated_copy (i) TO DIRECTORY '/dummy'");
+        assertThat(analysis.outputNames(), contains("i"));
+    }
 }


### PR DESCRIPTION
The output name must not be an double-quoted column name for upper case
columns.
For generated expressions, the column name must be used instead of
the full expression.

Fixes #10875.