### PR TITLE
Fix broken result ordering for selects with QTF

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchMapper.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import com.carrotsearch.hppc.IntContainer;
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.IntSet;
@@ -59,7 +59,7 @@ public class FetchMapper implements AsyncFlatMapper<ReaderBuckets, Row> {
         Iterator<Map.Entry<String, IntSet>> it = readerIdsByNode.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<String, IntSet> entry = it.next();
-            IntObjectHashMap<IntContainer> toFetch = readerBuckets.generateToFetch(entry.getValue());
+            IntObjectHashMap<IntArrayList> toFetch = readerBuckets.generateToFetch(entry.getValue());
             if (toFetch.isEmpty() && !isLastCall) {
                 continue;
             }

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchOperation.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.engine.fetch;
 
-import com.carrotsearch.hppc.IntContainer;
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectMap;
 import io.crate.data.Bucket;
 
@@ -36,6 +36,6 @@ public interface FetchOperation {
      * @param closeContext indicate if context must be closed after fetch
      */
     CompletableFuture<IntObjectMap<? extends Bucket>> fetch(String nodeId,
-                                                            IntObjectMap<? extends IntContainer> toFetch,
+                                                            IntObjectMap<IntArrayList> toFetch,
                                                             boolean closeContext);
 }

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
-import com.carrotsearch.hppc.IntContainer;
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
@@ -113,7 +113,7 @@ public class NodeFetchOperation {
 
     public CompletableFuture<? extends IntObjectMap<StreamBucket>> fetch(UUID jobId,
                                                                          int phaseId,
-                                                                         @Nullable IntObjectMap<? extends IntContainer> docIdsToFetch,
+                                                                         @Nullable IntObjectMap<IntArrayList> docIdsToFetch,
                                                                          boolean closeTaskOnFinish) {
         if (docIdsToFetch == null) {
             if (closeTaskOnFinish) {
@@ -168,16 +168,16 @@ public class NodeFetchOperation {
         return result;
     }
 
-    private CompletableFuture<? extends IntObjectMap<StreamBucket>> doFetch(FetchTask fetchTask, IntObjectMap<? extends IntContainer> toFetch) throws Exception {
+    private CompletableFuture<? extends IntObjectMap<StreamBucket>> doFetch(FetchTask fetchTask, IntObjectMap<IntArrayList> toFetch) throws Exception {
         HashMap<RelationName, TableFetchInfo> tableFetchInfos = getTableFetchInfos(fetchTask);
 
         // RamAccounting is per doFetch call instead of per FetchTask/fetchPhase
         // To be able to free up the memory count when the operation is complete
         final var ramAccounting = ConcurrentRamAccounting.forCircuitBreaker("fetch-" + fetchTask.id(), circuitBreaker);
         ArrayList<Supplier<StreamBucket>> collectors = new ArrayList<>(toFetch.size());
-        for (IntObjectCursor<? extends IntContainer> toFetchCursor : toFetch) {
+        for (IntObjectCursor<IntArrayList> toFetchCursor : toFetch) {
             final int readerId = toFetchCursor.key;
-            final IntContainer docIds = toFetchCursor.value;
+            final IntArrayList docIds = toFetchCursor.value;
 
             RelationName ident = fetchTask.tableIdent(readerId);
             final TableFetchInfo tfi = tableFetchInfos.get(ident);

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchRequest.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchRequest.java
@@ -43,12 +43,12 @@ public class NodeFetchRequest extends TransportRequest {
     private final boolean closeContext;
 
     @Nullable
-    private final IntObjectMap<? extends IntContainer> toFetch;
+    private final IntObjectMap<IntArrayList> toFetch;
 
     public NodeFetchRequest(UUID jobId,
                             int fetchPhaseId,
                             boolean closeContext,
-                            IntObjectMap<? extends IntContainer> toFetch) {
+                            IntObjectMap<IntArrayList> toFetch) {
         this.jobId = jobId;
         this.fetchPhaseId = fetchPhaseId;
         this.closeContext = closeContext;
@@ -72,7 +72,7 @@ public class NodeFetchRequest extends TransportRequest {
     }
 
     @Nullable
-    public IntObjectMap<? extends IntContainer> toFetch() {
+    public IntObjectMap<IntArrayList> toFetch() {
         return toFetch;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/fetch/ReaderBuckets.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/ReaderBuckets.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import com.carrotsearch.hppc.IntContainer;
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.IntSet;
@@ -117,12 +117,12 @@ public class ReaderBuckets {
         };
     }
 
-    public IntObjectHashMap<IntContainer> generateToFetch(IntSet readerIds) {
-        IntObjectHashMap<IntContainer> toFetch = new IntObjectHashMap<>(readerIds.size());
+    public IntObjectHashMap<IntArrayList> generateToFetch(IntSet readerIds) {
+        IntObjectHashMap<IntArrayList> toFetch = new IntObjectHashMap<>(readerIds.size());
         for (IntCursor readerIdCursor : readerIds) {
             ReaderBucket readerBucket = readerBuckets.get(readerIdCursor.value);
-            if (readerBucket != null && readerBucket.docs.size() > 0) {
-                toFetch.put(readerIdCursor.value, readerBucket.docs.keys());
+            if (readerBucket != null && !readerBucket.isEmpty()) {
+                toFetch.put(readerIdCursor.value, readerBucket.sortedDocs());
             }
         }
         return toFetch;

--- a/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchOperation.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.fetch;
 
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntContainer;
 import com.carrotsearch.hppc.IntObjectMap;
 import io.crate.Streamer;
@@ -61,7 +62,7 @@ public class TransportFetchOperation implements FetchOperation {
 
     @Override
     public CompletableFuture<IntObjectMap<? extends Bucket>> fetch(String nodeId,
-                                                                   IntObjectMap<? extends IntContainer> toFetch,
+                                                                   IntObjectMap<IntArrayList> toFetch,
                                                                    boolean closeContext) {
         FutureActionListener<NodeFetchResponse, IntObjectMap<? extends Bucket>> listener = new FutureActionListener<>(GET_FETCHED);
         transportFetchNodeAction.execute(

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchCollectorTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.fetch;
 
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,17 +37,16 @@ public class FetchCollectorTest {
     @Test
     public void test_sequential_docs_ids() {
         int start = randomIntBetween(0, Short.MAX_VALUE);
-        var sequential = new int[10];
-        for (int i = 0; i < 10; i++) {
-            sequential[i] = start;
-            start++;
+        IntArrayList sequential = new IntArrayList(10);
+        for (int i = start; i < start + 10; i++) {
+            sequential.add(i);
         }
         assertThat(FetchCollector.isSequential(sequential), is(true));
 
-        var random = new int[10];
-        for (int i = 0; i < 10; i++) {
-            random[i] = randomIntBetween(0, Short.MAX_VALUE);
-        }
-        assertThat(FetchCollector.isSequential(random), is(false));
+        IntArrayList nonSequential = new IntArrayList();
+        nonSequential.add(10);
+        nonSequential.add(2);
+        nonSequential.add(48);
+        assertThat(FetchCollector.isSequential(nonSequential), is(false));
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
@@ -21,6 +21,7 @@
  */
 package io.crate.execution.engine.fetch;
 
+import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import io.crate.data.ArrayBucket;
 import io.crate.data.Bucket;
@@ -80,7 +81,11 @@ public class FetchRowsTest extends CrateDummyClusterServiceUnitTest {
         long fetchIdRel1 = FetchId.encode(1, 1);
         long fetchIdRel2 = FetchId.encode(2, 1);
         var readerBuckets = new ReaderBuckets(fetchRows);
+        IntHashSet readerIds = new IntHashSet(2);
+        readerIds.add(1);
+        readerIds.add(2);
         readerBuckets.add(new RowN(fetchIdRel1, fetchIdRel2, 42));
+        readerBuckets.generateToFetch(readerIds);
         IntObjectHashMap<Bucket> results = new IntObjectHashMap<>();
         results.put(1, new ArrayBucket($$($("Arthur"))));
         results.put(2, new ArrayBucket($$($("Trillian"))));

--- a/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchRequestTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchRequestTest.java
@@ -22,25 +22,25 @@
 
 package io.crate.execution.engine.fetch;
 
-import com.carrotsearch.hppc.IntContainer;
-import com.carrotsearch.hppc.IntHashSet;
-import com.carrotsearch.hppc.IntObjectHashMap;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.junit.Test;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntObjectHashMap;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
 
 public class NodeFetchRequestTest {
 
     @Test
     public void testStreaming() throws Exception {
 
-        IntObjectHashMap<IntContainer> toFetch = new IntObjectHashMap<>();
-        IntHashSet docIds = new IntHashSet(3);
+        IntObjectHashMap<IntArrayList> toFetch = new IntObjectHashMap<>();
+        IntArrayList docIds = new IntArrayList(3);
         toFetch.put(1, docIds);
 
         NodeFetchRequest orig = new NodeFetchRequest(UUID.randomUUID(), 1, true, toFetch);

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1913,4 +1913,26 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
             is(1L)
         );
     }
+
+
+    @Test
+    public void test_query_then_fetch_result_order_of_all_columns_matches() throws Exception {
+        int numItems = 40;
+        Object[][] args = new Object[numItems][];
+        for (int i = 0; i < numItems; i++) {
+            args[i] = new Object[] { Integer.toString(i), i };
+        }
+        execute("create table tbl (x text, y int) clustered into 2 shards");
+        execute("insert into tbl (x, y) values (?, ?)", args);
+        execute("refresh table tbl");
+        Object[][] rows = execute("select x, y from tbl order by y desc").rows();
+        assertThat(
+            rows[0],
+            Matchers.arrayContaining(Integer.toString(numItems - 1), numItems - 1)
+        );
+        assertThat(
+            rows[1],
+            Matchers.arrayContaining(Integer.toString(numItems - 2), numItems - 2)
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/crate/crate/pull/10862 added an optimization that can
lead to incorrect leads.

Assuming the following data:

     x  | y
    ----+------
    ("A", "a")
    ("B", "b")
    ("C", "c")

In a query like

    SELECT x, y FROM tbl ORDER BY y

The value for `y` is eagerly collected, and only `x` is fetched. The
incoming rows might then look like the following. Note that they are
ordered by `y`:

     symbols  |    values
     ---------+----------
    (_doc, y) -> (4, "a")
    (_doc, y) -> (2, "b")
    (_doc, y) -> (8, "c")

The optimization logic ordered by `_doc`, and returned the values that are
fetched in this order

    2 -> "B"
    4 -> "A"
    8 -> "C"

Which are then stitched together like this:

    ("B", "a")
    ("A", "b")
    ("C", "c")


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)