### PR TITLE
Update hadoop version to existing version

### DIFF
--- a/blackbox/test_hdfs.py
+++ b/blackbox/test_hdfs.py
@@ -35,7 +35,7 @@ from crate.client import connect
 from urllib.error import HTTPError
 from urllib.request import urlretrieve
 
-HADOOP_VERSION = '2.8.5'
+HADOOP_VERSION = '2.10.1'
 HADOOP_SOURCE = ('http://www-eu.apache.org/dist/hadoop/common/'
                  'hadoop-{version}/hadoop-{version}.tar.gz'.format(version=HADOOP_VERSION))
 CACHE_DIR = os.environ.get(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

2.8.5 is no longer available

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)