### PR TITLE
Update broken link in secured communications documentation

### DIFF
--- a/docs/admin/ssl.rst
+++ b/docs/admin/ssl.rst
@@ -6,9 +6,10 @@ Secured communications (SSL/TLS)
 
 Secured communication allows you to encrypt traffic between the CrateDB node
 and a client. This applies to connections using HTTP (i.e. `Admin UI
-<https://crate.io/docs/crate/tutorials/en/latest/first-use.html#admin-ui>`_,
+<https://crate.io/docs/crate/tutorials/en/latest/first-use.html#introducing-the-admin-ui>`_,
 `Crash <https://crate.io/docs/crate/crash/en/latest/>`_,
-:ref:`sql_http_endpoint`) and the :ref:`postgres_wire_protocol` (i.e. JDBC, psql).
+:ref:`sql_http_endpoint`) and the :ref:`postgres_wire_protocol` (i.e. JDBC,
+psql).
 
 Connections are secured using Transport Layer Security (TLS).
 

--- a/docs/interfaces/http.rst
+++ b/docs/interfaces/http.rst
@@ -524,4 +524,4 @@ error::
    fails.
 
 .. _prepared statement: https://en.wikipedia.org/wiki/Prepared_statement
-.. _here documents: https://www.tldp.org/LDP/abs/html/here-docs.html
+.. _here documents: https://en.wikipedia.org/wiki/Here_document


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The title of the section changed, breaking the anchor.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)