### PR TITLE
Remove to_char(number, text) scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,7 +67,8 @@ Changes
   :ref:`NodeInfo MXBean <node_info_mxbean>` which is available as an
   enterprise feature.
 
-- Added the ``to_char`` scalar function for timestamp, interval and numeric types.
+- Added the ``to_char`` scalar function for ``timestamp`` and ``interval``
+  argument data types.
 
 - Added support for the ``split_part`` scalar function
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -1120,7 +1120,7 @@ It has two variants depending on the type of ``timestamp``:
 ``to_char(expression, format_string)``
 --------------------------------------
 
-The ``to_char`` function converts a timestamp, interval or numeric value to
+The ``to_char`` function converts a ``timestamp`` or ``interval`` value to
 a string, based on a given format string.
 
 Returns: ``text``
@@ -1133,7 +1133,7 @@ Synopsis
     TO_CHAR( expression, format_string )
 
 ``expression`` can be any value with the type of ``timestamp`` (with or without
-a timezone), ``interval`` or a ``numeric`` type.
+a timezone) or ``interval``.
 
 Format
 ......
@@ -1265,49 +1265,6 @@ interval added to the timestamp of ``0000/01/01 00:00:00``:
     +---------------------+
     SELECT 1 row in set (... sec)
 
-For ``numeric`` expressions, the syntax follows that of the `Java DecimalFormat`_.
-For reference, the table of permitted tokens is replicated below:
-
-+--------+---------------------+----------------------------------------------------------------------+
-| Symbol | Location            | Meaning                                                              |
-+========+=====================+======================================================================+
-| ``0``  | Number              | Digit                                                                |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``#``  | Number              | Digit, zero shows as absent                                          |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``.``  | Number              | Decimal/monetary seperator                                           |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``-``  | Number              | Minus sign                                                           |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``,``  | Number              | Grouping separator                                                   |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``E``  | Number              | Separates mantissa and exponent in scientific notation               |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``;``  | Subpattern boundary | Seperates positive and negative subpatterns                          |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``%``  | Prefix/Suffix       | Mulitply by 100 and show as percentage                               |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``‰``  | Prefix/Suffix       | Multiply by 1000 and show as per mille value                         |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``¤``  | Prefix/Suffix       | Currency sign, replaced by currency symbol. If doubled, replaced by  |
-|        |                     | international currency symbol. If present in a pattern, the monetary |
-|        |                     | decimal separator is used instead of the decimal separator           |
-+--------+---------------------+----------------------------------------------------------------------+
-| ``'``  | Prefix/Suffix       | Used to quote special characters in a prefix/suffix                  |
-+--------+---------------------+----------------------------------------------------------------------+
-
-For further documentation on the behaviour of the formatter, please consult the
-`Java DecimalFormat`_ documentation.
-
-::
-
-    cr> select to_char(123456.789, '###,###.0000') as number;
-    +--------------+
-    | number       |
-    +--------------+
-    | 123,456.7890 |
-    +--------------+
-    SELECT 1 row in set (... sec)
 
 
 Geo functions

--- a/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
@@ -32,12 +32,9 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.joda.time.Period;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Locale;
 import java.util.TimeZone;
 import java.util.function.BiFunction;
 
@@ -79,38 +76,6 @@ public class ToCharFunction extends Scalar<String, Object> {
                     ToCharFunction::evaluateInterval
                 )
         );
-
-        DataTypes.NUMERIC_PRIMITIVE_TYPES.stream()
-            .forEach(type -> {
-                module.register(
-                    Signature.scalar(
-                        NAME,
-                        type.getTypeSignature(),
-                        DataTypes.STRING.getTypeSignature(),
-                        DataTypes.STRING.getTypeSignature()
-                    ),
-                    (signature, boundSignature) ->
-                        new ToCharFunction(
-                            signature,
-                            boundSignature,
-                            ToCharFunction::evaluateNumber
-                        )
-                );
-            });
-        module.register(
-            Signature.scalar(
-                NAME,
-                DataTypes.NUMERIC.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ),
-            (signature, boundSignature) ->
-                new ToCharFunction(
-                    signature,
-                    boundSignature,
-                    ToCharFunction::evaluateNumber
-                )
-        );
     }
 
     private final Signature signature;
@@ -148,12 +113,6 @@ public class ToCharFunction extends Scalar<String, Object> {
             .plusSeconds(period.getSeconds())
             .plusNanos(period.getMillis() * 1000000);
         return formatter.format(dateTime);
-    }
-
-    private static String evaluateNumber(Object number, String pattern) {
-        DecimalFormat formatter = (DecimalFormat) NumberFormat.getNumberInstance(Locale.ENGLISH);
-        formatter.applyLocalizedPattern(pattern);
-        return formatter.format(number);
     }
 
     @Override

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
@@ -64,26 +64,4 @@ public class ToCharFunctionTest extends AbstractScalarFunctionsTest {
             null
         );
     }
-
-    @Test
-    public void testEvaluateNumeric() {
-        assertEvaluate("to_char(12345.678, '###,###.##')", "12,345.68");
-        assertEvaluate("to_char(125.6::real, '0000')", "0126");
-        assertEvaluate("to_char(-125.8, '###.00')", "-125.80");
-        assertEvaluate("to_char(-125.8::numeric(4, 1), '###.00')", "-125.80");
-    }
-
-    @Test
-    public void testEvaluateNumericWithEmptyPattern() {
-        assertEvaluate("to_char(12345.678, '')", "12,345.678");
-        assertEvaluate("to_char(-125.8, '')", "-125.8");
-    }
-
-    @Test
-    public void testEvaluateNumericWithNullPattern() {
-        assertEvaluate("to_char(12345.678, null)", null);
-        assertEvaluate("to_char(125.6::real, null)", null);
-        assertEvaluate("to_char(-125.8, null)", null);
-    }
-
 }


### PR DESCRIPTION
The current implementation of `to_char(number, text)` used the
Java DecimalFormatter and thus did not support PostgreSQL's
template patterns.
To be PostgreSQL compatible, we must come up with a new implementation.

Partly reverts https://github.com/crate/crate/commit/88981932462
and https://github.com/crate/crate/commit/6c827fb3c77.