### PR TITLE
bp: Fix testCancelRecoveryDuringPhase1

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -632,7 +632,7 @@ public class RecoverySourceHandler {
         }
     }
 
-    private void createRetentionLease(final long startingSeqNo, ActionListener<RetentionLease> listener) {
+    void createRetentionLease(final long startingSeqNo, ActionListener<RetentionLease> listener) {
         runUnderPrimaryPermit(
             () -> {
                 // Clone the peer recovery retention lease belonging to the source shard. We are retaining history between the the local


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Got a failure locally so I started investigating and it turned up this change:

https://github.com/elastic/elasticsearch/commit/50bd5842c3cbaa3a68f95cb84f6d893c7fabf50e


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)