### PR TITLE
Improve aggregation documentation

### DIFF
--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -287,7 +287,7 @@ SQL Standard and PostgreSQL compatibility improvements
   and the ``CURRENT ROW -> UNBOUNDED FOLLOWING`` frame definitions are now
   supported. See :ref:`window-functions`.
 
-- Added the :ref:`string_agg` aggregation function.
+- Added the :ref:`aggregation-string-agg` aggregation function.
 
 - Added support for `SQL Standard Timestamp Format
   <https://crate.io/docs/sql-99/en/latest/chapters/08.html#timestamp-literal>`_

--- a/docs/appendices/release-notes/4.1.0.rst
+++ b/docs/appendices/release-notes/4.1.0.rst
@@ -193,7 +193,7 @@ New statements and clauses
   :ref:`ref-alter-table`.
 
 - Added support for the filter clause in
-  :ref:`aggregate expressions <aggregate-expressions>` and
+  :ref:`aggregate expressions <aggregation-expressions>` and
   :ref:`window functions <window-function-call>` that are
   :ref:`aggregates <aggregation>`.
 

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -201,7 +201,7 @@ Functions and operators
 - Added :ref:`length <scalar-length>` and :ref:`repeat <scalar-repeat>`
   scalar functions.
 
-- Added the :ref:`array_agg <array_agg>` aggregation function.
+- Added the :ref:`array_agg <aggregation-array-agg>` aggregation function.
 
 - Added the :ref:`trunc <scalar-trunc>` scalar function.
 

--- a/docs/general/builtins/window-functions.rst
+++ b/docs/general/builtins/window-functions.rst
@@ -37,7 +37,7 @@ The synopsis of a window function call is one of the following
 
 where ``function_name`` is a name of
 a :ref:`general-purpose window <general-purpose-window-functions>` or
-:ref:`aggregate <aggregate-functions>` function
+:ref:`aggregate <aggregation-functions>` function
 and ``expression`` is a column reference, scalar function or literal.
 
 If ``FILTER`` is specified, then only the rows that met the

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -937,88 +937,13 @@ like so::
 
 .. _sql_dql_aggregation:
 
-Data aggregation
-================
+Aggregation
+===========
 
-CrateDB supports :ref:`aggregation` via the following aggregation functions.
+CrateDB provides built-in :ref:`aggregation functions <aggregation>` that allow
+you to calculate a single summary value for one or more columns.
 
-Aggregation works across all the rows that match a query or on all matching
-rows in every distinct group of a ``GROUP BY`` statement. Aggregating
-``SELECT`` statements without ``GROUP BY`` will always return one row.
-
-+---------------------+---------------+----------------------------------+-----------------------+
-| Name                | Arguments     | Description                      | Return Type           |
-+=====================+===============+==================================+=======================+
-| ARBITRARY           | column name of| Returns an undefined value of    | the input             |
-|                     | a primitive   | all the values in the argument   | column type or NULL   |
-|                     | typed         | column. Can be NULL.             | if some value of the  |
-|                     | column        |                                  | matching rows in that |
-|                     | (all but      |                                  | column is NULL        |
-|                     | object)       |                                  |                       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| AVG / MEAN          | column name of| Returns the arithmetic mean of   | double or NULL        |
-|                     | a numeric or  | the values in the argument       | if all values of all  |
-|                     | timestamp     | column.                          | matching rows in that |
-|                     | column        | NULL-values are ignored.         | column are NULL       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| COUNT(*)            | star as       | Counts the number of rows        | long                  |
-|                     | parameter or  | that match the query.            |                       |
-|                     | as constant   |                                  |                       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| COUNT               | column name   | Counts the number of rows        | long                  |
-|                     |               | that contain a non NULL          |                       |
-|                     |               | value for the given column.      |                       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| COUNT(DISTINCT col) | column name   | Counts the number of distinct    | long                  |
-|                     |               | values for the given column      |                       |
-|                     |               | that are not NULL.               |                       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| GEOMETRIC_MEAN      | column name of| Computes the geometric mean for  | double or NULL        |
-|                     | a numeric or  | positive numbers.                | if all values of all  |
-|                     | timestamp     |                                  | matching rows in that |
-|                     | column        |                                  | are NULL or if a value|
-|                     |               |                                  | is negative.          |
-+---------------------+---------------+----------------------------------+-----------------------+
-| MIN                 | column name of| Returns the smallest of the      | the input             |
-|                     | a numeric,    | values in the argument column    | column type or NULL   |
-|                     | timestamp     | in case of strings this          | if all values in that |
-|                     | or string     | means the lexicographically      | matching rows in that |
-|                     | column        | smallest. NULL-values are ignored| column are NULL       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| MAX                 | column name of| Returns the biggest of the       | the input             |
-|                     | a numeric,    | values in the argument column    | column type or NULL   |
-|                     | timestamp     | in case of strings this          | if all values of all  |
-|                     | or string     | means the lexicographically      | matching rows in that |
-|                     | column        | biggest. NULL-values are ignored | column are NULL       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| STDDEV              | column name of| Returns the standard deviation   | double or NULL        |
-|                     | a numeric or  | of the values in the argument    | if all values are NULL|
-|                     | timestamp     | column.                          | or we got no value at |
-|                     | column        | NULL-values are ignored.         | all                   |
-+---------------------+---------------+----------------------------------+-----------------------+
-| STRING_AGG          | an expression | Concatenated input values into   | text                  |
-|                     | and delimiter | a string, separated by a         |                       |
-|                     | of a text type| delimiter.                       |                       |
-|                     |               | NULL-values are ignored.         |                       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| PERCENTILE          | column of a   | Returns the provided percentile  | a double precision    |
-|                     | numeric type  | of the values in the argument    | value                 |
-|                     | and a double  | column.                          |                       |
-|                     | percentile    | NULL-values are ignored.         |                       |
-|                     | value         |                                  |                       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| SUM                 | column name of| Returns the sum of the values in | double or NULL        |
-|                     | a numeric or  | the argument column.             | if all values of all  |
-|                     | timestamp     | NULL-values are ignored.         | matching rows in that |
-|                     | column        |                                  | column are NULL       |
-+---------------------+---------------+----------------------------------+-----------------------+
-| VARIANCE            | column name of| Returns the variance of the      | double or NULL        |
-|                     | a numeric or  | values in the argument column.   | if all values are NULL|
-|                     | timestamp     | NULL-values are ignored.         | or we got no value at |
-|                     | column        |                                  | all                   |
-+---------------------+---------------+----------------------------------+-----------------------+
-
-Some Examples::
+Some examples::
 
     cr> select count(*) from locations;
     +----------+


### PR DESCRIPTION
closes https://github.com/crate/tech-writing-domain/issues/199

## Summary of the changes / Why this improves CrateDB

This change does the following:

- Drops the table of aggregation functions from `selects.rst`.

  This table was out-of-date and even if it was updated was likely to become
  out-of-date again in the future. This is because this information duplicates
  what is in `builtins/aggregation.rst` and developers adding support for new
  aggregation functions are likely to repeat the mistake of updating
  `aggregation.rst` and not the summary table in `selects.rst`.

  I tried moving the summary table to `aggregation.rst`, but after improving
  this page (see below) I found that the table repetitive and of little value.

- Reorganizes `aggregation.rst` so that functions are listed alphabetically and
  subsections are better organized. Expands headers to provide full syntax
  descriptions, per the headers elsewhere in the docs (e.g., `scalar.rst`).
  Splits out `mean(column)` into its own subsection and mentions that it is an
  alias for `avg(column)`.

  The result is that the page TOC functions as an easy-to-reference summary of
  the page content (thus obviating the need for a summary table).

- Some light copyedits.

  This page could do with more extensive reworking, but that is substantially
  out-of-scope for the parent issue.
