### PR TITLE
Fix nested joins with primary key lookups which require scroll

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,10 @@ None
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``stream has already been operated upon
+  or closed`` error when using primary key lookup operations as part of a query
+  with several JOIN clauses.
+
 - Fixed a regression that caused queries which used a parameter placeholder in
   a join condition to fail with an ``The assembled list of ParameterSymbols is
   invalid. Missing parameters`` error.

--- a/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -61,7 +61,7 @@ public class HashJoinOperation implements CompletionListenable {
                              long numberOfRowsForLeft) {
 
         this.resultConsumer = nlResultConsumer;
-        this.leftConsumer = new CapturingRowConsumer(false, nlResultConsumer.completionFuture());
+        this.leftConsumer = new CapturingRowConsumer(nlResultConsumer.requiresScroll(), nlResultConsumer.completionFuture());
         this.rightConsumer = new CapturingRowConsumer(true, nlResultConsumer.completionFuture());
         CompletableFuture.allOf(leftConsumer.capturedBatchIterator(), rightConsumer.capturedBatchIterator())
             .whenComplete((result, failure) -> {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `requiresScroll` property for a hash join was always set to `false`
for the left side. This is true if the hash-join is standalone, but not
if the hash-join has another parent that requires the hash-join itself
to be scrollable as well.

If the `requiresScroll` property is set to false, some BatchIterator
implementations do not support `moveToStart`.

One case where this happens is the primary key lookup. Users would get a
`stream has already been operated upon or closed` error because of that.

This is a bug that was present for a long time, but the change in
ab5e0a4a74e4b841661333f6aa1e8f79e6737c5c exposed this now in queries
which worked in 4.3

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)