### PR TITLE
bp: Added wait_for_metadata_version parameter to cluster state api

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -567,6 +567,7 @@ should be crossed out as well.
 - [s] a354c607228 Revert "Remove obsolete resolving logic from TRA (#49647)"
 - [s] 6cca2b04fa0 Remove obsolete resolving logic from TRA (#49647)
 - [x] 4b16d50cd4b Fix typo when assigning null_value in GeoPointFieldMapper  (#49645)
+- [x] 7624734f14b Added wait_for_metadata_version parameter to cluster state api (#35535)
 
 Below lists deferred patches. In-between patches that we applied or skipped
 are not listed anymore.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateResponse.java
@@ -19,13 +19,16 @@
 
 package org.elasticsearch.action.admin.cluster.state;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.transport.TransportResponse;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * The response for getting the cluster state.
@@ -34,10 +37,12 @@ public class ClusterStateResponse extends TransportResponse {
 
     private final ClusterName clusterName;
     private final ClusterState clusterState;
+    private boolean waitForTimedOut = false;
 
-    public ClusterStateResponse(ClusterName clusterName, ClusterState clusterState) {
+    public ClusterStateResponse(ClusterName clusterName, ClusterState clusterState, boolean waitForTimedOut) {
         this.clusterName = clusterName;
         this.clusterState = clusterState;
+        this.waitForTimedOut = waitForTimedOut;
     }
 
     /**
@@ -55,14 +60,78 @@ public class ClusterStateResponse extends TransportResponse {
         return this.clusterName;
     }
 
+    /**
+     * Returns whether the request timed out waiting for a cluster state with a metadata version equal or
+     * higher than the specified metadata.
+     */
+    public boolean isWaitForTimedOut() {
+        return waitForTimedOut;
+    }
+
     public ClusterStateResponse(StreamInput in) throws IOException {
         clusterName = new ClusterName(in);
-        clusterState = ClusterState.readFrom(in, null);
+        if (in.getVersion().onOrAfter(Version.V_4_4_0)) {
+            clusterState = in.readOptionalWriteable(innerIn -> ClusterState.readFrom(innerIn, null));
+            waitForTimedOut = in.readBoolean();
+        } else {
+            clusterState = ClusterState.readFrom(in, null);
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         clusterName.writeTo(out);
-        clusterState.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_4_4_0)) {
+            out.writeOptionalWriteable(clusterState);
+            out.writeBoolean(waitForTimedOut);
+        } else {
+            clusterState.writeTo(out);
+        }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClusterStateResponse response = (ClusterStateResponse) o;
+        return waitForTimedOut == response.waitForTimedOut &&
+            Objects.equals(clusterName, response.clusterName) &&
+            // Best effort. Only compare cluster state version and master node id,
+            // because cluster state doesn't implement equals()
+            Objects.equals(getVersion(clusterState), getVersion(response.clusterState)) &&
+            Objects.equals(getMasterNodeId(clusterState), getMasterNodeId(response.clusterState));
+    }
+
+    @Override
+    public int hashCode() {
+        // Best effort. Only use cluster state version and master node id,
+        // because cluster state doesn't implement  hashcode()
+        return Objects.hash(
+            clusterName,
+            getVersion(clusterState),
+            getMasterNodeId(clusterState),
+            waitForTimedOut
+        );
+    }
+
+    private static String getMasterNodeId(ClusterState clusterState) {
+        if (clusterState == null) {
+            return null;
+        }
+        DiscoveryNodes nodes = clusterState.getNodes();
+        if (nodes != null) {
+            return nodes.getMasterNodeId();
+        } else {
+            return null;
+        }
+    }
+
+    private static Long getVersion(ClusterState clusterState) {
+        if (clusterState != null) {
+            return clusterState.getVersion();
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateApiTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateApiTests.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.state;
+
+import io.crate.common.unit.TimeValue;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ClusterStateApiTests extends ESIntegTestCase {
+
+    public void testWaitForMetaDataVersion() throws Exception {
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        clusterStateRequest.waitForTimeout(TimeValue.timeValueHours(1));
+        ActionFuture<ClusterStateResponse> future1 = client().admin().cluster().state(clusterStateRequest);
+        assertBusy(() -> {
+            assertThat(future1.isDone(), is(true));
+        });
+        assertThat(future1.actionGet().isWaitForTimedOut(), is(false));
+        long metadataVersion = future1.actionGet().getState().getMetadata().version();
+
+        // Verify that cluster state api returns after the cluster settings have been updated:
+        clusterStateRequest = new ClusterStateRequest();
+        clusterStateRequest.waitForMetadataVersion(metadataVersion + 1);
+
+        ActionFuture<ClusterStateResponse> future2 = client().admin().cluster().state(clusterStateRequest);
+        assertThat(future2.isDone(), is(false));
+
+        // Pick an arbitrary dynamic cluster setting and change it. Just to get metadata version incremented:
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder().put(
+            "cluster.max_shards_per_node",
+            999)).execute().actionGet());
+
+        assertBusy(() -> {
+            assertThat(future2.isDone(), is(true));
+        });
+        ClusterStateResponse response = future2.actionGet();
+        assertThat(response.isWaitForTimedOut(), is(false));
+        assertThat(response.getState().metadata().version(), equalTo(metadataVersion + 1));
+
+        // Verify that the timed out property has been set"
+        metadataVersion = response.getState().getMetadata().version();
+        clusterStateRequest.waitForMetadataVersion(metadataVersion + 1);
+        clusterStateRequest.waitForTimeout(TimeValue.timeValueSeconds(1)); // Fail fast
+        ActionFuture<ClusterStateResponse> future3 = client().admin().cluster().state(clusterStateRequest);
+        assertBusy(() -> {
+            assertThat(future3.isDone(), is(true));
+        });
+        response = future3.actionGet();
+        assertThat(response.isWaitForTimedOut(), is(true));
+        assertThat(response.getState(), nullValue());
+
+        // Remove transient setting, otherwise test fails with the reason that this test leaves state behind:
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder().put(
+            "cluster.max_shards_per_node",
+            (String) null)).execute().actionGet());
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateResponseTests.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.state;
+
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+public class ClusterStateResponseTests extends AbstractWireSerializingTestCase<ClusterStateResponse> {
+
+
+    @Override
+    protected ClusterStateResponse createTestInstance() {
+        ClusterName clusterName = new ClusterName(randomAlphaOfLength(4));
+        ClusterState clusterState = null;
+        if (randomBoolean()) {
+            ClusterState.Builder clusterStateBuilder = ClusterState.builder(clusterName)
+                .version(randomNonNegativeLong());
+            if (randomBoolean()) {
+                clusterStateBuilder.nodes(DiscoveryNodes.builder().masterNodeId(randomAlphaOfLength(4)).build());
+            }
+            clusterState = clusterStateBuilder.build();
+        }
+        return new ClusterStateResponse(clusterName, clusterState, randomBoolean());
+    }
+
+    @Override
+    protected Writeable.Reader<ClusterStateResponse> instanceReader() {
+        return ClusterStateResponse::new;
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(ClusterModule.getNamedWriteables());
+    }
+}


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/commit/7624734f14b

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
