### PR TITLE
Fix join executor test case, expecting it to fail with previous version

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -40,7 +40,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         JoinTaskExecutor.ensureIndexCompatibility(Version.CURRENT, metadata);
 
         expectThrows(IllegalStateException.class, () ->
-        JoinTaskExecutor.ensureIndexCompatibility(VersionUtils.getPreviousVersion(Version.CURRENT),
+        JoinTaskExecutor.ensureIndexCompatibility(VersionUtils.getPreviousMinorVersion(),
             metadata));
     }
 


### PR DESCRIPTION
The existing test did not fail as expected if the previous version is on the
same major + minor number since we changed the logic by
https://github.com/crate/crate/commit/f939b02fe79.
A previous version with a different minor must be used now.

This popped up by the 4.3 backport of  https://github.com/crate/crate/commit/f939b02fe79 as on master no
previous version with same major + minor exists.
To make the backport tests succeed this change is already included in the backport, see #10933.