### PR TITLE
Jf/fix kill npe for normal users

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -88,3 +88,6 @@ Fixes
   versions.
 
 - Adjusted ``crate.bat`` to work with spaces in directory names.
+
+- Fixed a ``NullPointerException`` when trying to kill a job as normal user
+  which is no longer running.

--- a/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
@@ -228,7 +228,7 @@ public class TasksServiceTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_normal_user_cannot_kill_job_of_other_user() throws Exception {
+    public void testNormalUserCannotKillJobOfOtherUser() throws Exception {
         UUID jobId = UUID.randomUUID();
         RootTask.Builder builder = tasksService.newBuilder(jobId, "Arthur", "dummyNode", List.of());
         builder.addTask(new DummyTask());
@@ -236,5 +236,10 @@ public class TasksServiceTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(tasksService.killJobs(List.of(jobId), "Trillian", null).get(5L, TimeUnit.SECONDS), is(0));
         assertThat(tasksService.killJobs(List.of(jobId), "Arthur", null).get(5L, TimeUnit.SECONDS), is(1));
+    }
+
+    @Test
+    public void testKillNonExistingJobForNormalUser() throws Exception {
+        assertThat(tasksService.killJobs(List.of(UUID.randomUUID()), "Arthur", null).get(5L, TimeUnit.SECONDS), is(0));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Trying to kill a non-existing job for a normal users leads to an exception: `NullPointerException[Cannot invoke "io.crate.execution.jobs.RootTask.userName()" because "ctx" is null]`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
