### PR TITLE
Adjust versions checks on node joins to allow hotfix version differences

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -106,6 +106,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue inside the table version and node version compatibility check
+  which prevented downgrading from one hotfix version to another one.
+
 - Fixed an issue that could lead to a ``String index out of range`` error when
   streaming values of type ``TIMESTAMP WITH TIME ZONE`` using a PostgreSQL
   client.

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -318,6 +318,13 @@ public class Version implements Comparable<Version>, ToXContentFragment {
         return version.internalId < internalId;
     }
 
+    public boolean afterMajorMinor(Version version) {
+        if (version.major == major) {
+            return version.minor < minor;
+        }
+        return version.major < major;
+    }
+
     public boolean onOrAfter(Version version) {
         return version.internalId <= internalId;
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.junit.Test;
 
 public class JoinTaskExecutorTests extends ESTestCase {
 
@@ -61,5 +62,20 @@ public class JoinTaskExecutorTests extends ESTestCase {
         Metadata metadata = metaBuilder.build();
             JoinTaskExecutor.ensureIndexCompatibility(Version.CURRENT,
                 metadata);
+    }
+
+    @Test
+    public void test_nodes_with_same_major_and_minor_version_can_join() {
+        Settings.builder().build();
+        Metadata.Builder metaBuilder = Metadata.builder();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test")
+            .settings(settings(Version.V_4_3_3))
+            .numberOfShards(1)
+            .numberOfReplicas(1).build();
+        metaBuilder.put(indexMetadata, false);
+        Metadata metadata = metaBuilder.build();
+
+        JoinTaskExecutor.ensureIndexCompatibility(Version.V_4_3_2,
+            metadata);
     }
 }


### PR DESCRIPTION
On node joins, nodes with same major and minor version (so just
a different hotfix version number) should be allowed to join.
This will support running a cluster with nodes downgraded to a
different hotfix version number.