### PR TITLE
Fix type-aware source parsing on string encoded source values

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -21,12 +21,12 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import java.io.IOException;
-import java.util.Map;
-
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class DocCollectorExpression extends LuceneCollectorExpression<Map<String, Object>> {
 
@@ -94,10 +94,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
         @Override
         public Object value() {
-            // need to make sure it has the correct type;
-            // for example:
-            //      sourceExtractor might read byte as int and
-            //      then eq(byte, byte) would get eq(byte, int) and fail
+            // correct type detection is ensured by the source parser
             return sourceLookup.get(ref.column().path());
         }
     }


### PR DESCRIPTION
On COPY FROM, values are not sanitized and thus values for non-string
typed columns may end up as strings inside the _source.
Thus we must always precedence possible given data types for value
type detection over the parsers type detection.

Follow up of https://github.com/crate/crate/commit/96988544c86.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
