### PR TITLE
Release delayed messages on close channel

### DIFF
--- a/server/src/test/java/io/crate/protocols/postgres/DelayableWriteChannelTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/DelayableWriteChannelTest.java
@@ -1,0 +1,27 @@
+
+package io.crate.protocols.postgres;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class DelayableWriteChannelTest {
+
+    @Test
+    public void test_delayed_writes_are_released_on_close() throws Exception {
+        var channel = new DelayableWriteChannel(new EmbeddedChannel());
+        var future = new CompletableFuture<>();
+        channel.delayWritesUntil(future);
+        ByteBuf buffer = Unpooled.buffer();
+        channel.write(buffer);
+        channel.close();
+        assertThat(buffer.refCnt(), is(0));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Ensurse that any buffered messages get immediately released if a channel is
closed.

For example if a client is disconnected this should ensure that the messages
are still getting released. I'm not entirely sure if this was a problem in practice, as the future would have triggered eventually anyway(?)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)