### PR TITLE
Fix fetch rewrite on Eval operators

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``Can't handle Symbol`` error when
+  using views which are defined with column aliases.
+
 - Fixed a regression that led to ``max`` aggregations on columns of type
   ``double precision`` or ``real`` to return ``null`` instead of ``0.0`` if all
   aggregated values are ``0.0``.

--- a/server/src/main/java/io/crate/execution/dsl/projection/EvalProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/EvalProjection.java
@@ -97,4 +97,11 @@ public class EvalProjection extends Projection {
             .put("outputs", Lists2.joinOn(", ", outputs, Symbol::toString))
             .map();
     }
+
+    @Override
+    public String toString() {
+        return "EvalProjection{" +
+               "outputs=" + outputs +
+               '}';
+    }
 }

--- a/server/src/main/java/io/crate/planner/operators/MapBackedSymbolReplacer.java
+++ b/server/src/main/java/io/crate/planner/operators/MapBackedSymbolReplacer.java
@@ -36,7 +36,7 @@ public final class MapBackedSymbolReplacer extends FunctionCopyVisitor<Map<Symbo
     }
 
     public static Symbol convert(Symbol symbol, Map<Symbol, Symbol> replacements) {
-        return symbol.accept(INSTANCE, replacements);
+        return replacements.getOrDefault(symbol, symbol.accept(INSTANCE, replacements));
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/MapBackedSymbolReplacerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/MapBackedSymbolReplacerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.expression.symbol.AliasSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+
+public class MapBackedSymbolReplacerTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_convert_symbol_without_traversing() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int)")
+            .build();
+
+        Symbol x = e.asSymbol("x");
+        Symbol x_source_lookup = e.asSymbol("_doc['x']");
+        Symbol alias = new AliasSymbol("a_alias", x);
+        Symbol alias_source_lookup = new AliasSymbol("a_alias", x_source_lookup);
+
+        // Mapping contains the requested symbol directly, must not traverse alias symbols
+        Map<Symbol, Symbol> mapping = Map.of(
+            alias,
+            alias_source_lookup
+        );
+
+        assertThat(MapBackedSymbolReplacer.convert(alias, mapping), is(alias_source_lookup));
+    }
+
+    @Test
+    public void test_convert_symbol_by_traversing() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int)")
+            .build();
+
+        Symbol x = e.asSymbol("x");
+        Symbol x_source_lookup = e.asSymbol("_doc['x']");
+        Symbol alias = new AliasSymbol("a_alias", x);
+        Symbol alias_source_lookup = new AliasSymbol("a_alias", x_source_lookup);
+
+        // Mapping does not contain the requested symbol, but a child of it. Fallback to symbol traversing.
+        Map<Symbol, Symbol> mapping = Map.of(
+            x,
+            x_source_lookup
+        );
+
+        assertThat(MapBackedSymbolReplacer.convert(alias, mapping), is(alias_source_lookup));
+    }
+}


### PR DESCRIPTION
The fetch rewrite logic on the Eval operators uses the MapBackedSymbolReplacer for replacing the original (source) symbols with new onces, replaced on the source.
This replacer was always traversing the symbol's tree, but e.g. when Alias symbols are used, the source will add the complete alias symbol to the replacement map (in order to preserve all the information like the alias name) and not only the target reference. 
Such this replacer should first lookup for the given symbol inside the map before falling back to travers and search for child replacements.

Fixes #11049.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
