### PR TITLE
Prevent invalid version creation for default and empty versions

### DIFF
--- a/extensions/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
+++ b/extensions/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
@@ -53,6 +53,7 @@ import java.util.UUID;
 
 import static io.crate.testing.MoreMatchers.withFeature;
 import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
+import static org.elasticsearch.test.ESTestCase.settings;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -93,7 +94,7 @@ public class NodeInfoTest {
                                                        ShardRoutingState.UNASSIGNED));
 
         var routingTable = RoutingTable.builder().add(indexRoutingTableBuilder).build();
-        var meta = IndexMetadata.builder(tableName).numberOfShards(1).numberOfReplicas(2);
+        var meta = IndexMetadata.builder(tableName).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(2);
         this.clusterState = ClusterState.builder(new ClusterName("crate")).version(1L).routingTable(routingTable)
             .metadata(Metadata.builder().put(meta));
     }
@@ -224,7 +225,7 @@ public class NodeInfoTest {
 
 
         var routingTable = RoutingTable.builder().add(indexRoutingTableBuilder).build();
-        var meta = IndexMetadata.builder(tableName).numberOfShards(1).numberOfReplicas(2);
+        var meta = IndexMetadata.builder(tableName).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(2);
         var cs = ClusterState.builder(new ClusterName("crate")).version(1L).routingTable(routingTable)
             .metadata(Metadata.builder().put(meta));
 

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -149,6 +149,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
         assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
                 + org.apache.lucene.util.Version.LATEST + "] is still set to [" + CURRENT.luceneVersion + "]";
 
+        builder.put(V_EMPTY_ID, V_EMPTY);
         ID_TO_VERSION = builder.build();
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1084,7 +1084,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Version> versionSetting(final String key, final Version defaultValue, Property... properties) {
-        return new Setting<>(key, s -> Integer.toString(defaultValue.externalId), s -> Version.fromId(Integer.parseInt(s)), properties);
+        return new Setting<>(key, s -> Integer.toString(defaultValue.internalId), s -> Version.fromId(Integer.parseInt(s)), properties);
     }
 
     public static Setting<Float> floatSetting(String key, float defaultValue, Property... properties) {

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -22,6 +22,8 @@
 package org.elasticsearch.common.settings;
 
 import io.crate.common.collections.Tuple;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.AbstractScopedSettings.SettingUpdater;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -1011,4 +1013,22 @@ public class SettingTests extends ESTestCase {
         assertEquals("", value);
     }
 
+    /*
+     * The empty version lookup was not correctly handled and resulted in a wrong lucene version
+     */
+    @Test
+    public void test_empty_version_from_setting() {
+        var emptyVersion = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(Settings.EMPTY);
+        assertThat(emptyVersion, is((Version.V_EMPTY)));
+    }
+
+    /*
+     * The default version handling was broken because it was based on the external id and not the correct
+     * internal id and led to invalid ids.
+     */
+    @Test
+    public void test_default_version_from_setting() {
+        var defaultVersion = Setting.versionSetting(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).get(Settings.EMPTY);
+        assertThat(defaultVersion, is(Version.CURRENT));
+    }
 }


### PR DESCRIPTION
This prevents invalid version creation for the case where the version
id is either empty or handled as default value from the Setting.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
