### PR TITLE
bp: Remove close method in PageCacheRecycler/Recycler

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/recycler/AbstractRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/AbstractRecycler.java
@@ -28,9 +28,4 @@ abstract class AbstractRecycler<T> implements Recycler<T> {
         this.c = c;
     }
 
-    @Override
-    public void close() {
-        // no-op by default
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/common/recycler/ConcurrentDequeRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/ConcurrentDequeRecycler.java
@@ -38,13 +38,6 @@ public class ConcurrentDequeRecycler<T> extends DequeRecycler<T> {
     }
 
     @Override
-    public void close() {
-        assert deque.size() == size.get();
-        super.close();
-        size.set(0);
-    }
-
-    @Override
     public V<T> obtain() {
         final V<T> v = super.obtain();
         if (v.isRecycled()) {

--- a/server/src/main/java/org/elasticsearch/common/recycler/DequeRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/DequeRecycler.java
@@ -37,16 +37,6 @@ public class DequeRecycler<T> extends AbstractRecycler<T> {
     }
 
     @Override
-    public void close() {
-        // call destroy() for every cached object
-        for (T t : deque) {
-            c.destroy(t);
-        }
-        // finally get rid of all references
-        deque.clear();
-    }
-
-    @Override
     public V<T> obtain() {
         final T v = deque.pollFirst();
         if (v == null) {

--- a/server/src/main/java/org/elasticsearch/common/recycler/FilterRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/FilterRecycler.java
@@ -34,9 +34,4 @@ abstract class FilterRecycler<T> implements Recycler<T> {
         return wrap(getDelegate().obtain());
     }
 
-    @Override
-    public void close() {
-        getDelegate().close();
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/common/recycler/NoneRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/NoneRecycler.java
@@ -31,11 +31,6 @@ public class NoneRecycler<T> extends AbstractRecycler<T> {
         return new NV<>(c.newInstance());
     }
 
-    @Override
-    public void close() {
-        // no-op
-    }
-
     public static class NV<T> implements Recycler.V<T> {
 
         T value;

--- a/server/src/main/java/org/elasticsearch/common/recycler/Recycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/Recycler.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.lease.Releasable;
  * A recycled object, note, implementations should support calling obtain and then recycle
  * on different threads.
  */
-public interface Recycler<T> extends Releasable {
+public interface Recycler<T> {
 
     interface Factory<T> {
         Recycler<T> build();
@@ -52,8 +52,6 @@ public interface Recycler<T> extends Releasable {
         boolean isRecycled();
 
     }
-
-    void close();
 
     V<T> obtain();
 

--- a/server/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
@@ -145,13 +145,6 @@ public enum Recyclers {
                 return recyclers[slot()];
             }
 
-            @Override
-            public void close() {
-                for (Recycler<T> recycler : recyclers) {
-                    recycler.close();
-                }
-            }
-
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/PageCacheRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/util/PageCacheRecycler.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.recycler.AbstractRecyclerC;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.settings.Setting;
@@ -39,7 +37,7 @@ import static org.elasticsearch.common.recycler.Recyclers.dequeFactory;
 import static org.elasticsearch.common.recycler.Recyclers.none;
 
 /** A recycler of fixed-size pages. */
-public class PageCacheRecycler implements Releasable {
+public class PageCacheRecycler {
 
     public static final Setting<Type> TYPE_SETTING =
         new Setting<>("cache.recycler.page.type", Type.CONCURRENT.name(), Type::parse, Property.NodeScope);
@@ -71,11 +69,6 @@ public class PageCacheRecycler implements Releasable {
 
     static {
         NON_RECYCLING_INSTANCE = new PageCacheRecycler(Settings.builder().put(LIMIT_HEAP_SETTING.getKey(), "0%").build());
-    }
-
-    @Override
-    public void close() {
-        Releasables.close(true, bytePage, intPage, longPage, objectPage);
     }
 
     public PageCacheRecycler(Settings settings) {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -367,7 +367,6 @@ public class Node implements Closeable {
 
             PageCacheRecycler pageCacheRecycler = createPageCacheRecycler(settings);
             BigArrays bigArrays = createBigArrays(pageCacheRecycler, circuitBreakerService);
-            resourcesToClose.add(pageCacheRecycler);
             modules.add(settingsModule);
             List<NamedWriteableRegistry.Entry> namedWriteables = Stream.of(
                 NetworkModule.getNamedWriteables().stream(),
@@ -879,7 +878,6 @@ public class Node implements Closeable {
         toClose.add(() -> stopWatch.stop());
 
         toClose.add(injector.getInstance(NodeEnvironment.class));
-        toClose.add(injector.getInstance(PageCacheRecycler.class));
 
         if (logger.isTraceEnabled()) {
             logger.trace("Close times for each service:\n{}", stopWatch.prettyPrint());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Saw some failures on CI:

    Cause 1: java.lang.AssertionError
     	at __randomizedtesting.SeedInfo.seed([A2CA882FA1DE9F03]:0)
     	at org.elasticsearch.common.recycler.ConcurrentDequeRecycler.close(ConcurrentDequeRecycler.java:42)
     	at io.crate.common.io.IOUtils.close(IOUtils.java:99)
     	at io.crate.common.io.IOUtils.close(IOUtils.java:81)
     	at org.elasticsearch.common.lease.Releasables.close(Releasables.java:36)
     	at org.elasticsearch.common.lease.Releasables.close(Releasables.java:46)
     	at org.elasticsearch.common.lease.Releasables.close(Releasables.java:67)
     	at org.elasticsearch.common.lease.Releasables.close(Releasables.java:75)
     	at org.elasticsearch.common.util.PageCacheRecycler.close(PageCacheRecycler.java:78)
     	at io.crate.common.io.IOUtils.close(IOUtils.java:99)
     	at io.crate.common.io.IOUtils.close(IOUtils.java:81)
     	at org.elasticsearch.node.Node.close(Node.java:887)
     	at org.elasticsearch.test.InternalTestCluster$NodeAndClient.close(InternalTestCluster.java:904)

https://github.com/elastic/elasticsearch/commit/7953f9ac71850c8483f5b6b9b764f55ddf6d4119


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)