### PR TITLE
Fix `ReadyForQuery` message ordering on explicit flush

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,11 @@ None
 Fixes
 =====
 
+- Fixed an issue in the PostgreSQL wire protocol implementation that could lead
+  to incorrect results on the client side if a client invoked a write operation
+  and sent an explicit flush message before the sync message. The
+  ``node-postgres`` client is one client that uses such a message sequence.
+
 - Fixed an issue that could lead to a ``stream has already been operated upon
   or closed`` error when using primary key lookup operations as part of a query
   with several JOIN clauses.

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -477,7 +477,7 @@ public class PostgresWireProtocol {
             // (That we've been holding back, as we don't eager react to `execute` requests. (We do that to optimize batch inserts))
             // The sync will also trigger a flush eventually if there are deferred executions.
             if (session.hasDeferredExecutions()) {
-                session.sync();
+                session.flush();
             } else {
                 channel.flush();
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If the flush triggers the deferred executions, then a follow up `sync()`
returned a completed future. This led the pg-write layer to immediately
send a `ReadyForQuery` message to the client, even if the operations
triggered by the flush weren't finished.

This changes the logic so that `flush` sets the `activeExecution`
property, which will then be used by `sync`. This ensures that the
`ReadyForQuery` message is sent after the operations have completed.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)