### PR TITLE
Link create/drop table mentions to sql reference for these statements

### DIFF
--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -12,8 +12,8 @@ Creating tables
 Basics
 ======
 
-To create a table use the ``CREATE TABLE`` command. You must at least specify a
-name for the table and names and types of the columns.
+To create a table use the :ref:`ref-create-table` command. You must at least
+specify a name for the table and names and types of the columns.
 
 See :ref:`data-types` for information about the supported data types.
 
@@ -26,12 +26,12 @@ This query creates a simple table with two columns of type ``integer`` and
     ... );
     CREATE OK, 1 row affected (... sec)
 
-A table can be removed by using the ``DROP TABLE`` command::
+A table can be removed by using the :ref:`drop-table` command::
 
     cr> drop table my_table;
     DROP OK, 1 row affected (... sec)
 
-The ``DROP TABLE`` command takes the optional clause ``IF EXISTS`` which
+The :ref:`drop-table` command takes the optional clause ``IF EXISTS`` which
 prevents the generation of an error if the specified table does not exist::
 
     cr> drop table if exists my_table;


### PR DESCRIPTION
The sql reference of `CREATE TABLE`, specially all supported options,
is quite interesting. Linking to it should help directing users to it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
