### PR TITLE
Fix flaky `testQueryBreakerIsDecrementedWhenQueryCompletes`

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -46,7 +46,7 @@ public class CircuitBreakerIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testQueryBreakerIsDecrementedWhenQueryCompletes() {
+    public void testQueryBreakerIsDecrementedWhenQueryCompletes() throws Exception {
         execute("create table t1 (text string)");
         execute("insert into t1 values ('this is some text'), ('other text')");
         refresh();
@@ -57,7 +57,9 @@ public class CircuitBreakerIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("select text from t1 group by text");
 
-        assertThat(queryBreaker.getUsed(), is(breakerBytesUsedBeforeQuery));
+        assertBusy(() -> {
+            assertThat(queryBreaker.getUsed(), is(breakerBytesUsedBeforeQuery));
+        });
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adds an `assertBusy` because some of the "reset ramAccounting" actions
happen async and a client could receive a result before those actions
finished.

    ## FAILURE: Test testQueryBreakerIsDecrementedWhenQueryCompletes(io.crate.integrationtests.CircuitBreakerIntegrationTest)
    java.lang.AssertionError:
    Expected: is <0L>
         but: was <2576980L>
    	at __randomizedtesting.SeedInfo.seed([90FAD8CDD77B4CF1:58A674C822576952]:0)
    	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
    	at org.junit.Assert.assertThat(Assert.java:956)
    	at org.junit.Assert.assertThat(Assert.java:923)
    	at io.crate.integrationtests.CircuitBreakerIntegrationTest.testQueryBreakerIsDecrementedWhenQueryCompletes(CircuitBreakerIntegrationTest.java:58)

    REPRODUCE WITH: ./gradlew :server:test -Dtests.seed=90FAD8CDD77B4CF1 -Dtests.class=io.crate.integrationtests.CircuitBreakerIntegrationTest -Dtests.method="testQueryBreakerIsDecrementedWhenQueryCompletes" -Dtests.locale=om-KE -Dtests.timezone=Pacific/Chatham


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)