### PR TITLE
Fix links inside documentation pointing to old guide section

### DIFF
--- a/docs/admin/discovery.rst
+++ b/docs/admin/discovery.rst
@@ -22,7 +22,7 @@ cluster on Amazon EC2.
 
 .. _`Amazon EC2`: https://aws.amazon.com/ec2
 .. _`EC2 API`: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html
-.. _best practice: https://crate.io/docs/crate/guide/best_practices/ec2_setup.html
+.. _best practice: https://crate.io/docs/crate/howtos/best_practices/ec2_setup.html
 
 .. _azure_discovery:
 

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -303,6 +303,6 @@ Other Changes
 
 .. _admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
 .. _backup: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
-.. _full cluster restart: https://crate.io/docs/crate/guide/en/latest/admin/full-restart-upgrade.html
+.. _full cluster restart: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
 .. _HTTP Authorization header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated

--- a/docs/cli-tools.rst
+++ b/docs/cli-tools.rst
@@ -211,13 +211,13 @@ Options
 +---------------------+-----------------------------------------------------+
 
 
-.. _deployment guide: https://crate.io/docs/crate/guide/en/latest/deployment/index.html
-.. _Detach a node from its cluster: https://crate.io/docs/crate/guide/en/latest/best-practices/crate-node.html#detach-a-node-from-its-cluster
+.. _deployment guide: https://crate.io/docs/crate/howtos/en/latest/deployment/index.html
+.. _Detach a node from its cluster: https://crate.io/docs/crate/howtos/en/latest/best-practices/crate-node.html#detach-a-node-from-its-cluster
 .. _Getting Started With CrateDB: https://crate.io/docs/crate/getting-started/en/latest/install/index.html
-.. _graceful stop: https://crate.io/docs/crate/guide/en/latest/admin/rolling-upgrade.html#step-2-graceful-stop
+.. _graceful stop: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html#step-2-graceful-stop
 .. _PATH: https://kb.iu.edu/d/acar
-.. _Perform an unsafe cluster bootstrap: https://crate.io/docs/crate/guide/en/latest/best-practices/crate-node.html#perform-an-unsafe-cluster-bootstrap
-.. _Repurpose a node: https://crate.io/docs/crate/guide/en/latest/best-practices/crate-node.html#repurpose-a-node
+.. _Perform an unsafe cluster bootstrap: https://crate.io/docs/crate/howtos/en/latest/best-practices/crate-node.html#perform-an-unsafe-cluster-bootstrap
+.. _Repurpose a node: https://crate.io/docs/crate/howtos/en/latest/best-practices/crate-node.html#repurpose-a-node
 .. _Rolling Upgrade: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html
-.. _troubleshooting guide: https://crate.io/docs/crate/guide/en/latest/best-practices/crate-node.html
-.. _Troubleshooting with crate-node CLI: https://crate.io/docs/crate/guide/en/latest/best-practices/crate-node.html
+.. _troubleshooting guide: https://crate.io/docs/crate/howtos/en/latest/best-practices/crate-node.html
+.. _Troubleshooting with crate-node CLI: `troubleshooting guide`_

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1260,6 +1260,6 @@ Metadata gateway
   number of nodes in the cluster.
 
 
-.. _bootstrap checks: https://crate.io/docs/crate/guide/en/latest/admin/bootstrap-checks.html
+.. _bootstrap checks: https://crate.io/docs/crate/howtos/en/latest/admin/bootstrap-checks.html
 .. _`Azure Portal`: https://portal.azure.com
 .. _`Active Directory application`: https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/

--- a/docs/config/environment.rst
+++ b/docs/config/environment.rst
@@ -92,7 +92,7 @@ General
 
      `Appropriate memory configuration`_ is important for optimal performance.
 
-.. _appropriate memory configuration: https://crate.io/docs/crate/guide/en/latest/performance/memory.html
+.. _appropriate memory configuration: https://crate.io/docs/crate/howtos/en/latest/performance/memory.html
 
 .. _conf-env-dump-path:
 

--- a/docs/general/ddl/partitioned-tables.rst
+++ b/docs/general/ddl/partitioned-tables.rst
@@ -52,7 +52,7 @@ can be deleted and no expensive query is involved.
    Well tuned shard allocation is vital. Read the `Sharding Guide`_ to make
    sure you're getting the best performance out ot CrateDB.
 
-.. _Sharding Guide: https://crate.io/docs/crate/guide/best_practices/sharding.html
+.. _Sharding Guide: https://crate.io/docs/crate/howtos/best_practices/sharding.html
 
 Creation
 ========

--- a/docs/general/ddl/sharding.rst
+++ b/docs/general/ddl/sharding.rst
@@ -55,7 +55,7 @@ is applied, (see :ref:`ref_clustered_clause`).
    Well tuned shard allocation is vital. Read the `Sharding Guide`_ to make
    sure you're getting the best performance out ot CrateDB.
 
-.. _Sharding Guide: https://crate.io/docs/crate/howtos/best_practices/sharding.html
+.. _Sharding Guide: https://crate.io/docs/crate/howtos/en/latest/performance/sharding.html
 
 .. _routing:
 

--- a/docs/general/ddl/sharding.rst
+++ b/docs/general/ddl/sharding.rst
@@ -55,7 +55,7 @@ is applied, (see :ref:`ref_clustered_clause`).
    Well tuned shard allocation is vital. Read the `Sharding Guide`_ to make
    sure you're getting the best performance out ot CrateDB.
 
-.. _Sharding Guide: https://crate.io/docs/crate/guide/best_practices/sharding.html
+.. _Sharding Guide: https://crate.io/docs/crate/howtos/best_practices/sharding.html
 
 .. _routing:
 


### PR DESCRIPTION
Some links were pointing to the removed `guide` content, this
content was merged into the `howtos`.
