### PR TITLE
io related backports

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -571,6 +571,7 @@ should be crossed out as well.
 - [x] ba5b4f14131 ESIntegTestCase always cleans up static fields (#49105)
 - [x] 5ba4f5fb3c9 Use dynamic port ranges for ExternalTestCluster (#45601)
 - [x] 29235a637f7 Wait for events in waitForRelocation (#45074)
+- [x] f20414dd7d9 Optimize some StreamOutput Operations (#44660)
 - [x] f00b658130d Remove RemoteClusterConnection.ConnectedNodes (#44235)
 - [x] 433b3458522 Fix port range allocation with large worker IDs (#44213)
 - [x] c40b77b771b Simplify port usage in transport tests (#44157)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -571,6 +571,7 @@ should be crossed out as well.
 - [x] ba5b4f14131 ESIntegTestCase always cleans up static fields (#49105)
 - [x] 5ba4f5fb3c9 Use dynamic port ranges for ExternalTestCluster (#45601)
 - [x] 29235a637f7 Wait for events in waitForRelocation (#45074)
+- [x] 42a331c59ba Remove Unused Features Field on StreamOutput (#44667)
 - [x] f20414dd7d9 Optimize some StreamOutput Operations (#44660)
 - [x] f00b658130d Remove RemoteClusterConnection.ConnectedNodes (#44235)
 - [x] 433b3458522 Fix port range allocation with large worker IDs (#44213)

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.io.stream;
 
+
 import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -43,7 +44,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
 
@@ -58,8 +58,6 @@ import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.Writeable.Writer;
@@ -102,7 +100,6 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     private Version version = Version.CURRENT;
-    private Set<String> features = Collections.emptySet();
 
     /**
      * The version of the node on the other side of this stream.
@@ -116,27 +113,6 @@ public abstract class StreamOutput extends OutputStream {
      */
     public void setVersion(Version version) {
         this.version = version;
-    }
-
-    /**
-     * Test if the stream has the specified feature. Features are used when serializing {@link ClusterState.Custom} or
-     * {@link Metadata.Custom}; see also {@link ClusterState.FeatureAware}.
-     *
-     * @param feature the feature to test
-     * @return true if the stream has the specified feature
-     */
-    public boolean hasFeature(final String feature) {
-        return this.features.contains(feature);
-    }
-
-    /**
-     * Set the features on the stream. See {@link StreamOutput#hasFeature(String)}.
-     *
-     * @param features the features on the stream
-     */
-    public void setFeatures(final Set<String> features) {
-        assert this.features.isEmpty() : this.features;
-        this.features = Set.copyOf(features);
     }
 
     public long position() throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -54,7 +54,6 @@ import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.LockObtainFailedException;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
@@ -225,19 +224,25 @@ public abstract class StreamOutput extends OutputStream {
         write(bytes.bytes, bytes.offset, bytes.length);
     }
 
+    private static final ThreadLocal<byte[]> SCRATCH = ThreadLocal.withInitial(() -> new byte[1024]);
+
     public final void writeShort(short v) throws IOException {
-        writeByte((byte) (v >> 8));
-        writeByte((byte) v);
+        final byte[] buffer = SCRATCH.get();
+        buffer[0] = (byte) (v >> 8);
+        buffer[1] = (byte) v;
+        writeBytes(buffer, 0, 2);
     }
 
     /**
      * Writes an int as four bytes.
      */
     public void writeInt(int i) throws IOException {
-        writeByte((byte) (i >> 24));
-        writeByte((byte) (i >> 16));
-        writeByte((byte) (i >> 8));
-        writeByte((byte) i);
+        final byte[] buffer = SCRATCH.get();
+        buffer[0] = (byte) (i >> 24);
+        buffer[1] = (byte) (i >> 16);
+        buffer[2] = (byte) (i >> 8);
+        buffer[3] = (byte) i;
+        writeBytes(buffer, 0, 4);
     }
 
     /**
@@ -247,19 +252,30 @@ public abstract class StreamOutput extends OutputStream {
      * using {@link #writeInt}
      */
     public void writeVInt(int i) throws IOException {
+        final byte[] buffer = SCRATCH.get();
+        int index = 0;
         while ((i & ~0x7F) != 0) {
-            writeByte((byte) ((i & 0x7f) | 0x80));
+            buffer[index++] = ((byte) ((i & 0x7f) | 0x80));
             i >>>= 7;
         }
-        writeByte((byte) i);
+        buffer[index++] = ((byte) i);
+        writeBytes(buffer, 0, index);
     }
 
     /**
      * Writes a long as eight bytes.
      */
     public void writeLong(long i) throws IOException {
-        writeInt((int) (i >> 32));
-        writeInt((int) i);
+        final byte[] buffer = SCRATCH.get();
+        buffer[0] = (byte) (i >> 56);
+        buffer[1] = (byte) (i >> 48);
+        buffer[2] = (byte) (i >> 40);
+        buffer[3] = (byte) (i >> 32);
+        buffer[4] = (byte) (i >> 24);
+        buffer[5] = (byte) (i >> 16);
+        buffer[6] = (byte) (i >> 8);
+        buffer[7] = (byte) i;
+        writeBytes(buffer, 0, 8);
     }
 
     /**
@@ -279,11 +295,14 @@ public abstract class StreamOutput extends OutputStream {
      * {@link #writeVLong(long)} instead.
      */
     void writeVLongNoCheck(long i) throws IOException {
+        final byte[] buffer = SCRATCH.get();
+        int index = 0;
         while ((i & ~0x7F) != 0) {
-            writeByte((byte) ((i & 0x7f) | 0x80));
+            buffer[index++] = ((byte) ((i & 0x7f) | 0x80));
             i >>>= 7;
         }
-        writeByte((byte) i);
+        buffer[index++] = ((byte) i);
+        writeBytes(buffer, 0, index);
     }
 
     /**
@@ -294,13 +313,16 @@ public abstract class StreamOutput extends OutputStream {
      * If the numbers are known to be non-negative, use {@link #writeVLong(long)}
      */
     public void writeZLong(long i) throws IOException {
+        final byte[] buffer = SCRATCH.get();
+        int index = 0;
         // zig-zag encoding cf. https://developers.google.com/protocol-buffers/docs/encoding?hl=en
         long value = BitUtil.zigZagEncode(i);
         while ((value & 0xFFFFFFFFFFFFFF80L) != 0L) {
-            writeByte((byte)((value & 0x7F) | 0x80));
+            buffer[index++] = (byte) ((value & 0x7F) | 0x80);
             value >>>= 7;
         }
-        writeByte((byte) (value & 0x7F));
+        buffer[index++] = (byte) (value & 0x7F);
+        writeBytes(buffer, 0, index);
     }
 
     public void writeOptionalLong(@Nullable Long l) throws IOException {
@@ -351,18 +373,9 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
-    // we use a small buffer to convert strings to bytes since we want to prevent calling writeByte
-    // for every byte in the string (see #21660 for details).
-    // This buffer will never be the oversized limit of 1024 bytes and will not be shared across streams
-    private byte[] convertStringBuffer = BytesRef.EMPTY_BYTES; // TODO should we reduce it to 0 bytes once the stream is closed?
-
     public void writeString(String str) throws IOException {
         final int charCount = str.length();
-        final int bufferSize = Math.min(3 * charCount, 1024); // at most 3 bytes per character is needed here
-        if (convertStringBuffer.length < bufferSize) { // we don't use ArrayUtils.grow since copying the bytes is unnecessary
-            convertStringBuffer = new byte[ArrayUtil.oversize(bufferSize, Byte.BYTES)];
-        }
-        byte[] buffer = convertStringBuffer;
+        byte[] buffer = SCRATCH.get();
         int offset = 0;
         writeVInt(charCount);
         for (int i = 0; i < charCount; i++) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

These are open io related backports which i was missing on other upcoming prs. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
