### PR TITLE
Ensure param types can be resolved correctly in bind

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -89,6 +89,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue in the PostgreSQL wire protocol that prevented values from
+  being serialized correctly if the client didn't send a ``describe`` message
+  and used the binary serialization format.
+
 - Fixed an issue resulting in an error when using a ``ORDER BY`` clause inside
   the subquery of a ``INSERT INTO`` statement.
 

--- a/server/src/main/java/io/crate/action/sql/PreparedStmt.java
+++ b/server/src/main/java/io/crate/action/sql/PreparedStmt.java
@@ -60,6 +60,10 @@ public class PreparedStmt {
         this.describedParameterTypes = describedParameters;
     }
 
+    boolean isDescribed() {
+        return describedParameterTypes != null;
+    }
+
     Statement parsedStatement() {
         return parsedStatement;
     }
@@ -69,12 +73,12 @@ public class PreparedStmt {
      * of the {@link ParamTypeHints} and the types determined during ParameterDescription.
      * @param idx type at index (zero-based).
      */
-    DataType getEffectiveParameterType(int idx) {
+    DataType<?> getEffectiveParameterType(int idx) {
         if (describedParameterTypes == null) {
-            return paramTypeHints.getType(idx);
+            throw new IllegalStateException("Statement must be described before param types can be resolved");
         }
         if (idx >= describedParameterTypes.length) {
-            throw new IllegalStateException("Requested parameter index exceeds the number of parameters: " + idx);
+            return paramTypeHints.getType(idx);
         }
         return describedParameterTypes[idx];
     }

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -358,9 +358,7 @@ public class Session implements AutoCloseable {
 
                 DataType[] parameterSymbols =
                     parameterTypeExtractor.getParameterTypes(x -> Relations.traverseDeepSymbols(analyzedStatement, x));
-                if (parameterSymbols.length > 0) {
-                    preparedStmt.setDescribedParameters(parameterSymbols);
-                }
+                preparedStmt.setDescribedParameters(parameterSymbols);
                 return new DescribeResult(analyzedStatement.outputs(), parameterSymbols);
             default:
                 throw new AssertionError("Unsupported type: " + type);
@@ -729,5 +727,13 @@ public class Session implements AutoCloseable {
 
     public TransactionState transactionState() {
         return currentTransactionState;
+    }
+
+    public void ensureDescribed(String statementName) {
+        PreparedStmt stmt = getSafeStmt(statementName);
+        if (stmt.isDescribed()) {
+            return;
+        }
+        describe('S', statementName);
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -541,6 +541,7 @@ public class PostgresWireProtocol {
         String statementName = readCString(buffer);
 
         FormatCodes.FormatCode[] formatCodes = FormatCodes.fromBuffer(buffer);
+        session.ensureDescribed(statementName);
 
         short numParams = buffer.readShort();
         List<Object> params = createList(numParams);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Clients like postgresql-typed[1] don't send a `describe` message, but
`parse` followed by a `bind`.

In such a case the type resolved to `undefined` - which broke reading
integer and other types if serialized as binary.

This commit ensures we always do an implicit `describe` if it hasn't
been done explicitly to ensure that the types can be read properly.

[1]: https://hackage.haskell.org/package/postgresql-typed

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)