### PR TITLE
bp: Remove pre 6.0.0 support from InternalEngine

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -592,6 +592,7 @@ should be crossed out as well.
 - [x] 328ba09f84b Omit non-masters in ClusterFormationFailureHelper (#41344)
 - [x] 2f41b1b64de Remove `Tracer` from `MockTransportService` (#40237)
 - [x] 7624734f14b Added wait_for_metadata_version parameter to cluster state api (#35535)
+- [x] ebb93db0102 Remove pre 6.0.0 support from InternalEngine (#27720)
 
 Below lists deferred patches. In-between patches that we applied or skipped
 are not listed anymore.


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/commit/ebb93db01029698d0204991a9e75be791f9c6306

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
