### PR TITLE
Fix UncaughtExceptionError in testRestartNodeWhileIndexing

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
@@ -390,7 +390,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                         execute("insert into t (id, x) values (?, ?)", new Object[]{id, randomInt(5000)});
                         logger.info("--> index id={}", id);
                         ackedDocs.add(id);
-                    } catch (ElasticsearchException ignore) {
+                    } catch (Exception ignore) {
                         logger.info("--> fail to index id={}", id);
                     }
                 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This should fix:

    com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=7870, name=Thread-89, state=RUNNABLE, group=FailOnTimeoutGroup]
    	at __randomizedtesting.SeedInfo.seed([787987641FBBD68F:1799545C17B39E7D]:0)
    Caused by: org.postgresql.util.PSQLException: ERROR: node closed {node_t2}{JQ4k7ahLQzSAqd7tGnBKUQ}{KzA2V0yhQ8-TsePpAk5q_Q}{127.0.0.1}{127.0.0.1:41943}{http_address=0.0.0.0:0}
    	at __randomizedtesting.SeedInfo.seed([787987641FBBD68F]:0)
    	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2553)
    	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2285)
    	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:323)
    	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:473)
    	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:393)
    	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:164)
    	at org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:153)
    	at io.crate.testing.SQLTransportExecutor.executeAndConvertResult(SQLTransportExecutor.java:378)
    	at io.crate.testing.SQLTransportExecutor.executeWithPg(SQLTransportExecutor.java:329)
    	at io.crate.testing.SQLTransportExecutor.executeTransportOrJdbc(SQLTransportExecutor.java:173)
    	at io.crate.testing.SQLTransportExecutor.exec(SQLTransportExecutor.java:130)
    	at io.crate.integrationtests.SQLTransportIntegrationTest.execute(SQLTransportIntegrationTest.java:374)
    	at io.crate.integrationtests.disruption.discovery.ClusterDisruptionIT.lambda$testRestartNodeWhileIndexing$5(ClusterDisruptionIT.java:390)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)