### PR TITLE
Fix NullPointerException in AsyncFlatMapBatchIterator

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``NullPointerException`` when using a
+  SELECT statement containing an INNER JOIN.
+
 - Fixed an issue in the PostgreSQL wire protocol that would cause
   de-serialization of arrays to fail if they contained unquoted strings
   starting with digits.

--- a/libs/dex/src/main/java/io/crate/data/AsyncFlatMapBatchIterator.java
+++ b/libs/dex/src/main/java/io/crate/data/AsyncFlatMapBatchIterator.java
@@ -73,6 +73,10 @@ public final class AsyncFlatMapBatchIterator<I, O> implements BatchIterator<O> {
                 }
                 return false;
             } else {
+                if (mappedElements == null) {
+                    // This is the case if a consumer didn't call loadNextBatch after a previous moveNext call returned false
+                    return false;
+                }
                 if (mappedElements.hasNext()) {
                     current = mappedElements.next();
                     return true;

--- a/libs/dex/src/test/java/io/crate/data/AsyncFlatMapBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/AsyncFlatMapBatchIteratorTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.data;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
@@ -57,6 +58,17 @@ public class AsyncFlatMapBatchIteratorTest {
             new Integer[] {3, 3},
             new Integer[] {3, 3}
         ));
+    }
+
+    @Test
+    public void test_async_flatMap_does_not_fail_if_consumer_calls_moveNext_after_negative_moveNext_result() throws Exception {
+        InMemoryBatchIterator<Integer> source = new InMemoryBatchIterator<>(Arrays.asList(1, 2, 3), null, false);
+        var asyncFlatMap = new AsyncFlatMapBatchIterator<>(
+            source,
+            (x, isLast) -> CompletableFuture.completedFuture(Arrays.asList(new Integer[] {x, x}, new Integer[] {x, x}).iterator())
+        );
+        assertThat("first moveNext must return false, because the async-mapper must run next", asyncFlatMap.moveNext(), is(false));
+        assertThat("Calling moveNext again must not fail", asyncFlatMap.moveNext(), is(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `HashInnerJoinBatchIterator` called `moveNext` again after a
previous `moveNext` call already returned false.

This triggered a `NullPointerException` because the
`AsyncFlatMapBatchIterator` didn't account for this kind of access
pattern.

Fixes https://github.com/crate/crate/issues/11034

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)