### PR TITLE
Create a glossary (including related improvements for the main docs)

### DIFF
--- a/docs/admin/monitoring.rst
+++ b/docs/admin/monitoring.rst
@@ -295,7 +295,8 @@ name and has following attributes:
 +-----------------------+---------------------------------------------------------+
 | ``Management``        | Thread pool statistics of the ``management`` thread     |
 |                       | pool used by management tasks like stats collecting,    |
-|                       | repository information, shard allocations, etc.         |
+|                       | repository information, :ref:`shard allocations         |
+|                       | <gloss-shard-allocation>`, etc.                         |
 +-----------------------+---------------------------------------------------------+
 | ``Flush``             | Thread pool statistics of the ``flush`` thread pool     |
 |                       | used for fsyncing to disk and merging segments in the   |
@@ -317,7 +318,8 @@ name and has following attributes:
 |                       | used when querying ``sys.nodes`` or ``sys.shards``.     |
 +-----------------------+---------------------------------------------------------+
 | ``FetchShardStarted`` | Thread pool statistics of the ``fetch_shard_started``   |
-|                       | thread pool used on shard allocation.                   |
+|                       | thread pool used on :ref:`shard allocation              |
+|                       | <gloss-shard-allocation>` .                             |
 +-----------------------+---------------------------------------------------------+
 | ``FetchShardStore``   | Thread pool statistics of the ``fetch_shard_store``     |
 |                       | used on shard replication.                              |

--- a/docs/admin/optimization.rst
+++ b/docs/admin/optimization.rst
@@ -28,7 +28,7 @@ If required one or more tables or table partitions can be optimized explicitly
 in order to improve performance. A few parameters can also be configured for
 the optimization process, like the max number of segments you wish to have when
 optimization is completed, or if you only wish to merge segments with deleted
-data, etc. See :ref:`sql_ref_optimize` for detailed description of parameters.
+data, etc. See :ref:`sql-optimize` for detailed description of parameters.
 
 ::
 
@@ -78,13 +78,13 @@ Partition optimization
 ======================
 
 Additionally it is possible to define a specific ``PARTITION`` of a partitioned
-table which should be optimized (see :ref:`partitioned_tables`).
+table which should be optimized (see :ref:`partitioned-tables`).
 
 By using the ``PARTITION`` clause in the optimize statement a separate request
 for a given partition can be performed. That means that only specific
 partitions of a partitioned table are optimized. For further details on how to
 create an optimize request on partitioned tables see the SQL syntax and its
-synopsis (see :ref:`sql_ref_optimize`).
+synopsis (see :ref:`sql-optimize`).
 
 ::
 

--- a/docs/admin/snapshots.rst
+++ b/docs/admin/snapshots.rst
@@ -52,7 +52,7 @@ Creating a snapshot
 ...................
 
 Snapshots are created inside a repository and can contain any number of tables.
-The :ref:`ref-create-snapshot` statement is used to create a snapshots::
+The :ref:`sql-create-snapshot` statement is used to create a snapshots::
 
     cr> CREATE SNAPSHOT where_my_snapshots_go.snapshot1 ALL
     ... WITH (wait_for_completion=true, ignore_unavailable=true);
@@ -83,7 +83,7 @@ listing them explicitly::
     cr> REFRESH TABLE parted_table;
     REFRESH OK, 2 rows affected (... sec)
 
-Even single partition of :ref:`partitioned_tables` can be selected for backup.
+Even single partition of :ref:`partitioned-tables` can be selected for backup.
 This is especially useful if old partitions need to be deleted but it should be
 possible to restore them if needed::
 
@@ -135,7 +135,7 @@ To restore a table from a snapshot we have to drop it beforehand::
     cr> DROP TABLE quotes;
     DROP OK, 1 row affected (... sec)
 
-Restoring a snapshot using the :ref:`ref-restore-snapshot` statement.::
+Restoring a snapshot using the :ref:`sql-restore-snapshot` statement.::
 
     cr> RESTORE SNAPSHOT where_my_snapshots_go.snapshot2
     ... TABLE quotes

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -789,6 +789,8 @@ flag::
    Updates on this column are transient, so changed values are lost after the
    affected node is restarted.
 
+.. _sys-node-checks-settings:
+
 Description of checked node settings
 ------------------------------------
 
@@ -797,8 +799,8 @@ Recovery expected nodes
 
 The check for the :ref:`gateway.expected_nodes <gateway.expected_nodes>`
 setting checks that the number of nodes that should be waited for the immediate
-cluster state recovery, must be equal to the maximum number of data and master
-nodes in the cluster.
+cluster state :ref:`recovery <gloss-shard-recovery>`. This value must be equal
+to the maximum number of data and master nodes in the cluster.
 
 Recovery after nodes
 ....................
@@ -806,14 +808,14 @@ Recovery after nodes
 The check for the :ref:`gateway.recover_after_nodes
 <gateway.recover_after_nodes>` verifies that the number of started nodes before
 the cluster starts must be greater than the half of the expected number of
-nodes and equal/less than number of nodes in the cluster.
+nodes and equal to or less than number of nodes in the cluster.
 
 ::
 
   (E / 2) < R <= E
 
-where ``R`` is the number of recovery nodes, ``E`` is the number of expected
-nodes.
+Here, ``R`` is the number of :ref:`recovery <gloss-shard-recovery>` nodes and
+``E`` is the number of expected nodes.
 
 Recovery after time
 ...................
@@ -901,11 +903,7 @@ Table schema
       - Indicates if this shard is the primary shard.
       - ``BOOLEAN``
     * - ``recovery``
-      - Recovery statistics of a shard.
-
-        Recovery is the process of moving a shard to a different node or
-        loading a shard from disk, e.g. during node startup or snapshot
-        recovery.
+      - :ref:`Recovery <gloss-shard-recovery>` statistics for a shard.
       - ``OBJECT``
     * - ``recovery['files']``
       - File recovery statistics
@@ -1312,7 +1310,7 @@ Classification
 
 Certain statement types (such as ``SELECT`` statements) have additional labels
 in their classification. These labels are the names of the logical plan
-operators that are involved in the query.
+:ref:`operators <gloss-operator>` that are involved in the query.
 
 For example, the following ``UNION`` statement::
 
@@ -1548,7 +1546,7 @@ Current Checks
 Number of partitions
 ....................
 
-This check warns if any :ref:`partitioned table <partitioned_tables>` has more
+This check warns if any :ref:`partitioned table <partitioned-tables>` has more
 than 1000 partitions to detect the usage of a high cardinality field for
 partitioning.
 
@@ -1605,18 +1603,18 @@ Avoiding reindex using partitioned tables
 
 Reindexing tables is an expensive operation which can take a long time. If you
 are storing time series data for a certain retention period and intend to
-delete old data, it is possible to use the :ref:`partitioned_tables` feature to
-avoid reindex operations.
+delete old data, it is possible to use the :ref:`partitioned tables
+<partitioned-tables>` to avoid reindex operations.
 
-You will have to partition a table by a column that denotes time. For example,
-if you have a retention period of nine months, you could partition a table by a
-``month`` column. Then, every month, the system will create a new partition.
-This new partition is created using the active CrateDB version and is
-compatible with the next major CrateDB version. Now to achieve your goal of
-avoiding a reindex, you must manually delete any partition older than nine
-months. If you do that, then after nine months you rolled through all
-partitions and the remaining nine are compatible with the next major CrateDB
-version.
+You will have to use a :ref:`partition column <gloss-partition-column>` that
+denotes time. For example, if you have a retention period of nine months, you
+could partition a table by a ``month`` column. Then, every month, the system
+will create a new partition. This new partition is created using the active
+CrateDB version and is compatible with the next major CrateDB version. Now to
+achieve your goal of avoiding a reindex, you must manually delete any partition
+older than nine months. If you do that, then after nine months you rolled
+through all partitions and the remaining nine are compatible with the next
+major CrateDB version.
 
 
 How to reindex
@@ -2062,7 +2060,7 @@ Allocations
 ===========
 
 The ``sys.allocations`` table contains information about shards and their
-allocation state. The table contains:
+:ref:`allocation <gloss-shard-allocation>` state. The table contains:
 
 * shards that are unassigned and why they are unassigned
 * shards that are assigned but cannot be moved or rebalanced and why they

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -54,7 +54,7 @@ how data types of `standard SQL`_ map to CrateDB :ref:`data-types`.
 Create table
 ------------
 
-:ref:`ref-create-table` supports additional storage and table parameters for
+:ref:`sql-create-table` supports additional storage and table parameters for
 sharding, replication and routing of data, and does not support inheritance.
 
 
@@ -62,7 +62,7 @@ Alter table
 -----------
 
 ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported (see
-:ref:`ref-alter-table`).
+:ref:`sql-alter-table`).
 
 
 System information tables
@@ -133,7 +133,7 @@ These **functions** of `standard SQL`_ are either not supported or only partly s
 
 - ``IS DISTINCT FROM``
 
-- Network address functions and operators
+- Network address functions and :ref:`operators <gloss-operator>`
 
 - Mathematical functions
 

--- a/docs/appendices/glossary.rst
+++ b/docs/appendices/glossary.rst
@@ -1,0 +1,275 @@
+.. _appendix-glossary:
+
+========
+Glossary
+========
+
+This glossary defines key terms used in the CrateDB reference manual.
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+Terms
+=====
+
+
+.. _gloss-a:
+
+
+.. _gloss-b:
+
+
+.. _gloss-c:
+
+C
+-
+
+.. _gloss-clustered-by-column:
+
+**CLUSTERED BY column**
+    Better known as a :ref:`routing column <gloss-routing-column>`.
+
+
+.. _gloss-d:
+
+
+.. _gloss-e:
+
+
+.. _gloss-f:
+
+
+.. _gloss-g:
+
+
+.. _gloss-h:
+
+
+.. _gloss-i:
+
+
+.. _gloss-j:
+
+
+.. _gloss-k:
+
+
+.. _gloss-l:
+
+
+.. _gloss-m:
+
+M
+-
+
+.. _gloss-metadata-gateway:
+
+**Metadata gateway**
+    Persists cluster metadata on disk every time the metadata changes. This
+    data is stored persistently across full cluster restarts and recovered
+    after nodes are started again.
+
+    .. SEEALSO::
+
+         :ref:`Cluster configuration: Metadata gateway <metadata_gateway>`
+
+
+.. _gloss-n:
+
+
+.. _gloss-o:
+
+O
+-
+
+.. _gloss-operator:
+
+**Operator**
+    A reserved keyword (e.g., :ref:`IN <sql_in_array_comparison>`) or sequence
+    of symbols (e.g., :ref:`>= <comparison-operators-basic>`) that can be used
+    in an SQL statement to manipulate one or more expressions and returns a
+    result (e.g., ``true`` or ``false``). This process is known as an
+    *operation* and the expressions can be called operands or arguments.
+
+    .. SEEALSO::
+
+        :ref:`arithmetic`
+
+        :ref:`comparison-operators`
+
+        :ref:`sql_array_comparisons`
+
+        :ref:`sql_subquery_expressions`
+
+
+.. _gloss-p:
+
+P
+-
+
+.. _gloss-partition-column:
+
+**Partition column**
+    A column used to :ref:`partition a table <partitioned-tables>`. Specified
+    by the :ref:`PARTITIONED BY clause <sql-create-table-partitioned-by>`.
+
+    Also known as a :ref:`PARTITIONED BY column <gloss-partitioned-by-column>`
+    or :ref:`partitioned column <gloss-partitioned-column>`.
+
+    A table may be partitioned by one or more columns:
+
+    - If a table is partitioned by one column, a new partition is created for
+      every unique value in that partition column
+
+    - If a table is partitoned by multiple columns, a new partition is created
+      for every unique combination of row values in those partition columns
+
+    .. SEEALSO::
+
+        :ref:`partitioned-tables`
+
+        :ref:`Generated columns: Partitioning
+        <ddl-generated-columns-partitioning>`
+
+        :ref:`CREATE TABLE: PARTITIONED BY clause
+        <sql-create-table-partitioned-by>`
+
+        :ref:`ALTER TABLE: PARTITION clause <sql-alter-table-partition>`
+
+        :ref:`REFRESH: PARTITION clause <sql-refresh-partition>`
+
+        :ref:`OPTIMIZE: PARTITION clause <sql-optimize-partition>`
+
+        :ref:`COPY TO: PARTITION clause <sql-copy-to-partition>`
+
+        :ref:`COPY FROM: PARTITION clause <sql-copy-from-partition>`
+
+        :ref:`CREATE SNAPSHOT: PARTITION clause
+        <sql-create-snapshot-partition>`
+
+        :ref:`RESTORE SNAPSHOT: PARTITION clause
+        <sql-restore-snapshot-partition>`
+
+.. _gloss-partitioned-by-column:
+
+**PARTITIONED BY column**
+    Better known as a :ref:`partition column <gloss-partition-column>`.
+
+.. _gloss-partitioned-column:
+
+**Partitioned column**
+    Better known as a :ref:`partition column <gloss-partition-column>`.
+
+
+.. _gloss-q:
+
+
+.. _gloss-r:
+
+R
+-
+
+.. _gloss-routing-column:
+
+**Routing column**
+    Values in this column are used to compute a hash which is then used to
+    route the corresponding row to a specific shard.
+
+    Also known as the :ref:`CLUSTERED BY column <gloss-clustered-by-column>`.
+
+    .. NOTE::
+
+        The routing of rows to a specific shard is not the same as the routing
+        of shards to a specific node (also known as :ref:`shard allocation
+        <gloss-shard-allocation>`).
+
+    .. SEEALSO::
+
+        :ref:`Storage and consistency: Addressing documents
+        <concepts_addressing_documents>`
+
+        :ref:`Sharding: Routing <routing>`
+
+        :ref:`CREATE TABLE: CLUSTERED clause <sql-create-table-clustered>`
+
+
+.. _gloss-s:
+
+S
+-
+
+.. _gloss-shard-allocation:
+
+**Shard allocation**
+    The process by which CrateDB allocates shards to a specific nodes.
+
+    .. NOTE::
+
+        Shard allocation is also known as *shard routing*, which is not to be
+        confused with :ref:`row routing <gloss-routing-column>`.
+
+    .. SEEALSO::
+
+        :ref:`ddl_shard_allocation`
+
+        :ref:`Cluster configuration: Routing allocation <conf_routing>`
+
+        :ref:`Sharding: Number of shards <number-of-shards>`
+
+        :ref:`Altering tables: Changing the number of shards
+        <alter-shard-number>`
+
+        :ref:`Altering tables: Reroute shards <ddl_reroute_shards>`
+
+.. _gloss-shard-recovery:
+
+**Shard recovery**
+    The process by which CrateDB synchronizes a replica shard from a primary
+    shard.
+
+    Shard recovery can happen during node startup, after node failure, when
+    :ref:`replicating <replication>` a primary shard, when moving a shard to
+    another node (i.e., when rebalancing the cluster), or during :ref:`snapshot
+    restoration <snapshot-restore>`.
+
+    A shard that is being recovered cannot be queried until the recovery
+    process is complete.
+
+    .. SEEALSO::
+
+        :ref:`Cluster settings: Recovery <indices.recovery>`
+
+        :ref:`System information: Checked node settings
+        <sys-node-checks-settings>`
+
+
+.. _gloss-t:
+
+
+.. _gloss-u:
+
+U
+-
+
+.. _gloss-uncorrelated-subquery:
+
+**Uncorrelated subquery**
+    A subquery that does not reference any relations in a parent statement.
+
+
+.. _gloss-v:
+
+
+.. _gloss-w:
+
+
+.. _gloss-x:
+
+
+.. _gloss-y:
+
+
+.. _gloss-z:

--- a/docs/appendices/index.rst
+++ b/docs/appendices/index.rst
@@ -15,3 +15,4 @@ Supplementary information for the CrateDB reference manual.
     compatibility
     compliance
     resiliency
+    glossary

--- a/docs/appendices/release-notes/1.0.2.rst
+++ b/docs/appendices/release-notes/1.0.2.rst
@@ -70,7 +70,7 @@ Fixes
 
  - Fixed an issue that causes ``UnhandledServerException`` on joins when
    ``WHERE`` clause contains conditions on columns of array type of both tables
-   which are separated with the ``OR`` operator. e.g.::
+   which are separated with the ``OR`` :ref:`operator <gloss-operator>`. e.g.::
 
        SELECT * FROM t1 join t2 ON t1.id = t2.id
        WHERE 'foo' = ANY(a.strArray) OR 'bar' = ANY(b.strArray)

--- a/docs/appendices/release-notes/1.0.4.rst
+++ b/docs/appendices/release-notes/1.0.4.rst
@@ -36,8 +36,8 @@ Changelog
 Changes
 -------
 
- - Removed limitation which didn't allow ordering on partitioned columns in a
-   ``GROUP BY`` query.
+ - Removed limitation which didn't allow ordering on :ref:`partition columns
+   <gloss-partition-column>` in a ``GROUP BY`` query.
 
  - Updated crate-admin to 1.0.5 which includes the following change:
 
@@ -60,9 +60,10 @@ Fixes
  - Fixed an issue which caused restoring a whole partitioned table from a
    snapshot to fail.
 
- - Fixed the low/high disk-based shard allocation watermark settings. When a
-   percentage value is provided for either of settings, it won't be converted
-   to an absolute byte value.
+ - Fixed the low/high disk-based :ref:`shard allocation
+   <gloss-shard-allocation>` watermark settings. When a percentage value is
+   provided for either of settings, it won't be converted to an absolute byte
+   value.
 
  - Index columns based on string arrays are correctly populated with values.
 

--- a/docs/appendices/release-notes/1.1.0.rst
+++ b/docs/appendices/release-notes/1.1.0.rst
@@ -89,7 +89,8 @@ Changes
 
  - Added support for filtering and ordering on ``ignored`` object columns.
 
- - Added support for the double colon (``::``) cast operator.
+ - Added support for the double colon (``::``) cast :ref:`operator
+   <gloss-operator>`.
 
  - Upgraded the parser from ANTLR3 to ANTLR4.
 

--- a/docs/appendices/release-notes/1.1.3.rst
+++ b/docs/appendices/release-notes/1.1.3.rst
@@ -38,11 +38,13 @@ Fixes
 
  - Admin UI improvements.
 
- - Improved the accuracy of results if arithmetic operators +,-,*,/ are used
-   in expressions that contain only float-type values.
+ - Improved the accuracy of results if  :ref:`arithmetic operators
+   <arithmetic>` +,-,*,/ are used in expressions that contain only float-type
+   values.
 
  - Fixed ``COPY FROM`` to be able to copy data into a partitioned table with a
-   generated column as both the primary key and the partitioned column.
+   generated column as both the primary key and a :ref:`partition column
+   <gloss-partition-column>`.
 
  - Fixed a ``NullPointerException`` which occured when selecting
    ``routing_hash_function`` or ``version`` columns from ``sys.shards`` for
@@ -61,7 +63,8 @@ Fixes
  - Improved error message when trying to update an element of an array.
 
  - Fixed a regression that lead to ``ArrayIndexOutOfBoundsException`` if a
-   ``JOIN`` query was made with a WHERE clause on partitioned columns.
+   ``JOIN`` query was made with a WHERE clause on :ref:`partition columns
+   <gloss-partition-column>`.
 
  - Fixed a ``NullPointerException`` which could occur if an attempt was made to
    use ``match`` on two different relations within an explicit join condition.

--- a/docs/appendices/release-notes/2.0.7.rst
+++ b/docs/appendices/release-notes/2.0.7.rst
@@ -69,7 +69,8 @@ Fixes
    ``CASE/WHEN`` expression is not a boolean.
 
  - Fixed an issue which caused an exception if ``EXPLAIN`` is used on a
-   statement that uses the ``ANY (array_expression)`` operator.
+   statement that uses the ``ANY (array_expression)`` :ref:`operator
+   <gloss-operator>`.
 
  - Allow support of conditional expressions with different return types that can
    be converted to a single return type.

--- a/docs/appendices/release-notes/2.1.1.rst
+++ b/docs/appendices/release-notes/2.1.1.rst
@@ -89,7 +89,8 @@ Fixes
    ``CASE/WHEN`` expression is not a boolean.
 
  - Fixed an issue which caused an exception if ``EXPLAIN`` is used on a
-   statement that uses the ``ANY (array_expression)`` operator.
+   statement that uses the ``ANY (array_expression)`` :ref:`operators
+   <gloss-operator>`.
 
  - Allow support of conditional expression with different return types that can
    be converted to a single return type.

--- a/docs/appendices/release-notes/2.1.9.rst
+++ b/docs/appendices/release-notes/2.1.9.rst
@@ -47,7 +47,8 @@ Fixes
 - Fixed an issue that prevented the complete graceful shutdown of CrateDB node.
 
 - Fixed an issue that caused a ``NullPointerException`` for queries that use
-  the ``IN`` or ``ANY`` operator on timestamp fields.
+  the ``IN`` or ``ANY`` :ref:`operators <gloss-operator>` on timestamp
+  fields.
 
 - Improves resiliency of ``COPY FROM`` and ``INSERT FROM SUBQUERY`` statements
   when lot of new partitions will be created on demand.
@@ -63,7 +64,7 @@ Fixes
 
 - Fixed an issue that caused an error ``Primary key value must not be NULL``
   to be thrown when trying to insert rows in a table that has a generated
-  column which is used both in ``PARTITION_BY`` and ``PRIMARY KEY``.
+  column which is used both in ``PARTITION BY`` and ``PRIMARY KEY``.
 
 - The PostgreSQL wire protocol service can now be bound to IPv6 addresses as
   documented.

--- a/docs/appendices/release-notes/2.2.0.rst
+++ b/docs/appendices/release-notes/2.2.0.rst
@@ -44,7 +44,8 @@ Breaking Changes
    real column will no longer fail as the real column will be used in the
    ``GROUP BY`` clause (this will not be ambiguous anymore).
 
- - Change semantics of ``IN`` operator to behave like ``= ANY``.
+ - Change semantics of ``IN`` :ref:`operator <gloss-operator>` to behave
+   like ``= ANY``.
 
    The argument list for ``IN`` now has to be comprised of the same type. For
    example, this is now an illegal ``IN`` query because the list mixes integer

--- a/docs/appendices/release-notes/2.2.2.rst
+++ b/docs/appendices/release-notes/2.2.2.rst
@@ -54,7 +54,8 @@ Fixes
 - Fixed an issue that prevented the complete graceful shutdown of CrateDB node.
 
 - Fixed an issue that caused a ``NullPointerException`` for queries that use
-  the ``IN`` or ``ANY`` operator on timestamp fields.
+  the ``IN`` or ``ANY`` :ref:`operators <gloss-operator>` on timestamp
+  fields.
 
 - Improves resiliency of ``COPY FROM`` and ``INSERT FROM SUBQUERY`` statements
   when lot of new partitions will be created.
@@ -73,4 +74,4 @@ Fixes
 
 - Fixed an issue that caused an error ``Primary key value must not be NULL``
   to be thrown when trying to insert rows in a table that has a generated
-  column which is used both in ``PARTITION_BY`` and ``PRIMARY KEY``.
+  column which is used both in ``PARTITION BY`` and ``PRIMARY KEY``.

--- a/docs/appendices/release-notes/2.3.0.rst
+++ b/docs/appendices/release-notes/2.3.0.rst
@@ -99,8 +99,8 @@ Changes
 
 - Added support for scalar subqueries in ``DELETE`` and ``UPDATE`` statements.
 
-- Added ``UNION ALL`` operator to produce the combined result of two or more
-  queries, e.g.:
+- Added ``UNION ALL`` :ref:`operator <gloss-operator>` to produce the combined
+  result of two or more queries, e.g.:
 
   .. code-block:: psql
 
@@ -137,9 +137,9 @@ Changes
 - Added new cluster setting ``routing.rebalance.enable`` that allows to
   enable or disable shard rebalancing on the cluster.
 
-- Added support to manually control the allocation of shards using ``ALTER
-  TABLE REROUTE``. Supported reroute-options are: MOVE, ALLOCATE REPLICA,
-  CANCEL
+- Added support to manually control the :ref:`allocation of shards
+  <gloss-shard-allocation>` using ``ALTER TABLE REROUTE``. Supported
+  reroute-options are: ``MOVE``, ``ALLOCATE REPLICA``, and ``CANCEL``.
 
 - Added support to manually retry the allocation of shards that failed to
   allocate using ``ALTER CLUSTER REROUTE RETRY FAILED``.

--- a/docs/appendices/release-notes/2.3.2.rst
+++ b/docs/appendices/release-notes/2.3.2.rst
@@ -34,9 +34,9 @@ Changelog
 Changes
 -------
 
-- Implemented a performance optimization when ``IN()`` or ``= ANY()`` operators
-  are used with a subquery. For further details see:
-  https://github.com/crate/crate/issues/6755
+- Implemented a performance optimization when ``IN()`` or ``= ANY()``
+  :ref:`operators <gloss-operator>` are used with a subquery. For further
+  details see: https://github.com/crate/crate/issues/6755
 
 Fixes
 -----

--- a/docs/appendices/release-notes/2.3.3.rst
+++ b/docs/appendices/release-notes/2.3.3.rst
@@ -67,8 +67,9 @@ Fixes
 - Fixed an issue that caused the ``percentile`` aggregation to fail if an array
   containing a single item was passed as ``fractions``.
 
-- Fixed an issue which resulted in an exception when a routing column was
-  compared against a sub-query inside a ``WHERE`` clause.
+- Fixed an issue which resulted in an exception when a :ref:`routing column
+  <gloss-routing-column>` was compared against a sub-query inside a
+  ``WHERE`` clause.
 
 - Fixed a performance regression resulting in a table scan instead of a
   NO-MATCH if a sub-query used inside a ``WHERE`` clause returns no result

--- a/docs/appendices/release-notes/2.3.4.rst
+++ b/docs/appendices/release-notes/2.3.4.rst
@@ -49,11 +49,12 @@ Fixes
   results.
 
 - Re-enable implicit casting for columns whenever columns are used on both
-  sides of an operator or function. The implicit cast will obey the type
-  precedence (eg. long > integer).
+  sides of an :ref:`operator <gloss-operator>` or function. The implicit cast
+  will obey the type precedence (eg. long > integer).
 
 - Fixed an issue that caused incorrect results to be returned when a ``WHERE``
-  clause filters on a partitioned and an non-partitioned column. E.g.::
+  clause filters on a :ref:`partition column <gloss-partition-column>` and a
+  non partition column. E.g.::
 
     SELECT * FROM t WHERE parted_col='value' AND other_col='some_value'
 

--- a/docs/appendices/release-notes/2.3.6.rst
+++ b/docs/appendices/release-notes/2.3.6.rst
@@ -45,7 +45,8 @@ Fixes
 
 - Fixed an issue that caused an error to be thrown when filtering on a
   partitioned table using a column which is a source column for a ``GENERATED``
-  column which in turn is used for partitioning. E.g.::
+  column which in turn is used as :ref:`partition column
+  <gloss-partition-column>`. E.g.::
 
     CREATE TABLE parted_t(
         t TIMESTAMP,

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -125,7 +125,8 @@ Changes
   PostgreSQL Wire Protocol clients (e.g. libpq) to deallocate a prepared
   statement and release its resources.
 
-- Added support for ordering on analysed or partitioned columns.
+- Added support for ordering on analysed columns and :ref:`partition columns
+  <gloss-partition-column>`.
 
 - Added support for views which can be created using the new ``CREATE VIEW``
   statement and dropped using the ``DROP VIEW`` statement. Views are listed in

--- a/docs/appendices/release-notes/3.1.0.rst
+++ b/docs/appendices/release-notes/3.1.0.rst
@@ -93,7 +93,8 @@ Changes
 - Added a new scalar function ``ignore3vl`` which eliminates the 3-valued logic
   of null handling for every logical expression beneath it. If 3-valued logic
   is not required, the use of this function in the ``WHERE`` clause beneath a
-  ``NOT`` operator can boost the query performance significantly. E.g.::
+  ``NOT`` :ref:`operator <gloss-operator>` can boost the query performance
+  significantly. E.g.::
 
     SELECT * FROM t
     WHERE NOT IGNORE3VL(5 = ANY(t.int_array_col))

--- a/docs/appendices/release-notes/3.2.0.rst
+++ b/docs/appendices/release-notes/3.2.0.rst
@@ -52,8 +52,9 @@ Logging Configuration Changes
 -----------------------------
 
 The default logging configuration for CrateDB in ``log4j2.properties`` has been
-changed. If you have customised this :ref:`logging configuration <conf-logging-log4j>`,
-you should replace the ``$marker`` entry with ``[%node_name] %marker``.
+changed. If you have customised this :ref:`logging configuration
+<conf-logging-log4j>`, you should replace the ``$marker`` entry with
+``[%node_name] %marker``.
 
 Deprecated Settings and Features
 --------------------------------
@@ -69,8 +70,8 @@ The ``http.enabled`` setting has been deprecated, and will be removed in the
 future.
 
 The ``delimited_payload_filter`` built-in token filter for fulltext analyzers
-has been renamed to ``delimited_payload``. The ``delimited_payload_filter`` name
-can still be used, but is deprecated, and will be removed in the future.
+has been renamed to ``delimited_payload``. The ``delimited_payload_filter``
+name can still be used, but is deprecated, and will be removed in the future.
 
 Changelog
 =========
@@ -121,10 +122,9 @@ SQL Improvements
   :ref:`ARRAY(subquery) <sql_expressions_array_subquery>` expression,
   which can turn the result from a subquery into an array.
 
-- The :ref:`= ANY <sql_dql_any_array>` operator now also supports
-  operations on object arrays or
-  nested arrays. This enables queries like ``WHERE ['foo', 'bar'] =
-  ANY(object_array(string_array))``.
+- The :ref:`= ANY <sql_dql_any_array>` :ref:`operator <gloss-operator>` now
+  also supports operations on object arrays or nested arrays. This enables
+  queries like ``WHERE ['foo', 'bar'] = ANY(object_array(string_array))``.
 
 - Added support for :ref:`SHOW parameter_name | ALL <ref-show>` to retrieve
   one or all session setting value(s).
@@ -140,13 +140,13 @@ SQL Improvements
 - Functions like :ref:`CURRENT_SCHEMA <scalar_current_schema>` and
   :ref:`CURRENT_USER <current_user>` which depend on the
   active session can now be used as
-  :ref:`generated columns <sql-ddl-generated-columns>`.
+  :ref:`generated columns <ddl-generated-columns>`.
 
 - Added support for using :ref:`table functions <ref-table-functions>` in the
   select list of a query.
 
-- :ref:`geo_shape <geo_shape_data_type>` columns can now be casted to ``object``
-  with ``cast`` in addition to ``try_cast``.
+- :ref:`geo_shape <geo_shape_data_type>` columns can now be casted to
+  ``object`` with ``cast`` in addition to ``try_cast``.
 
 - Improved the handling of function expressions inside subscripts used on
   object columns. This allows expressions like ``obj['x' || 'x']`` to be used.
@@ -154,9 +154,9 @@ SQL Improvements
 - ``<object_column> = <object_literal>`` comparisons now try to utilize the
   index for the objects contents and can therefore run much faster.
 
-- Values of byte-size and time based configuration setting do not require a unit
-  suffix anymore. Without a unit time values are treat as milliseconds since
-  epoch and byte size values are treat as bytes.
+- Values of byte-size and time based configuration setting do not require a
+  unit suffix anymore. Without a unit time values are treat as milliseconds
+  since epoch and byte size values are treat as bytes.
 
 - Added support of using units inside byte-size or time bases statement
   parameters values. E.g. '1mb' for 1 MegaByte or '1s' for 1 Second.
@@ -189,22 +189,22 @@ Database Administration
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 - Added support for changing the number of shards on an existing table or
-  partition using the :ref:`ALTER TABLE SET <alter_table_set_reset>`
+  partition using the :ref:`ALTER TABLE SET <sql-alter-table-set-reset>`
   statement.
 
-- Improved resiliency of the :ref:`ALTER TABLE RENAME <alter_table_rename>`
-  operation by making it an atomic operation.
+- Improved resiliency of the :ref:`ALTER TABLE: RENAME TO
+  <sql-alter-table-rename-to>` operation by making it an atomic operation.
 
 - Added an :ref:`ALTER CLUSTER SWAP TABLE <alter_cluster_swap_table>`
   statement that can be used to switch the names of two tables.
 
-- Added a :ref:`ALTER CLUSTER GC DANGLING ARTIFACTS <alter_cluster_gc_dangling_artifacts>`
-  statement that can be used to
-  clean up internal structures that weren't properly cleaned up due to cluster
-  failures during operations which create such temporary artifacts.
+- Added a :ref:`ALTER CLUSTER GC DANGLING ARTIFACTS
+  <alter_cluster_gc_dangling_artifacts>` statement that can be used to clean up
+  internal structures that weren't properly cleaned up due to cluster failures
+  during operations which create such temporary artifacts.
 
-- Added support for per-table
-  :ref:`shard allocation filtering <ddl_shard_allocation>`.
+- Added support for per-table :ref:`shard allocation filtering
+  <ddl_shard_allocation>`.
 
 Admin UI Upgrade to 1.11.3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -232,8 +232,8 @@ Deprecations
 Other
 ~~~~~
 
-- Upgraded to Elasticsearch 6.5.1, which includes changes to the default logging
-  configuration.
+- Upgraded to Elasticsearch 6.5.1, which includes changes to the default
+  logging configuration.
 
 - Added a :ref:`remove_duplicates <analyzers_remove_duplicates>` token
   filter.
@@ -246,5 +246,6 @@ Other
 
 For further information on CrateDB 3.2.0 see our
 `announcement blogpost <blogpost_>`__.
+
 
 .. _blogpost: https://crate.io/a/cratedb-3-2-stable-available-now/

--- a/docs/appendices/release-notes/3.2.4.rst
+++ b/docs/appendices/release-notes/3.2.4.rst
@@ -62,13 +62,14 @@ Fixes
   contained a ``GROUP BY`` clause on one number column.
 
 - Fixed an issue that caused ``INSERT INTO`` with a subquery to not insert into
-  partitioned tables where the partitioned by columns had a ``NOT NULL``
-  constraint.
+  partitioned tables where the :ref:`partition columns
+  <gloss-partition-column>` had a ``NOT NULL`` constraint.
 
 - Fixed a regression that caused inserts which create new dynamic columns to
   fail if the table was created in an earlier version of CrateDB.
 
 - Fixed an issue that caused inserts into partitioned tables where the
-  partitioned column is generated and based on the child of an object to fail.
+  :ref:`partition column <gloss-partitioned-column>` is generated and based on
+  the child of an object to fail.
 
 - Fixed an issue that caused the Basic Authentication prompt to fail in Safari.

--- a/docs/appendices/release-notes/3.3.3.rst
+++ b/docs/appendices/release-notes/3.3.3.rst
@@ -60,9 +60,9 @@ Fixes
   causing queries on the view to fail and also breaking
   ``information_schema.views``.
 
-- Increased the precedence of the double colon cast operator, so that a
-  statement like ``x::double / y::double`` applies both casts before the
-  division.
+- Increased the precedence of the double colon cast :ref:`operator
+  <gloss-operator>`, so that a statement like ``x::double / y::double`` applies
+  both casts before the division.
 
 - Fixed an issue with the disk watermark sys checks which would incorrectly
   report all of them as failed if

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -136,7 +136,7 @@ General
   are registered as aliases for backward comparability.
 
 - Changed the ordering of columns to be based on their position in the
-  :ref:`CREATE TABLE <ref-create-table>` statement. This was done to improve
+  :ref:`CREATE TABLE <sql-create-table>` statement. This was done to improve
   compatibility with PostgreSQL and will affect queries like ``SELECT * FROM``
   or ``INSERT INTO <table> VALUES (...)``
 
@@ -281,7 +281,8 @@ SQL Standard and PostgreSQL compatibility improvements
 - Added support for using relation aliases with column aliases. Example:
   ``SELECT x, y from unnest([1], ['a']) as u(x, y)``
 
-- Added support for column :ref:`ref-default-clause` for :ref:`ref-create-table`.
+- Added support for column :ref:`sql-create-table-default-clause` for
+  :ref:`sql-create-table`.
 
 - Extended the support for window functions. The ``PARTITION BY`` definition
   and the ``CURRENT ROW -> UNBOUNDED FOLLOWING`` frame definitions are now
@@ -300,7 +301,8 @@ SQL Standard and PostgreSQL compatibility improvements
   :ref:`TIMESTAMP WITH TIME ZONE <datetime-with-time-zone>` data type.
 
 - Added support for the :ref:`type 'string' <type_cast_from_string_literal>`
-  cast operator, which is used to initialize a constant of an arbitrary type.
+  cast :ref:`operator <gloss-operator>`, which is used to initialize a constant
+  of an arbitrary type.
 
 - Added the :ref:`pg_get_userbyid` scalar function to enhance PostgreSQL
   compatibility.
@@ -365,7 +367,7 @@ Repositories and Snapshots
   ``compress``, to ``true``. See
   :ref:`fs repository parameters<ref-create-repository-types-fs>`.
 
-- Improved resiliency of the :ref:`ref-create-snapshot` operation.
+- Improved resiliency of the :ref:`sql-create-snapshot` operation.
 
 
 Performance and resiliency improvements

--- a/docs/appendices/release-notes/4.0.10.rst
+++ b/docs/appendices/release-notes/4.0.10.rst
@@ -53,11 +53,11 @@ Fixes
 
 - Fixed an issue that would lead to incorrect behaviour of the insert from
   sub query statement for the scenario when the target table contains a
-  :ref:`generated column <sql-ddl-generated-columns>` with the
-  :ref:`not_null_constraint` constraint and a value for the
-  :ref:`generated column <sql-ddl-generated-columns>` is not provided
-  explicitly. For example, the insert statement below failed due to the
-  :ref:`not_null_constraint` constraint violation::
+  :ref:`generated column <ddl-generated-columns>` with the
+  :ref:`not_null_constraint` constraint and a value for the :ref:`generated
+  column <ddl-generated-columns>` is not provided explicitly. For example, the
+  insert statement below failed due to the :ref:`not_null_constraint`
+  constraint violation::
 
      CREATE TABLE t (x INT, y AS x + 1 NOT NULL)
      INSERT INTO t (x) (SELECT 1)
@@ -73,10 +73,11 @@ Fixes
   altering an empty partitioned table.
 
 - Fixed a regression introduced in ``2.3.2`` which optimizes subqueries when
-  used inside multi-value producing functions and operators like ``IN()``,
-  ``ANY()`` or ``ARRAY()`` by applying an implicit ordering. When using data
-  types (e.g. like an object: ``select array(select {a = col} from test)`` which
-  do not support ordering, an NPE was raised.
+  used inside multi-value producing functions and :ref:`operators
+  <gloss-operator>` like ``IN()``, ``ANY()`` or ``ARRAY()`` by applying an
+  implicit ordering. When using data types (e.g. like an object: ``select
+  array(select {a = col} from test)`` which do not support ordering, an NPE was
+  raised.
 
 - Fixed a possible OutOfMemory issue which may happen on ``GROUP BY`` statement
   using a group key of type ``TEXT`` on tables containing at least one shard

--- a/docs/appendices/release-notes/4.0.11.rst
+++ b/docs/appendices/release-notes/4.0.11.rst
@@ -83,5 +83,6 @@ Fixes
   cluster if a resource error like a ``CircuitBreakingException`` occurs.
 
 - Fixed an issue that caused a ``INSERT INTO ... (SELECT ... FROM ..)``
-  statement to fail if not all columns of a ``PARTITIONED BY`` clause
-  appeared in the target list of the ``INSERT INTO`` statement.
+  statement to fail if not all :ref:`partition columns
+  <gloss-partition-column>` appeared in the target list of the ``INSERT INTO``
+  statement.

--- a/docs/appendices/release-notes/4.0.12.rst
+++ b/docs/appendices/release-notes/4.0.12.rst
@@ -62,8 +62,8 @@ Fixes
 
 - Fixed the following issues in the Admin UI:
 
-  - Fixed an issue that prevents the value for nested partitioned columns showing
-    up in the table partitions overview.
+  - Fixed an issue that prevents the value for nested :ref:`partition columns
+    <gloss-partition-column>` showing up in the table partitions overview.
 
   - Fixed capitalization of ``Shards`` tab label
 
@@ -73,8 +73,8 @@ Fixes
   distributed execution plans, e.g. a ``CircuitBreakingException`` due to
   exceeded memory usage.
 
-- Fixed an issue that resulted in the values for nested partitioned columns to
-  be missing from the result.
+- Fixed an issue that resulted in the values for nested :ref:`partitioned
+  columns <gloss-partitioned-column>` to be missing from the result.
 
 - Fixed an issue that caused ``SELECT *`` to include nested columns of type
   ``geo_shape`` instead of only selecting top-level columns.

--- a/docs/appendices/release-notes/4.0.5.rst
+++ b/docs/appendices/release-notes/4.0.5.rst
@@ -55,8 +55,8 @@ Fixes
 - Fixed an issue in the admin-ui to no longer display all columns as being
   generated columns in the table/column view section.
 
-- Fixed an issue introduced in CrateDB 4.0 resulting in dysfunctional disk-based
-  allocation thresholds.
+- Fixed an issue introduced in CrateDB 4.0 resulting in dysfunctional
+  disk-based :ref:`allocation <gloss-shard-allocation>`  thresholds.
 
 - Fixed an issue resulting in ``pg_catalog.pg_attribute.attnum`` and
   ``information_schema.columns.ordinal_position`` being ``NULL`` on tables

--- a/docs/appendices/release-notes/4.0.6.rst
+++ b/docs/appendices/release-notes/4.0.6.rst
@@ -73,7 +73,7 @@ Fixes
 
 - Fixed bug in the disk threshold decider logic that would ignore to account
   new relocating shard (``STARTED`` to ``RELOCATING``) when deciding how to
-  allocate or relocate shards with respect to
+  :ref:`allocate <gloss-shard-allocation>` or relocate shards with respect to
   :ref:`cluster.routing.allocation.disk.watermark.low
   <cluster.routing.allocation.disk.watermark.low>` and
   :ref:`cluster.routing.allocation.disk.watermark.high

--- a/docs/appendices/release-notes/4.1.0.rst
+++ b/docs/appendices/release-notes/4.1.0.rst
@@ -30,9 +30,9 @@ Released on 2020/01/15.
 Breaking Changes
 ================
 
-- Changed arithmetic operations ``*``, ``+``, and ``-`` of types ``integer``
-  and ``bigint`` to throw an exception instead of rolling over from positive
-  to negative or the other way around.
+- Changed :ref:`arithmetic operations <arithmetic>` ``*``, ``+``, and ``-`` of
+  types ``integer`` and ``bigint`` to throw an exception instead of rolling over
+  from positive to negative or the other way around.
 
 - Changed how columns of type :ref:`geo_point_data_type` are being communicated
   to PostgreSQL clients.
@@ -63,7 +63,7 @@ Resiliency improvements
 
 - Allow user to limit the number of threads on a single shard that may be
   merging at once via the :ref:`merge.scheduler.max_thread_count
-  <merge.scheduler.max_thread_count>` table parameter.
+  <sql-create-table-merge-scheduler-max-thread-count>` table parameter.
 
 - Some ``ALTER TABLE`` operations now internally invoke a single cluster state
   update instead of multiple cluster state updates. This change improves
@@ -103,7 +103,7 @@ Performance improvements
   efficiently in some cases.
 
 - Allow user to control how table data is stored and accessed on a disk
-  via the :ref:`store.type <table_parameter.store_type>` table parameter and
+  via the :ref:`store.type <sql-create-table-store-type>` table parameter and
   :ref:`node.store.allow_mmap <node.store_allow_mmap>` node setting.
 
 - Changed the default table data store type from ``mmapfs`` to ``hybridfs``.
@@ -134,8 +134,8 @@ Window function extensions
 Functions and operators
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- Added support for the :ref:`ALL <all_array_comparison>` clause for array and
-  subquery comparisons.
+- Added support for the :ref:`ALL <all_array_comparison>` operator for array
+  and subquery comparisons.
 
 - Added a :ref:`PG_GET_KEYWORDS <pg_catalog.pg_get_keywords>` table function.
 
@@ -175,7 +175,7 @@ Functions and operators
   insensitive complement to ``LIKE``.
 
 - Added support for CIDR notation comparisons through special purpose
-  operator ``<<`` associated with type IP.
+  :ref:`operator <gloss-operator>` ``<<`` associated with type IP.
 
   Statements like ``192.168.0.0 << 192.168.0.1/24`` evaluate as true,
   meaning ``SELECT ip FROM ips_table WHERE ip << 192.168.0.1/24`` returns
@@ -189,8 +189,8 @@ New statements and clauses
   statistical data about the contents of the tables in the CrateDB cluster.
   This data is visible in a newly added :ref:`pg_stats <pg_stats>` table.
 
-- Added a :ref:`PROMOTE REPLICA <alter_table_reroute>` sub command to
-  :ref:`ref-alter-table`.
+- Added a :ref:`PROMOTE REPLICA <sql-alter-table-reroute>` sub command to
+  :ref:`sql-alter-table`.
 
 - Added support for the filter clause in
   :ref:`aggregate expressions <aggregation-expressions>` and
@@ -228,8 +228,8 @@ Observability improvements
 Others
 ------
 
-- Changed the default for :ref:`sql_ref_write_wait_for_active_shards` from
-  ``ALL`` to ``1``. This update improves the out of the box experience by
+- Changed the default for :ref:`sql-create-table-write-wait-for-active-shards`
+  from ``ALL`` to ``1``. This update improves the out of the box experience by
   allowing a subset of nodes to become unavailable without blocking write
   operations. See the documentation linked above for more details about the
   implications.
@@ -240,18 +240,20 @@ Others
   ``haasephonetik``, ``beider_morse``, and ``daitch_mokotoff``.
 
 - Removed a restriction for predicates in the ``WHERE`` clause involving
-  ``PARTITIONED BY`` columns, which could result in a failure response with the
-  message: ``logical conjunction of the conditions in the WHERE clause which
-  involve partitioned columns led to a query that can't be executed``.
+  :ref:`partitioned columns <gloss-partitioned-column>`, which could result in
+  a failure response with the message: ``logical conjunction of the conditions
+  in the WHERE clause which involve partitioned columns led to a query that
+  can't be executed``.
 
 - Support implicit object creation in update statements. For example,
   ``UPDATE t SET obj['x'] = 10`` will now implicitly set ``obj`` to
   ``{obj: {x: 10}}`` on rows where ``obj`` was ``null``.
 
-- Added the :ref:`table_parameter.codec` parameter to :ref:`ref-create-table`
+- Added the :ref:`sql-create-table-codec` parameter to :ref:`sql-create-table`
   to control the compression algorithm used to store data.
 
-- The ``node`` argument of the :ref:`REROUTE <alter_table_reroute>` commands of
-  :ref:`ref-alter-table` can now either be the ID or the name of a node.
+- The ``node`` argument of the :ref:`REROUTE <sql-alter-table-reroute>`
+  commands of :ref:`sql-alter-table` can now either be the ID or the name of a
+  node.
 
 - Added support for the PostgreSQL array string literal notation.

--- a/docs/appendices/release-notes/4.1.1.rst
+++ b/docs/appendices/release-notes/4.1.1.rst
@@ -39,8 +39,8 @@ Fixes
 
 - Fixed the following issues in the Admin UI:
 
-  - Fixed an issue that prevents the value for nested partitioned columns
-    showing up in the table partitions overview.
+  - Fixed an issue that prevents the value for nested :ref:`partition columns
+    <gloss-partition-column>` showing up in the table partitions overview.
 
   - Fixed capitalization of ``Shards`` tab label.
 
@@ -50,8 +50,8 @@ Fixes
   distributed execution plans, e.g., a ``CircuitBreakingException`` due to
   exceeded memory usage.
 
-- Fixed an issue that resulted in the values for nested partitioned columns to
-  be missing from the result.
+- Fixed an issue that resulted in the values for nested :ref:`partition columns
+  <gloss-partition-column>` to be missing from the result.
 
 - Fixed an issue that caused ``SELECT *`` to include nested columns of type
   ``geo_shape`` instead of only selecting top-level columns.

--- a/docs/appendices/release-notes/4.1.3.rst
+++ b/docs/appendices/release-notes/4.1.3.rst
@@ -39,7 +39,7 @@ Fixes
   ``<literalValue>`` expressions are equal.
 
 - Fixed an issue that led to a ``NullPointerException`` when using ``GROUP BY``
-  on a nested ``PARTITIONED BY`` column.
+  on a nested :ref:`partition column <gloss-partition-column>`.
 
 - Fixed an issue that led to an ``ArrayIndexOutOfBoundsException`` if using
   ``ON CONFLICT (...) UPDATE SET`` in an ``INSERT`` statement.

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -169,8 +169,8 @@ SQL Standard and PostgreSQL compatibility improvements
 
 - Added entries for primary keys to ``pg_class`` and ``pg_index`` table.
 
-- Added support for :ref:`record subscript <record-subscript>` syntax as
-  alternative to the existing :ref:`object subscript <object-subscript>`
+- Added support for :ref:`record subscript <sql-record-subscript>` syntax as
+  alternative to the existing :ref:`object subscript <sql-object-subscript>`
   syntax.
 
 - Added support for using columns of type ``long`` inside subscript expressions
@@ -189,8 +189,9 @@ SQL Standard and PostgreSQL compatibility improvements
 Functions and operators
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- Fixed arithmetics containing a non-floating numeric column type and a
-  floatling literal which resulted wrongly in a non-floating return type.
+- Fixed :ref:`arithmetics <arithmetic>` containing a non-floating numeric
+  column type and a floatling literal which resulted wrongly in a non-floating
+  return type.
 
 - Replaced the ``Nashorn`` JavaScript engine with ``GraalVM`` for JavaScript
   :ref:`user-defined functions <sql_administration_udf>`. This change upgrades

--- a/docs/appendices/release-notes/4.2.2.rst
+++ b/docs/appendices/release-notes/4.2.2.rst
@@ -40,7 +40,7 @@ Fixes
   bound exception.
 
 - Fixed a regression that caused ``INSERT INTO`` statements in tables with a
-  nested ``CLUSTERED BY`` column to fail.
+  nested :ref:`CLUSTERED BY column <gloss-clustered-by-column>` to fail.
 
 - Fixed a regression introduced in 4.2.0 that caused subscript lookups on
   ignored object columns to raise an error instead of a null value if the key
@@ -57,8 +57,8 @@ Fixes
   virtual table, and both a ``ORDER BY`` and ``LIMIT`` clause to fail.
 
 - Fixed a regression introduced in 4.2.0 that resulted in ``NULL`` values being
-  returned for columns used in the ``PARTITIONED BY`` clause instead of the
-  actual values.
+  returned for :ref:`partition columns <gloss-partition-column>` instead of
+  the actual values.
 
 - Allow all users to execute ``DISCARD`` and ``SET TRANSACTION`` statement.
   These are session local statements and shouldn't require special privileges.

--- a/docs/appendices/release-notes/4.2.4.rst
+++ b/docs/appendices/release-notes/4.2.4.rst
@@ -36,9 +36,9 @@ Fixes
 =====
 
 - Fixed a performance regression that caused ``SELECT`` statements on tables
-  with generated partitioned columns and a predicate that uses a column used to
-  compute the partitioned column to hit all partitions instead of only a
-  subset.
+  with generated :ref:`partition columns  <gloss-partition-column>` and a
+  predicate that uses a column used to compute the partition column to hit all
+  partitions instead of only a subset.
 
 - Fixed an issue that could lead to a ``IndexOutOfBoundsException`` when using
   virtual tables and joins.

--- a/docs/appendices/release-notes/4.3.0.rst
+++ b/docs/appendices/release-notes/4.3.0.rst
@@ -65,7 +65,7 @@ Performance improvements
   scenarios we saw performance improvements by up to 70%.
 
 - Changed the default for :ref:`soft deletes
-  <table_parameter.soft_deletes.enabled>`. Soft deletes are now enabled by
+  <sql-create-table-soft-deletes-enabled>`. Soft deletes are now enabled by
   default for new tables. This should improve the speed of recovery operations
   when replica shard copies were unavailable for a short period.
 
@@ -103,7 +103,7 @@ Administration
   column of the :ref:`information_schema.tables <information_schema_tables>`
   and :ref:`information_schema.table_partitions <is_table_partitions>` tables.
 
-- Changed :ref:`OPTIMIZE <sql_ref_optimize>` to no longer implicitly refresh a
+- Changed :ref:`OPTIMIZE <sql-optimize>` to no longer implicitly refresh a
   table.
 
 - Changed the privileges for ``KILL``, all users are now allowed to kill their

--- a/docs/appendices/release-notes/4.3.2.rst
+++ b/docs/appendices/release-notes/4.3.2.rst
@@ -35,9 +35,9 @@ Fixes
   if ``SSL`` is enabled on the server side, even if no cert authentication
   method is configured.
 
-- Fixed a regression introduced in CrateDB ``4.1`` resulting in duplicated recovery
-  file chunk responses sent.
-  This causes log entries of ``Transport handler not found ...``.
+- Fixed a regression introduced in CrateDB ``4.1`` resulting in duplicated
+  recovery file chunk responses sent. This causes log entries of ``Transport
+  handler not found ...``.
 
 - Fixed an issue that resulted in records in ``pg_catalog.pg_proc`` which
   wouldn't be joined with ``pg_catalog.pg_type``. Clients like ``npgsql`` use
@@ -56,9 +56,9 @@ Fixes
   validation was by passed and resulted in an execution exception instead of
   an user friendly validation exception.
 
-- Fixed an issue that caused ``IS NULL`` and ``IS NOT NULL`` operators on
-  columns of type ``OBJECT`` with the column policy ``IGNORED`` to match
-  incorrect records.
+- Fixed an issue that caused ``IS NULL`` and ``IS NOT NULL`` :ref:`operators
+  <gloss-operator>` on columns of type ``OBJECT`` with the column policy
+  ``IGNORED`` to match incorrect records.
 
 - Fixed an issue that led to an error like ``UnsupportedOperationException:
   Can't handle Symbol [ParameterSymbol: $1]`` if using ``INSERT INTO`` with a

--- a/docs/appendices/release-notes/4.4.0.rst
+++ b/docs/appendices/release-notes/4.4.0.rst
@@ -44,7 +44,7 @@ Performance improvements
 - Improved the performance of queries on the ``sys.health`` table.
 
 - Added support for using the optimized primary key lookup plan if additional
-  filters are combined via ``AND`` operators.
+  filters are combined via ``AND`` :ref:`operators <gloss-operator>`.
 
 - Improved the performance of queries on the ``sys.allocations`` table in cases
   where there are filters restricting the result set or if only a sub-set of
@@ -56,7 +56,8 @@ Performance improvements
 SQL and PostgreSQL compatibility improvements
 ---------------------------------------------
 
-- Added arithmetic operation support for the :ref:`numeric <numeric_type>`.
+- Added :ref:`arithmetic operation <arithmetic>` support for the :ref:`numeric
+  <numeric_type>` type.
 
 - Added support for the :ref:`numeric <numeric_type>` data type and allow the
   ``sum`` aggregation on the :ref:`numeric <numeric_type>` type.
@@ -72,10 +73,10 @@ SQL and PostgreSQL compatibility improvements
   compatible type name notation with ``[]`` suffixes for arrays, instead of
   ``_array``.
 
-- Added the ``delimiter`` option for :ref:`copy_from` CSV files. The option is
-  used to specify the character that separates columns within a row.
+- Added the ``delimiter`` option for :ref:`sql-copy-from` CSV files. The option
+  is used to specify the character that separates columns within a row.
 
-- Added the ``empty_string_as_null`` option for :ref:`copy_from` CSV files.
+- Added the ``empty_string_as_null`` option for :ref:`sql-copy-from` CSV files.
   If the option is enabled, all column's values represented by an empty string,
   including a quoted empty string, are set to ``NULL``.
 

--- a/docs/appendices/resiliency.rst
+++ b/docs/appendices/resiliency.rst
@@ -426,16 +426,17 @@ Make table creation resilient to closing and full cluster crashes
 
 .. rubric:: Scenario
 
-Recovering a table requires a quorum of shard copies to be available to allocate
-a primary. This means that a primary cannot be assigned if the cluster dies
-before enough shards have been allocated. The same happens if a table is closed
-before enough shard copies were started, making it impossible to reopen the
-table. Allocation IDs solve this issue by tracking allocated shard copies in the
-cluster. This makes it possible to safely recover a table in the presence of a
-single shard copy. Allocation IDs can also distinguish the situation where a
-table has been created but none of the shards have been started. If such an
-table was inadvertently closed before at least one shard could be started, a
-fresh shard will be allocated upon reopening the table.
+Recovering a table requires a quorum of shard copies to be available to
+:ref:`allocate <gloss-shard-allocation>` a primary. This means that a
+primary cannot be assigned if the cluster dies before enough shards have been
+allocated. The same happens if a table is closed before enough shard copies
+were started, making it impossible to reopen the table. Allocation IDs solve
+this issue by tracking allocated shard copies in the cluster. This makes it
+possible to safely recover a table in the presence of a single shard copy.
+Allocation IDs can also distinguish the situation where a table has been
+created but none of the shards have been started. If such an table was
+inadvertently closed before at least one shard could be started, a fresh shard
+will be allocated upon reopening the table.
 
 .. rubric:: Consequence
 

--- a/docs/concepts/clustering.rst
+++ b/docs/concepts/clustering.rst
@@ -1,3 +1,5 @@
+.. _clustering:
+
 ==========
 Clustering
 ==========

--- a/docs/concepts/index.rst
+++ b/docs/concepts/index.rst
@@ -10,6 +10,6 @@ This section of the documentation covers important CrateDB concepts.
     :maxdepth: 1
 
     joins
-    shared-nothing
+    clustering
     storage-consistency
     resiliency

--- a/docs/concepts/resiliency.rst
+++ b/docs/concepts/resiliency.rst
@@ -7,7 +7,7 @@ Resiliency
 Distributed systems are tricky. All sorts of things can go wrong that are
 beyond your control. The network can go away, disks can fail, hosts can be
 terminated unexpectedly. CrateDB tries very hard to cope with these sorts of
-issues while maintaining :doc:`availability <shared-nothing>`,
+issues while maintaining :doc:`availability <clustering>`,
 :ref:`consistency <consistency>`, and :ref:`durability <durability>`.
 
 However, as with any distributed system, sometimes, *rarely*, things can go
@@ -53,9 +53,9 @@ Code that expects the behavior of an `ACID
 <https://en.wikipedia.org/wiki/ACID>`_ compliant database like MySQL may not
 always work as expected with CrateDB.
 
-CrateDB does not support ACID transactions, but instead has :ref:`atomic operations
-<concepts_atomic_document_level>` and :doc:`eventual consistency
-<shared-nothing>` at the row level. Eventual consistency is the trade-off that
+CrateDB does not support ACID transactions, but instead has :ref:`atomic
+operations <concepts_atomic_document_level>` and :doc:`eventual consistency
+<clustering>` at the row level. Eventual consistency is the trade-off that
 CrateDB makes in exchange for high-availability that can tolerate most hardware
 and network failures. So you may observe data from different cluster nodes
 temporarily falling very briefly out-of-sync with each other, although over
@@ -63,7 +63,7 @@ time they will become consistent.
 
 For example, you know a row has been written as soon as you get the ``INSERT
 OK`` message. But that row might not be read back by a subsequent ``SELECT`` on
-a different node until after a :ref:`table refresh <sql_ref_refresh>` (which
+a different node until after a :ref:`table refresh <sql-refresh>` (which
 typically occurs within one second).
 
 Your applications should be designed to work this storage and consistency model.

--- a/docs/concepts/storage-consistency.rst
+++ b/docs/concepts/storage-consistency.rst
@@ -29,9 +29,9 @@ index broken down into segments getting stored on the filesystem. Physically
 the files reside under one of the configured data directories of a node.
 
 Lucene only appends data to segment files, which means that data written to the
-disc will never be mutated. This makes it easy for replication and recovery,
-since syncing a shard is simply a matter of fetching data from a specific
-marker.
+disc will never be mutated. This makes it easy for replication and
+:ref:`recovery <gloss-shard-recovery>`, since syncing a shard is simply a
+matter of fetching data from a specific marker.
 
 An arbitrary number of replica shards can be configured per table. Every
 operational replica holds a full synchronized copy of the primary shard.
@@ -96,18 +96,21 @@ permanent.
 
 The translog is also directly transferred when a newly allocated replica
 initializes itself from the primary shard. There is no need to flush segments
-to disc just for replica-recovery purposes.
+to disc just for replica :ref:`recovery <gloss-shard-recovery>` purposes.
 
-Addressing of documents
-=======================
+.. _concepts_addressing_documents:
+
+Addressing documents
+====================
 
 Every document has an `internal identifier`_. By default this identifier
 is derived from the primary key. Documents living in tables without a primary
 key are assigned a unique auto-generated ID automatically when created.
 
-Each document is routed by its routing key to one specific shard. By default
-this key is the value of the ``_id`` column. However this can be configured in
-the table schema (see `Routing`_).
+Each document is routed by its :ref:`routing column <gloss-routing-column>` to
+one specific shard. By default, the :ref:`internal document ID
+<sql_administration_system_column_id>` is used. However, this can be configured
+in the table schema (see `Routing`_).
 
 While transparent to the user, internally there are two ways how CrateDB
 accesses documents:

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -294,9 +294,9 @@ nodes of the cluster:
   | *Default:*   ``2h``
   | *Runtime:*  ``yes``
 
-  Defines the maximum waiting time in milliseconds for the reallocation process
-  to finish. The ``force`` setting will define the behaviour when the shutdown
-  process runs into this timeout.
+  Defines the maximum waiting time in milliseconds for the :ref:`reallocation
+  <gloss-shard-allocation>` process to finish. The ``force`` setting will
+  define the behaviour when the shutdown process runs into this timeout.
 
   The timeout expects a time value either as a ``bigint`` or
   ``double precision`` or alternatively as a string literal with a time suffix
@@ -317,7 +317,7 @@ nodes of the cluster:
 Bulk operations
 ---------------
 
-SQL DML Statements involving a huge amount of rows like :ref:`copy_from`,
+SQL DML Statements involving a huge amount of rows like :ref:`sql-copy-from`,
 :ref:`ref-insert` or :ref:`ref-update` can take an enormous amount of time and
 resources. The following settings change the behaviour of those queries.
 
@@ -628,8 +628,8 @@ Routing allocation
   | *Runtime:*  ``yes``
   | *Allowed values:* ``all | none | primaries | new_primaries``
 
-  ``all`` allows all shard allocations, the cluster can allocate all kinds of
-  shards.
+  ``all`` allows all :ref:`shard allocations <gloss-shard-allocation>`, the
+  cluster can allocate all kinds of shards.
 
   ``none`` allows no shard allocations at all. No shard will be moved or
   created.
@@ -646,9 +646,10 @@ Routing allocation
 
 .. NOTE::
 
-   This allocation setting has no effect on recovery of primary shards! Even
-   when ``cluster.routing.allocation.enable`` is set to ``none``, nodes will
-   recover their unassigned local primary shards immediatelly after restart.
+   This allocation setting has no effect on the :ref:`recovery
+   <gloss-shard-recovery>` of primary shards! Even when
+   ``cluster.routing.allocation.enable`` is set to ``none``, nodes will recover
+   their unassigned local primary shards immediatelly after restart.
 
 .. _cluster.routing.rebalance.enable:
 
@@ -657,15 +658,12 @@ Routing allocation
   | *Runtime:*  ``yes``
   | *Allowed values:* ``all | none | primaries | replicas``
 
-  Enables/Disables rebalancing for different types of shards.
+  Enables or disables rebalancing for different types of shards:
 
-  ``all`` allows shard rebalancing for all types of shards.
-
-  ``none`` disables shard rebalancing for any types.
-
-  ``primaries`` allows shard rebalancing only for primary shards.
-
-  ``replicas`` allows shard rebalancing only for replica shards.
+  - ``all`` allows shard rebalancing for all types of shards.
+  - ``none`` disables shard rebalancing for any types.
+  - ``primaries`` allows shard rebalancing only for primary shards.
+  - ``replicas`` allows shard rebalancing only for replica shards.
 
 .. _cluster.routing.allocation.allow_rebalance:
 
@@ -674,9 +672,11 @@ Routing allocation
   | *Runtime:*  ``yes``
   | *Allowed values:* ``always | indices_primary_active | indices_all_active``
 
-  Allow to control when rebalancing will happen based on the total state of all
-  the indices shards in the cluster. Defaulting to ``indices_all_active`` to
-  reduce chatter during initial recovery.
+  Defines when rebalancing will happen based on the total state of all
+  the indices shards in the cluster.
+
+  Defaults to ``indices_all_active`` to reduce chatter during initial
+  :ref:`recovery <gloss-shard-recovery>`.
 
 .. _cluster.routing.allocation.cluster_concurrent_rebalance:
 
@@ -684,7 +684,7 @@ Routing allocation
   | *Default:*   ``2``
   | *Runtime:*  ``yes``
 
-  Define how many concurrent rebalancing tasks are allowed cluster wide.
+  Defines how many concurrent rebalancing tasks are allowed across all nodes.
 
 .. _cluster.routing.allocation.node_initial_primaries_recoveries:
 
@@ -692,9 +692,12 @@ Routing allocation
   | *Default:*   ``4``
   | *Runtime:*  ``yes``
 
-  Define the number of initial recoveries of primaries that are allowed per
-  node. Since most times local gateway is used, those should be fast and we can
-  handle more of those per node without creating load.
+  Defines how many concurrent primary shard recoveries are allowed on a node.
+
+  Since primary recoveries use data that is already on disk (as opposed to
+  inter-node recoveries), recovery should be fast and so this
+  setting can be higher than :ref:`node_concurrent_recoveries
+  <cluster.routing.allocation.node_concurrent_recoveries>`.
 
 .. _cluster.routing.allocation.node_concurrent_recoveries:
 
@@ -702,15 +705,15 @@ Routing allocation
   | *Default:*   ``2``
   | *Runtime:*  ``yes``
 
-  How many concurrent recoveries are allowed to happen on a node.
+  Defines how many concurrent recoveries are allowed on a node.
 
 .. _conf-routing-allocation-awareness:
 
 Awareness
 .........
 
-Cluster allocation awareness allows to configure shard and replicas allocation
-across generic attributes associated with nodes.
+Cluster allocation awareness allows to configure :ref:`shard allocation
+<gloss-shard-allocation>` across generic attributes associated with nodes.
 
 .. _cluster.routing.allocation.awareness.attributes:
 
@@ -718,8 +721,8 @@ across generic attributes associated with nodes.
   | *Runtime:*  ``no``
 
   You may define :ref:`custom node attributes <conf-node-attributes>` which can
-  then be used to do awareness based on the allocation of a shard and its
-  replicas.
+  then be used to do awareness based on the :ref:`allocation
+  <gloss-shard-allocation>` of a shard and its replicas.
 
   For example, let's say we want to use an attribute named ``rack_id``. We
   start two nodes with ``node.attr.rack_id`` set to ``rack_one``. Then we
@@ -739,9 +742,9 @@ across generic attributes associated with nodes.
 **cluster.routing.allocation.awareness.force.\*.values**
   | *Runtime:*  ``no``
 
-  Attributes on which shard allocation will be forced. Here, ``*`` is a
-  placeholder for the awareness attribute, which can be configured using the
-  :ref:`cluster.routing.allocation.awareness.attributes
+  Attributes on which :ref:`shard allocation <gloss-shard-allocation>` will be
+  forced. Here, ``*`` is a placeholder for the awareness attribute, which can
+  be configured using the :ref:`cluster.routing.allocation.awareness.attributes
   <cluster.routing.allocation.awareness.attributes>` setting.
 
   For example, let's say we configured forced shard allocation for an awareness
@@ -780,9 +783,9 @@ can bring the respective properties of each node closer together.
   | *Default:*   ``0.45f``
   | *Runtime:*  ``yes``
 
-  Defines the weight factor for shards allocated on a node (float). Raising
-  this raises the tendency to equalize the number of shards across all nodes in
-  the cluster.
+  Defines the weight factor for shards :ref:`allocated
+  <gloss-shard-allocation>` on a node (float). Raising this raises the tendency
+  to equalize the number of shards across all nodes in the cluster.
 
 .. _cluster.routing.allocation.balance.index:
 
@@ -790,9 +793,10 @@ can bring the respective properties of each node closer together.
   | *Default:*   ``0.55f``
   | *Runtime:*  ``yes``
 
-  Defines a factor to the number of shards per index allocated on a specific
-  node (float). Increasing this value raises the tendency to equalize the
-  number of shards per index across all nodes in the cluster.
+  Defines a factor to the number of shards per index :ref:`allocated
+  <gloss-shard-allocation>` on a specific node (float). Increasing this value
+  raises the tendency to equalize the number of shards per index across all
+  nodes in the cluster.
 
 .. _cluster.routing.allocation.balance.threshold:
 
@@ -810,7 +814,8 @@ can bring the respective properties of each node closer together.
 Cluster-wide allocation filtering
 .................................
 
-Control which shards are allocated to which nodes.
+Control which shards are :ref:`allocated <gloss-shard-allocation>` to which
+nodes.
 
 Filter definitions are retroactively enforced. If a filter prevents matching
 shards from being newly allocated to a node, existing matching shards will also
@@ -824,16 +829,24 @@ addresses.
 **cluster.routing.allocation.include.***
   | *Runtime:*  ``yes``
 
-  Place shards only on nodes where one of the specified values matches the
-  attribute. e.g.: cluster.routing.allocation.include.zone: "zone1,zone2"
+  Only :ref:`allocate shards <gloss-shard-allocation>` on nodes where one of
+  the specified values matches the attribute.
+
+  For example::
+
+      cluster.routing.allocation.include.zone: "zone1,zone2"`
 
 .. _cluster.routing.allocation.exclude.*:
 
 **cluster.routing.allocation.exclude.***
   | *Runtime:*  ``yes``
 
-  Place shards only on nodes where none of the specified values matches the
-  attribute. e.g.: cluster.routing.allocation.exclude.zone: "zone1"
+  Only :ref:`allocate shards <gloss-shard-allocation>` on nodes where none of
+  the specified values matches the attribute.
+
+  For example::
+
+      cluster.routing.allocation.exclude.zone: "zone1"
 
 .. _cluster.routing.allocation.require.*:
 
@@ -841,8 +854,8 @@ addresses.
   | *Runtime:*  ``yes``
 
   Used to specify a number of rules, which all MUST match for a node in order
-  to allocate a shard on it. This is in contrast to include which will include
-  a node if ANY rule matches.
+  to :ref:`allocate a shard  <gloss-shard-allocation>` on it. This is in
+  contrast to include which will include a node if ANY rule matches.
 
 
 .. _cluster.routing.allocation.disk:
@@ -856,7 +869,8 @@ Disk-based shard allocation
   | *Default:*   ``true``
   | *Runtime:*  ``yes``
 
-  Prevent shard allocation on nodes depending of the disk usage.
+  Prevent :ref:`shard allocation <gloss-shard-allocation>` on nodes depending
+  of the disk usage.
 
 .. _cluster.routing.allocation.disk.watermark.low:
 
@@ -864,11 +878,11 @@ Disk-based shard allocation
   | *Default:*   ``85%``
   | *Runtime:*  ``yes``
 
-  Defines the lower disk threshold limit for shard allocations. New shards will
-  not be allocated on nodes with disk usage greater than this value. It can
-  also be set to an absolute bytes value (like e.g. ``500mb``) to prevent the
-  cluster from allocating new shards on node with less free disk space than
-  this value.
+  Defines the lower disk threshold limit for :ref:`shard allocations
+  <gloss-shard-allocation>`. New shards will not be allocated on nodes with
+  disk usage greater than this value. It can also be set to an absolute bytes
+  value (like e.g. ``500mb``) to prevent the cluster from allocating new shards
+  on node with less free disk space than this value.
 
 .. _cluster.routing.allocation.disk.watermark.high:
 
@@ -876,11 +890,11 @@ Disk-based shard allocation
   | *Default:*   ``90%``
   | *Runtime:*  ``yes``
 
-  Defines the higher disk threshold limit for shard allocations. The cluster
-  will attempt to relocate existing shards to another node if the disk usage on
-  a node rises above this value. It can also be set to an absolute bytes value
-  (like e.g. ``500mb``) to relocate shards from nodes with less free disk space
-  than this value.
+  Defines the higher disk threshold limit for :ref:`shard allocations
+  <gloss-shard-allocation>`. The cluster will attempt to relocate existing
+  shards to another node if the disk usage on a node rises above this value. It
+  can also be set to an absolute bytes value (like e.g. ``500mb``) to relocate
+  shards from nodes with less free disk space than this value.
 
 .. _cluster.routing.allocation.disk.watermark.flood_stage:
 
@@ -889,12 +903,16 @@ Disk-based shard allocation
   | *Runtime:*  ``yes``
 
   Defines the threshold on which CrateDB enforces a read-only block on every
-  index that has at least one shard allocated on a node with at least one disk
-  exceeding the flood stage.
-  Note, that the read-only blocks are not automatically removed from the
-  indices if the disk space is freed and the threshold is undershot. To remove
-  the block, execute ``ALTER TABLE ... SET ("blocks.read_only_allow_delete" =
-  FALSE)`` for affected tables (see :ref:`table-settings-blocks.read_only_allow_delete`).
+  index that has at least one :ref:`shard allocated <gloss-shard-allocation>`
+  on a node with at least one disk exceeding the flood stage.
+
+  .. NOTE::
+
+      Read-only blocks are not automatically removed from the indices if the
+      disk space is freed and the threshold is undershot. To remove the block,
+      execute ``ALTER TABLE ... SET ("blocks.read_only_allow_delete" = FALSE)``
+      for affected tables (see
+      :ref:`sql-create-table-blocks-read-only-allow-delete`).
 
 ``cluster.routing.allocation.disk.watermark`` settings may be defined as
 percentages or bytes values. However, it is not possible to mix the value
@@ -908,10 +926,11 @@ nodes every 30 seconds. This can also be changed by setting the
 
    The watermark settings are also used for the
    :ref:`node_checks_watermark_low` and :ref:`node_checks_watermark_high` node
-   check. Setting ``cluster.routing.allocation.disk.threshold_enabled`` to
-   false will disable the allocation decider, but the node checks will still be
-   active and warn users about running low on disk space.
+   check.
 
+   Setting ``cluster.routing.allocation.disk.threshold_enabled`` to false will
+   disable the allocation decider, but the node checks will still be active and
+   warn users about running low on disk space.
 
 .. _cluster.routing.allocation.total_shards_per_node:
 
@@ -919,12 +938,15 @@ nodes every 30 seconds. This can also be changed by setting the
    | *Default*: ``-1``
    | *Runtime*: ``yes``
 
-   Limits the number of shards that can be allocated per node. ``-1`` means
-   unlimited.
-   Setting this to for example ``1000`` will prevent CrateDB from assigning
+   Limits the number of shards that can be :ref:`allocated
+   <gloss-shard-allocation>` per node. A value of ``-1`` means unlimited.
+
+   Setting this to ``1000``, for example, will prevent CrateDB from assigning
    more than 1000 shards per node. A node with 1000 shards would be excluded
    from allocation decisions and CrateDB would attempt to allocate shards to
    other nodes, or leave shards unassigned if no suitable node can be found.
+
+.. _indices.recovery:
 
 Recovery
 --------
@@ -935,11 +957,11 @@ Recovery
   | *Default:*   ``40mb``
   | *Runtime:*  ``yes``
 
-  Specifies the maximum number of bytes that can be transferred during shard
-  recovery per seconds. Limiting can be disabled by setting it to ``0``. This
-  setting allows to control the network usage of the recovery process. Higher
-  values may result in higher network utilization, but also faster recovery
-  process.
+  Specifies the maximum number of bytes that can be transferred during
+  :ref:`shard recovery <gloss-shard-recovery>` per seconds. Limiting can be
+  disabled by setting it to ``0``. This setting allows to control the network
+  usage of the recovery process. Higher values may result in higher network
+  utilization, but also faster recovery process.
 
 .. _indices.recovery.retry_delay_state_sync:
 
@@ -948,7 +970,7 @@ Recovery
   | *Runtime:*  ``yes``
 
   Defines the time to wait after an issue caused by cluster state syncing
-  before retrying to recover.
+  before retrying to :ref:`recover <gloss-shard-recovery>`.
 
 .. _indices.recovery.retry_delay_network:
 
@@ -957,7 +979,7 @@ Recovery
   | *Runtime:*  ``yes``
 
   Defines the time to wait after an issue caused by the network before retrying
-  to recover.
+  to :ref:`recover <gloss-shard-recovery>`.
 
 .. _indices.recovery.internal_action_timeout:
 
@@ -965,7 +987,8 @@ Recovery
   | *Default:*  ``15m``
   | *Runtime:*  ``yes``
 
-  Defines the timeout for internal requests made as part of the recovery.
+  Defines the timeout for internal requests made as part of the :ref:`recovery
+  <gloss-shard-recovery>`.
 
 .. _indices.recovery.internal_action_long_timeout:
 
@@ -973,9 +996,10 @@ Recovery
   | *Default:*  ``30m``
   | *Runtime:*  ``yes``
 
-  Defines the timeout for internal requests made as part of the recovery that
-  are expected to take a long time. Defaults to twice
-  :ref:`internal_action_timeout <indices.recovery.internal_action_timeout>`.
+  Defines the timeout for internal requests made as part of the :ref:`recovery
+  <gloss-shard-recovery>` that are expected to take a long time. Defaults to
+  twice :ref:`internal_action_timeout
+  <indices.recovery.internal_action_timeout>`.
 
 .. _indices.recovery.recovery_activity_timeout:
 
@@ -983,8 +1007,9 @@ Recovery
   | *Default:*  ``30m``
   | *Runtime:*  ``yes``
 
-  Recoveries that don't show any activity for more then this interval will
-  fail. Defaults to :ref:`internal_action_long_timeout
+  :ref:`Recoveries <gloss-shard-recovery>` that don't show any activity for
+  more then this interval will fail. Defaults to
+  :ref:`internal_action_long_timeout
   <indices.recovery.internal_action_long_timeout>`.
 
 .. _indices.recovery.max_concurrent_file_chunks:
@@ -993,12 +1018,13 @@ Recovery
   | *Default:*  ``2``
   | *Runtime:*  ``yes``
 
-  Controls the number of file chunk requests that can be sent in parallel
-  per recovery. As multiple recoveries are already running in parallel,
-  controlled by :ref:`cluster.routing.allocation.node_concurrent_recoveries
+  Controls the number of file chunk requests that can be sent in parallel per
+  :ref:`recovery <gloss-shard-recovery>`. As multiple recoveries are already
+  running in parallel, controlled by
+  :ref:`cluster.routing.allocation.node_concurrent_recoveries
   <cluster.routing.allocation.node_concurrent_recoveries>`, increasing this
-  expert-level setting might only help in situations where peer recovery of
-  a single shard is not reaching the total inbound and outbound peer recovery
+  expert-level setting might only help in situations where peer recovery of a
+  single shard is not reaching the total inbound and outbound peer recovery
   traffic as configured by :ref:`indices.recovery.max_bytes_per_sec
   <indices.recovery.max_bytes_per_sec>`, but is CPU-bound instead, typically
   when using transport-level security or compression.
@@ -1012,15 +1038,12 @@ Memory management
   | *Default:*  ``on-heap``
   | *Runtime:*  ``yes``
 
-
 Supported values are ``on-heap`` and ``off-heap``. This influences if memory is
 preferably allocated in the heap space or in the off-heap/direct memory region.
-
 
 Setting this to ``off-heap`` doesn't imply that the heap won't be used anymore.
 Most allocations will still happen in the heap space but some operations will
 be allowed to utilize off heap buffers.
-
 
 .. warning::
 
@@ -1244,9 +1267,8 @@ Metadata
 Metadata gateway
 ................
 
-  The gateway persists cluster meta data on disk every time the meta data
-  changes. This data is stored persistently across full cluster restarts and
-  recovered after nodes are started again.
+The following settings can be used to configure the behavior of the
+:ref:`metadata gateway <gloss-metadata-gateway>`.
 
 .. _gateway.expected_nodes:
 

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -54,7 +54,7 @@ Basics
 Node types
 ==========
 
-CrateDB supports different kinds of nodes.
+CrateDB supports different types of nodes.
 
 The following settings can be used to differentiate nodes upon startup:
 
@@ -731,9 +731,9 @@ Queries
   | *Default:* ``8192``
   | *Runtime:* ``no``
 
-  This setting defines the maximum number of elements an array can have so
-  that the ``!= ANY()``, ``LIKE ANY()``, ``ILIKE ANY()``, ``NOT LIKE ANY()``
-  and the ``NOT ILIKE ANY()`` operators can be applied on it.
+  This setting defines the maximum number of elements an array can have so that
+  the ``!= ANY()``, ``LIKE ANY()``, ``ILIKE ANY()``, ``NOT LIKE ANY()`` and the
+  ``NOT ILIKE ANY()`` :ref:`operators <gloss-operator>` can be applied on it.
 
   .. NOTE::
 

--- a/docs/general/blobs.rst
+++ b/docs/general/blobs.rst
@@ -1,4 +1,5 @@
 .. highlight:: sh
+
 .. _blob_support:
 
 =====
@@ -61,7 +62,7 @@ It is also possible to define a custom blob data path per table instead of
 global by config. Also per table setting take precedence over the config
 setting.
 
-See :ref:`ref-create-blob-table` for details.
+See :ref:`sql-create-blob-table` for details.
 
 Creating a blob table with a custom blob data path::
 
@@ -203,4 +204,4 @@ If the blob doesn't exist a 404 Not Found error is returned::
     sh$ crash -c "drop blob table myblobs"
     DROP OK, 1 row affected (... sec)
 
-.. _`binary large objects`: https://en.wikipedia.org/wiki/Binary_large_object
+.. _binary large objects: https://en.wikipedia.org/wiki/Binary_large_object

--- a/docs/general/builtins/arithmetic.rst
+++ b/docs/general/builtins/arithmetic.rst
@@ -6,33 +6,20 @@
 Arithmetic operators
 ====================
 
-Arithmetic operators perform mathematical operations on two expressions of
-numeric data types or timestamps.
-
-.. NOTE::
-
-    The same restrictions that apply to scalar functions also apply to
-    arithmetic operators. See :ref:`scalar`.
-
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-Supported operators
--------------------
+Arithmetic :ref:`operators <gloss-operator>` perform mathematical operations on
+numeric values (including timestamps):
 
 ========   =========================================================
-operator   description
+Operator   Description
 ========   =========================================================
-\+         add one number to another
-\-         subtract the second number from the first
-\*         multiply the first number with the second
-/          divide the first number by the second
-%          finds the remainder of division of one number by another
+``+``      Add one number to another
+``-``      Subtract the second number from the first
+``*``      Multiply the first number with the second
+``/``      Divide the first number by the second
+``%``      Finds the remainder of division of one number by another
 ========   =========================================================
 
-Below is an example using all available arithmetic operators::
+Here's an example that uses all of the available arithmetic operators::
 
     cr> select ((2 * 4.0 - 2 + 1) / 2) % 3 AS n;
     +-----+
@@ -42,13 +29,11 @@ Below is an example using all available arithmetic operators::
     +-----+
     SELECT 1 row in set (... sec)
 
-Result types
-------------
-
 Arithmetic operators always return the data type of the argument with the
-higher precision. In the case of ``divide`` this means that if both arguments
-are of type integer the result will also be an integer with the fractional part
-truncated::
+higher precision.
+
+In the case of devision, if both arguments are integers, the result will also
+be an integer with the fractional part truncated::
 
     cr> select 5 / 2 AS a,  5 / 2.0 AS b;
     +---+-----+
@@ -57,3 +42,9 @@ truncated::
     | 2 | 2.5 |
     +---+-----+
     SELECT 1 row in set (... sec)
+
+.. NOTE::
+
+    The same restrictions that apply to :ref:`scalar functions <scalar>` also
+    apply to arithmetic operators.
+

--- a/docs/general/builtins/array-comparisons.rst
+++ b/docs/general/builtins/array-comparisons.rst
@@ -1,16 +1,17 @@
 .. highlight:: psql
+
 .. _sql_array_comparisons:
 
 Array comparisons
 =================
 
-This section contains several constructs that can be used to make comparisons
-between a list of values. Comparison operations result in a boolean value
-(``true``/``false``) or ``null``.
+An array comparison :ref:`operator <gloss-operator>` tests the relationship
+between two arrays and returns a corresponding value of ``true``, ``false``, or
+``NULL``.
 
-These operators are supported for doing array comparisons.
+.. SEEALSO::
 
-For additional examples of row comparisons, see :ref:`sql_subquery_expressions`.
+    :ref:`sql_subquery_expressions`
 
 .. rubric:: Table of contents
 
@@ -28,12 +29,6 @@ Syntax:
 
     expression IN (value [, ...])
 
-The binary operator ``IN`` allows you to verify the membership of the left-hand
-operand in the right-hand parenthesized list of scalar expressions.
-
-Returns ``true`` if any of the right-hand expression is found in the result of
-the left-hand expression. It returns ``false`` otherwise.
-
 Here's an example::
 
     cr> select 1 in (1,2,3) AS a, 4 in (1,2,3) AS b;
@@ -44,12 +39,16 @@ Here's an example::
     +------+-------+
     SELECT 1 row in set (... sec)
 
-The result of the ``IN`` construct yields ``null`` if:
+The ``IN`` :ref:`operator <gloss-operator>` returns ``true`` if any of the
+right-hand values matches the left-hand operand. Otherwise, it returns
+``false`` (including the case where there are no right-hand values).
 
-- The left-hand expression evaluates to ``null``, and
+The operator returns ``NULL`` if:
 
-- There are no equal right-hand values and at least one right-hand value yields
-  ``null``
+- The left-hand expression evaluates to ``NULL``
+
+- There are no matching right-hand values and at least one right-hand value is
+  ``NULL``
 
 
 .. _sql_any_array_comparison:
@@ -61,14 +60,13 @@ Syntax:
 
 .. code-block:: sql
 
-    expression operator ANY | SOME (array expression)
+    expression comparison ANY | SOME (array_expression)
 
-The ``ANY`` construct returns ``true`` if the defined comparison is ``true``
-for any of the values on the right-hand side array expression. It returns
-``false`` if the values in the array expression do not match with the provided
-comparison.
+Here, ``comparison`` can be any :ref:`basic comparison operator
+<comparison-operators-basic>`. Objects and arrays of objects are not supported
+for either operand.
 
-For example::
+Here's an example::
 
     cr> select 1 = any ([1,2,3]) AS a, 4 = any ([1,2,3]) AS b;
     +------+-------+
@@ -78,51 +76,44 @@ For example::
     +------+-------+
     SELECT 1 row in set (... sec)
 
+The ``ANY`` :ref:`operator <gloss-operator>` returns ``true`` if the defined
+comparison is ``true`` for any of the values in the right-hand array
+expression.
 
-The result of the ``ANY`` construct yields ``null`` if:
+The operator returns ``false`` if the comparison returns ``false`` for all
+right-hand values or there are no right-hand values.
 
-- Either the expression or the array is ``null``, and
+The operator returns ``NULL`` if:
 
-- No ``true`` comparison is obtained and any element of the array is ``null``
+- The left-hand expression evaluates to ``NULL``
 
-.. NOTE::
-
-    The following is not supported by the ``ANY`` operator:
-
-    - ``is null`` and ``is not null`` as ``operator``
-
-    - Arrays of type ``object``
-
-    - Objects as ``expressions``
+- There are no matching right-hand values and at least one right-hand value is
+  ``NULL``
 
 .. TIP::
 
-    When using ``NOT <value> = ANY(<array_col>)`` the performance of the query
-    could be quite bad, because special handling is required to implement the
-    `3-valued logic`_. To achieve better performance, consider using the
-    :ref:`ignore3vl function<ignore3vl>`.
+    When doing ``NOT <value> = ANY(<array_col>)``, query performance may be
+    degraded because special handling is required to implement the `3-valued
+    logic`_. To achieve better performance, consider using the :ref:`ignore3vl
+    function<ignore3vl>`.
 
 
 .. _all_array_comparison:
 
-``ALL (array expression)``
+``ALL (array_expression)``
 --------------------------
 
 Syntax:
 
 .. code-block:: sql
 
-    value operator ALL (array)
+    value comparison ALL (array_expression)
 
-The left-hand expression is evaluated and compared against each element of the
-right-hand array using the supplied operator. The result of ``ALL`` is ``true``
-if all comparisons yield ``true``. The result is ``false`` if the comparison of
-at least one element does not match.
+Here, ``comparison`` can be any :ref:`basic comparison operator
+<comparison-operators-basic>`. Objects and arrays of objects are not supported
+for either operand.
 
-The result is ``NULL`` if either the value or the array is ``NULL`` or if no
-comparison is ``false`` and at least one comparison returns ``NULL``.
-
-::
+Here's an example::
 
     cr> SELECT 1 <> ALL(ARRAY[2, 3, 4]) AS x;
     +------+
@@ -133,14 +124,17 @@ comparison is ``false`` and at least one comparison returns ``NULL``.
     SELECT 1 row in set (... sec)
 
 
-Supported operators are:
+The ``ALL`` :ref:`operator <gloss-operator>` returns ``true`` if the defined
+comparison is ``true`` for all values in the right-hand array expression.
 
-- ``=``
-- ``>=``
-- ``>``
-- ``<=``
-- ``<``
-- ``<>``
+The operator returns ``false`` if the comparison returns ``false`` for all
+right-hand values.
+
+The operator returns ``NULL`` if:
+
+- The left-hand expression evaluates to ``NULL``
+
+- No comparison returns ``false`` and at least one right-hand value is ``NULL``
 
 
-.. _`3-valued logic`: https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)
+.. _3-valued logic: https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)

--- a/docs/general/builtins/comparison-operators.rst
+++ b/docs/general/builtins/comparison-operators.rst
@@ -6,10 +6,23 @@
 Comparison operators
 ====================
 
-A comparison operator tests the relationship between two values and returns a
-corresponding value of ``true``, ``false``, or ``null``.
+A comparison :ref:`operator <gloss-operator>` tests the relationship between
+two values and returns a corresponding value of ``true``, ``false``, or
+``NULL``.
 
-The following operators can be used for all simple data types:
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+.. _comparison-operators-basic:
+
+Basic operators
+===============
+
+For simple :ref:`data types <data-types>`, the following basic operators can be
+used:
 
 ========  ==========================
 Operator  Description
@@ -29,8 +42,7 @@ Operator  Description
 ``!=``    Not equal (same as ``<>``)
 ========  ==========================
 
-When comparing strings, a lexicographical comparison is performed. For
-example::
+When comparing strings, a `lexicographical comparison`_ is performed::
 
     cr> select name from locations where name > 'Argabuthon' order by name;
     +------------------------------------+
@@ -44,11 +56,7 @@ example::
     +------------------------------------+
     SELECT 5 rows in set (... sec)
 
-.. SEEALSO::
-
-    For more details, refer to the *Apache Lucene* `TermRangeQuery`_ documentation.
-
-When comparing dates, strings using ISO date formats can be used::
+When comparing dates, `ISO date formats`_ can be used::
 
     cr> select date, position from locations where date <= '1979-10-12' and
     ... position < 3 order by position;
@@ -60,17 +68,12 @@ When comparing dates, strings using ISO date formats can be used::
     +--------------+----------+
     SELECT 2 rows in set (... sec)
 
-.. SEEALSO::
-
-    For more details, refer to the *Joda Time* `dateOptionalTimeParser`_
-    documentation.
-
 .. TIP::
 
     Comparison operators are commonly used to filter rows (e.g., in the
     ``WHERE`` and ``HAVING`` clauses of a :ref:`sql_reference_select`
-    statement). However, basic comparison operators can be used as value
-    expressions in any context. For example::
+    statement). However, basic comparison operators can be used as :ref:`value
+    expressions <sql-operator-invocation>` in any context. For example::
 
         cr> SELECT 1 < 10 as my_column;
         +--------------+
@@ -80,8 +83,12 @@ When comparing dates, strings using ISO date formats can be used::
         +--------------+
         SELECT 1 rows in set (... sec)
 
-Within a :ref:`sql_dql_where_clause`, the following operators are also
-available:
+.. _comparison-operators-where:
+
+``WHERE`` clause operators
+==========================
+
+Within a :ref:`sql_dql_where_clause`, the following operators can also be used:
 
 ==========================  ===================================================
 Operator                    Description
@@ -112,9 +119,10 @@ Operator                    Description
 .. SEEALSO::
 
     - :ref:`sql_array_comparisons`
+
     - :ref:`sql_subquery_expressions`
 
 
 .. _CIDR notation: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
-.. _dateOptionalTimeParser: http://joda-time.sourceforge.net/api-release/org/joda/time/format/ISODateTimeFormat.html#dateOptionalTimeParser%28%29
-.. _TermRangeQuery: https://lucene.apache.org/core/6_6_0/core/org/apache/lucene/search/TermRangeQuery.html
+.. _ISO date formats: http://joda-time.sourceforge.net/api-release/org/joda/time/format/ISODateTimeFormat.html#dateOptionalTimeParser%28%29
+.. _lexicographical comparison: https://lucene.apache.org/core/6_6_0/core/org/apache/lucene/search/TermRangeQuery.html

--- a/docs/general/builtins/index.rst
+++ b/docs/general/builtins/index.rst
@@ -1,14 +1,13 @@
 .. highlight:: psql
-.. -sql-functions-operators:
+
+.. _sql-functions-operators:
 
 ================================
 Built-in functions and operators
 ================================
 
-This chapter provides an overview of built-in functions and operators.
-
-Operators are reserved keywords that are primarily used in a
-:ref:`sql_dql_where_clause` to perform arithmetic operations or comparisons.
+This chapter provides an overview of built-in functions and :ref:`operators
+<gloss-operator>`.
 
 .. rubric:: Table of contents
 

--- a/docs/general/builtins/scalar.rst
+++ b/docs/general/builtins/scalar.rst
@@ -35,7 +35,7 @@ Returns: ``text``
     +--------+
     SELECT 1 row in set (... sec)
 
-You can also use the ``||`` operator::
+You can also use the ``||`` :ref:`operator <gloss-operator>`::
 
     cr> select 'foo' || 'bar' AS col;
     +--------+
@@ -930,9 +930,9 @@ fractional seconds (milliseconds) are given.
 .. NOTE::
 
     If the ``CURRENT_TIMESTAMP`` function is used in
-    :ref:`sql-ddl-generated-columns` it behaves slightly different in
-    ``UPDATE`` operations. In such a case the actual timestamp of each row
-    update is returned.
+    :ref:`ddl-generated-columns` it behaves slightly different in ``UPDATE``
+    operations. In such a case the actual timestamp of each row update is
+    returned.
 
     The return value of expressions ``CURRENT_TIMESTAMP`` and ``CURRENT_TIME``
     depends on the system clock and the JVM implementation.
@@ -1932,12 +1932,12 @@ Regular expression functions
 
 The regular expression functions in CrateDB use `Java Regular Expressions`_.
 
-See the api documentation for more details.
+See the API documentation for more details.
 
 .. NOTE::
 
    Be aware that, in contrast to the functions, the :ref:`regular expression
-   operator <sql_ddl_regexp>` is using `Lucene Regular Expressions`_.
+   operator <sql_ddl_regexp>` uses `Lucene Regular Expressions`_.
 
 .. _Lucene Regular Expressions: https://lucene.apache.org/core/4_9_0/core/org/apache/lucene/util/automaton/RegExp.html
 
@@ -2100,9 +2100,8 @@ It can be used to append elements to array fields
    are made by fetching the newest version again and if they all fail, the
    query fails.
 
-You can also use the concat operator ``||`` with arrays
-
-::
+You can also use the concat :ref:`operator <gloss-operator>` ``||`` with
+arrays::
 
     cr> select [1,2,3] || [4,5,6] || [7,8,9] AS arr;
     +-----------------------------+
@@ -3005,9 +3004,9 @@ Special functions
 ----------------------
 
 The ``ignore3vl`` function operates on a boolean argument and eliminates the
-`3-valued logic`_ on the whole tree of operators beneath it. More specifically,
-``FALSE`` is evaluated to ``FALSE``, ``TRUE`` to ``TRUE`` and ``NULL`` to
-``FALSE``.
+`3-valued logic`_ on the whole tree of :ref:`operators <gloss-operator>`
+beneath it. More specifically, ``FALSE`` is evaluated to ``FALSE``, ``TRUE`` to
+``TRUE`` and ``NULL`` to ``FALSE``.
 
 Returns: ``boolean``
 

--- a/docs/general/builtins/subquery-expressions.rst
+++ b/docs/general/builtins/subquery-expressions.rst
@@ -1,21 +1,17 @@
 .. highlight:: psql
+
 .. _sql_subquery_expressions:
 
 Subquery expressions
 ====================
 
-The following operators can be used with a subquery to form a subquery
-expression that results in a boolean value (``true``/``false``) or ``null``.
+Some :ref:`operators <gloss-operator>` can be used with an :ref:`uncorrelated
+subquery <gloss-uncorrelated-subquery>` to form a *subquery expression* that
+returns a boolean value (i.e., ``true`` or ``false``) or ``NULL``.
 
-.. NOTE::
+.. SEEALSO::
 
-    The used subquery has to be uncorrelated which means that the subquery does
-    not contain references to relations in a parent statement.
-
-These operators are supported for subquery expressions.
-
-To compare a list of values other than subqueries, see
-:ref:`sql_array_comparisons`.
+    :ref:`sql_array_comparisons`
 
 .. rubric:: Table of contents
 
@@ -33,15 +29,9 @@ Syntax:
 
     expression IN (subquery)
 
-The binary operator ``IN``, which allows you to verify the membership of
-left-hand operand in the right-hand side subquery that returns exactly one
-column.
+The ``subquery`` must produce result rows with a single column only.
 
-Returns ``true`` if any equal subquery row equals the left-hand operand.
-Returns ``false`` otherwise (including the case where the subquery returns no
-rows).
-
-For example::
+Here's an example::
 
     cr> select name, surname, sex from employees
     ... where dept_id in (select id from departments where name = 'Marketing')
@@ -56,17 +46,20 @@ For example::
     +--------+----------+-----+
     SELECT 4 rows in set (... sec)
 
-The result of the ``IN`` construct yields to ``null`` if:
+The ``IN`` :ref:`operator <gloss-operator>` returns ``true`` if any subquery
+row equals the left-hand operand. Otherwise, it returns ``false`` (including
+the case where the subquery returns no rows).
 
-- The left-hand expression evaluates to ``null``
+The operator returns ``NULL`` if:
 
-- There are no equal right-hand values and at least one right-hand value yields
-  ``null``
+- The left-hand expression evaluates to ``NULL``
+
+- There are no matching right-hand values and at least one right-hand value is
+  ``NULL``
 
 .. NOTE::
 
-    ``IN (subquery)`` is an alias for ``= ANY (subquery)`` and therefore their
-    results are equivalent.
+    ``IN (subquery)`` is an alias for ``= ANY (subquery)``
 
 
 .. _sql_any_subquery_expression:
@@ -78,16 +71,16 @@ Syntax:
 
 .. code-block:: sql
 
-    expression operator ANY | SOME (subquery)
+    expression comparison ANY | SOME (subquery)
 
-The ``ANY`` construct returns ``true`` if the defined comparison is ``true``
-for any of the values in the column that is returned by the subquery.
+Here, ``comparison`` can be any :ref:`basic comparison operator
+<comparison-operators-basic>`. The ``subquery`` must produce result rows with a
+single column only.
 
-It returns ``false`` if the subquery does not match with the provided comparison
-or the subquery returns no rows::
+Here's an example::
 
     cr> select name, population from countries
-    ... where population > any (select * from unnest([8000000, 22000000, null]))
+    ... where population > any (select * from unnest([8000000, 22000000, NULL]))
     ... order by population, name;
     +--------------+------------+
     | name         | population |
@@ -100,23 +93,27 @@ or the subquery returns no rows::
     +--------------+------------+
     SELECT 5 rows in set (... sec)
 
+The ``ANY`` :ref:`operator <gloss-operator>` returns ``true`` if the defined
+comparison is ``true`` for any of the result rows of the right-hand subquery.
 
-The result of the ``ANY`` construct yields ``null`` if:
+The operator returns ``false`` if the comparison returns ``false`` for all
+result rows of the subquery or if the subquery returns no rows.
 
-- Either the expression or the array is ``null``, and
+The operator returns ``NULL`` if:
 
-- No ``true`` comparison is obtained and any element of the array is ``null``
+- The left-hand expression evaluates to ``NULL``
+
+- There are no matching right-hand values and at least one right-hand value is
+  ``NULL``
 
 .. NOTE::
 
-    The following is not supported by the ``ANY`` operator:
+    The following is not supported:
 
-    - ``is null`` and ``is not null`` as ``operator``
+    - ``IS NULL`` or ``IS NOT NULL`` as ``comparison``
 
     - Matching as many columns as there are expressions on the left-hand row
       e.g. ``(x,y) = ANY (select x, y from t)``
-
-      Only single-column subqueries are supported
 
 
 ``ALL (subquery)``
@@ -126,23 +123,13 @@ Syntax:
 
 .. code-block:: sql
 
-    value operator ALL (subquery)
+    value comparison ALL (subquery)
 
+Here, ``comparison`` can be any :ref:`basic comparison operator
+<comparison-operators-basic>`. The ``subquery`` must produce result rows with a
+single column only.
 
-This is like :ref:`ALL for array comparisons <all_array_comparison>` except for
-subqueries.
-
-The left-hand expression is evaluated and compared against each row of the
-right-hand subquery using the supplied operator. The result of ``ALL`` is ``true``
-if all comparisons yield ``true``. The result is ``false`` if the comparison of
-at least one element does not match.
-
-The result is ``NULL`` if either the value or the array is ``NULL`` or if no
-comparison is ``false`` and at least one comparison returns ``NULL``.
-
-The subquery must return a single column.
-
-::
+Here's an example::
 
     cr> select 100 <> ALL (select height from sys.summits) AS x;
     +------+
@@ -152,12 +139,14 @@ The subquery must return a single column.
     +------+
     SELECT 1 row in set (... sec)
 
+The ``ALL`` :ref:`operator <gloss-operator>` returns ``true`` if the defined
+comparison is ``true`` for all of the result rows of the right-hand subquery.
 
-Supported operators are:
+The operator returns ``false`` if the comparison returns ``false`` for any
+result rows of the subquery.
 
-- ``=``
-- ``>=``
-- ``>``
-- ``<=``
-- ``<``
-- ``<>``
+The operator returns ``NULL`` if:
+
+- The left-hand expression evaluates to ``NULL``
+
+- No comparison returns ``false`` and at least one right-hand value is ``NULL``

--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -32,7 +32,8 @@ In order to set a parameter to its default value use ``reset``::
     cr> alter table my_table reset (number_of_replicas);
     ALTER OK, -1 rows affected (... sec)
 
-.. _alter_change_number_of_shard:
+
+.. _alter-shard-number:
 
 Changing the number of shards
 -----------------------------
@@ -54,6 +55,9 @@ Changing the number of shards in general works in the following steps.
 To change the number of primary shards of a table, it is necessary to first
 satisfy certain conditions.
 
+
+.. _alter-shard-number-decrease:
+
 Decreasing the number of shards
 ...............................
 
@@ -62,8 +66,9 @@ two conditions:
 
 First, a (primary or replica) copy of every shard of the table must be present
 on the **same** node. The user can choose the most suitable node for this
-operation and then restrict table shard allocation on that node using the
-:ref:`ddl_shard_allocation`.
+operation and then restrict table :ref:`shard allocation
+<gloss-shard-allocation>` on that node using the :ref:`shard allocation
+filtering <ddl_shard_allocation>`.
 
 The second condition for decreasing a table's number of shards is to block write
 operations to the table::
@@ -85,6 +90,9 @@ The user should then revert the restrictions applied on the table, for instance
 It is necessary to use a factor of the current number of primary shards as
 the target number of shards. For example, a table with 8 shards can be shrunk
 into 4, 2 or 1 primary shards.
+
+
+.. _alter-shard-number-increase:
 
 Increase the number of shards
 .............................
@@ -112,7 +120,7 @@ for instance::
     cr> alter table my_table set ("blocks.write" = false);
     ALTER OK, -1 rows affected (... sec)
 
-Read :ref:`Alter Partitioned Tables <partitioned_tables_alter>` to see how to
+Read :ref:`Alter Partitioned Tables <partitioned-alter>` to see how to
 alter parameters of partitioned tables.
 
 Adding columns
@@ -169,7 +177,7 @@ clause::
 
 .. NOTE::
 
-    This setting is *not* the same as :ref:`table-settings-blocks.read_only`.
+    This setting is *not* the same as :ref:`sql-create-table-blocks-read-only`.
     Closing and opening a table will preserve these settings if they are
     already set.
 
@@ -188,10 +196,11 @@ During the rename operation the shards of the table become temporarily unavailab
 Reroute shards
 ==============
 
-With the ``REROUTE`` command it is possible to control the allocations of
-shards. This gives you the ability to re-balance the cluster state manually.
-The supported reroute options are listed in the reference documentation of
-:ref:`ALTER TABLE REROUTE <alter_table_reroute>`.
+With the ``REROUTE`` command it is possible to control the :ref:`allocations
+<gloss-shard-allocation>` of shards. This gives you the ability to re-balance
+the cluster state manually. The supported reroute options are listed in the
+reference documentation of :ref:`ALTER TABLE REROUTE
+<sql-alter-table-reroute>`.
 
 Shard rerouting can help solve several problems:
 

--- a/docs/general/ddl/constraints.rst
+++ b/docs/general/ddl/constraints.rst
@@ -1,3 +1,5 @@
+.. _constraints:
+
 ===========
 Constraints
 ===========
@@ -9,11 +11,15 @@ Columns can be constrained in three ways:
 
 The values of a constrained column must comply with the constraint.
 
+
+.. _constraints-primary-key:
+
 Primary key
 ===========
 
 The primary key constraint combines a unique constraint and a not-null
-constraint. It also defines the default routing value used for sharding.
+constraint. It also defines the default :ref:`routing value
+<gloss-routing-column>` used for sharding.
 
 Example::
 
@@ -51,6 +57,9 @@ Or using a alternate syntax::
 
    For further details see :ref:`primary_key_constraint`.
 
+
+.. _constraints-not-null:
+
 Not null
 ========
 
@@ -68,6 +77,9 @@ Example::
 .. NOTE::
 
    For further details see :ref:`not_null_constraint`.
+
+
+.. _constraints-check:
 
 Check
 =====

--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -12,7 +12,7 @@ Creating tables
 Basics
 ======
 
-To create a table use the :ref:`ref-create-table` command. You must at least
+To create a table use the :ref:`sql-create-table` command. You must at least
 specify a name for the table and names and types of the columns.
 
 See :ref:`data-types` for information about the supported data types.
@@ -152,9 +152,10 @@ Advanced use
 
 Tables can be:
 
-- :ref:`Clustered <ref_clustered_clause>` into multiple :ref:`shards <sql_ddl_sharding>`
-- :ref:`Partitioned <partitioned_by_clause>` by column (to create
-  :ref:`partitioned tables <partitioned_tables>`)
-- Fine-tuned with :ref:`table paramaters <with_clause>` (e.g., to configure
-  :ref:`replication <replication>`)
+- :ref:`Clustered <sql-create-table-clustered>` into multiple :ref:`shards
+  <sql_ddl_sharding>`
+- :ref:`sql-create-table-partitioned-by` one or more columns (to create
+  :ref:`partitioned tables <partitioned-tables>`)
+- Fine-tuned with :ref:`table paramaters <sql-create-table-with>` (e.g., to
+  configure :ref:`replication <replication>`)
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -7,7 +7,7 @@ Data types
 ==========
 
 Data can be stored in different formats. CrateDB has different types that can
-be specified if a table is created using the the :ref:`ref-create-table`
+be specified if a table is created using the the :ref:`sql-create-table`
 statement. Data types play a central role as they limit what kind of data can
 be inserted, how it is stored and they also influence the behaviour when the
 records are queried.
@@ -358,9 +358,10 @@ Example::
     ... values ('localhost', 'not.a.real.ip');
     SQLParseException[Cannot cast `'not.a.real.ip'` of type `text` to type `ip`]
 
-Ip addresses support the binary operator `<<`, which checks for subnet inclusion
-using `CIDR notation`_ [ip address/prefix_length]. The left operand must be of
-type ``ip`` and the right of ``text`` e.g. `'192.168.1.5' << '192.168.1/24'`.
+IP addresses support the :ref:`operator <gloss-operator>` ``<<``, which checks
+for subnet inclusion using `CIDR notation`_. The left-hand operand must be of
+type :ref:`ip <ip-type>` and the right-hand must be of type :ref:`text
+<data-type-text>` (e.g., ``'192.168.1.5' << '192.168.1/24'``).
 
 .. _date-time-types:
 
@@ -714,20 +715,20 @@ For example::
 Temporal arithmetic
 -------------------
 
-The following table specifies the declared types of
-:ref:`arithmetic <arithmetic>` expressions that involves temporal operands.
+The following table specifies the declared types of :ref:`arithmetic
+<arithmetic>` expressions that involves temporal operands.
 
-+---------------+----------+---------------+
-|       Operand | Operator |       Operand |
-+===============+==========+===============+
-| ``timestamp`` |       \- | ``timestamp`` |
-+---------------+----------+---------------+
-|  ``interval`` |       \+ | ``timestamp`` |
-+---------------+----------+---------------+
-| ``timestamp`` | \+ or \- |  ``interval`` |
-+---------------+----------+---------------+
-|  ``interval`` | \+ or \- |  ``interval`` |
-+---------------+----------+---------------+
++---------------+----------------+---------------+
+|       Operand | Operator       |       Operand |
++===============+================+===============+
+| ``timestamp`` |          ``-`` | ``timestamp`` |
++---------------+----------------+---------------+
+|  ``interval`` |          ``+`` | ``timestamp`` |
++---------------+----------------+---------------+
+| ``timestamp`` | ``+`` or ``-`` |  ``interval`` |
++---------------+----------------+---------------+
+|  ``interval`` | ``+`` or ``-`` |  ``interval`` |
++---------------+----------------+---------------+
 
 
 .. _geo_point_data_type:
@@ -893,8 +894,8 @@ Alternatively a `WKT`_ string can be used to represent a geo_shape as well::
 
     It is not possible to detect a geo_shape type for a dynamically created
     column. Like with :ref:`geo_point_data_type` type, geo_shape columns need
-    to be created explicitly using either :ref:`ref-create-table` or
-    :ref:`ref-alter-table`.
+    to be created explicitly using either :ref:`sql-create-table` or
+    :ref:`sql-alter-table`.
 
 .. _object_data_type:
 
@@ -1157,8 +1158,8 @@ Nested object::
 
     { nested_obj_colmn = { int_col = 1234, str_col = 'text value' } }
 
-You can even specify a :ref:`placeholder parameter <expression-parameter>` for
-a value::
+You can even specify a :ref:`placeholder parameter <sql-parameter-reference>`
+for a value::
 
     { my_other_column = ? }
 
@@ -1223,8 +1224,8 @@ Nested object::
 
 .. NOTE::
 
-    You cannot use :ref:`placeholder parameters <expression-parameter>` inside
-    a JSON string.
+    You cannot use :ref:`placeholder parameters <sql-parameter-reference>`
+    inside a JSON string.
 
 
 .. _data-type-array:

--- a/docs/general/ddl/generated-columns.rst
+++ b/docs/general/ddl/generated-columns.rst
@@ -1,4 +1,4 @@
-.. _sql-ddl-generated-columns:
+.. _ddl-generated-columns:
 
 =================
 Generated columns
@@ -7,6 +7,17 @@ Generated columns
 It is possible to define columns whose value is computed by applying a
 *generation expression* in the context of the current row. The generation
 expression can reference the values of other columns.
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+.. _ddl-generated-columns-expressions:
+
+Generation expressions
+======================
 
 Generated columns are defined by providing a generation expression. Providing
 a data type is optional. It is inferred by the return type of the supplied
@@ -21,7 +32,7 @@ expression if omitted::
 
 .. SEEALSO::
 
-   For a full syntax description, see :ref:`ref-create-table`.
+   For a full syntax description, see :ref:`sql-create-table`.
 
 Generated columns are read-only. Their values are computed as needed for every
 ``INSERT`` and ``UPDATE`` operation.
@@ -70,6 +81,12 @@ against the result of applying the generation expression::
    Supplied values for generated columns are not validated when they are
    imported using ``COPY FROM``.
 
+
+.. _ddl-generated-columns-last-modified:
+
+Last modified dates
+===================
+
 Because :ref:`current_timestamp` is non-deterministic, you can use this
 expression to record a last modified date that is set when the row is first
 inserted, and subsequently updated every time the row is updated::
@@ -80,8 +97,15 @@ inserted, and subsequently updated every time the row is updated::
     ... )
     CREATE OK, 1 row affected (... sec)
 
-They can also be used in the :ref:`partitioned_by_clause` in order to compute
-the value to partition by from existing columns in the table::
+
+.. _ddl-generated-columns-partitioning:
+
+Partitioning
+============
+
+Generated columns can be used with the :ref:`sql-create-table-partitioned-by`
+clause to compute the :ref:`partition column <gloss-partition-column>` value
+from existing columns in the table::
 
     cr> CREATE TABLE computed_and_partitioned (
     ...   huge_cardinality bigint,
@@ -89,6 +113,10 @@ the value to partition by from existing columns in the table::
     ...   partition_value GENERATED ALWAYS AS (huge_cardinality % 10)
     ... ) PARTITIONED BY (partition_value);
     CREATE OK, 1 row affected (... sec)
+
+.. SEEALSO::
+
+    :ref:`Partitioned tables: Generated columns <partitioned-generated>`
 
 .. Hidden: drop tables::
 

--- a/docs/general/ddl/replication.rst
+++ b/docs/general/ddl/replication.rst
@@ -11,7 +11,7 @@ better read performance and high availability.
 If not specified, CrateDB creates zero to one replica depending on the number
 of available nodes at the cluster. At a single-node cluster, replicas are set
 to zero to allow fast write operations with the default setting of
-:ref:`sql_ref_write_wait_for_active_shards`.
+:ref:`sql-create-table-write-wait-for-active-shards`.
 
 .. rubric:: Table of contents
 
@@ -21,8 +21,8 @@ to zero to allow fast write operations with the default setting of
 Configuration
 =============
 
-Defining the number of replicas is done using the ``number_of_replicas``
-property.
+Defining the number of replicas is done using the
+:ref:`sql-create-table-number-of-replicas` property.
 
 Example::
 
@@ -58,11 +58,12 @@ Range Explanation
 0-all Will expand the number of replicas to the available number of nodes.
 ===== =========================================================================
 
-For details of the range syntax refer to :ref:`number_of_replicas`.
+For details of the range syntax refer to :ref:`the CREATE TABLE
+documentation <sql-create-table-number-of-replicas>`.
 
 .. NOTE::
 
-  The number of replicas can be changed at any time.
+    The number of replicas can be changed at any time.
 
 .. SEEALSO::
 

--- a/docs/general/ddl/shard-allocation.rst
+++ b/docs/general/ddl/shard-allocation.rst
@@ -4,8 +4,9 @@
  Shard allocation filtering
 ============================
 
-Shard allocation filters allows to configure shard and replicas allocation per
-table across generic attributes associated with nodes.
+:ref:`Shard allocation <gloss-shard-allocation>` filters allows to configure
+shard and replicas allocation per table across generic attributes associated
+with nodes.
 
 .. NOTE::
 
@@ -21,9 +22,9 @@ table to a particular group of nodes.
 Settings
 ========
 
-The following settings are dynamic, allowing tables to be allocated (when
-defined on table creation) or moved (when defined by altering a table) from one
-set of nodes to another:
+The following settings are dynamic, allowing tables to be :ref:`allocated
+<gloss-shard-allocation>` (when defined on table creation) or moved (when
+defined by altering a table) from one set of nodes to another:
 
 :routing.allocation.include.{attribute}:
    Assign the table to a node whose *{attribute}* has **at least one** of the

--- a/docs/general/ddl/sharding.rst
+++ b/docs/general/ddl/sharding.rst
@@ -12,7 +12,7 @@ Sharding
 Introduction
 ============
 
-Every table partition (see :ref:`partitioned_tables`) is split into a
+Every table partition (see :ref:`partitioned-tables`) is split into a
 configured number of shards. Shards are then distributed across the cluster. As
 nodes are added to the cluster, CrateDB will move shards around to achieve
 maximum possible distribution.
@@ -28,6 +28,9 @@ think about shards when querying a table.
 Read requests are broken down and executed in parallel across multiple shards
 on multiple nodes, massively improving read performance.
 
+
+.. _number-of-shards:
+
 Number of shards
 ================
 
@@ -42,22 +45,24 @@ Example::
     CREATE OK, 1 row affected (... sec)
 
 If the number of shards is not defined explicitly, the sensible default value
-is applied, (see :ref:`ref_clustered_clause`).
+is applied, (see :ref:`sql-create-table-clustered`).
 
 .. NOTE::
 
-   The number of shards :ref:`can be changed <alter_change_number_of_shard>`
-   after table creation, providing the value is a multiple of
-   :ref:`number_of_routing_shards <sql_ref_number_of_routing_shards>` (set at
-   table-creation time). Altering the number of shards will put the table into
-   a read-only state until the operation has completed.
+   The number of shards :ref:`can be changed <alter-shard-number>` after table
+   creation, providing the value is a multiple of
+   :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>`
+   (set at table-creation time). Altering the number of shards will put the
+   table into a read-only state until the operation has completed.
 
 .. CAUTION::
 
-   Well tuned shard allocation is vital. Read the `Sharding Guide`_ to make
-   sure you're getting the best performance out ot CrateDB.
+   Well tuned :ref:`shard allocation <sql_ddl_sharding>` is vital. Read the
+   `Sharding Guide`_ to make sure you're getting the best performance out ot
+   CrateDB.
 
 .. _Sharding Guide: https://crate.io/docs/crate/howtos/en/latest/performance/sharding.html
+
 
 .. _routing:
 
@@ -65,7 +70,7 @@ Routing
 =======
 
 Given a fixed number of primary shards, individual rows can be routed to a
-fixed shard number using a simple formula:
+fixed shard number with a simple formula:
 
 *shard number = hash(routing column) % total primary shards*
 
@@ -73,8 +78,9 @@ When hash values are distributed evenly (which will be approximately true in
 most cases), rows will be distributed evenly amongst the fixed amount of
 available shards.
 
-The routing column can be specified with the ``CLUSTERED BY (<column>)``
-statement. If no column is specified, the internal document ID is used.
+The :ref:`routing column <gloss-routing-column>` can be specified with the
+``CLUSTERED BY (<column>)`` statement. If no column is specified, the
+:ref:`internal document ID <sql_administration_system_column_id>` is used.
 
 Example::
 
@@ -85,8 +91,9 @@ Example::
     CREATE OK, 1 row affected (... sec)
 
 
-If primary key constraints are defined, the routing column definition can be
-omitted as primary key columns are always used for routing by default.
+If :ref:`primary key constraints <constraints-primary-key>` are defined, the
+routing column definition can be omitted as primary key columns are always used
+for routing by default.
 
 If the routing column is defined explicitly, it must match a primary key
 column::

--- a/docs/general/ddl/system-columns.rst
+++ b/docs/general/ddl/system-columns.rst
@@ -41,16 +41,16 @@ _primary_term
   example, if a primary is isolated in a minority partition, a possible up to
   date replica shard on the majority partition will be promoted to be the new
   primary shard and continue to process write operations, subject to the
-  :ref:`sql_ref_write_wait_for_active_shards` setting. When this partition
-  heals we need a reliable way to know that the operations that come from the
-  other shard are from an old primary and, equally, the operations that we send
-  to the shard re-joining the cluster are from the newer primary. The cluster
-  needs to have a consensus on which shards are the current serving primaries.
-  In order to achieve this we use the primary terms which are generational
-  counters that are incremented when a primary is promoted. Used in conjunction
-  with :ref:`_seq_no <sql_administration_system_columns_seq_no>` we can obtain
-  a total order of operations across shards and
-  `Optimistic Concurrency Control`_.
+  :ref:`sql-create-table-write-wait-for-active-shards` setting. When this
+  partition heals we need a reliable way to know that the operations that come
+  from the other shard are from an old primary and, equally, the operations
+  that we send to the shard re-joining the cluster are from the newer primary.
+  The cluster needs to have a consensus on which shards are the current serving
+  primaries. In order to achieve this we use the primary terms which are
+  generational counters that are incremented when a primary is promoted. Used
+  in conjunction with :ref:`_seq_no <sql_administration_system_columns_seq_no>`
+  we can obtain a total order of operations across shards and `Optimistic
+  Concurrency Control`_.
 
 .. _sql_administration_system_column_score:
 
@@ -73,9 +73,9 @@ _id
 
   The value is a unique identifier for each row in a table and is a compound
   string representation of all primary key values of that row. If no primary
-  keys are defined the id is randomly generated. If no dedicated routing column
-  is defined the ``_id`` value is used for distributing the records on the
-  shards.
+  keys are defined the id is randomly generated. If no dedicated :ref:`routing
+  column <gloss-routing-column>` is defined the ``_id`` value is used for
+  distributing the records on the shards.
 
 .. _Optimistic Concurrency Control: https://en.wikipedia.org/wiki/Optimistic_concurrency_control
 

--- a/docs/general/dml.rst
+++ b/docs/general/dml.rst
@@ -21,7 +21,7 @@ Inserting data to CrateDB is done by using the SQL ``INSERT`` statement.
 .. NOTE::
 
     The column list is always ordered based on the column position
-    in the :ref:`ref-create-table` statement of the table. If the insert
+    in the :ref:`sql-create-table` statement of the table. If the insert
     columns are omitted, the values in the ``VALUES`` clauses must
     correspond to the table columns in that order.
 
@@ -67,9 +67,10 @@ When inserting multiple rows, if an error occurs for some of these rows there
 is no error returned but instead the number of rows affected would be decreased
 by the number of rows that failed to be inserted.
 
-When inserting into tables containing :ref:`ref-generated-columns`
-or :ref:`ref-base-columns` having the :ref:`ref-default-clause` specified,
-their values can be safely omitted. They are *generated* upon insert:
+When inserting into tables containing :ref:`sql-create-table-generated-columns`
+or :ref:`sql-create-table-base-columns` having the
+:ref:`sql-create-table-default-clause` specified, their values can be safely
+omitted. They are *generated* upon insert:
 
 ::
 
@@ -103,8 +104,9 @@ their values can be safely omitted. They are *generated* upon insert:
     +-------------------+-----------+-----------+-----------+-------+
     SELECT 1 row in set (... sec)
 
-For :ref:`ref-generated-columns`, if the value is given, it is validated
-against the *generation clause* of the column and the currently inserted row::
+For :ref:`sql-create-table-generated-columns`, if the value is given, it is
+validated against the *generation clause* of the column and the currently
+inserted row::
 
     cr> insert into debit_card (owner, num_part1, num_part2, check_sum) values
     ... ('Arthur Dent', 9876, 5432, 642935);
@@ -414,9 +416,9 @@ Using the ``COPY FROM`` statement, CrateDB nodes can import data from local
 files or files that are available over the network.
 
 The supported data formats are JSON and CSV. The format is inferred from the
-file extension, if possible. Alternatively the format can also be provided as an
-option (see :ref:`with_option`). If the format is not provided and cannot be
-inferred from the file extension, it will be processed as JSON.
+file extension, if possible. Alternatively the format can also be provided as
+an option (see :ref:`sql-copy-from-with`). If the format is not provided and
+cannot be inferred from the file extension, it will be processed as JSON.
 
 JSON files must contain a single JSON object per line.
 
@@ -445,7 +447,7 @@ Example CSV data::
     they were quoted in a SQL statement).
 
 For further information, including how to import data to
-:ref:`partitioned_tables`, take a look at the :ref:`copy_from` reference.
+:ref:`partitioned-tables`, take a look at the :ref:`sql-copy-from` reference.
 
 Example
 .......
@@ -474,7 +476,7 @@ uses it to create a table named ``quotes``.
     ``COPY FROM``, you must first transfer the file to one of the CrateDB
     nodes.
 
-    Consult the :ref:`copy_from` reference for additional information.
+    Consult the :ref:`sql-copy-from` reference for additional information.
 
 .. Hidden: delete imported data
 
@@ -560,7 +562,7 @@ If an error happens while processing the URI in general, the ``error_count`` and
     +--...--+-----------...---------+---------------+-------------+------------------------...------------------------+
    COPY 1 row in set (... sec)
 
-See :ref:`copy_from` for more information.
+See :ref:`sql-copy-from` for more information.
 
 .. _exporting_data:
 
@@ -600,7 +602,7 @@ exported::
     cr> COPY quotes WHERE match(quote_ft, 'time') TO DIRECTORY '/tmp/' WITH (compression='gzip');
     COPY OK, 2 rows affected ...
 
-For further details see :ref:`copy_to`.
+For further details see :ref:`sql-copy-to`.
 
 .. _crate-python: https://pypi.python.org/pypi/crate/
 .. _PCRE: https://www.pcre.org/

--- a/docs/general/dql/fulltext.rst
+++ b/docs/general/dql/fulltext.rst
@@ -99,9 +99,9 @@ Arguments
   name of the index.
 
   By default every column is indexed but only the raw data is stored, so
-  matching against a ``text`` column without a fulltext index is
-  equivalent to using the ``=`` operator. To perform real fulltext
-  searches use a :ref:`sql_ddl_index_fulltext`.
+  matching against a ``text`` column without a fulltext index is equivalent to
+  using the ``=`` :ref:`operator <gloss-operator>`. To perform real fulltext
+  searches use a :ref:`fulltext index <sql_ddl_index_fulltext>`.
 
 :boost:
   A column ident can have a boost attached. That is a weight factor that
@@ -243,10 +243,10 @@ See the options below for details.
   used. Defaults to ``1``.
 
 :operator:
-  Can be ``or`` or ``and``. The default is ``or``. It is used to combine
-  the tokens of the ``query_term``. If ``and`` is used, every token from
-  the ``query_term`` has to match. If ``or`` is used only the number of
-  ``minimum_should_match`` have to match.
+  Can be ``or`` or ``and``. The default :ref:`operator <gloss-operator>` is
+  ``or``. It is used to combine the tokens of the ``query_term``. If ``and`` is
+  used, every token from the ``query_term`` has to match. If ``or`` is used
+  only the number of ``minimum_should_match`` have to match.
 
 :prefix_length:
   When used with ``fuzziness`` option or with ``phrase_prefix`` this
@@ -413,9 +413,10 @@ value relative to the highest score of all results and consequently never
 absolute or comparable across searches the usefulness outside of sorting is
 very limited.
 
-Although possible, filtering by the greater-than-or-equals('>=') operator on
-the :ref:`_score <sql_administration_system_column_score>` column would not
-make much sense and can lead to unpredictable result sets.
+Although possible, filtering by the greater-than-or-equals :ref:`operator
+<gloss-operator>` (``>=``)  on the :ref:`_score
+<sql_administration_system_column_score>` column would not make much sense and
+can lead to unpredictable result sets.
 
 Anyway let's do it here for demonstration purpose::
 

--- a/docs/general/dql/joins.rst
+++ b/docs/general/dql/joins.rst
@@ -192,8 +192,8 @@ tuples for all other records from *right* that don't match any record on the
 Join conditions
 ---------------
 
-CrateDB supports all operators and scalar functions as join conditions in the
-``WHERE`` clause.
+CrateDB supports all :ref:`operators <gloss-operator>` and scalar functions as
+join conditions in the ``WHERE`` clause.
 
 Example with ``within`` scalar function::
 
@@ -238,12 +238,12 @@ available memory, only a certain block size of a relation is loaded at once. The
 whole operation will be repeated with the next block of the first relation once
 scanning the second relation has finished.
 
-This optimisation cannot be applied unless the join is an  **INNER** join and
-the `join condition` obeys the following rules:
+This optimisation cannot be applied unless the join is an ``INNER`` join and
+the join condition satisfies the following rules:
 
-  - contains at least one ``EQUAL`` operator
-  - contains no ``OR`` operator
-  - every argument of a ``EQUAL`` operator can only references fields from one
+  - Contains at least one ``EQUAL`` :ref:`operator <gloss-operator>`
+  - Contains no ``OR`` operator
+  - Every argument of a ``EQUAL`` operator can only references fields from one
     relation
 
 The `Hash Join`_ algorithm is faster but has a bigger memory footprint. As such

--- a/docs/general/dql/refresh.rst
+++ b/docs/general/dql/refresh.rst
@@ -28,7 +28,7 @@ that the latest state of the table gets fetched.
 A table is refreshed periodically with a specified refresh interval. By
 default, the refresh interval is set to 1000 milliseconds. The refresh interval
 of a table can be changed with the table parameter ``refresh_interval`` (see
-:ref:`sql_ref_refresh_interval`).
+:ref:`sql-create-table-refresh-interval`).
 
 .. SEEALSO::
 
@@ -74,13 +74,13 @@ Partition Refresh
 =================
 
 Additionally it is possible to define a specific ``PARTITION`` of a partitioned
-table which should be refreshed (see :ref:`partitioned_tables`).
+table which should be refreshed (see :ref:`partitioned-tables`).
 
 By using the ``PARTITION`` clause in the refresh statement a separate request
 for a given partition can be performed. That means that only specific
 partitions of a partitioned table are refreshed. For further details on how to
 create a refresh request on partitioned tables see the SQL syntax and its
-synopsis (see :ref:`sql_ref_refresh`).
+synopsis (see :ref:`sql-refresh`).
 
 ::
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -34,8 +34,8 @@ A simple select::
     +----+-------------------+
     SELECT 2 rows in set (... sec)
 
-If the '*' operator is used, all columns defined in the schema are returned for
-each row::
+If the ``*`` :ref:`operator <gloss-operator>` is used, all columns defined in
+the schema are returned for each row::
 
     cr> select * from locations order by id limit 2;
     +----+-------------------+--------------+--------+----------+-------------...-+-----------+
@@ -70,7 +70,7 @@ based upon. Can be a single table, many tables, a view, a :ref:`JOIN
 Tables and views are referenced by schema and table name and can optionally be
 aliased.  If the relation ``t`` is only referenced by name, CrateDB assumes the
 relation ``doc.t`` was meant. Schemas that were newly created using
-:ref:`ref-create-table` must be referenced explicitly.
+:ref:`sql-create-table` must be referenced explicitly.
 
 The two following queries are equivalent::
 
@@ -171,7 +171,7 @@ and so on).
 Regular expressions
 -------------------
 
-Operators for matching using regular expressions:
+:ref:`Operators <gloss-operator>` for matching using regular expressions:
 
 .. list-table::
    :widths: 5 20 15
@@ -273,10 +273,10 @@ Examples::
 ``LIKE (ILIKE)``
 ----------------
 
-CrateDB supports the ``LIKE`` and ``ILIKE`` operators. These operators can
-be used to query for rows where only part of a columns value should match
-something. The only difference is that, in the case of ``ILIKE``, the
-matching is case insensitive.
+CrateDB supports the ``LIKE`` and ``ILIKE`` :ref:`operators <gloss-operator>`.
+These operators can be used to query for rows where only part of a columns
+value should match something. The only difference is that, in the case of
+``ILIKE``, the matching is case insensitive.
 
 For example to get all locations where the name starts with 'Ar' the following
 queries can be used::
@@ -303,10 +303,10 @@ queries can be used::
 
 The following wildcard operators are available:
 
-== ========================================
-%  A substitute for zero or more characters
-_  A substitute for a single character
-== ========================================
+===== ========================================
+``%``  A substitute for zero or more characters
+``_``  A substitute for a single character
+===== ========================================
 
 The wildcard operators may be used at any point in the string literal. For
 example a more complicated like clause could look like this::
@@ -465,10 +465,10 @@ CrateDB supports a variety of :ref:`array comparisons <sql_array_comparisons>`.
 ``IN``
 ------
 
-CrateDB also supports the binary operator ``IN``, which allows you to verify
-the membership of the left-hand operand in a right-hand set of expressions.
-Returns ``true`` if any evaluated expression value from a right-hand set equals
-left-hand operand. Returns ``false`` otherwise::
+CrateDB supports the :ref:`operator <gloss-operator>` ``IN`` which allows you
+to verify the membership of the left-hand operand in a right-hand set of
+expressions. Returns ``true`` if any evaluated expression value from a
+right-hand set equals left-hand operand. Returns ``false`` otherwise::
 
     cr> select name, kind from locations
     ... where (kind in ('Star System', 'Planet'))  order by name asc;
@@ -496,8 +496,8 @@ The ``IN`` construct can be used in :ref:`sql_subquery_expressions` or
 ``ANY (array)``
 ---------------
 
-The ANY (or SOME) function allows you to query elements within :ref:`arrays
-<sql_dql_arrays>`.
+The ANY (or SOME) :ref:`operator <gloss-operator>` allows you to query elements
+within :ref:`arrays <sql_dql_arrays>`.
 
 For example, this query returns any row where the array
 ``inhabitants['interests']`` contains a ``netball`` element::
@@ -512,7 +512,7 @@ For example, this query returns any row where the array
     +---------------------+------------------------------+
     SELECT 2 rows in set (... sec)
 
-This query combines the ``ANY`` function with the :ref:`LIKE <sql_dql_like>`
+This query combines the ``ANY`` operator with the :ref:`LIKE <sql_dql_like>`
 operator::
 
     cr> select inhabitants['name'], inhabitants['interests'] from locations
@@ -524,7 +524,7 @@ operator::
     +---------------------+------------------------------+
     SELECT 1 row in set (... sec)
 
-This query passes a literal array value to the ``ANY`` function::
+This query passes a literal array value to the ``ANY`` operator::
 
     cr> select name, inhabitants['interests'] from locations
     ... where name = ANY(ARRAY['Bartledan', 'Algol'])
@@ -558,7 +558,7 @@ This query selects any locations with at least one (i.e., :ref:`ANY
     as it cannot utilize the table index and requires the equivalent of a table
     scan.
 
-The ``ANY`` construct can be used in :ref:`subquery expressions
+The ``ANY`` operator can be used in :ref:`subquery expressions
 <sql_subquery_expressions>` and :ref:`array comparisons
 <sql_array_comparisons>`.
 
@@ -689,9 +689,9 @@ Individual array elements can also be addressed in the :ref:`where clause
     +----------+-------------------------------------------+
     SELECT 1 row in set (... sec)
 
-When using the ``=`` operator, as above, the value of the array element at
-index ``n`` is compared. To compare against *any* array element, see
-:ref:`sql_dql_any_array`.
+When using the ``=`` :ref:`operator <gloss-operator>`, as above, the value of
+the array element at index ``n`` is compared. To compare against *any* array
+element, see :ref:`sql_dql_any_array`.
 
 
 .. _sql_dql_objects:
@@ -1130,7 +1130,8 @@ This is useful if used in conjunction with aggregation functions::
 The having clause is the equivalent to the where clause for the resulting rows
 of a group by clause.
 
-A simple having clause example using an equality operator::
+A simple having clause example using an equality :ref:`operator
+<gloss-operator>`::
 
     cr> select count(*), kind from locations
     ... group by kind having count(*) = 4 order by kind;

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -119,9 +119,9 @@ number of replicas.
     +--------------------+-------------------------+------------+------------------+--------------------+
     SELECT 50 rows in set (... sec)
 
-The table also contains additional information such as specified routing
-(:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)
-columns::
+The table also contains additional information such as the specified
+:ref:`routing column <gloss-routing-column>` and :ref:`partition columns
+<gloss-partition-column>`::
 
     cr> SELECT table_name, clustered_by, partitioned_by
     ... FROM information_schema.tables
@@ -146,7 +146,7 @@ columns::
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``closed``                       | The state of the table                                                             | ``BOOLEAN`` |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
-| ``clustered_by``                 | The routing column used to cluster the table                                       | ``TEXT``    |
+| ``clustered_by``                 | The :ref:`routing column <gloss-routing-column>` used to cluster the table         | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``column_policy``                | Defines whether the table uses a ``STRICT`` or a ``DYNAMIC`` :ref:`column_policy`  | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
@@ -154,15 +154,16 @@ columns::
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``number_of_shards``             | The number of shards the table is currently distributed across                     | ``INTEGER`` |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
-| ``partitioned_by``               | The column used to partition the table                                             | ``TEXT``    |
+| ``partitioned_by``               | The :ref:`partition columns <gloss-partition-column>` (used to partition the       | ``TEXT``    |
+|                                  | table)                                                                             |             |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``reference_generation``         | Specifies how values in the self-referencing column are generated                  | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
-| ``routing_hash_function``        | The name of the hash function used for internal routing                            | ``TEXT``    |
+| ``routing_hash_function``        | The name of the hash function used for internal :ref:`routing <routing>`           | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``self_referencing_column_name`` | The name of the column that uniquely identifies each row (always ``_id``)          | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
-| ``settings``                     | :ref:`with_clause`                                                                 | ``OBJECT``  |
+| ``settings``                     | :ref:`sql-create-table-with`                                                       | ``OBJECT``  |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``table_catalog``                | Refers to the ``table_schema``                                                     | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
@@ -181,14 +182,15 @@ columns::
 Table settings specify configuration parameters for tables. Some settings can
 be set during Cluster runtime and others are only applied on cluster restart.
 
-This list of table settings in :ref:`with_clause` shows detailed information
-of each parameter.
+This list of table settings in :ref:`sql-create-table-with` shows detailed
+information of each parameter.
 
 Table parameters can be applied with ``CREATE TABLE`` on creation of a table.
 With ``ALTER TABLE`` they can be set on already existing tables.
 
 The following statement creates a new table and sets the refresh interval of
-shards to 500 ms and sets the shard allocation for primary shards only::
+shards to 500 ms and sets the :ref:`shard allocation <gloss-shard-allocation>`
+for primary shards only::
 
     cr> create table parameterized_table (id integer, content text)
     ... with ("refresh_interval"=500, "routing.allocation.enable"='primaries');
@@ -534,13 +536,12 @@ tables:
 ``table_partitions``
 --------------------
 
-This table can be queried to get information about all partitioned tables, Each
-partition of a table is represented as one row. The row contains the
-information table name, schema name, partition ident, and the values of the
-partition. ``values`` is a key-value object with the 'partitioned by column' as
-key(s) and the corresponding value as value(s).
-
-For further information see :ref:`partitioned_tables`.
+This table can be queried to get information about all :ref:`partitioned tables
+<partitioned-tables>`, Each partition of a table is represented as one row. The
+row contains the information table name, schema name, partition ident, and the
+values of the partition. ``values`` is a key-value object with the
+:ref:`partition column <gloss-partition-column>` (or columns) as key(s) and the
+corresponding value as value(s).
 
 .. hide:
 
@@ -563,10 +564,10 @@ For further information see :ref:`partitioned_tables`.
     cr> insert into a_partitioned_table (id, content) values (2, 'content_b');
     INSERT OK, 1 row affected (... sec)
 
-The following example shows a table where the column 'content' of table
-'a_partitioned_table' has been used to partition the table. The table has two
-partitions. The partitions are introduced when data is inserted where 'content'
-is 'content_a', and 'content_b'.::
+The following example shows a table where the column ``content`` of table
+``a_partitioned_table`` has been used to partition the table. The table has two
+partitions. The partitions are introduced when data is inserted where
+``content`` is ``content_a``, and ``content_b``.::
 
     cr> select table_name, table_schema as schema, partition_ident, "values"
     ... from information_schema.table_partitions

--- a/docs/general/occ.rst
+++ b/docs/general/occ.rst
@@ -59,9 +59,9 @@ and deletes.
 
 .. NOTE::
 
-    Optimistic concurrency control only works using the ``=`` operator,
-    checking for the exact ``_seq_no`` and ``_primary_term`` your update/delete
-    is based on.
+    Optimistic concurrency control only works using the ``=`` :ref:`operator
+    <gloss-operator>`, checking for the exact ``_seq_no`` and ``_primary_term``
+    your update or delete is based on.
 
 Optimistic update
 =================

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -330,8 +330,8 @@ CrateDB's SQL query engine enables real-time search & aggregations for online
 analytic processing (OLAP) and business intelligence (BI) with the benefit of
 the ability to scale horizontally. The use-cases of CrateDB are different than
 those of PostgreSQL, as CrateDB's specialized storage schema and query
-execution engine address different requirements (see :doc:`Clustering
-<../concepts/shared-nothing>`).
+execution engine address different requirements (see :ref:`Clustering
+<clustering>`).
 
 The listed features below cover the main differences in implementation and
 dialect between CrateDB and PostgreSQL. A detailed comparison between CrateDB's
@@ -343,7 +343,7 @@ SQL dialect and standard SQL is defined in
 
 CrateDB does not support the distinct sub-protocol that is used to serve
 ``COPY`` operations and provides another implementation for transferring bulk
-data using the :ref:`copy_from` and :ref:`copy_to` statements.
+data using the :ref:`sql-copy-from` and :ref:`sql-copy-to` statements.
 
 Objects
 -------
@@ -387,10 +387,10 @@ is not supported.
 Text search functions and operators
 -----------------------------------
 
-The functions and operators provided by PostgreSQL for full-text search (see
-`PostgreSQL Fulltext Search`_) are not compatible with those provided by
-CrateDB. For more information about the built-in full-text search in CrateDB
-refer to :ref:`sql_dql_fulltext_search`.
+The functions and :ref:`operators <gloss-operator>` provided by PostgreSQL for
+full-text search (see `PostgreSQL Fulltext Search`_) are not compatible with
+those provided by CrateDB. For more information about the built-in full-text
+search in CrateDB refer to :ref:`sql_dql_fulltext_search`.
 
 If you are missing features, functions or dialect improvements and have a great
 use case for it, let us know on `Github`_. We're always improving and extending

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _sql_reference_expression:
+
+.. _sql-value-expressions:
 
 =================
 Value expressions
@@ -13,6 +14,9 @@ They can be used in many contexts of many statements.
 
 .. contents::
    :local:
+
+
+.. _sql-literal-value:
 
 Literal value
 =============
@@ -30,6 +34,9 @@ Different types have different notations. The simplest forms are:
 
     - :ref:`sql_lexical`
     - :ref:`data-types`
+
+
+.. _sql-column-reference:
 
 Column reference
 ================
@@ -51,7 +58,8 @@ multiple alias or table definitions::
 
     :ref:`sql_lexical`
 
-.. _expression-parameter:
+
+.. _sql-parameter-reference:
 
 Parameter reference
 ===================
@@ -66,10 +74,14 @@ Parameter references can either be unnumbered or numbered:
 
 - ``$n`` as numbered placeholder: ``select * from t where x = $1 or x = $2``
 
+
+.. _sql-operator-invocation:
+
 Operator invocation
 ===================
 
-There are two different types of operators in CrateDB:
+An :ref:`operator <gloss-operator>` can be invoked as a value expression in two
+ways:
 
 - Binary: ``expression operator expression``
 
@@ -77,16 +89,16 @@ There are two different types of operators in CrateDB:
 
 .. SEEALSO::
 
-    - :ref:`sql_dql_where_clause`
-    - :ref:`arithmetic`
+    :ref:`comparison-operators`
 
-.. _sql_expressions_subscript:
+.. _sql-subscripts:
 
-Subscript expression
-====================
+Subscripts
+==========
 
-A subscript expression is an expression which contains a subscript operator
-(``[ ]``). It can be used to access a sub value of a composite type value.
+A subscript expression is an expression which contains a subscript
+:ref:`operator <gloss-operator>` (``[ ]``). It can be used to access a sub
+value of a composite type value.
 
 Array subscript
 ---------------
@@ -103,7 +115,8 @@ the array which should be retrieved.
 
     :ref:`sql_dql_object_arrays`
 
-.. _object-subscript:
+
+.. _sql-object-subscript:
 
 Object subscript
 ----------------
@@ -120,13 +133,14 @@ should be retrieved.
 
     :ref:`sql_dql_objects`
 
-.. _record-subscript:
+
+.. _sql-record-subscript:
 
 Record subscript
 ----------------
 
 Record subscript retrieves the value of a field within a record or object. This
-is similar to :ref:`object subscripts <object-subscript>`.
+is similar to :ref:`object subscripts <sql-object-subscript>`.
 
 
 Synopsis:
@@ -152,6 +166,8 @@ Example::
 an identifier that must refer to a field of the record.
 
 
+.. _sql-function-call:
+
 Function call
 =============
 
@@ -166,6 +182,9 @@ parentheses::
     - :ref:`scalar`
     - :ref:`aggregation`
     - :ref:`window-functions`
+
+
+.. _sql-type-cast:
 
 Type cast
 =========
@@ -183,6 +202,9 @@ this returns ``null`` if a value cannot be converted to the given type::
 
     :ref:`data-types`
 
+
+.. _sql-object-constructor:
+
 Object constructor
 ==================
 
@@ -197,6 +219,9 @@ enclosed in curly brackets::
 .. SEEALSO::
 
     :ref:`data-type-object-literals`
+
+
+.. _sql-array-constructor:
 
 Array constructor
 =================
@@ -232,6 +257,9 @@ Example::
 .. NOTE::
 
     Array constructor only supports subqueries returning a single column.
+
+
+.. _sql-scalar-subquery:
 
 Scalar subquery
 ===============

--- a/docs/sql/statements/alter-cluster.rst
+++ b/docs/sql/statements/alter-cluster.rst
@@ -17,7 +17,7 @@ Synopsis
 
 ::
 
-    ALTER CLUSTER 
+    ALTER CLUSTER
       { REROUTE RETRY FAILED
       | DECOMMISSION <nodeId | nodeName>
       | SWAP TABLE source TO target [ WITH ( expr = expr [ , ... ] ) ]
@@ -36,9 +36,11 @@ Arguments
 ``REROUTE RETRY FAILED``
 ------------------------
 
-The index setting :ref:`allocation.max_retries <allocation_max_retries>`
-indicates the maximum of attempts to allocate a shard on a node. If this limit
-is reached it leaves the shard unallocated.
+The index setting :ref:`routing.allocation.max_retries
+<sql-create-table-routing-allocation-max-retries>` indicates the maximum of
+attempts to :ref:`allocate a shard <gloss-shard-allocation>` on a node. If this
+limit is reached it leaves the shard unallocated.
+
 This command allows the enforcement to retry the allocation of shards which
 failed to allocate. See :ref:`ddl_reroute_shards` to get convenient use-cases.
 

--- a/docs/sql/statements/alter-table.rst
+++ b/docs/sql/statements/alter-table.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _ref-alter-table:
+
+.. _sql-alter-table:
 
 ===============
 ``ALTER TABLE``
@@ -11,6 +12,9 @@ Alter an existing table.
 
 .. contents::
    :local:
+
+
+.. _sql-alter-table-synopsis:
 
 Synopsis
 ========
@@ -38,12 +42,15 @@ where ``column_constraint`` is::
     }
 
 
+.. _sql-alter-table-description:
+
 Description
 ===========
 
 ``ALTER TABLE`` can be used to modify an existing table definition. It provides
-options to add columns, modify constraints, enabling or disabling
-table parameters and allows to execute a shard reroute allocation.
+options to add columns, modify constraints, enabling or disabling table
+parameters and allows to execute a shard  :ref:`reroute allocation
+<sql-alter-table-reroute>`.
 
 Use the ``BLOB`` keyword in order to alter a blob table (see
 :ref:`blob_support`). Blob tables cannot have custom columns which means that
@@ -54,49 +61,78 @@ table **only** and not for any possible existing partitions. So these changes
 will only be applied to new partitions. The ``ONLY`` keyword cannot be used
 together with a `PARTITION`_ clause.
 
-See the CREATE TABLE :ref:`with_clause` for a list of available parameters.
+See the CREATE TABLE :ref:`sql-create-table-with` for a list of available
+parameters.
 
 :table_ident:
   The name (optionally schema-qualified) of the table to alter.
 
-.. _ref-alter-table-partition-clause:
+
+.. _sql-alter-table-clauses:
 
 Clauses
 =======
 
+
+.. _sql-alter-table-partition:
+
 ``PARTITION``
 -------------
 
-If the table is partitioned this clause can be used to alter only a single
-partition.
+.. EDITORIAL NOTE
+   ##############
 
-.. NOTE::
+   Multiple files (in this directory) use the same standard text for
+   documenting the ``PARTITION`` clause. (Minor verb changes are made to
+   accomodate the specifics of the parent statement.)
 
-   BLOB tables cannot be partitioned and hence this clause cannot be used.
+   For consistency, if you make changes here, please be sure to make a
+   corresponding change to the other files.
 
-This clause identifies a single partition. It takes one or more partition
-columns with a value each to identify the partition to alter.
+If the table is :ref:`partitioned <partitioned-tables>`, the optional
+``PARTITION`` clause can be used to alter one partition exclusively.
 
 ::
 
     [ PARTITION ( partition_column = value [ , ... ] ) ]
 
 :partition_column:
-  The name of the column by which the table is partitioned.
-
-  All partition columns that were part of the :ref:`partitioned_by_clause` of
-  the :ref:`ref-create-table` statement must be specified.
+  One of the column names used for table partitioning.
 
 :value:
-  The columns value.
+  The respective column value.
 
-.. SEEALSO:: :ref:`Alter Partitioned Tables <partitioned_tables_alter>`
+All :ref:`partition columns <gloss-partition-column>` (specified by the
+:ref:`sql-create-table-partitioned-by` clause) must be listed inside the
+parentheses along with their respective values using the ``partition_column =
+value`` syntax (separated by commas).
 
+Because each partition corresponds to a unique set of :ref:`partition column
+<gloss-partition-column>` row values, this clause uniquely identifies a single
+partition to alter.
+
+.. TIP::
+
+    The :ref:`ref-show-create-table` statement will show you the complete list
+    of partition columns specified by the
+    :ref:`sql-create-table-partitioned-by` clause.
+
+.. NOTE::
+
+   BLOB tables cannot be partitioned and hence this clause cannot be used.
+
+.. SEEALSO::
+
+    :ref:`Partitioned tables: Alter <partitioned-alter>`
+
+
+.. _sql-alter-table-arguments:
 
 Arguments
 =========
 
-.. _alter_table_set_reset:
+
+.. _sql-alter-table-set-reset:
 
 ``SET/RESET``
 -------------
@@ -108,26 +144,33 @@ Using ``RESET`` will reset the parameter to its default value.
   The name of the parameter that is set to a new value or its default.
 
 The supported parameters are listed in the :ref:`CREATE TABLE WITH CLAUSE
-<with_clause>` documentation. In addition to those, for dynamically
-changing the number of allocated shards, the parameter ``number_of_shards``
-can be used. For more more info on that, see :ref:`alter_change_number_of_shard`.
+<sql-create-table-with>` documentation. In addition to those, for dynamically
+changing the number of :ref:`allocated shards <gloss-shard-allocation>`, the
+parameter ``number_of_shards`` can be used. For more more info on that, see
+:ref:`alter-shard-number`.
 
+
+.. _sql-alter-table-add-column:
 
 ``ADD COLUMN``
 --------------
 
 Can be used to add an additional column to a table. While columns can be added
-at any time, adding a new :ref:`generated column <ref-generated-columns>` is
-only possible if the table is empty. In addition, adding a base column with
-:ref:`ref-default-clause` is not supported. It is possible to define a CHECK
-constraint with the restriction that only the column being added may be used
-in the boolean expression.
+at any time, adding a new :ref:`generated column
+<sql-create-table-generated-columns>` is only possible if the table is empty.
+In addition, adding a base column with :ref:`sql-create-table-default-clause`
+is not supported. It is possible to define a CHECK constraint with the
+restriction that only the column being added may be used in the boolean
+expression.
 
 :data_type:
   Data type of the column which should be added.
 
 :column_name:
   Name of the column which should be added.
+
+
+.. _sql-alter-table-open-close:
 
 ``OPEN/CLOSE``
 --------------
@@ -138,7 +181,8 @@ partitions will not produce an exception, but will have no effect. Similarly,
 like ``SELECT`` and ``INSERT`` on partitioned will exclude closed partitions and
 continue working.
 
-.. _alter_table_rename:
+
+.. _sql-alter-table-rename-to:
 
 ``RENAME TO``
 -------------
@@ -146,23 +190,24 @@ continue working.
 Can be used to rename a table, while maintaining its schema and data. During
 this operation the shards of the table will become temporarily unavailable.
 
-.. _alter_table_reroute:
+
+.. _sql-alter-table-reroute:
 
 ``REROUTE``
 -----------
 
 The ``REROUTE`` command provides various options to manually control the
-allocation of shards. It allows the enforcement of explicit allocations,
-cancellations and the moving of shards between nodes in a cluster. See
-:ref:`ddl_reroute_shards` to get the convenient use-cases.
+:ref:`allocation of shards <gloss-shard-allocation>`. It allows the enforcement
+of explicit allocations, cancellations and the moving of shards between nodes
+in a cluster. See :ref:`ddl_reroute_shards` to get the convenient use-cases.
 
 The rowcount defines if the reroute or allocation process of a shard was
 acknowledged or rejected.
 
 .. NOTE::
 
-   Partitioned tables require a :ref:`Partition Clause <ref-alter-table-partition-clause>`
-   in order to specify a unique ``shard_id``.
+    Tables require a :ref:`sql-alter-table-partition` clause in order to
+    specify a unique ``shard_id``.
 
 ::
 
@@ -216,6 +261,6 @@ where ``reroute_option`` is::
   error out.
 
 **CANCEL**
-  This cancels the allocation/recovery of a ``shard_id`` of a ``table_ident``
-  on a given ``node``. The ``allow_primary`` flag indicates if it is allowed to
-  cancel the allocation of a primary shard.
+  This cancels the allocation or :ref:`recovery <gloss-shard-recovery>` of a
+  ``shard_id`` of a ``table_ident`` on a given ``node``. The ``allow_primary``
+  flag indicates if it is allowed to cancel the allocation of a primary shard.

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _copy_to:
+
+.. _sql-copy-to:
 
 ===========
 ``COPY TO``
@@ -12,6 +13,9 @@ Export table contents to files on CrateDB node machines.
 .. contents::
    :local:
 
+
+.. _sql-copy-to-synopsis:
+
 Synopsis
 ========
 
@@ -22,6 +26,9 @@ Synopsis
                      [ WHERE condition ]
                      TO DIRECTORY output_uri
                      [ WITH ( copy_parameter [= value] [, ... ] ) ]
+
+
+.. _sql-copy-to-description:
 
 Description
 ===========
@@ -46,6 +53,9 @@ Here's an example:
    Currently only user tables can be exported. System tables like ``sys.nodes``
    and blob tables don't work with the ``COPY TO`` statement.
 
+
+.. _sql-copy-to-parameters:
+
 Parameters
 ==========
 
@@ -60,91 +70,147 @@ Parameters
    Declaring columns changes the output to JSON list format, which is
    currently not supported by the COPY FROM statement.
 
-Clauses
--------
 
-``WHERE``
-.........
-
-``WHERE`` clauses use the same syntax as ``SELECT`` statements, allowing partial
-exports. (see :ref:`sql_dql_where_clause` for more information).
-
-Output URI
-==========
-
-The ``output_uri`` can be any expression evaluating to a string.
-
-The resulting string should be a valid URI of one of the supporting schemes:
-
- * ``file://``
- * ``s3://[<accesskey>:<secretkey>@]<bucketname>/<path>``
-
-If no scheme is given (e.g.: '/path/to/dir') the default uri-scheme ``file://``
-will be used.
-
-.. NOTE::
-
-    If you are using Microsoft Windows, you must include the drive letter in
-    the file URI.
-
-    For example, the above file URI should instead be written as
-    ``file:///C://tmp/import_data/quotes.json``.
-
-    Consult the `Windows documentation`_ for more information.
-
-.. TIP::
-
-    If you are running CrateDB inside a container (e.g., you are running
-    CrateDB on Docker) the file URI must point to a file inside the container.
-
-    You may have to configure a new `Docker volume`_ to accomplish this.
-
-.. NOTE::
-
-   A ``secretkey`` provided by Amazon Web Service can contain characters such
-   as '/', '+' or '='. Such characters must be URI encoded. The same encoding
-   as in :ref:`copy_from_s3` applies.
-
-   Additionally, versions prior to 0.51.x use HTTP for connections to S3. Since
-   0.51.x these connections are using the HTTPS protocol. Please make sure you
-   update your firewall rules to allow outgoing connections on port ``443``.
+.. _sql-copy-to-clauses:
 
 Clauses
 =======
 
+
+.. _sql-copy-to-partition:
+
 ``PARTITION``
 -------------
 
-If the table is partitioned this clause can be used to only export data from a
-specific partition.
+.. EDITORIAL NOTE
+   ##############
 
-The exported data doesn't contain the partition columns or values as they are
-not part of the partitioned tables.
+   Multiple files (in this directory) use the same standard text for
+   documenting the ``PARTITION`` clause. (Minor verb changes are made to
+   accomodate the specifics of the parent statement.)
+
+   For consistency, if you make changes here, please be sure to make a
+   corresponding change to the other files.
+
+If the table is :ref:`partitioned <partitioned-tables>`, the optional
+``PARTITION`` clause can be used to export data from a one partition
+exclusively.
 
 ::
 
     [ PARTITION ( partition_column = value [ , ... ] ) ]
 
 :partition_column:
-  The name of the column by which the table is partitioned. All
-  partition columns that were part of the :ref:`partitioned_by_clause` of the
-  :ref:`ref-create-table` statement must be specified.
+  One of the column names used for table partitioning.
 
 :value:
-  The columns value.
+  The respective column value.
 
-.. NOTE::
+All :ref:`partition columns <gloss-partition-column>` (specified by the
+:ref:`sql-create-table-partitioned-by` clause) must be listed inside the
+parentheses along with their respective values using the ``partition_column =
+value`` syntax (separated by commas).
 
-   If ``COPY TO`` is used on a partitioned table without the
-   ``PARTITION`` clause, the partition columns and values will be
-   included in the rows of the exported files. If a partition column is
-   a generated column, it will not be included even if the ``PARTITION``
-   clause is missing.
+Because each partition corresponds to a unique set of :ref:`partition column
+<gloss-partition-column>` row values, this clause uniquely identifies a single
+partition to export.
+
+.. TIP::
+
+    The :ref:`ref-show-create-table` statement will show you the complete list
+    of partition columns specified by the
+    :ref:`sql-create-table-partitioned-by` clause.
+
+.. CAUTION::
+
+    The exported data doesn't contain the partition columns or the
+    corresponding values because they are not part of the partitioned tables.
+
+    If ``COPY TO`` is used on a partitioned table without the ``PARTITION``
+    clause, the partition columns and values will be included in the rows of
+    the exported files. If a partition column is a generated column, it will
+    not be included even if the ``PARTITION`` clause is missing.
+
+
+.. _sql-copy-to-where:
+
+``WHERE``
+---------
+
+The ``WHERE`` clauses use the same syntax as ``SELECT`` statements, allowing
+partial exports. (see :ref:`sql_dql_where_clause` for more information).
+
+
+.. _sql-copy-to-to:
+
+``TO``
+------
+
+The ``TO`` clause allows you to specify an output location.
+::
+
+    TO DIRECTORY output_uri
+
+:output_uri:
+  The output URI.
+
+The output URI can be any expression that evaluates to a string. The string
+must be a valid URI that uses the ``file://`` or ``s3://`` URI scheme.
+
+For example:
+
+  - ``file:///path/to/dir``
+  - ``s3://[<accesskey>:<secretkey>@]<bucketname>/<path>``
+
+If no URI scheme is given (e.g., ``/path/to/dir``) the default scheme
+``file://`` will be used.
+
+
+.. _sql-copy-to-containers:
+
+Containers
+..........
+
+If you are running CrateDB inside a container (e.g., you are running CrateDB on
+*Docker*) the URI must point to a file inside the container.
+
+You may have to configure a new `Docker volume`_ to accomplish this.
+
+
+.. _sql-copy-to-windows:
+
+Microsoft Windows
+.................
+
+If you are using *Microsoft Windows*, you must include the drive letter in
+the file URI.
+
+For example, the above file URI should instead be written as
+``file:///C://tmp/import_data/quotes.json``.
+
+Consult the `Windows documentation`_ for more information.
+
+
+.. _sql-copy-to-aws:
+
+Amazon Web Services
+...................
+
+A ``secretkey`` provided by *Amazon Web Services* (AWS) can contain characters
+such as '/', '+' or '='. Such characters must be URI encoded. The same encoding
+as in :ref:`sql-copy-from-s3` applies.
+
+Additionally, versions prior to 0.51.x use HTTP for connections to S3. Since
+0.51.x these connections are using the HTTPS protocol. Please make sure you
+update your firewall rules to allow outgoing connections on port ``443``.
+
+
+.. _sql-copy-to-with:
 
 ``WITH``
 --------
 
-The optional WITH clause can specify parameters for the copy statement.
+The optional ``WITH`` clause can specify parameters for the copy statement.
 
 ::
 
@@ -152,7 +218,8 @@ The optional WITH clause can specify parameters for the copy statement.
 
 Possible copy_parameters are:
 
-.. _compression:
+
+.. _sql-copy-to-compression:
 
 ``compression``
 ...............
@@ -166,7 +233,8 @@ Possible values for the ``compression`` setting are:
 :gzip:
   Use gzip_ to compress the data output.
 
-.. _format:
+
+.. _sql-copy-to-format:
 
 ``format``
 ..........
@@ -179,12 +247,13 @@ Possible values for the ``format`` settings are:
   Each row in the result set is serialized as JSON object and written to
   an output file where one line contains one object. This is the default
   behavior if no columns are defined. Use this format to import with
-  :ref:`copy_from`.
+  :ref:`sql-copy-from`.
 
 :json_array:
   Each row in the result set is serialized as JSON array, storing one
   array per line in an output file. This is the default behavior if
   columns are defined.
+
 
 .. _Amazon S3: https://aws.amazon.com/s3/
 .. _Docker volume: https://docs.docker.com/storage/volumes/

--- a/docs/sql/statements/create-blob-table.rst
+++ b/docs/sql/statements/create-blob-table.rst
@@ -1,16 +1,20 @@
 .. highlight:: psql
-.. _ref-create-blob-table:
+
+.. _sql-create-blob-table:
 
 =====================
 ``CREATE BLOB TABLE``
 =====================
 
-Define a new table for storing binary large objects.
+Create a new table for storing *Binary Large OBjects* (BLOBS).
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
+
+.. _sql-create-blob-table-synopsis:
 
 Synopsis
 ========
@@ -21,22 +25,47 @@ Synopsis
     [CUSTERED [ BY (routing_column) ] INTO num_shards SHARDS ]
     [ WITH ( storage_parameter [= value] [, ... ] ) ]
 
+
+.. _sql-create-blob-table-description:
+
 Description
 ===========
 
-CREATE BLOB TABLE will create a new table for holding BLOBS. For details and
-examples see :ref:`blob_support`.
+``CREATE BLOB TABLE`` will create a new table for holding BLOBS.
 
-The CLUSTERED and WITH clauses follow the same semantics described under
-:ref:`ref_clustered_clause` and :ref:`with_clause`.
+.. SEEALSO::
 
-Additional to the storage parameter described at :ref:`with_clause`, following
-parameters are supported here:
+    :ref:`BLOB support <blob_support>`
 
-.. _ref-blobs-path:
+
+.. _sql-create-blob-table-clauses:
+
+Clauses
+=======
+
+
+.. _sql-create-blob-table-clustered:
+
+``CLUSTERED``
+-------------
+
+Follows the same syntax as the :ref:`CREATE TABLE ... CLUSTERED
+<sql-create-table-clustered>` clause.
+
+
+.. _sql-create-blob-table-with:
+
+``WITH``
+--------
+
+Follows the same syntax as the :ref:`CREATE TABLE ... WITH
+<sql-create-table-with>` clause with the following additional parameter.
+
+
+.. _sql-create-blob-table-blobs-path:
 
 ``blobs_path``
---------------
+..............
 
 Specifies a custom path for storing blob data of a blob table.
 

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -423,7 +423,7 @@ Client specific settings
 A read-only repository that points to the location of a
 :ref:`ref-create-repository-types-fs` repository via ``http``, ``https``,
 ``ftp``, ``file`` and ``jar`` urls. It only allows for
-:ref:`ref-restore-snapshot` operations.
+:ref:`sql-restore-snapshot` operations.
 
 .. rubric:: Parameters
 

--- a/docs/sql/statements/create-snapshot.rst
+++ b/docs/sql/statements/create-snapshot.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _ref-create-snapshot:
+
+.. _sql-create-snapshot:
 
 ===================
 ``CREATE SNAPSHOT``
@@ -13,6 +14,9 @@ state of the given tables and/or partitions and the cluster metadata.
 .. contents::
    :local:
 
+
+.. _sql-create-snapshot-synopsis:
+
 Synopsis
 ========
 
@@ -21,6 +25,9 @@ Synopsis
     CREATE SNAPSHOT repository_name.snapshot_name
     { TABLE ( table_ident [ PARTITION (partition_column = value [ , ... ])] [, ...] ) | ALL }
     [ WITH (snapshot_parameter [= value], [, ...]) ]
+
+
+.. _sql-create-snapshot-description:
 
 Description
 ===========
@@ -58,6 +65,9 @@ If ``ALL`` is used, every table in the cluster (except system tables, blob
 tables and information_schema tables) as well as all persistent settings and
 the full cluster metadata is included in the snapshot.
 
+
+.. _sql-create-snapshot-parameters:
+
 Parameters
 ==========
 
@@ -71,11 +81,59 @@ Parameters
   The name (optionally schema-qualified) of an existing table that is to
   be included in the snapshot.
 
-:partition_column:
-  Column name by which the table is partitioned.
+
+.. _sql-create-snapshot-clauses:
 
 Clauses
 =======
+
+
+.. _sql-create-snapshot-partition:
+
+``PARTITION``
+-------------
+
+.. EDITORIAL NOTE
+   ##############
+
+   Multiple files (in this directory) use the same standard text for
+   documenting the ``PARTITION`` clause. (Minor verb changes are made to
+   accomodate the specifics of the parent statement.)
+
+   For consistency, if you make changes here, please be sure to make a
+   corresponding change to the other files.
+
+If the table is :ref:`partitioned <partitioned-tables>`, the optional
+``PARTITION`` clause can be used to create a snapshot from one partition
+exclusively.
+
+::
+
+    [ PARTITION ( partition_column = value [ , ... ] ) ]
+
+:partition_column:
+  One of the column names used for table partitioning
+
+:value:
+  The respective column value.
+
+All :ref:`partition columns <gloss-partition-column>` (specified by the
+:ref:`sql-create-table-partitioned-by` clause) must be listed inside the
+parentheses along with their respective values using the ``partition_column =
+value`` syntax (separated by commas).
+
+Because each partition corresponds to a unique set of :ref:`partition column
+<gloss-partition-column>` row values, this clause uniquely identifies a single
+partition to snapshot.
+
+.. TIP::
+
+    The :ref:`ref-show-create-table` statement will show you the complete list
+    of partition columns specified by the
+    :ref:`sql-create-table-partitioned-by` clause.
+
+
+.. _sql-create-snapshot-with:
 
 ``WITH``
 --------

--- a/docs/sql/statements/create-table-as.rst
+++ b/docs/sql/statements/create-table-as.rst
@@ -33,7 +33,7 @@ Only the column names, types, and the output rows will be used from the
 the table creation.
 
 For further details on the default values of the optional parameters,
-see :ref:`ref-create-table`.
+see :ref:`sql-create-table`.
 
 
 Parameters

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -1,16 +1,20 @@
 .. highlight:: psql
-.. _ref-create-table:
+
+.. _sql-create-table:
 
 ================
 ``CREATE TABLE``
 ================
 
-Define a new table.
+Create a new table.
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
+
+.. _sql-create-table-synopsis:
 
 Synopsis
 ========
@@ -60,10 +64,13 @@ and ``table_constraint`` is::
            [ WITH ( analyzer = analyzer_name ) ]
     }
 
+
+.. _sql-create-table-description:
+
 Description
 ===========
 
-CREATE TABLE will create a new, initially empty table.
+``CREATE TABLE`` will create a new, initially empty table.
 
 If the ``table_ident`` does not contain a schema, the table is created in the
 ``doc`` schema. Otherwise it is created in the given schema, which is
@@ -84,10 +91,18 @@ encompass more than one column. Every column constraint can also be written as
 a table constraint; a column constraint is only a notational convenience for
 use when the constraint only affects one column.
 
+.. SEEALSO::
+
+    :ref:`sql_ddl_create`
+
+
+.. _sql-create-table-elements:
+
 Table elements
 --------------
 
-.. _ref-base-columns:
+
+.. _sql-create-table-base-columns:
 
 Base Columns
 ~~~~~~~~~~~~
@@ -100,7 +115,8 @@ Base columns are readable and writable (if the table itself is writable).
 Values for base columns are given in DML statements explicitly or omitted, in
 which case their value is null.
 
-.. _ref-default-clause:
+
+.. _sql-create-table-default-clause:
 
 Default clause
 ^^^^^^^^^^^^^^
@@ -112,7 +128,8 @@ contain an explicit value for it.
 The default clause expression is variable-free, it means that subqueries and
 cross-references to other columns are not allowed.
 
-.. _ref-generated-columns:
+
+.. _sql-create-table-generated-columns:
 
 Generated columns
 ~~~~~~~~~~~~~~~~~
@@ -130,7 +147,10 @@ The ``GENERATED ALWAYS`` part of the syntax is optional.
 
 .. SEEALSO::
 
-   For more information, see :ref:`sql-ddl-generated-columns`.
+   For more information, see :ref:`ddl-generated-columns`.
+
+
+.. _sql-create-table-table-constraints:
 
 Table constraints
 ~~~~~~~~~~~~~~~~~
@@ -140,6 +160,9 @@ to the table as a whole.
 
 For further details see :ref:`table_constraints`.
 
+
+.. _sql-create-table-column-constraints:
+
 Column constraints
 ~~~~~~~~~~~~~~~~~~
 
@@ -148,12 +171,18 @@ separately.
 
 For further details see :ref:`column_constraints`.
 
+
+.. _sql-create-table-storage-options:
+
 Storage options
 ~~~~~~~~~~~~~~~
 
 Storage options can be applied on each column of the table separately.
 
 For further details and available options see :ref:`ddl-storage`.
+
+
+.. _sql-create-table-parameters:
 
 Parameters
 ==========
@@ -175,19 +204,27 @@ Parameters
   supported. The generation expression is evaluated each time a row is
   inserted or the referenced base columns are updated.
 
+
+.. _sql-create-table-if-not-exists:
+
 ``IF NOT EXISTS``
 =================
 
 If the optional IF NOT EXISTS clause is used this statement won't do anything
 if the table exists already.
 
-.. _ref_clustered_clause:
+
+.. _sql-create-table-clustered:
 
 ``CLUSTERED``
 =============
 
 The optional CLUSTERED clause specifies how a table should be distributed
 accross a cluster.
+
+::
+
+    [ CLUSTERED [ BY (routing_column) ] INTO num_shards SHARDS ]
 
 :num_shards:
   Specifies the number of :ref:`shards <sql_ddl_sharding>` a table is stored
@@ -204,52 +241,53 @@ accross a cluster.
      minimum value to each table or partition as default.
 
 :routing_column:
-  Allows to explicitly specify a column or field on which basis rows are
-  sharded. All rows having the same value in ``routing_column`` are
-  stored in the same shard. The default is the primary key if specified,
-  otherwise the internal ``_id`` column.
+  Specify a :ref:`routing column <gloss-routing-column>` on which basis rows
+  are sharded. All rows having the same value in ``routing_column`` are stored
+  in the same shard. The default is the primary key if specified, otherwise the
+  internal ``_id`` column.
 
 .. SEEALSO::
 
     :ref:`sql_ddl_sharding`
 
 
-.. _partitioned_by_clause:
+.. _sql-create-table-partitioned-by:
 
 ``PARTITIONED BY``
 ==================
 
 The ``PARTITIONED`` clause splits the created table into separate
-:ref:`partitions <partitioned_tables>` for every distinct combination of values
-in the listed columns.
+:ref:`partitions <partitioned-tables>` for every distinct combination of row
+values in the specified :ref:`partition columns <gloss-partition-column>`.
 
 ::
 
     [ PARTITIONED BY ( column_name [ , ... ] ) ]
 
 :column_name:
-  A column from the table definition this table gets partitioned by.
-
-Several restrictions apply to columns that can be used here:
-
-* columns may not be part of :ref:`ref_clustered_clause`.
-* columns must have a :ref:`primitive type <sql_ddl_datatypes_primitives>`.
-* columns may not be inside an object array.
-* columns may not be indexed with a :ref:`sql_ddl_index_fulltext`.
-* if the table has a :ref:`primary_key_constraint` the columns in PARTITIONED
-  clause have to be part of it
-
-.. NOTE::
-
-   Columns referenced in the PARTITIONED clause cannot be altered by an
-   ``UPDATE`` statement.
-
-.. SEEALSO::
-
-    :ref:`partitioned_tables`
+  The name of a column to be used for partitioning. Multiple columns names can
+  be specified inside the parentheses and must be separated by commas.
 
 
-.. _with_clause:
+The following restrictions apply:
+
+* Partition columns may not be part of the :ref:`sql-create-table-clustered`
+  clause
+* Partition columns must only contain :ref:`primitive types
+  <sql_ddl_datatypes_primitives>`
+* Partition columns may not be inside an object array
+* Partition columns may not be indexed with a :ref:`fulltext index with
+  analyzer <sql_ddl_index_fulltext>`
+* If the table has a :ref:`primary_key_constraint` constraint, all of the
+  partition columns must be included in the primary key definition
+
+.. CAUTION::
+
+    Partition columns :ref:`cannot be altered <partitioned-update>` by an
+    ``UPDATE`` statement.
+
+
+.. _sql-create-table-with:
 
 ``WITH``
 ========
@@ -265,13 +303,18 @@ The optional WITH clause can specify parameters for tables.
 
 .. NOTE::
 
-   Some parameters are nested, and therefore need to be wrapped in double quotes in order to be set:
-   ``WITH ("allocation.max_retries" = 5)``.
-   Nested parameters are those that contain a ``.`` between parameter names, e.g. ``write.wait_for_active_shards``.
+   Some parameters are nested, and therefore need to be wrapped in double
+   quotes in order to be set. For example::
+
+       WITH ("allocation.max_retries" = 5)
+
+   Nested parameters are those that contain a ``.`` between parameter names
+   (e.g. ``write.wait_for_active_shards``).
 
 Available parameters are:
 
-.. _number_of_replicas:
+
+.. _sql-create-table-number-of-replicas:
 
 ``number_of_replicas``
 ----------------------
@@ -295,7 +338,8 @@ The number of replicas is defined like this::
 
 For further details and examples see :ref:`replication`.
 
-.. _sql_ref_number_of_routing_shards:
+
+.. _sql-create-table-number-of-routing-shards:
 
 ``number_of_routing_shards``
 ----------------------------
@@ -304,10 +348,10 @@ This number specifies the hashing space that is used internally to distribute
 documents across shards.
 
 This is an optional setting that enables users to later on increase the number
-of shards using :ref:`ref-alter-table`.
+of shards using :ref:`sql-alter-table`.
 
 
-.. _sql_ref_refresh_interval:
+.. _sql-create-table-refresh-interval:
 
 ``refresh_interval``
 --------------------
@@ -326,9 +370,12 @@ to 1000 milliseconds.
    visible to subsequent reads. Only the periodic refresh is disabled. There
    are other internal factors that might trigger a refresh.
 
-For further details see :ref:`refresh_data` or :ref:`sql_ref_refresh`.
+For further details see :ref:`refresh_data` or :ref:`sql-refresh`.
 
-.. _sql_ref_write_wait_for_active_shards:
+
+.. _sql-create-table-write-wait:
+
+.. _sql-create-table-write-wait-for-active-shards:
 
 ``write.wait_for_active_shards``
 --------------------------------
@@ -359,9 +406,9 @@ system eventually, but in case a node holding the primary copy has a system
 failure, the replica copy couldn't be promoted automatically as it would lead
 to data loss since the system is aware that the replica shard didn't receive
 all writes. In such a scenario, :ref:`ALTER TABLE .. REROUTE PROMOTE REPLICA
-<alter-table-reroute-promote-replica>` can be used to force the allocation of a
-stale replica copy to at least recover the data that is available in the stale
-replica copy.
+<alter-table-reroute-promote-replica>` can be used to force the
+:ref:`allocation <gloss-shard-recovery>` of a stale replica copy to at least
+recover the data that is available in the stale replica copy.
 
 Say you've a 3 node cluster and a table with 1 configured replica. With
 ``write.wait_for_active_shards=1`` and ``number_of_replicas=1`` a node in the
@@ -374,7 +421,9 @@ again or the write operations would timeout in case the replication is not fast
 enough.
 
 
-.. _table-settings-blocks.read_only:
+.. _sql-create-table-blocks:
+
+.. _sql-create-table-blocks-read-only:
 
 ``blocks.read_only``
 --------------------
@@ -385,7 +434,8 @@ Allows to have a read only table.
   Table is read only if value set to ``true``. Allows writes and table
   settings changes if set to ``false``.
 
-.. _table-settings-blocks.read_only_allow_delete:
+
+.. _sql-create-table-blocks-read-only-allow-delete:
 
 ``blocks.read_only_allow_delete``
 ---------------------------------
@@ -406,6 +456,9 @@ Allows to have a read only table that additionally can be deleted.
 
     :ref:`Disk-based shard allocation <cluster.routing.allocation.disk>`
 
+
+.. _sql-create-table-blocks-read:
+
 ``blocks.read``
 ---------------
 
@@ -415,7 +468,8 @@ Allows to have a read only table that additionally can be deleted.
   Set to ``true`` to disable all read operations for a table, otherwise
   set ``false``.
 
-.. _table-settings-blocks.write:
+
+.. _sql-create-table-blocks-write:
 
 ``blocks.write``
 ----------------
@@ -426,6 +480,9 @@ Allows to have a read only table that additionally can be deleted.
   Set to ``true`` to disable all write operations and table settings
   modifications, otherwise set ``false``.
 
+
+.. _sql-create-table-blocks-metadata:
+
 ``blocks.metadata``
 -------------------
 
@@ -435,7 +492,10 @@ Allows to have a read only table that additionally can be deleted.
   Disables the table settings modifications if set to ``true``, if set
   to ``false`` — table settings modifications are enabled.
 
-.. _table_parameter.soft_deletes.enabled:
+
+.. _sql-create-table-soft-deletes:
+
+.. _sql-create-table-soft-deletes-enabled:
 
 ``soft_deletes.enabled``
 ------------------------
@@ -443,7 +503,8 @@ Allows to have a read only table that additionally can be deleted.
 Indicates whether soft deletes are enabled or disabled.
 
 Soft deletes allow CrateDB to preserve recent deletions within the Lucene
-index. This information is used for shard recovery.
+index. This information is used for :ref:`shard recovery
+<gloss-shard-recovery>`.
 
 Before the introduction of soft deletes, CrateDB had to retain the information
 in the :ref:`Translog <durability>`. Using soft deletes uses less storage than
@@ -454,12 +515,11 @@ cannot be changed using ``ALTER TABLE``.
 
 Soft deletes will become mandatory in CrateDB 5.0.
 
-
 :value:
   Defaults to ``true``. Set to ``false`` to disable soft deletes.
 
 
-.. _table_parameter.soft_deletes.retention_lease.period:
+.. _sql-create-table-soft-deletes-retention-lease-period:
 
 ``soft_deletes.retention_lease.period``
 ---------------------------------------
@@ -498,7 +558,7 @@ has expired, CrateDB will fall back to copying the whole index since it can no
 longer replay the missing history.
 
 
-.. _table_parameter.codec:
+.. _sql-create-table-codec:
 
 ``codec``
 ---------
@@ -510,7 +570,10 @@ the expense of slower column value lookups.
 :values:
   ``default`` or ``best_compression``
 
-.. _table_parameter.store_type:
+
+.. _sql-create-table-store:
+
+.. _sql-create-table-store-type:
 
 ``store.type``
 --------------
@@ -550,6 +613,11 @@ and accessed on disk. The following storage types are supported:
 It is possible to restrict the use of the ``mmapfs`` and ``hybridfs`` store
 type via the :ref:`node.store.allow_mmap <node.store_allow_mmap>` node setting.
 
+
+.. _sql-create-table-mapping:
+
+.. _sql-create-table-mapping-total-fields-limit:
+
 ``mapping.total_fields.limit``
 ------------------------------
 
@@ -559,6 +627,11 @@ Sets the maximum number of columns that is allowed for a table. Default is ``100
   Maximum amount of fields in the Lucene index mapping. This includes
   both the user facing mapping (columns) and internal fields.
 
+
+.. _sql-create-table-translog:
+
+.. _sql-create-table-translog-flush-threshold-size:
+
 ``translog.flush_threshold_size``
 ---------------------------------
 
@@ -566,6 +639,9 @@ Sets size of transaction log prior to flushing.
 
 :value:
   Size (bytes) of translog.
+
+
+.. _sql-create-table-translog-disable-flush:
 
 ``translog.disable_flush``
 --------------------------
@@ -579,6 +655,9 @@ Sets size of transaction log prior to flushing.
 
    It is recommended to use ``disable_flush`` only for short periods of time.
 
+
+.. _sql-create-table-translog-interval:
+
 ``translog.interval``
 ---------------------
 
@@ -587,7 +666,8 @@ Sets frequency of flush necessity check.
 :value:
   Frequency in milliseconds.
 
-.. _translog_sync_interval:
+
+.. _sql-create-table-translog-sync-interval:
 
 ``translog.sync_interval``
 --------------------------
@@ -596,36 +676,49 @@ How often the translog is fsynced to disk. Defaults to 5s.
 When setting this interval, please keep in mind that changes logged
 during this interval and not synced to disk may get lost in case of a
 failure. This setting only takes effect if :ref:`translog.durability
-<translog_durability>` is set to ``ASYNC``.
+<sql-create-table-translog-durability>` is set to ``ASYNC``.
 
 :value:
   Interval in milliseconds.
 
-.. _translog_durability:
+
+.. _sql-create-table-translog-durability:
 
 ``translog.durability``
 -----------------------
 
-If set to ``ASYNC`` the translog gets flushed to disk in the background
-every :ref:`translog.sync_interval <translog_sync_interval>`. If set to
-``REQUEST`` the flush happens after every operation.
+If set to ``ASYNC`` the translog gets flushed to disk in the background every
+:ref:`translog.sync_interval <sql-create-table-translog-sync-interval>`. If set
+to ``REQUEST`` the flush happens after every operation.
 
 :value:
   ``REQUEST`` (default), ``ASYNC``
+
+
+.. _sql-create-table-routing:
+
+.. _sql-create-table-routing-allocation:
+
+.. _sql-create-table-routing-allocation.total-shards-per-node:
 
 ``routing.allocation.total_shards_per_node``
 --------------------------------------------
 
 Controls the total number of shards (replicas and primaries) allowed to be
-allocated on a single node. Defaults to unbounded (-1).
+:ref:`allocated <gloss-shard-allocation>` on a single node. Defaults to
+unbounded (-1).
 
 :value:
   Number of shards per node.
 
+
+.. _sql-create-table-routing-allocation-enable:
+
 ``routing.allocation.enable``
 -----------------------------
 
-Controls shard allocation for a specific table. Can be set to:
+Controls shard :ref:`allocation <gloss-shard-allocation>` for a specific table.
+Can be set to:
 
 :all:
   Allows shard allocation for all shards. (Default)
@@ -639,62 +732,76 @@ Controls shard allocation for a specific table. Can be set to:
 :none:
   No shard allocation allowed.
 
-.. _allocation_max_retries:
+
+.. _sql-create-table-routing-allocation-max-retries:
 
 ``routing.allocation.max_retries``
 ----------------------------------
 
-Defines the number of attempts to allocate a shard before giving up and leaving
-the shard unallocated.
+Defines the number of attempts to :ref:`allocate <gloss-shard-allocation>` a
+shard before giving up and leaving the shard unallocated.
 
 :value:
   Number of retries to allocate a shard. Defaults to 5.
+
+
+.. _sql-create-table-routing-allocation-include:
 
 ``routing.allocation.include.{attribute}``
 ------------------------------------------
 
 Assign the table to a node whose ``{attribute}`` has at least one of the
 comma-separated values.
-See :ref:`ddl_shard_allocation` for details.
+
+.. SEEALSO::
+
+    :ref:`ddl_shard_allocation`
+
+
+.. _sql-create-table-routing-allocation-require:
 
 ``routing.allocation.require.{attribute}``
 ------------------------------------------
 
 Assign the table to a node whose ``{attribute}`` has all of the comma-separated
 values.
-See :ref:`ddl_shard_allocation` for details.
+
+.. SEEALSO::
+
+    :ref:`ddl_shard_allocation`
+
+
+.. _sql-create-table-routing-allocation-exclude:
 
 ``routing.allocation.exclude.{attribute}``
 ------------------------------------------
 
-Assign the table to a node whose ``{attribute}`` has none of the comma-separated
-values.
-See :ref:`ddl_shard_allocation` for details.
+Assign the table to a node whose ``{attribute}`` has none of the
+comma-separated values.
 
-``warming.enable``
-------------------
+.. SEEALSO::
 
-``disable``/``enable`` table warming.
+    :ref:`ddl_shard_allocation`
 
-Table warming allows to run registered queries to warm up the table before it
-is available.
 
-Enabled by default.
+.. _sql-create-table-unassigned:
 
-:value:
-  `true`` to enable warming up, otherwise ``false``
+.. _sql-create-table-unassigned.node-left:
+
+.. _sql-create-table-unassigned.node-left-delayed-timeout:
 
 ``unassigned.node_left.delayed_timeout``
 ----------------------------------------
 
-Delay the allocation of replica shards which have become unassigned because a
-node has left. It defaults to ``1m`` to give a node time to restart
-completely (which can take some time when the node has lots of shards).
-Setting the timeout to ``0`` will start allocation immediately. This setting
-can be changed on runtime in order to increase/decrease the delayed
-allocation if needed.
+Delay the :ref:`allocation <gloss-shard-allocation>` of replica shards which
+have become unassigned because a node has left. It defaults to ``1m`` to give a
+node time to restart completely (which can take some time when the node has
+lots of shards). Setting the timeout to ``0`` will start allocation
+immediately. This setting can be changed on runtime in order to
+increase/decrease the delayed allocation if needed.
 
-.. _sql_ref_column_policy:
+
+.. _sql-create-table-column-policy:
 
 ``column_policy``
 -----------------
@@ -718,11 +825,17 @@ The column policy is defined like this::
 
 For further details and examples see :ref:`column_policy` or :ref:`config`.
 
+
+.. _sql-create-table-max-ngram-diff:
+
 ``max_ngram_diff``
 ------------------
 
 Specifies the maximum difference between max_ngram and min_ngram when using
 the NGramTokenizer or the NGramTokenFilter. The default is 1.
+
+
+.. _sql-create-table-max-shingle-diff:
 
 ``max_shingle_diff``
 --------------------
@@ -731,7 +844,11 @@ Specifies the maximum difference between min_shingle_size and max_shingle_size
 when using the ShingleTokenFilter. The default is 3.
 
 
-.. _merge.scheduler.max_thread_count:
+.. _sql-create-table-merge:
+
+.. _sql-create-table-merge-scheduler:
+
+.. _sql-create-table-merge-scheduler-max-thread-count:
 
 ``merge.scheduler.max_thread_count``
 ------------------------------------

--- a/docs/sql/statements/optimize.rst
+++ b/docs/sql/statements/optimize.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _sql_ref_optimize:
+
+.. _sql-optimize:
 
 ============
 ``OPTIMIZE``
@@ -12,13 +13,19 @@ Optimize one or more tables explicitly.
 .. contents::
    :local:
 
+
+.. _sql-optimize-synopsis:
+
 Synopsis
 ========
 
 ::
 
-    OPTIMIZE TABLE table_ident [ PARTITION (partition_column=value [ , ... ]) ] [, ...] 
+    OPTIMIZE TABLE table_ident [ PARTITION (partition_column=value [ , ... ]) ] [, ...]
     [ WITH ( optimization_parameter [= value] [, ... ] ) ]
+
+
+.. _sql-optimize-description:
 
 Description
 ===========
@@ -31,19 +38,23 @@ the connection to CrateDB is lost, the request will continue in the background,
 and any new requests will block until the previous optimization is complete.
 
 The ``PARTITION`` clause can be used to only optimize specific partitions of a
-partitioned table. All columns by which a table is partitioned are required.
+partitioned table. Specified values for all :ref:`partition columns
+<gloss-partition-column>` are required.
 
 In case the ``PARTITION`` clause is omitted all open partitions will be
 optimized. Closed partitions are not optimized.
 For performance reasons doing that should be avoided if possible.
 
-See :ref:`partitioned_tables` for more information on partitioned tables.
+See :ref:`partitioned-tables` for more information on partitioned tables.
 
 For further information see :ref:`optimize`.
 
 .. NOTE::
 
-    System tables cannot be optimized
+    System tables cannot be optimized.
+
+
+.. _sql-optimize-parameters:
 
 Parameters
 ==========
@@ -52,27 +63,59 @@ Parameters
   The name (optionally schema-qualified) of an existing table that is to
   be optimized.
 
-:partition_column:
-  Column name by which the table is partitioned.
+
+.. _sql-optimize-clauses:
 
 Clauses
 =======
 
+
+.. _sql-optimize-partition:
+
 ``PARTITION``
 -------------
+
+.. EDITORIAL NOTE
+   ##############
+
+   Multiple files (in this directory) use the same standard text for
+   documenting the ``PARTITION`` clause. (Minor verb changes are made to
+   accomodate the specifics of the parent statement.)
+
+   For consistency, if you make changes here, please be sure to make a
+   corresponding change to the other files.
+
+If the table is :ref:`partitioned <partitioned-tables>`, the optional
+``PARTITION`` clause can be used to optimize one partition exclusively.
 
 ::
 
     [ PARTITION ( partition_column = value [ , ... ] ) ]
 
-:partition_column:
-  The name of the column by which the table is partitioned.
 
-  All partition columns that were part of the :ref:`partitioned_by_clause` of
-  the :ref:`ref-create-table` statement must be specified.
+:partition_column:
+  One of the column names used for table partitioning.
 
 :value:
-  The columns value.
+  The respective column value.
+
+All :ref:`partition columns <gloss-partition-column>` (specified by the
+:ref:`sql-create-table-partitioned-by` clause) must be listed inside the
+parentheses along with their respective values using the ``partition_column =
+value`` syntax (separated by commas).
+
+Because each partition corresponds to a unique set of :ref:`partition column
+<gloss-partition-column>` row values, this clause uniquely identifies a single
+partition to optimize.
+
+.. TIP::
+
+    The :ref:`ref-show-create-table` statement will show you the complete list
+    of partition columns specified by the
+    :ref:`sql-create-table-partitioned-by` clause.
+
+
+.. _sql-optimize-with:
 
 ``WITH``
 --------

--- a/docs/sql/statements/refresh.rst
+++ b/docs/sql/statements/refresh.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _sql_ref_refresh:
+
+.. _sql-refresh:
 
 ===========
 ``REFRESH``
@@ -12,12 +13,18 @@ Refresh one or more tables explicitly.
 .. contents::
    :local:
 
+
+.. _sql-refresh-synopsis:
+
 Synopsis
 ========
 
 ::
 
     REFRESH TABLE (table_ident [ PARTITION (partition_column=value [ , ... ])] [, ...] )
+
+
+.. _sql-refresh-description:
 
 Description
 ===========
@@ -27,19 +34,21 @@ to that table visible to subsequent commands.
 
 The ``PARTITION`` clause can be used to refresh specific partitions of a
 partitioned table instead of all partitions. The ``PARTITION`` clause requires
-all partitioned columns with the values that identify the partition as
+a list of all :ref:`partition columns <gloss-partitioned-column>` as an
 argument.
 
 In case the ``PARTITION`` clause is omitted all open partitions will be
 refreshed. Closed partitions are not refreshed.
 
-See :ref:`partitioned_tables` for more information on partitioned tables.
+.. SEEALSO::
 
+    :ref:`partitioned-tables`
 
 For performance reasons, refreshing tables or partitions should be avoided as
 it is an expensive operation. By default CrateDB periodically refreshes the
-tables anyway. See :ref:`refresh_data` and :ref:`sql_ref_refresh_interval` for
-more information about the periodic refreshes.
+tables anyway. See :ref:`refresh_data` and
+:ref:`sql-create-table-refresh-interval` for more information about the
+periodic refreshes.
 
 Without an explicit ``REFRESH``, other statements like ``UPDATE``, ``DELETE``
 or ``SELECT`` won't see data until the periodic refresh happens.
@@ -74,8 +83,9 @@ These kind of filters will result in a primary key lookup. You can use the
     EXPLAIN 1 row in set (... sec)
 
 
-This lists a ``Get`` operator, which is the internal operator name for a
-primary key lookup. Compare this with the following output::
+This lists a ``Get`` :ref:`operator <gloss-operator>`, which is the internal
+operator name for a primary key lookup. Compare this with the following
+output::
 
     cr> EXPLAIN SELECT * FROM pk_demo WHERE id > 1;
     +----------------------------------------+
@@ -89,13 +99,13 @@ primary key lookup. Compare this with the following output::
 The filter changed to ``id > 1``, in this case CrateDB can no longer use a
 primary key lookup and the used operator changed to a ``Collect`` operator.
 
-
 To avoid the need for manual refreshes it can be useful to make use of primary
 key lookups, as they see the data even if the table hasn't been refreshed yet.
 
-
 See also :ref:`consistency`.
 
+
+.. _sql-refresh-parameters:
 
 Parameters
 ==========
@@ -104,24 +114,52 @@ Parameters
   The name (optionally schema-qualified) of an existing table that is to
   be refreshed.
 
-:partition_column:
-  Column name by which the table is partitioned.
+
+.. _sql-refresh-clauses:
 
 Clauses
 =======
 
+
+.. _sql-refresh-partition:
+
 ``PARTITION``
 -------------
+
+.. EDITORIAL NOTE
+   ##############
+
+   Multiple files (in this directory) use the same standard text for
+   documenting the ``PARTITION`` clause. (Minor verb changes are made to
+   accomodate the specifics of the parent statement.)
+
+   For consistency, if you make changes here, please be sure to make a
+   corresponding change to the other files.
+
+If the table is :ref:`partitioned <partitioned-tables>`, the optional
+``PARTITION`` clause can be used to refresh one partition exclusively.
 
 ::
 
     [ PARTITION ( partition_column = value [ , ... ] ) ]
 
 :partition_column:
-  The name of the column by which the table is partitioned.
-
-  All partition columns that were part of the :ref:`partitioned_by_clause` of
-  the :ref:`ref-create-table` statement must be specified.
+  One of the column names used for table partitioning.
 
 :value:
-  The columns value.
+  The respective column value.
+
+All :ref:`partition columns <gloss-partition-column>` (specified by the
+:ref:`sql-create-table-partitioned-by` clause) must be listed inside the
+parentheses along with their respective values using the ``partition_column =
+value`` syntax (separated by commas).
+
+Because each partition corresponds to a unique set of :ref:`partition column
+<gloss-partition-column>` row values, this clause uniquely identifies a single
+partition to refresh.
+
+.. TIP::
+
+    The :ref:`ref-show-create-table` statement will show you the complete list
+    of partition columns specified by the
+    :ref:`sql-create-table-partitioned-by` clause.

--- a/docs/sql/statements/restore-snapshot.rst
+++ b/docs/sql/statements/restore-snapshot.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _ref-restore-snapshot:
+
+.. _sql-restore-snapshot:
 
 ====================
 ``RESTORE SNAPSHOT``
@@ -12,6 +13,9 @@ Restore a snapshot into the cluster.
 .. contents::
    :local:
 
+
+.. _sql-restore-snapshot-synopsis:
+
 Synopsis
 ========
 
@@ -20,6 +24,9 @@ Synopsis
     RESTORE SNAPSHOT repository_name.snapshot_name
     { TABLE ( table_ident [ PARTITION (partition_column = value [ , ... ])] [, ...] ) | ALL }
     [ WITH (restore_parameter [= value], [, ...]) ]
+
+
+.. _sql-restore-snapshot-description:
 
 Description
 ===========
@@ -37,6 +44,9 @@ Tables that are to be restored must not exist yet.
 
 To cancel a restore operation simply drop the tables that are being restored.
 
+
+.. _sql-restore-snapshot-parameters:
+
 Parameters
 ==========
 
@@ -50,11 +60,59 @@ Parameters
   The name (optionally schema-qualified) of an existing table that is to be
   restored from the snapshot.
 
-:partition_column:
-  Column name by which the table is partitioned.
+
+.. _sql-restore-snapshot-clauses:
 
 Clauses
 =======
+
+
+.. _sql-restore-snapshot-partition:
+
+``PARTITION``
+-------------
+
+.. EDITORIAL NOTE
+   ##############
+
+   Multiple files (in this directory) use the same standard text for
+   documenting the ``PARTITION`` clause. (Minor verb changes are made to
+   accomodate the specifics of the parent statement.)
+
+   For consistency, if you make changes here, please be sure to make a
+   corresponding change to the other files.
+
+If the table is :ref:`partitioned <partitioned-tables>`, the optional
+``PARTITION`` clause can be used to restore a snapshot from one partition
+exclusively.
+
+::
+
+    [ PARTITION ( partition_column = value [ , ... ] ) ]
+
+:partition_column:
+  One of the column names used for table partitioning
+
+:value:
+  The respective column value.
+
+All :ref:`partition columns <gloss-partition-column>` (specified by the
+:ref:`sql-create-table-partitioned-by` clause) must be listed inside the
+parentheses along with their respective values using the ``partition_column =
+value`` syntax (separated by commas).
+
+Because each partition corresponds to a unique set of :ref:`partition column
+<gloss-partition-column>` row values, this clause uniquely identifies a single
+partition to restore.
+
+.. TIP::
+
+    The :ref:`ref-show-create-table` statement will show you the complete list
+    of partition columns specified by the
+    :ref:`sql-create-table-partitioned-by` clause.
+
+
+.. _sql-restore-snapshot-with:
 
 ``WITH``
 --------

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -147,7 +147,7 @@ view with an optional alias::
 
 .. SEEALSO::
 
-    :ref:`ref-create-table`
+    :ref:`sql-create-table`
 
     :ref:`ref-create-view`
 
@@ -286,11 +286,12 @@ resulting row of a group by clause.
 UNION ALL
 .........
 
-The UNION ALL operator combines the result sets of two or more SELECT
-statements. The two SELECT statements that represent the direct operands of the
-UNION ALL must produce the same number of columns, and corresponding columns
-must be of the same data types. The result of UNION ALL may contain duplicate
-rows. You can find :ref:`here <sql_union>` sample usage of UNION ALL.
+The UNION ALL :ref:`operator <gloss-operator>` combines the result sets of two
+or more SELECT statements. The two SELECT statements that represent the direct
+operands of the UNION ALL must produce the same number of columns, and
+corresponding columns must be of the same data types. The result of UNION ALL
+may contain duplicate rows. You can find :ref:`here <sql_union>` sample usage
+of UNION ALL.
 
 ::
 


### PR DESCRIPTION
parent issue: https://github.com/crate/tech-writing-domain/issues/382

this PR is going to collect changes needed to add a glossary to the reference manual

I have decided to stage this as a series of relatively-atomic commits to make the review process easier. once the PR is ready and approved, I will squash the commits down into a single commit

for the most part, changes will be limited to:

- expanding `glossary.rst`
- peppering cross-references throughout the docs that link back to the glossary

I may perform some very light copyediting while adding those cross-references. however, strictly speaking, this is beyond the scope of work. limiting edits for existing material as is necessary for the implementation of the glossary will keep the size of this work manageable
 
please see the commit messages for specific info

I am looking for two types of feedback:

- general feedback re what has been changed
- reviewing my definitions for accuracy

I will do my best to define terms as they are added. however, a good portion of that work is going to be based on reviewing and synthesizing information from multiple sources (e.g., our docs, ES docs, other third-party docs). this work will require scrutiny from someone with more hands-on experience with the CrateDB internals 

additionally, it would be ideal if I could pair up with one person on this and get iterative feedback nice and early as things progress.  I would like to avoid having to go back to make large revisions to my approach. for example, if I receive feedback after defining and cross-linking 30 terms asking me to reduce the number of cross-references, a lot of effort is potentially going to be thrown away