### PR TITLE
Move discovery.initial_state_timeout from DiscoverySettings to Node

### DIFF
--- a/app/src/test/java/io/crate/node/UnsafeBootstrapAndDetachCommandIT.java
+++ b/app/src/test/java/io/crate/node/UnsafeBootstrapAndDetachCommandIT.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.junit.Test;
@@ -45,7 +46,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static org.elasticsearch.discovery.DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING;
 import static org.hamcrest.Matchers.containsString;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numClientNodes = 0, numDataNodes = 0, autoMinMasterNodes = false)
@@ -98,12 +98,12 @@ public class UnsafeBootstrapAndDetachCommandIT extends SQLTransportIntegrationTe
 
         logger.info("--> start 1st master-eligible node");
         masterNodes.add(internalCluster().startMasterOnlyNode(Settings.builder()
-                .put(INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
+                .put(Node.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
                 .build())); // node ordinal 0
 
         logger.info("--> start one data-only node");
         String dataNode = internalCluster().startDataOnlyNode(Settings.builder()
-                .put(INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
+                .put(Node.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
                 .build()); // node ordinal 1
 
         logger.info("--> start 2nd and 3rd master-eligible nodes and bootstrap");

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -347,7 +347,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING,
         SeedHostsResolver.DISCOVERY_SEED_RESOLVER_MAX_CONCURRENT_RESOLVERS_SETTING,
         SeedHostsResolver.DISCOVERY_SEED_RESOLVER_TIMEOUT_SETTING,
-        DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING,
+        Node.INITIAL_STATE_TIMEOUT_SETTING,
         Node.WRITE_PORTS_FILE_SETTING,
         Node.NODE_NAME_SETTING,
         Node.NODE_DATA_SETTING,

--- a/server/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -65,8 +65,6 @@ public class DiscoverySettings {
                             Property.Dynamic,
                             Property.Deprecated,
                             Property.NodeScope);
-    public static final Setting<TimeValue> INITIAL_STATE_TIMEOUT_SETTING =
-        Setting.positiveTimeSetting("discovery.initial_state_timeout", TimeValue.timeValueSeconds(30), Property.NodeScope);
 
     private volatile ClusterBlock noMasterBlock;
     private volatile TimeValue publishTimeout;

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -21,7 +21,6 @@ package org.elasticsearch.node;
 
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.cluster.node.DiscoveryNode.getRolesFromSettings;
-import static org.elasticsearch.discovery.DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING;
 
 import java.io.BufferedWriter;
 import java.io.Closeable;
@@ -209,6 +208,9 @@ public class Node implements Closeable {
             Property.NodeScope
         )
     );
+
+    public static final Setting<TimeValue> INITIAL_STATE_TIMEOUT_SETTING =
+        Setting.timeSetting("discovery.initial_state_timeout", TimeValue.timeValueSeconds(30), Property.NodeScope);
 
     private final Lifecycle lifecycle = new Lifecycle();
 

--- a/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -25,7 +25,7 @@ import static org.apache.lucene.util.LuceneTestCase.rarely;
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.ZEN2_DISCOVERY_TYPE;
-import static org.elasticsearch.discovery.DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING;
+import static org.elasticsearch.node.Node.INITIAL_STATE_TIMEOUT_SETTING;
 import static org.elasticsearch.discovery.FileBasedSeedHostsProvider.UNICAST_HOSTS_FILE;
 import static org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING;
 import static org.elasticsearch.test.ESTestCase.assertBusy;

--- a/server/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/server/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -81,7 +81,7 @@ import java.util.function.Supplier;
  * Matching requests to rules is based on the delegate address associated with the
  * discovery node of the request, namely by DiscoveryNode.getAddress().
  * This address is usually the publish address of the node but can also be a different one
- * (for example, @see org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing, which constructs
+ * (for example, @see org.elasticsearch.discovery.HandshakingTransportAddressConnector, which constructs
  * fake DiscoveryNode instances where the publish address is one of the bound addresses).
  */
 public final class MockTransportService extends TransportService {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We decided to keep the `DiscoverySettings` for now as deprecated, this removes it only from the usage. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
