### PR TITLE
Remove AwaitsFix from test_retrieve_segment_information

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
@@ -22,22 +22,21 @@
 
 package io.crate.integrationtests;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Test;
-
-import java.util.Map;
-
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 
+import java.util.Map;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class SysSegmentsTableInfoTest extends SQLTransportIntegrationTest {
 
-    @AwaitsFix(bugUrl = "https://github.com/crate/crate/issues/10843")
     @Test
     public void test_retrieve_segment_information() {
         execute("create table t1 (id INTEGER, name STRING) clustered into 1 shards" +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Not reproducable locally. Let's see if it still fails on CI

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)