### PR TITLE
Fix default traversal of match predicate

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -95,4 +95,6 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that could result in a ``The assembled list of
+  ParameterSymbols is invalid. Missing parameters.`` error if using the
+  ``MATCH`` predicate and parameter placeholders within a query.

--- a/server/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
@@ -93,6 +93,8 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
         for (Symbol field : matchPredicate.identBoostMap().keySet()) {
             field.accept(this, context);
         }
+        matchPredicate.queryTerm().accept(this, context);
+        matchPredicate.options().accept(this, context);
         return null;
     }
 

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -545,4 +545,17 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         session.sync().get(5, TimeUnit.SECONDS);
         assertThat(jobsLogs.metrics().iterator().next().totalCount(), is(1L));
     }
+
+
+    @Test
+    public void test_can_extract_parameters_from_match_predicate() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table users (name text, keywords text)")
+            .build();
+        AnalyzedStatement statement = e.analyze(
+            "select * from users where match(keywords, ?) using best_fields with (fuzziness= ?) and name = ?");
+        ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
+        DataType[] parameterTypes = typeExtractor.getParameterTypes(statement::visitSymbols);
+        assertThat(parameterTypes, arrayContaining(DataTypes.STRING, DataTypes.UNDEFINED, DataTypes.STRING));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We must visit all symbols of the match predicate in order for other
components like the `ParameterTypeExtractor` to work.

This fixes https://github.com/crate/crate/issues/10897


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)