### PR TITLE
Fix flaky testSetResetGlobalSetting

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -83,9 +83,9 @@ public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
         assertThat(response.rows()[0][1], is(JobsLogService.STATS_JOBS_LOG_SIZE_SETTING.getDefault()));
         assertThat(response.rows()[0][2], is(JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING.getDefault()));
 
-        execute("set global transient \"indices.breaker.query.limit\" = '2mb'");
+        execute("set global transient \"indices.breaker.query.limit\" = '20mb'");
         execute("select settings from sys.cluster");
-        assertSettingsValue(HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "2mb");
+        assertSettingsValue(HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "20mb");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The test could sometimes fail with:

    Error executing stmt=select settings from sys.cluster args=null error=org.postgresql.util.PSQLException:
    ERROR: [query] Data too large, data for [hash-join: 12] would be [2099414/2mb], which is larger than the limit of [2097152/2mb]

Given that the test only asserts that the setting can be changed and is
not related to query breaking or accounting behavior it's fine to
increase the limit that is being set.

The PostgreSQL client can do some `pg_catalog` queries up-front, and we
recently increased the amount of rows returned in some cases. So it's
feasible to assume that the amount of required memory increased for
these queries.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)