### PR TITLE
Fix trace logging of negative byte values in ChildMemoryCircuitBreaker

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,6 +74,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that led to ``Values less than -1 bytes`` errors if ``TRACE``
+  logging was activated for the circuit breaker package.
+
 - Fixed an issue that could lead to a stuck ``INNER JOIN`` query involving the
   ``sys.shards`` table on a cluster without user tables.
 

--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -156,11 +156,11 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
                 logger.trace(
                     "[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: {} [{}]]",
                     this.name,
-                    new ByteSizeValue(bytes),
+                    ByteSizeValue.humanReadableBytes(bytes),
                     label,
-                    new ByteSizeValue(newUsed),
+                    ByteSizeValue.humanReadableBytes(newUsed),
                     memoryBytesLimit,
-                    new ByteSizeValue(memoryBytesLimit)
+                    ByteSizeValue.humanReadableBytes(memoryBytesLimit)
                 );
             }
             if (memoryBytesLimit > 0 && newUsed > memoryBytesLimit) {
@@ -168,10 +168,10 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
                     "[{}] New used memory {} [{}] for data of [{}] would be larger than configured breaker: {} [{}], breaking",
                     this.name,
                     newUsed,
-                    new ByteSizeValue(newUsed),
+                    ByteSizeValue.humanReadableBytes(newUsed),
                     label,
                     memoryBytesLimit,
-                    new ByteSizeValue(memoryBytesLimit)
+                    ByteSizeValue.humanReadableBytes(memoryBytesLimit)
                 );
                 circuitBreak(label, newUsed);
             }

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -94,24 +94,8 @@ public class ByteSizeValue implements Comparable<ByteSizeValue>, ToXContentFragm
         return unit.toPB(size);
     }
 
-    public double getKbFrac() {
-        return ((double) getBytes()) / ByteSizeUnit.C1;
-    }
-
     public double getMbFrac() {
         return ((double) getBytes()) / ByteSizeUnit.C2;
-    }
-
-    public double getGbFrac() {
-        return ((double) getBytes()) / ByteSizeUnit.C3;
-    }
-
-    public double getTbFrac() {
-        return ((double) getBytes()) / ByteSizeUnit.C4;
-    }
-
-    public double getPbFrac() {
-        return ((double) getBytes()) / ByteSizeUnit.C5;
     }
 
     /**
@@ -131,26 +115,34 @@ public class ByteSizeValue implements Comparable<ByteSizeValue>, ToXContentFragm
 
     @Override
     public String toString() {
-        long bytes = getBytes();
+        return humanReadableBytes(getBytes());
+    }
+
+    public static String humanReadableBytes(long bytes) {
+        String prefix = "";
+        if (bytes < 0) {
+            bytes = bytes * -1;
+            prefix = "-";
+        }
         double value = bytes;
         String suffix = ByteSizeUnit.BYTES.getSuffix();
         if (bytes >= ByteSizeUnit.C5) {
-            value = getPbFrac();
+            value = ((double) bytes) / ByteSizeUnit.C5;
             suffix = ByteSizeUnit.PB.getSuffix();
         } else if (bytes >= ByteSizeUnit.C4) {
-            value = getTbFrac();
+            value = ((double) bytes) / ByteSizeUnit.C4;
             suffix = ByteSizeUnit.TB.getSuffix();
         } else if (bytes >= ByteSizeUnit.C3) {
-            value = getGbFrac();
+            value = ((double) bytes) / ByteSizeUnit.C3;
             suffix = ByteSizeUnit.GB.getSuffix();
         } else if (bytes >= ByteSizeUnit.C2) {
-            value = getMbFrac();
+            value = ((double) bytes) / ByteSizeUnit.C2;
             suffix = ByteSizeUnit.MB.getSuffix();
         } else if (bytes >= ByteSizeUnit.C1) {
-            value = getKbFrac();
+            value = ((double) bytes) / ByteSizeUnit.C1;
             suffix = ByteSizeUnit.KB.getSuffix();
         }
-        return Strings.format1Decimals(value, suffix);
+        return prefix + Strings.format1Decimals(value, suffix);
     }
 
     public static ByteSizeValue parseBytesSizeValue(String sValue, String settingName) throws ElasticsearchParseException {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTest.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTest.java
@@ -1,0 +1,17 @@
+
+package org.elasticsearch.common.unit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ByteSizeValueTest {
+
+    @Test
+    public void test_can_print_negative_byte_values() throws Exception {
+        assertThat(ByteSizeValue.humanReadableBytes(- 283479283), is("-270.3mb"));
+    }
+}
+
+


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `ByteSizeValue` constructor doesn't permit negative values.
Activating trace logging for the breaker package resulted in exceptions:

    SQLParseException[Values less than -1 bytes are not supported: -2097152b]
    io.crate.exceptions.SQLParseException: Values less than -1 bytes are not supported: -2097152b

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)