### PR TITLE
Log connection reset errors on info instead of error

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -53,6 +53,7 @@ import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 import java.net.InetAddress;
+import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -390,7 +391,12 @@ public class PostgresWireProtocol {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            LOGGER.error("Uncaught exception: ", cause);
+            if (cause instanceof SocketException && cause.getMessage().equals("Connection reset")) {
+                LOGGER.info("Connection reset. Client likely terminated connection");
+                closeSession();
+            } else {
+                LOGGER.error("Uncaught exception: ", cause);
+            }
         }
 
         @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Connection reset errors from PostgreSQL clients are mostly harmless and
logging them on error level with full stacktrace can unnecessarily scare
system administrators.

This changes the log level to info and excludes the stacktrace.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)