### PR TITLE
Improve object cast error messages

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,8 @@ None
 Changes
 =======
 
+- Improved the error messages for cast errors for values of type ``object``.
+
 - Added support for the :ref:`CREATE TABLE AS <ref-create-table-as>` statement.
 
 Fixes

--- a/server/src/main/java/io/crate/exceptions/ConversionException.java
+++ b/server/src/main/java/io/crate/exceptions/ConversionException.java
@@ -21,11 +21,11 @@
 
 package io.crate.exceptions;
 
-import io.crate.expression.symbol.Symbol;
-import io.crate.types.DataType;
-
 import java.util.Arrays;
 import java.util.Locale;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.types.DataType;
 
 public class ConversionException extends IllegalArgumentException {
 
@@ -55,5 +55,19 @@ public class ConversionException extends IllegalArgumentException {
             sourceValue.getClass().isArray() ? Arrays.deepToString((Object[]) sourceValue) : sourceValue,
             targetType.getName()
         ));
+    }
+
+    public static ConversionException forObjectChild(String key, Object sourceValue, DataType<?> targetType) {
+        return new ConversionException(String.format(
+            Locale.ENGLISH,
+            "Cannot cast object element `%s` with value `%s` to type `%s`",
+            key,
+            sourceValue,
+            targetType
+        ));
+    }
+
+    private ConversionException(String message) {
+        super(message);
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -67,6 +67,8 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
     public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         try {
             return returnType.explicitCast(args[0].value());
+        } catch (ConversionException e) {
+            throw e;
         } catch (ClassCastException | IllegalArgumentException e) {
             throw new ConversionException(args[0].value(), returnType);
         }
@@ -95,6 +97,8 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
             Object value = ((Input<?>) argument).value();
             try {
                 return Literal.ofUnchecked(returnType, returnType.explicitCast(value));
+            } catch (ConversionException e) {
+                throw e;
             } catch (ClassCastException | IllegalArgumentException e) {
                 throw new ConversionException(argument, returnType);
             }

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -66,6 +66,8 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
         var targetType = targetTypeSignature.createType();
         try {
             return targetType.implicitCast(args[0].value());
+        } catch (ConversionException e) {
+            throw e;
         } catch (ClassCastException | IllegalArgumentException e) {
             throw new ConversionException(args[0].value(), targetType);
         }
@@ -98,6 +100,8 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
             Object value = ((Input<?>) argument).value();
             try {
                 return Literal.ofUnchecked(targetType, targetType.implicitCast(value));
+            } catch (ConversionException e) {
+                throw e;
             } catch (ClassCastException | IllegalArgumentException e) {
                 throw new ConversionException(argument, targetType);
             }

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -314,11 +314,14 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         execute("insert into t1 values ({a='abc'})");
         waitForMappingUpdateOnAll("t1", "o.a");
 
-        assertThrows(() -> execute("insert into t1 values ({a=['123', '456']})"),
-                     isSQLError(is("Cannot cast `{\"a\"=['123', '456']}` of type `object` to type `object`"),
-                         INTERNAL_ERROR,
-                         BAD_REQUEST,
-                         4000));
+        assertThrows(
+            () -> execute("insert into t1 values ({a=['123', '456']})"),
+            isSQLError(
+                is("Cannot cast object element `a` with value `[123, 456]` to type `text`"),
+                INTERNAL_ERROR,
+                BAD_REQUEST,
+                4000)
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Highlights the key and inner source/target type instead of having a
`Cannot cast {...} to type object` message.

Closes https://github.com/crate/crate/issues/10158

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)