### PR TITLE
Improve path settings documentation

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -217,12 +217,16 @@ auth:
 
 #################################### Paths ###################################
 
+# Relative paths are relative to CRATE_HOME. Absolute paths override this
+# behavior.
+
+
 # Path to directory containing configuration (this file and
 # log4j2.properties):
-#path.conf: /path/to/conf
+#path.conf: config
 
 # Path to directory where to store table data allocated for this node.
-#path.data: /path/to/data
+#path.data: data
 #
 # Can optionally include more than one location, causing data to be striped
 # across the locations (a la RAID 0) on a file level, favouring locations with
@@ -230,20 +234,17 @@ auth:
 #path.data: /path/to/data1,/path/to/data2
 
 # Path to log files:
-#path.logs: /path/to/logs
+#path.logs: logs
 
-# Path to where plugins are installed:
-#path.plugins: /path/to/plugins
-
+# Alternative syntax for configuring path settings
 #path:
 #  logs: /var/log/crate
 #  data: /var/lib/crate
 
-# BLOBS: Path to directory where to store blob data allocated for this node.
-# By default blobs will be stored under the same path as normal data.
-# A relative path value is relative to CRATE_HOME.
-#blobs.path: /path/to/blobs
+# Path to directory where to store blob data allocated for this node.
+#blobs.path: blobs
 
+# See also: path.repo (further down)
 
 ################################### Memory ###################################
 

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -216,9 +216,15 @@ Ports
 Paths
 =====
 
+.. NOTE::
+
+    Relative paths are relative to :ref:`CRATE_HOME <conf-env-crate-home>`.
+    Absolute paths override this behavior.
+
 .. _path.conf:
 
 **path.conf**
+  | *Default:* ``config``
   | *Runtime:* ``no``
 
   Filesystem path to the directory containing the configuration files
@@ -227,19 +233,27 @@ Paths
 .. _path.data:
 
 **path.data**
+  | *Default:* ``data``
   | *Runtime:* ``no``
 
   Filesystem path to the directory where this CrateDB node stores its data
   (table data and cluster metadata).
 
   Multiple paths can be set by using a comma separated list and each of these
-  paths will hold full shards (instead of striping data across them). In case
-  CrateDB finds striped shards at the provided locations (from CrateDB
+  paths will hold full shards (instead of striping data across them). For
+  example:
+
+  .. code-block:: yaml
+
+      path.data: /path/to/data1,/path/to/data2
+
+  When CrateDB finds striped shards at the provided locations (from CrateDB
   <0.55.0), these shards will be migrated automatically on startup.
 
 .. _path.logs:
 
 **path.logs**
+  | *Default:* ``logs``
   | *Runtime:* ``no``
 
   Filesystem path to a directory where log files should be stored.
@@ -269,6 +283,10 @@ Paths
 
   See also :ref:`location <ref-create-repository-types-fs-location>` setting of
   repository type ``fs``.
+
+.. SEEALSO::
+
+    :ref:`blobs.path <blobs.path>`
 
 Plug-ins
 ========
@@ -751,3 +769,6 @@ You can create any attribute you want under this namespace, like
 distinguish them from core node attribute like ``node.name``.
 
 Custom attributes are not validated by CrateDB, unlike core node attributes.
+
+
+.. _plugins: https://github.com/crate/crate/blob/master/devs/docs/plugins.rst


### PR DESCRIPTION
Specifically:

- Note that relative paths use `CRATE_HOME` (docs and config file)
- Specify the default values used (docs)
- Add an example to `paths.data` entry that specifies multiple paths (docs)
- Add `path.plugins` entry (docs, to mirror config file)
- Add cross reference for `blobs.path` (docs)
- Add cross reference for `path.repo` (config file)

This work is an off-shoot of the work necessary for
https://github.com/crate/crate-howtos/issues/211
