### PR TITLE
Fix pg array parsing regressions

### DIFF
--- a/libs/pgwire/src/main/antlr/PgArray.g4
+++ b/libs/pgwire/src/main/antlr/PgArray.g4
@@ -16,47 +16,42 @@ representations. E.g.:
     {\"{\\\"x\\\": 10}\", \"{\\\"y\\\": 20}\"}
 */
 
+
+
 array
-   : '{' item (',' item)* '}'
-   | '{' '}'
-   ;
-
-item
-   : string         #value
-   | NUMBER         #value
-   | array          #noop
-   | 'true'         #value
-   | 'false'        #value
-   | 'NULL'         #null
-   ;
-
-
-string
-    : STRING        #quotedString
-    | QSTRING       #unquotedString
+    : '{' item (',' item)* '}'
+    | '{' '}'
     ;
 
-STRING
+item
+    : string
+    | array
+    ;
+
+string
+    : QUOTED_STRING     #quotedString
+    | NULL              #null
+    | UNQUOTED_STRING   #unquotedString
+    ;
+
+
+NULL
+    : [nN] [uU] [lL] [lL]
+    ;
+
+
+QUOTED_STRING
     : '"' (ESC | ~["\\])* '"'
     ;
 
-
-QSTRING
-    : DIGIT* CHAR+
+UNQUOTED_STRING
+    : CHAR+ (' ')* CHAR+
+    | CHAR+
     ;
 
-CHAR
-    : [a-zA-Z]
-    | [!-+]
-    | '-'
-    | '_'
-    | DIGIT
+fragment CHAR
+    : ~[,"\\{} \t\n\r]
     ;
-
-NUMBER
-    : '-'? DIGIT ('.' [0-9] +)? EXP?
-    ;
-
 
 fragment ESC
     : '\\' (["\\/bfnrt] | UNICODE)
@@ -70,14 +65,4 @@ fragment HEX
     : [0-9a-fA-F]
     ;
 
-fragment DIGIT
-    : '0' | [1-9] [0-9]*
-    ;
-
-fragment EXP
-    : [Ee] [+\-]? DIGIT
-    ;
-
-WS
-   : [ \t\n\r] + -> skip
-   ;
+WS: [ \t\n\r]+ -> skip;

--- a/libs/pgwire/src/main/java/io/crate/protocols/postgres/parser/PgArrayParser.java
+++ b/libs/pgwire/src/main/java/io/crate/protocols/postgres/parser/PgArrayParser.java
@@ -22,7 +22,12 @@
 
 package io.crate.protocols.postgres.parser;
 
-import io.crate.protocols.postgres.antlr.v4.PgArrayLexer;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -32,11 +37,7 @@ import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.function.Function;
+import io.crate.protocols.postgres.antlr.v4.PgArrayLexer;
 
 public class PgArrayParser {
 
@@ -90,8 +91,7 @@ public class PgArrayParser {
                 parser.getInterpreter().setPredictionMode(PredictionMode.LL);
                 tree = parseFunction.apply(parser);
             }
-
-            return new PgArrayASTVisitor(convert).visit(tree);
+            return tree.accept(new PgArrayASTVisitor(convert));
         } catch (StackOverflowError e) {
             throw new PgArrayParsingException("stack overflow while parsing: " + e.getLocalizedMessage());
         } catch (IOException e) {

--- a/libs/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
+++ b/libs/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
@@ -71,6 +71,11 @@ public class PgArrayParserTest {
     }
 
     @Test
+    public void test_quoted_string_can_contain_curly_brackets() throws Exception {
+        assertThat(parse("{\"}}}{{{\"}", String::new), is(List.of("}}}{{{")));
+    }
+
+    @Test
     public void test_string_array_with_digits_and_no_quotes() throws Exception {
         assertThat(parse("{23ab-38cd,42xy}", String::new), is(Arrays.asList("23ab-38cd", "42xy")));
     }
@@ -129,7 +134,22 @@ public class PgArrayParserTest {
 
     @Test
     public void test_bool_array_with_quoted_items() {
-        assertThat(parse("{\"false\", \"true\"}", toBoolean), is(List.of(false, true)));
+        assertThat(parse("{\"false\",\"true\"}", toBoolean), is(List.of(false, true)));
+    }
+
+    @Test
+    public void test_unquoted_string_can_contain_whitespace() throws Exception {
+        assertThat(parse("{foo bar}", String::new), is(List.of("foo bar")));
+    }
+
+    @Test
+    public void test_unquoted_string_trailing_whitespace_is_removed() throws Exception {
+        assertThat(parse("{foo  }", String::new), is(List.of("foo")));
+    }
+
+    @Test
+    public void test_unquoted_string_leading_whitespace_is_removed() throws Exception {
+        assertThat(parse("{  foo}", String::new), is(List.of("foo")));
     }
 
     @Test
@@ -183,5 +203,16 @@ public class PgArrayParserTest {
         assertThat(
             parse("{\"(1.3, 2.1)\", \"(3.4, 5.1)\"}", String::new),
             is(List.of("(1.3, 2.1)", "(3.4, 5.1)")));
+    }
+
+    @Test
+    public void test_unquoted_item_can_contain_dots() throws Exception {
+        assertThat(
+            parse("{foo.bar,two}", String::new),
+            is(List.of(
+                "foo.bar",
+                "two"
+            ))
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a follow up to https://github.com/crate/crate/commit/85379d2747caa5e62719aee5fb5a6c23a1060875
It made the allowed unquoted characters too restrictive, causing a
regression.

The referenced commit wasn't released yet, so no release notes.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)