### PR TITLE
Deprecate zen 1 Discovery Settings

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -48,7 +48,9 @@ None
 Deprecations
 ============
 
-None
+- The settings ``discovery.zen.publish_timeout``, ``discovery.zen.commit_timeout``,
+  ``discovery.zen.no_master_block``, ``discovery.zen.publish_diff.enable``
+  have been marked as deprecated and will be removed in a future version.
 
 Changes
 =======

--- a/server/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -32,7 +32,9 @@ import java.util.EnumSet;
 
 /**
  * Exposes common discovery settings that may be supported by all the different discovery implementations
+ * @deprecated The discovery settings are not used anymore for the zen 2 discovery and will be removed.
  */
+@Deprecated
 public class DiscoverySettings {
 
     public static final int NO_MASTER_BLOCK_ID = 2;
@@ -44,7 +46,7 @@ public class DiscoverySettings {
      **/
     public static final Setting<TimeValue> PUBLISH_TIMEOUT_SETTING =
         Setting.positiveTimeSetting("discovery.zen.publish_timeout", TimeValue.timeValueSeconds(30),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.Deprecated, Property.NodeScope);
 
     /**
      * sets the timeout for receiving enough acks for a specific cluster state and committing it. failing
@@ -53,12 +55,16 @@ public class DiscoverySettings {
     public static final Setting<TimeValue> COMMIT_TIMEOUT_SETTING =
         new Setting<>("discovery.zen.commit_timeout", (s) -> PUBLISH_TIMEOUT_SETTING.getRaw(s),
             (s) -> TimeValue.parseTimeValue(s, TimeValue.timeValueSeconds(30), "discovery.zen.commit_timeout"),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.Deprecated, Property.NodeScope);
     public static final Setting<ClusterBlock> NO_MASTER_BLOCK_SETTING =
         new Setting<>("discovery.zen.no_master_block", "write", DiscoverySettings::parseNoMasterBlock,
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.Deprecated, Property.NodeScope);
     public static final Setting<Boolean> PUBLISH_DIFF_ENABLE_SETTING =
-        Setting.boolSetting("discovery.zen.publish_diff.enable", true, Property.Dynamic, Property.NodeScope);
+        Setting.boolSetting("discovery.zen.publish_diff.enable",
+                            true,
+                            Property.Dynamic,
+                            Property.Deprecated,
+                            Property.NodeScope);
     public static final Setting<TimeValue> INITIAL_STATE_TIMEOUT_SETTING =
         Setting.positiveTimeSetting("discovery.initial_state_timeout", TimeValue.timeValueSeconds(30), Property.NodeScope);
 


### PR DESCRIPTION
This deprecates the  settings ``discovery.zen.publish_timeout``,
``discovery.zen.commit_timeout``, ``discovery.zen.no_master_block``,
``discovery.zen.publish_diff.enable`` because they are not used for zen2 anymore.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
