### PR TITLE
Make source parsing eagerly type aware

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -98,7 +98,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
             // for example:
             //      sourceExtractor might read byte as int and
             //      then eq(byte, byte) would get eq(byte, int) and fail
-            return ref.valueType().implicitCast(sourceLookup.get(ref.column().path()));
+            return sourceLookup.get(ref.column().path());
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -124,7 +124,7 @@ public final class SourceLookup {
     }
 
     public SourceLookup registerRef(Reference ref) {
-        sourceParser.register(ref.column());
+        sourceParser.register(ref.column(), ref.valueType());
         return this;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So far we parsed the source into an `Map<String, Object>`, where we
typed the `Object` based on the value encountered in the JSON source.

This could lead to values that should be typed as `LONG` to be typed as
`INTEGER`. Because of that we added a `implicitCast` call to ensure the
types returned from the parser match the expected types.

The problem with that is that `implicitCast` can be a costly operation
for arrays or objects, as it has to create a full copy.

This commit makes the source parser type aware, so that we can type the
leaf values in the correct type to begin with and don't need to correct
the types later on with an `implicitCast`.


```
V1: 4.4.0-448cd98d04139fdf900fbbdc25a65e345c6dcb2b
V2: 4.4.0-b2d65d0cb12974352616c53f196f4dacef02e07c

Q: select xs from huge_arrays
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2666.777 ±   26.360 |   2615.485 |   2666.564 |   2677.335 |   3078.698 |
|   V2    |     2430.608 ±   23.981 |   2379.717 |   2429.558 |   2439.431 |   2831.962 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   9.27%                           -   9.30%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 9.27%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  203     3.32     4.05 |  152    68.25    80.73 |     4295     1228 |   409.09     370740
 V2 |  120     3.56     3.80 |  120    62.99    90.64 |     4295     1220 |   402.16     272094

V1 top allocation frames
  Arrays.copyOf(...):200214240643
  Integer.valueOf(int):110440021328
  ArrayUtil.growExact(...):20393781376
  CompressingStoredFieldsReader.readField(...):11137842696
  ArrayList.<init>(int):7368289800
V2 top allocation frames
  Arrays.copyOf(...):153710881412
  Integer.valueOf(int):84746049582
  ArrayUtil.growExact(...):16149348144
  CompressingStoredFieldsReader.readField(...):5989420176
  BufferRecycler.balloc(int):4436438416
 ```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)