### PR TITLE
Fix max aggregation of 0.0 values

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression that led to ``max`` aggregations on columns of type
+  ``double precision`` or ``real`` to return ``null`` instead of ``0.0`` if all
+  aggregated values are ``0.0``.
+
 - Fixed an issue that could lead to an ``OutOfMemoryError`` when retrieving
   large result sets with large individual records.
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -132,7 +132,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         @Override
         public MutableDouble initialState(RamAccounting ramAccounting) {
             ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
-            return new MutableDouble(Double.MIN_VALUE);
+            return new MutableDouble(- Double.MAX_VALUE);
         }
 
         @Override
@@ -173,7 +173,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         @Override
         public MutableFloat initialState(RamAccounting ramAccounting) {
             ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
-            return new MutableFloat(Float.MIN_VALUE);
+            return new MutableFloat(- Float.MAX_VALUE);
         }
 
         @Override

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -103,7 +103,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         public void apply(RamAccounting ramAccounting, int doc, MutableLong state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 long value = values.nextValue();
-                if (value > state.value()) {
+                if (value >= state.value()) {
                     state.setValue(value);
                 }
             }
@@ -144,7 +144,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         public void apply(RamAccounting ramAccounting, int doc, MutableDouble state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 double value = NumericUtils.sortableLongToDouble(values.nextValue());
-                if (value > state.value()) {
+                if (value >= state.value()) {
                     state.setValue(value);
                 }
             }
@@ -185,7 +185,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         public void apply(RamAccounting ramAccounting, int doc, MutableFloat state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 float value = NumericUtils.sortableIntToFloat((int) values.nextValue());
-                if (value > state.value()) {
+                if (value >= state.value()) {
                     state.setValue(value);
                 }
             }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -85,6 +85,24 @@ public class MaximumAggregationTest extends AggregationTest {
     }
 
     @Test
+    public void test_aggregate_min_float() throws Exception {
+        Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{- Float.MAX_VALUE}, {- Float.MAX_VALUE}});
+        assertThat(result, is(- Float.MAX_VALUE));
+    }
+
+    @Test
+    public void test_aggregate_min_double() throws Exception {
+        Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{- Double.MAX_VALUE}, {- Double.MAX_VALUE}});
+        assertThat(result, is(- Double.MAX_VALUE));
+    }
+
+    @Test
+    public void test_aggregate_min_long() throws Exception {
+        Object result = executeAggregation(DataTypes.LONG, new Object[][]{{Long.MIN_VALUE}, {Long.MIN_VALUE}});
+        assertThat(result, is(Long.MIN_VALUE));
+    }
+
+    @Test
     public void testLong() throws Exception {
         Object result = executeAggregation(DataTypes.LONG, new Object[][]{{8L}, {3L}});
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -73,6 +73,18 @@ public class MaximumAggregationTest extends AggregationTest {
     }
 
     @Test
+    public void test_aggregate_double_zero() throws Exception {
+        Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.0}, {0.0}});
+        assertThat(result, is(0.0d));
+    }
+
+    @Test
+    public void test_aggregate_float_zero() throws Exception {
+        Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.0f}, {0.0f}});
+        assertThat(result, is(0.0f));
+    }
+
+    @Test
     public void testLong() throws Exception {
         Object result = executeAggregation(DataTypes.LONG, new Object[][]{{8L}, {3L}});
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -66,6 +66,18 @@ public class MinimumAggregationTest extends AggregationTest {
     }
 
     @Test
+    public void test_aggregate_double_zero() throws Exception {
+        Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.0}, {0.0}});
+        assertThat(result, is(0.0d));
+    }
+
+    @Test
+    public void test_aggregate_float_zero() throws Exception {
+        Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.0f}, {0.0f}});
+        assertThat(result, is(0.0f));
+    }
+
+    @Test
     public void testInteger() throws Exception {
         Object result = executeAggregation(DataTypes.INTEGER, new Object[][]{{8}, {3}});
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Both `Float.MIN_VALUE` and `Double.MIN_VALUE` are positive numbers, not
negative so `0.0 > Double.MIN_VALUE` is false. 🤦

Fixes #11056

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)