### PR TITLE
Add restart callback back to InternalTestCluster to fix DiskDisruptionIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1689,6 +1689,7 @@ public final class InternalTestCluster extends TestCluster {
             final List<NodeAndClient> nodesByRole = nodesByRoles.get(roles);
             startUpOrder.add(nodesByRole.remove(0));
         }
+        callback.onAllNodesStopped();
         assert nodesByRoles.values().stream().mapToInt(List::size).sum() == 0;
 
         for (NodeAndClient nodeAndClient : startUpOrder) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
