### PR TITLE
Stop sampling on CircuitBreakingException instead of failing

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,6 +74,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that led to a ``CircuitBreakingException`` when using the
+  ``ANALYZE`` statement.
+
 - Fixed an issue that led to ``Values less than -1 bytes`` errors if ``TRACE``
   logging was activated for the circuit breaker package.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11107

I first tried a different approach that uses the `numDocs` and
`getSizeInBytes` information of the index reader to calculate the number
of samples that safely fit into the available memory.

But the `bytesPerDoc` estimates that I ended up calculating were much
lower than the `RowAccounting` instances is calculating.
I suspect it's partly because of UTF-16 `String` vs. utf-8 bytes
differences.

So I choose this different approach of simply stopping sampling.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)