### PR TITLE
Fix flaky CommonAnalyzerITest / add visitSymbols to create analyzer stmt

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedCreateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCreateAnalyzer.java
@@ -27,6 +27,7 @@ import io.crate.common.collections.Tuple;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class AnalyzedCreateAnalyzer implements DDLStatement {
 
@@ -82,5 +83,15 @@ public class AnalyzedCreateAnalyzer implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitCreateAnalyzerStatement(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        if (tokenizer != null) {
+            tokenizer.v2().properties().values().forEach(consumer);
+        }
+        tokenFilters.values().forEach(x -> x.properties().values().forEach(consumer));
+        charFilters.values().forEach(x -> x.properties().values().forEach(consumer));
+        genericAnalyzerProperties.properties().values().forEach(consumer);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/crate/crate/pull/10901 made the tests flaky because
of a missing `visitSymbols` implementation.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)