### PR TITLE
Extend filtered source parsing to object columns

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -26,9 +26,10 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
+
+import javax.annotation.Nullable;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -43,7 +44,8 @@ import io.crate.metadata.doc.DocSysColumns;
 
 public final class SourceParser {
 
-    private final Set<String> requiredColumns = new HashSet<>();
+    private static final Object FULL_OBJECT = new Object();
+    private final Map<String, Object> requiredColumns = new HashMap<>();
 
     public SourceParser() {
     }
@@ -52,7 +54,29 @@ public final class SourceParser {
         assert docColumn.name().equals(DocSysColumns.DOC.name()) && docColumn.path().size() > 0
             : "All columns registered for sourceParser must start with _doc";
 
-        requiredColumns.add(docColumn.path().get(0));
+        List<String> path = docColumn.path();
+        if (path.size() == 1) {
+            requiredColumns.put(docColumn.path().get(0), FULL_OBJECT);
+        } else {
+            Map<String, Object> columns = requiredColumns;
+            for (int i = 0; i < path.size(); i++) {
+                String part = path.get(i);
+                if (i + 1 == path.size()) {
+                    columns.put(part, FULL_OBJECT);
+                } else {
+                    Object object = columns.get(part);
+                    if (object instanceof Map) {
+                        columns = (Map) object;
+                    } else if (object == FULL_OBJECT) {
+                        break;
+                    } else {
+                        HashMap<String, Object> children = new HashMap<String, Object>();
+                        columns.put(part, children);
+                        columns = children;
+                    }
+                }
+            }
+        }
     }
 
     public Map<String, Object> parse(BytesReference bytes) {
@@ -74,10 +98,20 @@ public final class SourceParser {
                 String fieldName = parser.currentName();
                 parser.nextToken();
                 // empty means the full _doc is required
-                if (requiredColumns.isEmpty() || requiredColumns.contains(fieldName)) {
-                    result.put(fieldName, parseValue(parser));
+                if (requiredColumns.isEmpty()) {
+                    result.put(fieldName, parseValue(parser, null));
                 } else {
-                    parser.skipChildren();
+                    Object required = requiredColumns.get(fieldName);
+                    if (required == null) {
+                        parser.skipChildren();
+                    } else if (required == FULL_OBJECT) {
+                        result.put(fieldName, parseValue(parser, null));
+                    } else {
+                        assert required instanceof Map
+                            : "requiredColumns must either contain the FULL_OBJECT marker or a Map with child columns to load";
+
+                        result.put(fieldName, parseValue(parser, (Map) required));
+                    }
                 }
             }
             return result;
@@ -86,18 +120,38 @@ public final class SourceParser {
         }
     }
 
-    private static Object parseValue(XContentParser parser) throws IOException {
+    private static Object parseValue(XContentParser parser, @Nullable Map<String, Object> requiredColumns) throws IOException {
         return switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case START_ARRAY -> {
                 ArrayList<Object> values = new ArrayList<>();
                 Token token = parser.nextToken();
                 for (; token != null && token != XContentParser.Token.END_ARRAY; token = parser.nextToken()) {
-                    values.add(parseValue(parser));
+                    values.add(parseValue(parser, requiredColumns));
                 }
                 yield values;
             }
-            case START_OBJECT -> parser.map();
+            case START_OBJECT -> {
+                if (requiredColumns == null) {
+                    yield parser.map();
+                } else {
+                    HashMap<String, Object> values = new HashMap<>();
+                    XContentParser.Token token = parser.nextToken(); // move past START_OBJECT;
+                    for (; token == XContentParser.Token.FIELD_NAME; token = parser.nextToken()) {
+                        String fieldName = parser.currentName();
+                        parser.nextToken();
+                        var required = requiredColumns.get(fieldName);
+                        if (required == null) {
+                            parser.skipChildren();
+                        } else if (required == FULL_OBJECT) {
+                            values.put(fieldName, parseValue(parser, null));
+                        } else {
+                            values.put(fieldName, parseValue(parser, (Map) required));
+                        }
+                    }
+                    yield values;
+                }
+            }
             case VALUE_STRING -> parser.text();
             case VALUE_NUMBER -> parser.numberValue();
             case VALUE_BOOLEAN -> parser.booleanValue();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Instead of applying the filtering only on the top-level columns, this
changes the filtering to also work on nested columns.

This should further reduce memory pressure in cases where only a subset of nested columns of a large object column is selected.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)