### PR TITLE
Change VersionUtils.getPreviousVersion() to return previous MAJOR.MINOR

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -345,6 +345,13 @@ public class Version implements Comparable<Version>, ToXContentFragment {
         return version.internalId > internalId;
     }
 
+    public boolean beforeMajorMinor(Version version) {
+        if (version.major == major) {
+            return version.minor > minor;
+        }
+        return version.major > major;
+    }
+
     public boolean onOrBefore(Version version) {
         return version.internalId >= internalId;
     }

--- a/server/src/test/java/org/elasticsearch/test/VersionUtils.java
+++ b/server/src/test/java/org/elasticsearch/test/VersionUtils.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.test;
 
-import org.elasticsearch.Version;
-import javax.annotation.Nullable;
 import io.crate.common.collections.Tuple;
+import org.elasticsearch.Version;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -144,12 +144,12 @@ public class VersionUtils {
     }
 
     /**
-     * Get the released version before {@code version}.
+     * Get the released version before {@code version}'s MAJOR.MINOR.
      */
     public static Version getPreviousVersion(Version version) {
         for (int i = RELEASED_VERSIONS.size() - 1; i >= 0; i--) {
             Version v = RELEASED_VERSIONS.get(i);
-            if (v.before(version)) {
+            if (v.beforeMajorMinor(version)) {
                 return v;
             }
         }
@@ -157,7 +157,7 @@ public class VersionUtils {
     }
 
     /**
-     * Get the released version before {@link Version#CURRENT}.
+     * Get the released version before {@link Version#CURRENT}'s MAJOR.MINOR.
      */
     public static Version getPreviousVersion() {
         Version version = getPreviousVersion(Version.CURRENT);


### PR DESCRIPTION
Since https://github.com/crate/crate/commit/543e839b111, shard allocation
on previous versions is allowed if the previous version is on the
same MAJOR.MINOR.

In order for other tests which expect a failure on allocation with
a previous version, the helper method to retrieve a previous version
must be changed to return a version before current's MAJOR.MINOR.
On current master test are passing as no lower hotfix version exists.

Follow up of https://github.com/crate/crate/commit/543e839b111.

Relates to test failures seen at #11104.
I'll amend this commit at #11104 once approved. 

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
