### PR TITLE
Add release notes item about the JNA version bump

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -106,3 +106,6 @@ Fixes
 - Fixed an issue that could result in a ``The assembled list of
   ParameterSymbols is invalid. Missing parameters.`` error if using the
   ``MATCH`` predicate and parameter placeholders within a query.
+
+- Bumped JNA library to version 5.6.0. This will make CrateDB start flawlessly
+  and without warnings on recent versions of Windows.


### PR DESCRIPTION
Hi there,

this is the missing release notes item for e7022d6. Please let me know if that item should go to the "Fixes" section instead.

With kind regards,
Andreas.
