### PR TITLE
Support ISO format in TimestampZType decodeUTF8Text

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -106,6 +106,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``String index out of range`` error when
+  streaming values of type ``TIMESTAMP WITH TIME ZONE`` using a PostgreSQL
+  client.
+
 - Fixed an issue that could lead to errors like ``Can't map PGType with oid=26
   to Crate type`` using a PostgreSQL client.
 

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -266,20 +266,6 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_foo() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService)
-            .addTable("create table tbl (ts timestamp with time zone)")
-            .build();
-        AnalyzedStatement analyzedStatement = e.analyze(
-            "insert into tbl (ts) values (?)",
-            ParamTypeHints.EMPTY
-        );
-        ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
-        DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
-        assertThat(parameterTypes, is(new DataType[]{DataTypes.TIMESTAMPZ}));
-    }
-
-    @Test
     public void testExtractTypesFromInsertWithOnDuplicateKey() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .enableDefaultTables()

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -266,6 +266,20 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_foo() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (ts timestamp with time zone)")
+            .build();
+        AnalyzedStatement analyzedStatement = e.analyze(
+            "insert into tbl (ts) values (?)",
+            ParamTypeHints.EMPTY
+        );
+        ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
+        DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
+        assertThat(parameterTypes, is(new DataType[]{DataTypes.TIMESTAMPZ}));
+    }
+
+    @Test
     public void testExtractTypesFromInsertWithOnDuplicateKey() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .enableDefaultTables()

--- a/server/src/test/java/io/crate/protocols/postgres/types/TimestampZTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/TimestampZTypeTest.java
@@ -22,12 +22,13 @@
 
 package io.crate.protocols.postgres.types;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import org.junit.Test;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 public class TimestampZTypeTest extends BasePGTypeTest<Long> {
 
@@ -63,5 +64,21 @@ public class TimestampZTypeTest extends BasePGTypeTest<Long> {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot parse more than 9 digits for fraction of a second");
         TimestampZType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
+    }
+
+    @Test
+    public void test_decode_ts_string() throws Exception {
+        assertThat(
+            TimestampZType.INSTANCE.decodeUTF8Text("2021-01-13T14:37:17.25988Z".getBytes(UTF_8)),
+            is(1610548637259L)
+        );
+        assertThat(
+            TimestampZType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.000+00".getBytes(UTF_8)),
+            is(1467072000000L)
+        );
+        assertThat(
+            TimestampZType.INSTANCE.decodeUTF8Text("1000-12-22 00:00:00.000+00 BC".getBytes(UTF_8)),
+            is(-93661920000000L)
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Because of the fix in [960888989292a7657d999c3bf669d7143c66814f][1]
timestamp values were no longer streamed as undefined (text) and then
implicitly cast to timestamp using the `DataType` implementation, but
instead they were directly decoded using the `TimestampZType`
implementation, which supported a different set of formats.

This commit changes the decode implementation to first use the logic in
`DataType.TIMSTAMPZ` and then as fallback the previous decode
implementation. This ensures all formats we previously supported
continue to work.

We should eventually re-work the decode implementation to support all
PostgreSQL date/time input formats as described in their documentation:

- https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-INPUT
- https://www.postgresql.org/docs/current/datetime-input-rules.html

[1] https://github.com/crate/crate/commit/960888989292a7657d999c3bf669d7143c66814f

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)