### PR TITLE
Accept all inbound messages in PostgresWireProtocol

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -297,6 +297,11 @@ public class PostgresWireProtocol {
         }
 
         @Override
+        public boolean acceptInboundMessage(Object msg) throws Exception {
+            return true;
+        }
+
+        @Override
         public void channelRead0(ChannelHandlerContext ctx, ByteBuf buffer) throws Exception {
             assert channel != null : "Channel must be initialized";
             try {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Will save a nanosecond or two at most, but why not.
It eliminates a `ByteBuf.class.isInstance` check


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)