### PR TITLE
Fix repository verification error handling

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -58,6 +58,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue in the error handling of ``CREATE REPOSITORY`` statements
+  which could lead to a ``NullPointerException`` instead of a more meaningful
+  error message.
+
 - Fixed an issue that could lead to a ``Can't handle Symbol`` error when
   using views which are defined with column aliases.
 

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -881,12 +881,18 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 return seed;
             }
         } catch (Exception e) {
-            throw new RepositoryVerificationException(metadata.name(),
-                        String.format(Locale.ENGLISH,
-                                      "Unable to verify the repository, [%s] is not accessible on master node: %s '%s'",
-                                      metadata.name(),
-                                      e.getCause().getClass().getSimpleName(),
-                                      e.getCause().getMessage()));
+            Throwable cause = e.getCause();
+            Throwable errorInfo = cause == null ? e : cause;
+            throw new RepositoryVerificationException(
+                metadata.name(),
+                String.format(
+                    Locale.ENGLISH,
+                    "Unable to verify the repository, [%s] is not accessible on master node: %s '%s'",
+                    metadata.name(),
+                    errorInfo.getClass().getSimpleName(),
+                    errorInfo.getMessage()
+                )
+            );
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The cause can be `null` in which case the following NPE happened:

    NullPointerException[Cannot invoke "Object.getClass()" because the return value of "java.lang.Exception.getCause()" is null]
    java.lang.NullPointerException: Cannot invoke "Object.getClass()" because the return value of "java.lang.Exception.getCause()" is null
    	at org.elasticsearch.repositories.blobstore.BlobStoreRepository.startVerification(BlobStoreRepository.java:888)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)