### PR TITLE
Ensure all types returned via `pg_type` table can be looked up by oid

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -99,6 +99,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to errors like ``Can't map PGType with oid=26
+  to Crate type`` using a PostgreSQL client.
+
 - Fixed an issue that could result in a ``The assembled list of
   ParameterSymbols is invalid. Missing parameters.`` error if using the
   ``MATCH`` predicate and parameter placeholders within a query.

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -98,13 +98,15 @@ public class PGTypes {
         PG_TYPES_TO_CRATE_TYPE.put(0, DataTypes.UNDEFINED);
         PG_TYPES_TO_CRATE_TYPE.put(VarCharType.TextType.OID, DataTypes.STRING);
         PG_TYPES_TO_CRATE_TYPE.put(PGArray.TEXT_ARRAY.oid(), new ArrayType<>(DataTypes.STRING));
+        PG_TYPES_TO_CRATE_TYPE.put(AnyType.OID, DataTypes.UNDEFINED);
+        PG_TYPES_TO_CRATE_TYPE.put(PGArray.ANY_ARRAY.oid(), new ArrayType<>(DataTypes.UNDEFINED));
+        PG_TYPES_TO_CRATE_TYPE.put(VarCharType.NameType.OID, DataTypes.STRING);
+        PG_TYPES_TO_CRATE_TYPE.put(OidType.OID, DataTypes.INTEGER);
         TYPES = new HashSet<>(CRATE_TO_PG_TYPES.values()); // some pgTypes are used multiple times, de-dup them
-        // the following polymorphic types are added manually,
-        // because there are no corresponding data types in CrateDB
+
+        // There is no entry in `CRATE_TO_PG_TYPES` for these because we have no 1:1 mapping from dataType to pgType
         TYPES.add(AnyType.INSTANCE);
         TYPES.add(PGArray.ANY_ARRAY);
-        // the below is added manually as currently we do not want to expose this type to crateDB
-        // we merely need this type information in 'pg_types' static table for postgres compatibility
         TYPES.add(VarCharType.NameType.INSTANCE);
         TYPES.add(OidType.INSTANCE);
 

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -226,6 +226,17 @@ public class PGTypesTest extends ESTestCase {
         );
     }
 
+    @Test
+    public void test_all_types_exposed_via_pg_type_table_can_be_resolved_via_oid() throws Exception {
+        for (var type : PGTypes.pgTypes()) {
+            assertThat(
+                "Must be possible to retrieve " + type.typName() + "/" + type.oid() + " via PGTypes.fromOID",
+                PGTypes.fromOID(type.oid()),
+                Matchers.notNullValue()
+            );
+        }
+    }
+
     private Object writeAndReadBinary(Entry entry, PGType pgType) {
         ByteBuf buffer = Unpooled.buffer();
         try {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We should ensure that types we expose via the `pg_type` table can be used by
clients when serializing parameters.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)