### PR TITLE
Fix parameter type extraction for joins

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,4 +58,6 @@ None
 Fixes
 =====
 
-None
+- Fixed a regression that caused queries which used a parameter placeholder in
+  a join condition to fail with an ``The assembled list of ParameterSymbols is
+  invalid. Missing parameters`` error.

--- a/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -189,6 +189,11 @@ public class QueriedSelectRelation implements AnalyzedRelation {
         if (offset != null) {
             consumer.accept(offset);
         }
+        for (var joinPair : joinPairs) {
+            if (joinPair.condition() != null) {
+                consumer.accept(joinPair.condition());
+            }
+        }
     }
 
     public List<JoinPair> joinPairs() {

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -543,4 +543,24 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         DataType[] parameterTypes = typeExtractor.getParameterTypes(statement::visitSymbols);
         assertThat(parameterTypes, arrayContaining(DataTypes.STRING, DataTypes.UNDEFINED, DataTypes.STRING));
     }
+
+
+    @Test
+    public void test_can_extract_parameters_from_join_condition() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table subscriptions (id text primary key, name text not null)")
+            .addTable("create table clusters (id text, subscription_id text)")
+            .build();
+
+        AnalyzedStatement stmt = e.analyze("""
+            select
+                *
+            from subscriptions
+            join clusters on clusters.subscription_id = subscriptions.id
+                AND subscriptions.name = ?
+        """);
+        ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
+        DataType[] parameterTypes = typeExtractor.getParameterTypes(stmt::visitSymbols);
+        assertThat(parameterTypes, arrayContaining(DataTypes.STRING));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Queries with parameter placeholders in a join condition failed because
`QueriedSelectRelation.visitSymbol` didn't look at the join conditions.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)