### PR TITLE
Add an empty pg_tablespace table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ None
 Changes
 =======
 
+- Added an empty ``pg_tablespace`` table in the ``pg_catalog`` schema for
+  improved support for PostgreSQL tools.
+
 - Improved the error messages for cast errors for values of type ``object``.
 
 - Added support for the :ref:`CREATE TABLE AS <ref-create-table-as>` statement.

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -96,6 +96,7 @@ number of replicas.
     | pg_catalog         | pg_roles                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_settings             | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_stats                | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_tablespace           | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_type                 | BASE TABLE |             NULL | NULL               |
     | sys                | allocations             | BASE TABLE |             NULL | NULL               |
     | sys                | checks                  | BASE TABLE |             NULL | NULL               |
@@ -117,7 +118,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 50 rows in set (... sec)
+    SELECT 51 rows in set (... sec)
 
 The table also contains additional information such as the specified
 :ref:`routing column <gloss-routing-column>` and :ref:`partition columns

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -122,21 +122,22 @@ a ``BackendKeyData`` message during connection initialization.
 For improved compatibility, the ``pg_catalog`` schema is implemented containing
 following tables:
 
- - `pg_type`_
- - `pg_database <pgsql_pg_database_>`__
- - `pg_class <pgsql_pg_class_>`__
- - `pg_proc <pgsql_pg_proc_>`__
- - `pg_namespace <pgsql_pg_namespace_>`__
- - `pg_attribute <pgsql_pg_attribute_>`__
- - `pg_attrdef <pgsql_pg_attrdef_>`__
- - `pg_index <pgsql_pg_index_>`__
- - `pg_constraint <pgsql_pg_constraint_>`__
- - `pg_settings <pgsql_pg_settings_>`__
- - `pg_description`_
- - `pg_range`_
- - `pg_enum`_
- - `pg_roles`_
  - `pg_am`_
+ - `pg_attrdef <pgsql_pg_attrdef_>`__
+ - `pg_attribute <pgsql_pg_attribute_>`__
+ - `pg_class <pgsql_pg_class_>`__
+ - `pg_constraint <pgsql_pg_constraint_>`__
+ - `pg_database <pgsql_pg_database_>`__
+ - `pg_description`_
+ - `pg_enum`_
+ - `pg_index <pgsql_pg_index_>`__
+ - `pg_namespace <pgsql_pg_namespace_>`__
+ - `pg_proc <pgsql_pg_proc_>`__
+ - `pg_range`_
+ - `pg_roles`_
+ - `pg_settings <pgsql_pg_settings_>`__
+ - `pg_tablespace`_
+ - `pg_type`_
 
 
 .. _postgres_pg_type:
@@ -405,12 +406,13 @@ either because of the table is empty or by a not matching where clause.
 .. _Arrays: https://www.postgresql.org/docs/current/static/arrays.html
 .. _Extended Query: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 .. _Github: https://github.com/crate/crate
+.. _pg_am: https://www.postgresql.org/docs/10/catalog-pg-am.html
 .. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html
 .. _pg_enum: https://www.postgresql.org/docs/10/catalog-pg-enum.html
-.. _pgjdbc: https://github.com/pgjdbc/pgjdbc
-.. _pg_am: https://www.postgresql.org/docs/10/catalog-pg-am.html
 .. _pg_range: https://www.postgresql.org/docs/10/catalog-pg-range.html
 .. _pg_roles: https://www.postgresql.org/docs/10/view-pg-roles.html
+.. _pg_tablespace: https://www.postgresql.org/docs/13/catalog-pg-tablespace.html
+.. _pgjdbc: https://github.com/pgjdbc/pgjdbc
 .. _pgsql_pg_attrdef: https://www.postgresql.org/docs/10/static/catalog-pg-attrdef.html
 .. _pgsql_pg_attribute: https://www.postgresql.org/docs/10/static/catalog-pg-attribute.html
 .. _pgsql_pg_class: https://www.postgresql.org/docs/10/static/catalog-pg-class.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -69,7 +69,8 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgRangeTable.IDENT.name(), PgRangeTable.create()),
             Map.entry(PgEnumTable.IDENT.name(), PgEnumTable.create()),
             Map.entry(PgRolesTable.IDENT.name(), PgRolesTable.create()),
-            Map.entry(PgAmTable.IDENT.name(), PgAmTable.create())
+            Map.entry(PgAmTable.IDENT.name(), PgAmTable.create()),
+            Map.entry(PgTablespaceTable.IDENT.name(), PgTablespaceTable.create())
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -128,6 +128,11 @@ public class PgCatalogTableDefinitions {
             PgAmTable.create().expressions(),
             false
         ));
+        tableDefinitions.put(PgTablespaceTable.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgTablespaceTable.create().expressions(),
+            false
+        ));
         Iterable<NamedSessionSetting> sessionSettings =
             () -> sessionSettingRegistry.settings().entrySet().stream()
                 .map(s -> new NamedSessionSetting(s.getKey(), s.getValue()))

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgTablespaceTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgTablespaceTable.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.types.DataTypes;
+
+public final class PgTablespaceTable {
+
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_tablespace");
+
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(IDENT)
+            .add("oid", DataTypes.INTEGER, ignored -> null)
+            .add("spcname", DataTypes.STRING, ignored -> null)
+            .add("spcowner", DataTypes.INTEGER, ignored -> null)
+            // should be `aclitem[]` but we lack `aclitem`, so going with same choice that Cockroach made:
+            // https://github.com/cockroachdb/cockroach/blob/45deb66abbca3aae56bd27910a36d90a6a8bcafe/pkg/sql/vtable/pg_catalog.go#L746
+            .add("spcacl", DataTypes.STRING_ARRAY, ignored -> null)
+            .add("spcoptions", DataTypes.STRING_ARRAY, ignored -> null)
+            .build();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -61,7 +61,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(46L, response.rowCount());
+        assertEquals(47L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| character_sets| information_schema| BASE TABLE| NULL\n" +
@@ -90,6 +90,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_roles| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_settings| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_stats| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_tablespace| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_type| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| allocations| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| checks| sys| BASE TABLE| NULL\n" +
@@ -191,13 +192,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(46L, response.rowCount());
+        assertEquals(47L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(47L, response.rowCount());
+        assertEquals(48L, response.rowCount());
     }
 
     @Test
@@ -529,7 +530,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(841, response.rowCount());
+        assertEquals(846, response.rowCount());
     }
 
     @Test
@@ -773,7 +774,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(49L, response.rows()[0][0]);
+        assertEquals(50L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -99,7 +99,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(46L, response.rowCount());
+        assertEquals(47L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For compatibility with more PostgreSQL tools

Closes https://github.com/crate/crate/issues/10250

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)