### PR TITLE
Adjust "crate.bat" to work with spaces in directory names

### DIFF
--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -53,7 +53,7 @@ if NOT DEFINED "%CRATE_DISABLE_GC_LOGGING%" (
 
   SET LOGGC=!GC_LOG_DIR!\gc.log
 
-  SET JAVA_OPTS=!JAVA_OPTS! -Xlog:gc*,gc+age=trace,safepoint:file=\"!LOGGC!\":utctime,pid,tags:filecount=!GC_LOG_FILES!,filesize=!GC_LOG_SIZE!
+  SET JAVA_OPTS=!JAVA_OPTS! -Xlog:gc*,gc+age=trace,safepoint:file="!LOGGC!":utctime,pid,tags:filecount=!GC_LOG_FILES!,filesize=!GC_LOG_SIZE!
 )
 
 REM Disables explicit GC
@@ -104,7 +104,7 @@ for /F "usebackq tokens=* delims= " %%A in (!params!) do (
     )
 )
 
-set JAVA_HOME="%CRATE_HOME%\jdk"
+set JAVA_HOME=%CRATE_HOME%\jdk
 if not exist !JAVA_HOME! (
     ECHO JAVA_HOME environment variable must be set! 1>&2
     EXIT /B 1

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -83,3 +83,5 @@ Fixes
 - Fixed shard allocation on downgraded nodes where only the ``HOTFIX`` version
   part differs to fully support rolling downgrades to same ``MAJOR.MINOR``
   versions.
+
+- Adjusted ``crate.bat`` to work with spaces in directory names.


### PR DESCRIPTION
Hi there,

at #11110, @nkev reported some problems when trying to start CrateDB on Windows using `crate.bat` after expanding the Zip archive to his user's home directory containing spaces, like `C:\Users\Firstname Lastname\Downloads\crate-4.4.2`.

This patch coming from https://github.com/crate/crate/issues/11110#issuecomment-794650835 accounts for the situation and has been verified both on my Docker-based setup [1] and on @nkev's machine by applying it in an ad hoc manner. It accompanies the patch #10845 recently handed in by @mechanomi.

With kind regards,
Andreas.

[1] https://gist.github.com/amotl/69046c2c4a8e6744b1d6cde3f9523119