### PR TITLE
Increase default SQL request timeout in tests

### DIFF
--- a/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -100,7 +100,7 @@ public class SQLTransportExecutor {
     private static final String SQL_REQUEST_TIMEOUT = "CRATE_TESTS_SQL_REQUEST_TIMEOUT";
 
     public static final TimeValue REQUEST_TIMEOUT = new TimeValue(Long.parseLong(
-        Objects.requireNonNullElse(System.getenv(SQL_REQUEST_TIMEOUT), "5")), TimeUnit.SECONDS);
+        Objects.requireNonNullElse(System.getenv(SQL_REQUEST_TIMEOUT), "10")), TimeUnit.SECONDS);
 
     private static final Logger LOGGER = LogManager.getLogger(SQLTransportExecutor.class);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

On CI we sometimes see timeout related failures that do not seem to
origin from a real code problem but rather from a slow system.

A recent example is `testAlterTableRerouteMoveShard` which failed with
the following exception:

    org.elasticsearch.ElasticsearchTimeoutException: java.util.concurrent.TimeoutException: Timeout waiting for task.
    	at __randomizedtesting.SeedInfo.seed([167DB4162689A037:BA1875C29771609C]:0)
    	at org.elasticsearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:79)
    	at org.elasticsearch.action.support.AdapterActionFuture.actionGet(AdapterActionFuture.java:49)
    	at org.elasticsearch.action.support.AdapterActionFuture.actionGet(AdapterActionFuture.java:44)
    	at io.crate.testing.SQLTransportExecutor.executeTransportOrJdbc(SQLTransportExecutor.java:184)
    	at io.crate.testing.SQLTransportExecutor.exec(SQLTransportExecutor.java:130)
    	at io.crate.integrationtests.SQLTransportIntegrationTest.execute(SQLTransportIntegrationTest.java:374)
    	at io.crate.integrationtests.SQLTransportIntegrationTest.execute(SQLTransportIntegrationTest.java:520)
    	at io.crate.integrationtests.AlterTableRerouteIntegrationTest.testAlterTableRerouteMoveShard(AlterTableRerouteIntegrationTest.java:40)
    	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
    	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
    	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
    	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
    	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    	at java.base/java.lang.Thread.run(Thread.java:832)
    Caused by: java.util.concurrent.TimeoutException: Timeout waiting for task.
    	at org.elasticsearch.common.util.concurrent.BaseFuture$Sync.get(BaseFuture.java:235)
    	at org.elasticsearch.common.util.concurrent.BaseFuture.get(BaseFuture.java:64)
    	at org.elasticsearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:77)
    	... 19 more

In the stdout/logs the following message was present:

    2021-02-28T18:05:49,695][ERROR][i.c.t.SQLTransportExecutor] [[Time-limited test]] Timeout on SQL statement: create table my_table (id int primary key,date timestamp with time zone) clustered into 1 shards with (number_of_replicas=0) org.elasticsearch.ElasticsearchTimeoutException: java.util.concurrent.TimeoutException: Timeout waiting for task

But no other errors that would indicate that the root cause is a bug.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)