### PR TITLE
Fix hash join execution plan with empty sys.shards table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to a stuck ``INNER JOIN`` query involving the
+  ``sys.shards`` table on a cluster without user tables.
+
 - Fixed shard allocation on downgraded nodes where only the ``HOTFIX`` version
   part differs to fully support rolling downgrades to same ``MAJOR.MINOR``
   versions.


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/11089

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)