### PR TITLE
Fix flaky testPreferCopyCanPerformNoopRecovery

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -53,6 +53,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.types.DataTypes;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class ReplicaShardAllocatorIT extends SQLTransportIntegrationTest {
@@ -330,7 +331,10 @@ public class ReplicaShardAllocatorIT extends SQLTransportIntegrationTest {
             List<Map<String, Object>> rentetionLease = (List<Map<String, Object>>) response.rows()[0][2];
             assertThat(rentetionLease.size(), is(activeRetentionLeaseIds.size()));
             for (var activeRetentionLease : rentetionLease) {
-                assertThat(activeRetentionLease.get("retaining_seq_no"), is(globalCheckPoint + 1));
+                assertThat(
+                    DataTypes.LONG.explicitCast(activeRetentionLease.get("retaining_seq_no")),
+                    is(globalCheckPoint + 1L)
+                );
             }
         });
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Failed with

    java.lang.AssertionError:
    Expected: is <2L>
         but: was <2>

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)