### PR TITLE
Set initial loaded left batches to 0 in HashInnerJoinBatchIterator

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
@@ -117,8 +117,7 @@ public class HashInnerJoinBatchIterator extends JoinBatchIterator<Row, Row, Row>
         // resized upon block size calculation
         this.buffer = new IntObjectHashMap<>();
         resetBuffer();
-        // initially 1 page/batch is loaded
-        numberOfLeftBatchesLoadedForBlock = 1;
+        numberOfLeftBatchesLoadedForBlock = 0;
         this.activeIt = left;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a follow up to https://github.com/crate/crate/pull/11036
That the left source has one batch already loaded is not true.

This led to a `moveNext -> false; moveNext` call sequence.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)