### PR TITLE
Fix flaky testHealthWithClosedIndices

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -89,16 +89,18 @@ public class ClusterHealthIT extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testHealthWithClosedIndices() {
+    public void testHealthWithClosedIndices() throws Exception {
         var table_1 = getFqn("t1");
         execute("create table t1 (id int) with (number_of_replicas = 0)");
 
         var table_2 = getFqn("t2");
         execute("create table t2 (id int) with (number_of_replicas = 0)");
+        waitNoPendingTasksOnAll();
         execute("alter table t2 close");
 
         var table_3 = getFqn("t3");
         execute("create table t3 (id int) with (number_of_replicas = 20)");
+        waitNoPendingTasksOnAll();
         execute("alter table t3 close");
 
         {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It could have been the case that the closing & starting of a shard from
the CREATE and ALTER .. CLOSE statements interferred with each other
because these actions are asynchronously triggered by cluster state
change events resulting from the CREATE TABLE and ALTER TABLE
statements.

this adds some `waitNoPendingTasksOnAll` calls to ensure that there are
no pending operations from the CREATE TABLE statement running before
triggering the close operation.

The issue can be produced quite reliably with the following test case:

    for (int i = 0; i < 5; i++) {
        logger.info("XXX BEFORE create table");
        execute("create table t" + i + " (id int) with (number_of_replicas = 5)");
        logger.info("XXX BEFORE close table");
        execute("alter table t" + i + " close");
        logger.info("XXX BEFORE open table");
        execute("alter table t" + i + " open");
        logger.info("XXX BEFORE drop table");
        execute("drop table t" + i);
    }


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)