### PR TITLE
Enable slow tests for jenkins java tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           steps {
             sh 'git clean -xdff'
             checkout scm
-            sh './gradlew --no-daemon --parallel -PtestForks=8 test checkstyleMain forbiddenApisMain jacocoReport'
+            sh './gradlew --no-daemon --parallel -Dtests.crate.slow=true -PtestForks=8 test checkstyleMain forbiddenApisMain jacocoReport'
             sh 'curl -s https://codecov.io/bash | bash'
           }
           post {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This enables the slow integration tests for the default java tests on each pr. 

java tests without slow tests: 10m 56s
java tests with slow tests: 12m 45s

Surprisingly the difference is not so dramatic. I double checked that the tests are really executed.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
