### PR TITLE
Ensure (string → array) parsing error lead to clear errors

### DIFF
--- a/server/src/main/java/io/crate/exceptions/ConversionException.java
+++ b/server/src/main/java/io/crate/exceptions/ConversionException.java
@@ -24,6 +24,7 @@ package io.crate.exceptions;
 import io.crate.expression.symbol.Symbol;
 import io.crate.types.DataType;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 public class ConversionException extends IllegalArgumentException {
@@ -51,7 +52,7 @@ public class ConversionException extends IllegalArgumentException {
         super(String.format(
             Locale.ENGLISH,
             "Cannot cast value `%s` to type `%s`",
-            sourceValue,
+            sourceValue.getClass().isArray() ? Arrays.deepToString((Object[]) sourceValue) : sourceValue,
             targetType.getName()
         ));
     }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -40,6 +40,7 @@ import io.crate.analyze.relations.UnionSelect;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
+import io.crate.exceptions.ConversionException;
 import io.crate.execution.MultiPhaseExecutor;
 import io.crate.execution.dsl.phases.NodeOperationTree;
 import io.crate.execution.dsl.projection.builder.SplitPoints;
@@ -497,6 +498,8 @@ public class LogicalPlanner {
         try {
             executionPlan = logicalPlan.build(
                 plannerContext, executor.projectionBuilder(), -1, 0, null, null, params, subQueryResults);
+        } catch (ConversionException e) {
+            throw e;
         } catch (Exception e) {
             // This should really only happen if there are planner bugs,
             // so the additional costs of creating a more informative exception shouldn't matter.

--- a/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -23,6 +23,7 @@
 package io.crate.planner.operators;
 
 import io.crate.data.Row;
+import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ParameterSymbol;
@@ -87,6 +88,10 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void>
         if (type.equals(DataTypes.UNDEFINED)) {
             type = DataTypes.guessType(value);
         }
-        return Literal.ofUnchecked(type, type.implicitCast(value));
+        try {
+            return Literal.ofUnchecked(type, type.implicitCast(value));
+        } catch (ClassCastException | IllegalArgumentException e) {
+            throw new ConversionException(value, type);
+        }
     }
 }

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -27,6 +27,7 @@ import io.crate.data.Row1;
 import io.crate.data.RowN;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ColumnValidationException;
+import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.VersioninigValidationException;
@@ -283,8 +284,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedUpdateStatement update = analyze("update users set name=?, friends=? where other_id=?");
 
         Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast [{}] to type TEXT");
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("Cannot cast value `[{}]` to type `text`");
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
     }
 
@@ -421,8 +422,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         };
         AnalyzedUpdateStatement update = analyze("update users set tags=? where id=1");
 
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast [a, b] to type TEXT");
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("Cannot cast value `[[a, b]]` to type `text_array`");
         Assignments assignments = Assignments.convert(update.assignmentByTargetCol(), e.nodeCtx);
         assignments.bindSources(((DocTableInfo) update.table().tableInfo()), new RowN(params), SubQueryResults.EMPTY);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously passing a string value as argument to `ANY(?)` could lead to
an error like:

    Couldn't create execution plan from logical plan because of: line 1:0: mismatched input 'g' expecting '{':
    Eval[classname, name, sum(if((failure IS NULL), 0, 1)) AS failures, count(*)]
      ...

This changes the error handling a bit so that users receive the more
meaningful "Cannot cast value `...` to type `..`" error.

Closes https://github.com/crate/crate/issues/10998

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)