### PR TITLE
Exclude keys with null value from source

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,10 @@ None
 Changes
 =======
 
+- Optimized how ``NULL`` values are stored, reducing the amount of disk space
+  required. This can also improve the performance of value lookups on tables
+  with a lot of null values.
+
 - Added the ``regclass`` data type for improved compatibility with PostgreSQL
   tools.
 

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -105,7 +105,9 @@ public final class InsertSourceFromCells implements InsertSourceGen {
                 .valueType()
                 .valueForInsert(row.get(i));
             var column = target.column();
-            Maps.mergeInto(source, column.name(), column.path(), valueForInsert, Map::putIfAbsent);
+            if (valueForInsert != null) {
+                Maps.mergeInto(source, column.name(), column.path(), valueForInsert, Map::putIfAbsent);
+            }
         }
         for (int i = 0; i < partitionedByColumns.size(); i++) {
             var pCol = partitionedByColumns.get(i);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adapts the source generation so that keys with `null` value are
excluded from the source.

With this change both of the following statements lead to the same
`_raw` payload:

    INSERT INTO tbl (x, y) VALUES (1, null);
    INSERT INTO tbl (x) VALUES (1);

Before this commit, the first variant would lead to a `y` key being
present in `_raw`, while the second statement ommitted the key.

Closes https://github.com/crate/crate/issues/11109

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)