### PR TITLE
Adjust "crate-node" auxiliary program to use the bundled Java runtime

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -369,6 +369,44 @@ task createCrateNodeScripts(type: CreateStartScripts) {
     mainClassName = 'org.elasticsearch.cluster.coordination.NodeToolCli'
     applicationName = 'crate-node'
     classpath = sourceSets.main.runtimeClasspath + files('lib/crate-app.jar')
+
+
+    // Helper functions for manipulating start script contents.
+    ext.insertBefore = { String originalString, String needleString, String insertString ->
+        StringBuilder builder = new StringBuilder(originalString);
+        Integer position = builder.indexOf(needleString);
+        builder.insert(position, insertString);
+        return builder.toString();
+    }
+
+    ext.insertAfter = { String originalString, String needleString, String insertString ->
+        StringBuilder builder = new StringBuilder(originalString);
+        Integer position = builder.indexOf(needleString) + needleString.length();
+        builder.insert(position, insertString);
+        return builder.toString();
+    }
+
+    doLast {
+
+        // Unix: Prevent using the system-wide Java installation.
+        unixScript.text = insertAfter(unixScript.text, '#!/usr/bin/env sh\n', 'unset JAVA_HOME\n');
+
+        // Unix: Use the bundled Java runtime.
+        unixScript.text = unixScript.text.replace('JAVACMD="java"', """
+            if \${darwin}; then
+                JAVACMD="\${APP_HOME}/jdk/Contents/Home/bin/java"
+            else
+                JAVACMD="\${APP_HOME}/jdk"
+            fi
+        """)
+        unixScript.text = unixScript.text.replace('which java', 'which ${JAVACMD}')
+
+        // Windows: Prevent using the system-wide Java installation.
+        windowsScript.text = insertBefore(windowsScript.text, 'if defined JAVA_HOME', 'set JAVA_HOME=\n');
+
+        // Windows: Use the bundled Java runtime.
+        windowsScript.text = windowsScript.text.replace('set JAVA_EXE=java.exe', 'set JAVA_EXE=%APP_HOME%/jdk/bin/java.exe')
+    }
 }
 
 test {

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -89,5 +89,7 @@ Fixes
 
 - Adjusted ``crate.bat`` to work with spaces in directory names.
 
+- Adjusted ``crate-node`` auxiliary program to use the bundled Java runtime.
+
 - Fixed a ``NullPointerException`` when trying to kill a job as normal user
   which is no longer running.


### PR DESCRIPTION
Hi there,

@proddata discovered a flaw when trying to run the auxiliary `crate-node` program shipped within the distribution bundles. Thank you very much. After shipping CrateDB with the bundled Java runtime, this has not been adjusted appropriately.

## Observations

Those error messages reveal different conditions on Windows (no Java installed) and macOS (older Java runtime installed).

### Windows
```sh
PS C:\opt\crate> .\bin\crate-node.bat

ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
```

### macOS
```sh
$ ./bin/crate-node
Error: LinkageError occurred while loading main class org.elasticsearch.cluster.coordination.NodeToolCli
	java.lang.UnsupportedClassVersionError: org/elasticsearch/cluster/coordination/NodeToolCli has been compiled by a more recent version of the Java Runtime (class file version 59.0), this version of the Java Runtime only recognizes class file versions up to 58.0
```

## Mitigation
This patch adjusts the contents of the generated start scripts by Gradle's `CreateStartScripts` task type. It will prevent a) to accidentally use any system-wide Java installation and b) will adjust the program to use the bundled Java runtime.

## Outlook
We can also use this patch as a reference to bring an issue to Gradle in order to improve the vanilla start script templates [1]. I believe having an out-of-the-box option there to generate start scripts using a bundled Java runtime is nothing that is very much esoteric.

With kind regards,
Andreas.

P.S.: In order to debug such situations on Linux and macOS machines, I created a gist which walks you through the steps how to conveniently invoke CrateDB on Windows by using ready-made Docker Windows images through a Vagrant-managed VM. This makes approaching such flaws almost effortless compared to the expenditure needed to manually install such an environment.

[1] https://github.com/gradle/gradle/tree/v6.8.3/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins
[2] https://gist.github.com/amotl/69046c2c4a8e6744b1d6cde3f9523119
