### PR TITLE
Rewrite order by symbols to source lookups if collect symbols are rewritten

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -89,6 +89,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue resulting in an error when using a ``ORDER BY`` clause inside
+  the subquery of a ``INSERT INTO`` statement.
+
 - Fixed a regression introduced in CrateDB ``4.2.0`` leading to a NPE when
   copying data from one table to another using ``INSERT INTO ...`` while the
   source table contains more than 128 columns.

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -44,7 +44,6 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
-import io.crate.planner.optimizer.symbol.Optimizer;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RoutingProvider;
@@ -57,6 +56,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
 import io.crate.planner.consumer.OrderByPositionVisitor;
 import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.optimizer.symbol.Optimizer;
 import io.crate.planner.selectivity.SelectivityFunctions;
 import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
@@ -149,6 +149,9 @@ public class Collect implements LogicalPlan {
         RoutedCollectPhase collectPhase = createPhase(plannerContext, binder);
         PositionalOrderBy positionalOrderBy = getPositionalOrderBy(order, outputs);
         if (positionalOrderBy != null) {
+            if (preferSourceLookup) {
+                order = order.map(DocReferences::toSourceLookup);
+            }
             collectPhase.orderBy(
                 order.map(binder)
                     // Filter out literal constants as ordering by constants is a NO-OP and also not supported


### PR DESCRIPTION
If the collect symbols of a RoutedCollectPhase are rewritten to source
lookup references, possible order by symbols must be rewritten as well.

Relates #10884.