### PR TITLE
Remove license custom metadata for bwc

### DIFF
--- a/server/src/main/java/io/crate/license/LicenseCustomMetadataUpgrader.java
+++ b/server/src/main/java/io/crate/license/LicenseCustomMetadataUpgrader.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import io.crate.metadata.CustomMetadataUpgrader;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Map;
+
+/**
+ * Removes License related custom Metadata to be compatible with pre 4.5 nodes
+ */
+public class LicenseCustomMetadataUpgrader implements CustomMetadataUpgrader {
+
+    public static final String TYPE = "license";
+
+    @Override
+    public Map<String, Metadata.Custom> apply(Settings settings, Map<String, Metadata.Custom> customs) {
+        customs.remove(TYPE);
+        return customs;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -210,7 +210,7 @@ public class GatewayMetaState {
      *
      * @return input <code>metadata</code> if no upgrade is needed or an upgraded metadata
      */
-    static Metadata upgradeMetadata(Metadata metadata,
+    public static Metadata upgradeMetadata(Metadata metadata,
                                     MetadataIndexUpgradeService metadataIndexUpgradeService,
                                     MetadataUpgrader metadataUpgrader) {
         // upgrade index meta data

--- a/server/src/main/resources/META-INF/services/io.crate.metadata.CustomMetadataUpgrader
+++ b/server/src/main/resources/META-INF/services/io.crate.metadata.CustomMetadataUpgrader
@@ -1,0 +1,1 @@
+io.crate.license.LicenseCustomMetadataUpgrader

--- a/server/src/test/java/io/crate/license/LicenseCustomMetadataUpgraderTest.java
+++ b/server/src/test/java/io/crate/license/LicenseCustomMetadataUpgraderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.crate.metadata.CustomMetadataUpgraderLoader;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.gateway.GatewayMetaState;
+import org.elasticsearch.gateway.GatewayMetaStateTests;
+import org.elasticsearch.plugins.MetadataUpgrader;
+import org.elasticsearch.test.TestCustomMetadata;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.elasticsearch.gateway.GatewayMetaStateTests.randomMetadata;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class LicenseCustomMetadataUpgraderTest {
+
+    @Test
+    public void test_remove_license_custom_metadata() {
+        var metadata = randomMetadata(new LicenseCustomMetaData("license_key"));
+        var customMetadataUpgraderLoader = new CustomMetadataUpgraderLoader(Settings.EMPTY);
+        var metadataUpgrader = new MetadataUpgrader(
+            List.of(customs -> customMetadataUpgraderLoader.apply(customs)),
+            List.of()
+        );
+        var upgrade = GatewayMetaState.upgradeMetadata(metadata, new GatewayMetaStateTests.MockMetadataIndexUpgradeService(false), metadataUpgrader);
+        assertThat(upgrade != metadata, is(true));
+        assertThat(Metadata.isGlobalStateEquals(upgrade, metadata), is(false));
+        assertThat(upgrade.custom(LicenseCustomMetaData.TYPE), is(nullValue()));
+    }
+
+    private static class LicenseCustomMetaData extends TestCustomMetadata {
+        public static final String TYPE = "license";
+
+        protected LicenseCustomMetaData(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -251,10 +251,10 @@ public class GatewayMetaStateTests extends ESTestCase {
         }
     }
 
-    private static class MockMetadataIndexUpgradeService extends MetadataIndexUpgradeService {
+    public static class MockMetadataIndexUpgradeService extends MetadataIndexUpgradeService {
         private final boolean upgrade;
 
-        MockMetadataIndexUpgradeService(boolean upgrade) {
+        public MockMetadataIndexUpgradeService(boolean upgrade) {
             super(Settings.EMPTY, null, null, null, null);
             this.upgrade = upgrade;
         }
@@ -311,7 +311,7 @@ public class GatewayMetaStateTests extends ESTestCase {
         }
     }
 
-    private static Metadata randomMetadata(TestCustomMetadata... customMetadatas) {
+    public static Metadata randomMetadata(TestCustomMetadata... customMetadatas) {
         Metadata.Builder builder = Metadata.builder();
         for (TestCustomMetadata customMetadata : customMetadatas) {
             builder.putCustom(customMetadata.getWriteableName(), customMetadata);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This removes the License custom metadata to make sure `MetaData` from a pre-4.5 `Node` containing a license key can be read. Adressing https://github.com/crate/crate-qa/issues/186 

```
Caused by: java.lang.IllegalArgumentException: Unknown NamedWriteable [org.elasticsearch.cluster.metadata.Metadata$Custom][license]
	at org.elasticsearch.common.io.stream.NamedWriteableRegistry.getReader(NamedWriteableRegistry.java:113) ~[crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:45) ~[crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:39) ~[crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.cluster.metadata.Metadata.readFrom(Metadata.java:779) ~[crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.cluster.ClusterState.readFrom(ClusterState.java:717) ~[crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.cluster.coordination.ValidateJoinRequest.<init>(ValidateJoinRequest.java:39) ~[crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.transport.RequestHandlerRegistry.newRequest(RequestHandlerRegistry.java:56) ~[crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.transport.InboundHandler.handleRequest(InboundHandler.java:180) [crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.transport.InboundHandler.messageReceived(InboundHandler.java:115) [crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.transport.InboundHandler.inboundMessage(InboundHandler.java:104) [crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.transport.TcpTransport.inboundMessage(TcpTransport.java:701) [crate-app.jar:4.5.0-202102030003-9d281f0]
	at org.elasticsearch.transport.netty4.Netty4MessageChannelHandler.channelRead(Netty4MessageChannelHandler.java:53) [crate-app.jar:4.5.0-202102030003-9d281f0]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.58.Final.jar:4.1.58.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.58.Final.jar:4.1.58.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.58.Final.jar:4.1.58.Final]
```


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
