### PR TITLE
Support digits in unquoted pg array strings

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,9 @@ None
 Fixes
 =====
 
+- Fixed an issue in the PostgreSQL wire protocol that would cause
+  de-serialization of arrays to fail if they contained unquoted strings
+  starting with digits.
 
 - Fixed an issue that could lead to a serialization error when streaming values
   of the ``TIMESTAMP WITHOUT TIME ZONE`` type in text format using the

--- a/libs/pgwire/src/main/antlr/PgArray.g4
+++ b/libs/pgwire/src/main/antlr/PgArray.g4
@@ -22,40 +22,41 @@ array
    ;
 
 item
-   : NULL           #null
-   | string         #value
+   : string         #value
    | NUMBER         #value
-   | bool           #value
    | array          #noop
+   | 'true'         #value
+   | 'false'        #value
+   | 'NULL'         #null
    ;
-
-bool
-    : 'true'
-    | 'false'
-    ;
 
 
 string
     : STRING        #quotedString
-    | CHAR+         #unquotedString
+    | QSTRING       #unquotedString
     ;
 
 STRING
     : '"' (ESC | ~["\\])* '"'
     ;
 
-CHAR
-    : [!-z]
+
+QSTRING
+    : DIGIT* CHAR+
     ;
 
+CHAR
+    : [a-zA-Z]
+    | [!-+]
+    | '-'
+    | '_'
+    | DIGIT
+    ;
 
 NUMBER
-    : '-'? DIGIT '.' DIGIT EXP?
-    | '-'? DIGIT EXP
-    | '-'? DIGIT
+    : '-'? DIGIT ('.' [0-9] +)? EXP?
     ;
 
-NULL: 'NULL';
 
 fragment ESC
     : '\\' (["\\/bfnrt] | UNICODE)

--- a/libs/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
+++ b/libs/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
@@ -71,6 +71,11 @@ public class PgArrayParserTest {
     }
 
     @Test
+    public void test_string_array_with_digits_and_no_quotes() throws Exception {
+        assertThat(parse("{23ab-38cd,42xy}", String::new), is(Arrays.asList("23ab-38cd", "42xy")));
+    }
+
+    @Test
     public void test_dash_and_underline_are_allowed_in_unquoted_strings() {
         assertThat(parse("{catalog_name,end-exec}", String::new), contains("catalog_name","end-exec"));
     }

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 
 public class PGArrayTest extends BasePGTypeTest<PGArray> {
@@ -109,6 +110,26 @@ public class PGArrayTest extends BasePGTypeTest<PGArray> {
         s = new String(bytes, StandardCharsets.UTF_8);
         assertThat(s, is("{\"{\\\"names\\\":[\\\"Arthur\\\",\\\"Trillian\\\"]}\"," +
                          "\"{\\\"names\\\":[\\\"Ford\\\",\\\"Slarti\\\"]}\"}"));
+    }
+
+    @Test
+    public void test_can_decode_unquoted_strings_which_contain_numbers() throws Exception {
+        String s = "{33a10b73-377d-4788-bbd3-9f0a0db4d595,2ea0876d-a290-438b-9816-cb4d63f48f77}";
+        List<Object> values = PGArray.VARCHAR_ARRAY.decodeUTF8Text(s.getBytes(StandardCharsets.UTF_8));
+        assertThat(values, contains(
+            "33a10b73-377d-4788-bbd3-9f0a0db4d595",
+            "2ea0876d-a290-438b-9816-cb4d63f48f77"
+        ));
+    }
+
+    @Test
+    public void test_can_decode_unquoted_strings_which_do_not_contain_numbers() throws Exception {
+        String s = "{foo,bar}";
+        List<Object> values = PGArray.VARCHAR_ARRAY.decodeUTF8Text(s.getBytes(StandardCharsets.UTF_8));
+        assertThat(values, contains(
+            "foo",
+            "bar"
+        ));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11026

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)