### PR TITLE
tests: Dump active tasks on SQL request timeout

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -179,6 +179,9 @@ public class TransportDistributedResultAction implements NodeAction<DistributedR
             scheduler.schedule(operationRunnable::run, delay.getMillis(), TimeUnit.MILLISECONDS);
             return operationRunnable;
         } else {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Received a result for job={} but couldn't find a RootTask for it", request.jobId());
+            }
             List<String> excludedNodeIds = Collections.singletonList(clusterService.localNode().getId());
             /* The upstream (DistributingConsumer) forwards failures to other downstreams and eventually considers its job done.
              * But it cannot inform the handler-merge about a failure because the JobResponse is sent eagerly.

--- a/server/src/main/java/io/crate/execution/jobs/TasksService.java
+++ b/server/src/main/java/io/crate/execution/jobs/TasksService.java
@@ -266,4 +266,14 @@ public class TasksService extends AbstractLifecycleComponent {
             }
         }
     }
+
+    @VisibleForTesting
+    public void logActiveTasksToError() {
+        if (LOGGER.isErrorEnabled()) {
+            String localNodeId = clusterService.localNode().getId();
+            for (var entry : activeTasks.entrySet()) {
+                LOGGER.error("Active task node={} jobId={}, task={}", localNodeId, entry.getKey(), entry.getValue());
+            }
+        }
+    }
 }

--- a/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -185,9 +185,6 @@ public class SQLTransportExecutor {
                 }
             }
             return execute(stmt, args).actionGet(timeout);
-        } catch (ElasticsearchTimeoutException e) {
-            LOGGER.error("Timeout on SQL statement: {} {}", stmt, e);
-            throw e;
         } catch (RuntimeException e) {
             var cause = e.getCause();
             // ActionListener.onFailure takes `Exception` as argument instead of `Throwable`.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Can help figure out why a request ran into a timeout.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)