### PR TITLE
Remove unnecessary doGetSequentialStoredFieldsReader

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReader.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/index/ElasticsearchLeafReader.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.lucene.index;
 
-import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.index.shard.ShardId;
@@ -73,10 +72,5 @@ public final class ElasticsearchLeafReader extends SequentialStoredFieldsLeafRea
             }
         }
         return null;
-    }
-
-    @Override
-    protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
-        return reader;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/lucene/index/SequentialStoredFieldsLeafReader.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/index/SequentialStoredFieldsLeafReader.java
@@ -45,21 +45,15 @@ public abstract class SequentialStoredFieldsLeafReader extends FilterLeafReader 
     }
 
     /**
-     * Implementations should return a {@link StoredFieldsReader} that wraps the provided <code>reader</code>
-     * that is optimized for sequential access (adjacent doc ids).
-     */
-    protected abstract StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader);
-
-    /**
      * Returns a {@link StoredFieldsReader} optimized for sequential access (adjacent doc ids).
      */
     public StoredFieldsReader getSequentialStoredFieldsReader() throws IOException {
         if (in instanceof CodecReader) {
             CodecReader reader = (CodecReader) in;
-            return doGetSequentialStoredFieldsReader(reader.getFieldsReader().getMergeInstance());
+            return reader.getFieldsReader().getMergeInstance();
         } else if (in instanceof SequentialStoredFieldsLeafReader) {
             SequentialStoredFieldsLeafReader reader = (SequentialStoredFieldsLeafReader) in;
-            return doGetSequentialStoredFieldsReader(reader.getSequentialStoredFieldsReader());
+            return reader.getSequentialStoredFieldsReader();
         } else {
             throw new IOException("requires a CodecReader or a SequentialStoredFieldsLeafReader, got " + in.getClass());
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There was only a single class overriding the method and it returns the
reader as is.

In ES there are a couple of more implementations, but also all of the
Apache Licensed implementations return the reader as is.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)