### PR TITLE
Support full timestamp formats in pg wire

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,4 +58,7 @@ None
 Fixes
 =====
 
-None
+
+- Fixed an issue that could lead to a serialization error when streaming values
+  of the ``TIMESTAMP WITHOUT TIME ZONE`` type in text format using the
+  PostgreSQL wire protocol.

--- a/server/src/main/java/io/crate/protocols/postgres/types/TimestampType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/TimestampType.java
@@ -23,6 +23,7 @@
 package io.crate.protocols.postgres.types;
 
 import javax.annotation.Nonnull;
+
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -92,7 +93,11 @@ final class TimestampType extends BaseTimestampType {
     Object decodeUTF8Text(byte[] bytes) {
         String s = new String(bytes, StandardCharsets.UTF_8);
 
-        LocalDateTime dt = LocalDateTime.parse(s, PARSER_WITH_OPTIONAL_ERA);
-        return dt.toInstant(ZoneOffset.UTC).toEpochMilli();
+        try {
+            LocalDateTime dt = LocalDateTime.parse(s, PARSER_WITH_OPTIONAL_ERA);
+            return dt.toInstant(ZoneOffset.UTC).toEpochMilli();
+        } catch (Exception e) {
+            return io.crate.types.TimestampType.parseTimestampIgnoreTimeZone(s);
+        }
     }
 }

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -171,7 +171,7 @@ public final class TimestampType extends DataType<Long>
         }
     }
 
-    static long parseTimestampIgnoreTimeZone(String timestamp) {
+    public static long parseTimestampIgnoreTimeZone(String timestamp) {
         try {
             return Long.parseLong(timestamp);
         } catch (NumberFormatException e) {

--- a/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
@@ -26,8 +26,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
-import java.time.format.DateTimeParseException;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 
@@ -62,7 +60,15 @@ public class TimestampTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testDecodeUTF8TextWithUnexpectedNumberOfFractionDigits() {
-        expectedException.expect(DateTimeParseException.class);
+        expectedException.expectMessage("Text '2016-06-28 00:00:00.0000000001+05:00' could not be parsed");
         TimestampType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
+    }
+
+    @Test
+    public void test_decode_ts_string() throws Exception {
+        assertThat(
+            TimestampType.INSTANCE.decodeUTF8Text("2021-01-13T14:37:17.25988".getBytes(UTF_8)),
+            is(1610548637259L)
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/commit/63759d189d48c23ba64156ab7646d1911e703d50
Does the same thing but for the timestamp without time zone type.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)