### PR TITLE
Made stmt.visitSymbol impl mandatory, add missing implementations

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterBlobTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterBlobTable.java
@@ -25,6 +25,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.AlterTable;
 
+import java.util.function.Consumer;
+
 public class AnalyzedAlterBlobTable implements DDLStatement {
 
     private final TableInfo tableInfo;
@@ -46,5 +48,14 @@ public class AnalyzedAlterBlobTable implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitAnalyzedAlterBlobTable(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (var partitionProperty : alterTable.table().partitionProperties()) {
+            consumer.accept(partitionProperty.columnName());
+            partitionProperty.expressions().forEach(consumer);
+        }
+        alterTable.genericProperties().properties().values().forEach(consumer);
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAddColumn.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAddColumn.java
@@ -26,6 +26,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 
+import java.util.function.Consumer;
+
 public class AnalyzedAlterTableAddColumn implements DDLStatement {
 
     private final DocTableInfo tableInfo;
@@ -70,5 +72,15 @@ public class AnalyzedAlterTableAddColumn implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
         return visitor.visitAlterTableAddColumn(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (var col : analyzedTableElements.columns()) {
+            col.visitSymbols(consumer);
+        }
+        for (var col : analyzedTableElementsWithExpressions.columns()) {
+            col.visitSymbols(consumer);
+        }
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableDropCheckConstraint.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableDropCheckConstraint.java
@@ -22,7 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.doc.DocTableInfo;
+
+import java.util.function.Consumer;
 
 public class AnalyzedAlterTableDropCheckConstraint implements DDLStatement {
 
@@ -45,5 +48,9 @@ public class AnalyzedAlterTableDropCheckConstraint implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
         return visitor.visitAlterTableDropCheckConstraint(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableOpenClose.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableOpenClose.java
@@ -26,6 +26,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.Table;
 
+import java.util.function.Consumer;
+
 public class AnalyzedAlterTableOpenClose implements DDLStatement {
 
 
@@ -57,5 +59,13 @@ public class AnalyzedAlterTableOpenClose implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitAnalyzedAlterTableOpenClose(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (var partitionProperty : table.partitionProperties()) {
+            consumer.accept(partitionProperty.columnName());
+            partitionProperty.expressions().forEach(consumer);
+        }
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRename.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRename.java
@@ -22,8 +22,11 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
+
+import java.util.function.Consumer;
 
 public class AnalyzedAlterTableRename implements DDLStatement {
 
@@ -51,5 +54,9 @@ public class AnalyzedAlterTableRename implements DDLStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedAnalyze.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAnalyze.java
@@ -22,6 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public final class AnalyzedAnalyze implements DDLStatement {
 
     AnalyzedAnalyze() {
@@ -30,5 +34,9 @@ public final class AnalyzedAnalyze implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
         return visitor.visitAnalyze(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedBegin.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedBegin.java
@@ -22,6 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public class AnalyzedBegin implements AnalyzedStatement {
 
     @Override
@@ -32,5 +36,9 @@ public class AnalyzedBegin implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return false;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.elasticsearch.index.mapper.TypeParsers.DOC_VALUES;
@@ -78,9 +79,11 @@ public class AnalyzedColumnDefinition<T> {
     private String collectionType;
 
     private String geoTree;
+    @Nullable
     private GenericProperties<T> geoProperties;
 
     private Reference.IndexType indexType;
+    @Nullable
     private T analyzer;
     private String indexMethod;
     private Settings analyzerSettings = Settings.EMPTY;
@@ -95,6 +98,7 @@ public class AnalyzedColumnDefinition<T> {
     private boolean isIndex = false;
     private ArrayList<String> copyToTargets;
     private boolean isParentColumn;
+    @Nullable
     private GenericProperties<T> storageProperties;
 
     private boolean generated;
@@ -197,6 +201,26 @@ public class AnalyzedColumnDefinition<T> {
         );
     }
 
+    public void visitSymbols(Consumer<? super T> consumer) {
+        if (analyzer != null) {
+            consumer.accept(analyzer);
+        }
+        if (geoProperties != null) {
+            geoProperties.properties().values().forEach(consumer);
+        }
+        for (var child : children) {
+            child.visitSymbols(consumer);
+        }
+        if (storageProperties != null) {
+            storageProperties.properties().values().forEach(consumer);
+        }
+        if (generatedExpression != null) {
+            consumer.accept(generatedExpression);
+        }
+        if (defaultExpression != null) {
+            consumer.accept(defaultExpression);
+        }
+    }
 
     public void name(String name) {
         this.name = name;

--- a/server/src/main/java/io/crate/analyze/AnalyzedCommit.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCommit.java
@@ -22,6 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public class AnalyzedCommit implements AnalyzedStatement {
 
     @Override
@@ -32,5 +36,9 @@ public class AnalyzedCommit implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return false;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDeallocate.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDeallocate.java
@@ -23,7 +23,10 @@
 package io.crate.analyze;
 
 
+import io.crate.expression.symbol.Symbol;
+
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
 
 public class AnalyzedDeallocate implements AnalyzedStatement {
 
@@ -47,5 +50,9 @@ public class AnalyzedDeallocate implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return false;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDiscard.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDiscard.java
@@ -22,7 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.DiscardStatement.Target;
+
+import java.util.function.Consumer;
 
 public final class AnalyzedDiscard implements AnalyzedStatement {
 
@@ -44,5 +47,9 @@ public final class AnalyzedDiscard implements AnalyzedStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
         return visitor.visitDiscard(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropAnalyzer.java
@@ -22,6 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public class AnalyzedDropAnalyzer implements DDLStatement {
 
     private final String name;
@@ -37,5 +41,9 @@ public class AnalyzedDropAnalyzer implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitDropAnalyzerStatement(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropFunction.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropFunction.java
@@ -26,9 +26,11 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
 import io.crate.types.DataType;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public class AnalyzedDropFunction implements AnalyzedStatement {
 
@@ -68,5 +70,9 @@ public class AnalyzedDropFunction implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropRepository.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropRepository.java
@@ -22,6 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public class AnalyzedDropRepository implements DDLStatement {
 
     private final String name;
@@ -37,5 +41,9 @@ public class AnalyzedDropRepository implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitDropRepositoryAnalyzedStatement(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropSnapshot.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropSnapshot.java
@@ -21,6 +21,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public class AnalyzedDropSnapshot implements DDLStatement {
 
     private final String repository;
@@ -42,5 +46,9 @@ public class AnalyzedDropSnapshot implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitDropSnapshotAnalyzedStatement(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
@@ -21,10 +21,12 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.TableInfo;
 
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
 
 public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatement {
 
@@ -64,5 +66,9 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
         return visitor.visitDropTable(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropUser.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropUser.java
@@ -22,6 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public class AnalyzedDropUser implements AnalyzedStatement {
 
     private final String userName;
@@ -48,5 +52,9 @@ public class AnalyzedDropUser implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropView.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropView.java
@@ -22,9 +22,11 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public final class AnalyzedDropView implements AnalyzedStatement {
 
@@ -52,5 +54,9 @@ public final class AnalyzedDropView implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedGCDanglingArtifacts.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedGCDanglingArtifacts.java
@@ -22,6 +22,10 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public final class AnalyzedGCDanglingArtifacts implements AnalyzedStatement {
 
     public static final AnalyzedGCDanglingArtifacts INSTANCE = new AnalyzedGCDanglingArtifacts();
@@ -34,5 +38,9 @@ public final class AnalyzedGCDanglingArtifacts implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedPrivileges.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedPrivileges.java
@@ -23,9 +23,11 @@
 package io.crate.analyze;
 
 import io.crate.analyze.user.Privilege;
+import io.crate.expression.symbol.Symbol;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 public class AnalyzedPrivileges implements DCLStatement {
 
@@ -48,5 +50,9 @@ public class AnalyzedPrivileges implements DCLStatement {
 
     public Set<Privilege> privileges() {
         return privileges;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedRefreshTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedRefreshTable.java
@@ -26,6 +26,7 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.Table;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class AnalyzedRefreshTable implements DDLStatement {
 
@@ -42,5 +43,16 @@ public class AnalyzedRefreshTable implements DDLStatement {
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitRefreshTableStatement(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (var entry : tables.entrySet()) {
+            var table = entry.getKey();
+            for (var partitionProperty : table.partitionProperties()) {
+                consumer.accept(partitionProperty.columnName());
+                partitionProperty.expressions().forEach(consumer);
+            }
+        }
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedRerouteRetryFailed.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedRerouteRetryFailed.java
@@ -22,10 +22,18 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
+
+import java.util.function.Consumer;
+
 public class AnalyzedRerouteRetryFailed implements DDLStatement {
 
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
         return visitor.visitRerouteRetryFailedStatement(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedResetStatement.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedResetStatement.java
@@ -25,6 +25,7 @@ package io.crate.analyze;
 import io.crate.expression.symbol.Symbol;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 public class AnalyzedResetStatement implements AnalyzedStatement {
 
@@ -46,5 +47,10 @@ public class AnalyzedResetStatement implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        settingsToRemove.forEach(consumer);
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedSetSessionAuthorizationStatement.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedSetSessionAuthorizationStatement.java
@@ -21,9 +21,11 @@
 
 package io.crate.analyze;
 
+import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.SetSessionAuthorizationStatement;
 
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
 
 public class AnalyzedSetSessionAuthorizationStatement implements AnalyzedStatement {
 
@@ -61,5 +63,9 @@ public class AnalyzedSetSessionAuthorizationStatement implements AnalyzedStateme
     @Override
     public boolean isWriteOperation() {
         return false;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedSetTransaction.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedSetTransaction.java
@@ -21,9 +21,11 @@
 
 package io.crate.analyze;
 
-import java.util.List;
-
+import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.SetTransactionStatement.TransactionMode;
+
+import java.util.List;
+import java.util.function.Consumer;
 
 public final class AnalyzedSetTransaction implements AnalyzedStatement {
 
@@ -45,5 +47,9 @@ public final class AnalyzedSetTransaction implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return false;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatement.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatement.java
@@ -48,8 +48,7 @@ public interface AnalyzedStatement {
      * Use {@link Relations#traverseDeepSymbols(AnalyzedStatement, Consumer)}
      * For a variant that traverses into sub-relations.
      */
-    default void visitSymbols(Consumer<? super Symbol> consumer) {
-    }
+    void visitSymbols(Consumer<? super Symbol> consumer);
 
     /**
      * Expressions which define the output of the statement.


### PR DESCRIPTION
If a visitSymbol implementation is missing, possible parameter
symbols are missed to consume which leads to broken parameter
descriptions.
To avoid that, `AnalyzedStatement.visitSymbols` is mandatory to be
implemented by child classes now.

Additionally, this commit adds the missing implementations.