### PR TITLE
Add "function" to the glossary plus related improvements

### DIFF
--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -481,7 +481,7 @@ def load_tests(loader, suite, ignore):
                             'general/user-defined-functions.rst',
                             'general/information-schema.rst',
                             'general/builtins/aggregation.rst',
-                            'general/builtins/scalar.rst',
+                            'general/builtins/scalar-functions.rst',
                             'admin/user-management.rst',
                             'admin/system-information.rst',
                             'admin/privileges.rst',

--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -53,8 +53,8 @@ Privilege types
 
 Granting ``Data Query Language (DQL)`` privilege to a user, indicates that this
 user is allowed to execute ``SELECT``, ``SHOW``, ``REFRESH`` and ``COPY TO``
-statements, as well as using the available user defined functions, on the
-object for which the privilege applies.
+statements, as well as using the available :ref:`user-defined functions
+<user-defined-functions>`, on the object for which the privilege applies.
 
 
 ``DML``
@@ -141,7 +141,7 @@ those from a higher level:
   table view
 
 This statement will grant ``DQL`` privilege to user riley on all the tables
-and functions of the ``doc`` schema::
+and :ref:`functions <gloss-function>` of the ``doc`` schema::
 
     cr> GRANT DQL ON SCHEMA doc TO riley;
     GRANT OK, 1 row affected (... sec)

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -141,5 +141,5 @@ shows whether the user has superuser privileges or not.
 .. NOTE::
 
     CrateDB also supports retrieving the current connected user using the
-    system information functions: :ref:`CURRENT_USER <current_user>`,
-    :ref:`USER <user>` and :ref:`SESSION_USER <session_user>`.
+    :ref:`system information functions <scalar-sysinfo>`: :ref:`CURRENT_USER
+    <current_user>`, :ref:`USER <user>` and :ref:`SESSION_USER <session_user>`.

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -99,7 +99,7 @@ would otherwise require traditional transactions.
 Unsupported features and functions
 ==================================
 
-These **features** of `standard SQL`_ are not supported:
+These *features* of `standard SQL`_ are not supported:
 
 - Stored procedures
 
@@ -119,13 +119,14 @@ These **features** of `standard SQL`_ are not supported:
 
   - Exclusion constraints
 
-These **functions** of `standard SQL`_ are either not supported or only partly supported:
+These *functions* of `standard SQL`_ are either not supported or only partly
+supported:
 
-- Aggregate functions
+- :ref:`Aggregate functions <aggregation-functions>`
 
   - Various functions available (see :ref:`aggregation`)
 
-- Window functions
+- :ref:`Window functions <window-functions>`
 
   - Various functions available (see :ref:`window-functions`)
 
@@ -145,15 +146,16 @@ These **functions** of `standard SQL`_ are either not supported or only partly s
 
 - XML functions
 
-**Note**: The currently supported and unsupported features in CrateDB are
-exposed in the :ref:`information_schema` table (see :ref:`sql_features` for
-usage).
+.. NOTE::
+
+    The currently supported and unsupported features in CrateDB are exposed in
+    the :ref:`information_schema` table (see :ref:`sql_features` for usage).
 
 CrateDB also supports the `PostgreSQL wire protocol`_.
 
-If you have use cases for any missing features, functions, or dialect
-improvements, let us know on `Github`_! We are always improving and extending
-CrateDB and would love to hear your feedback.
+If you have use cases for any missing features, :ref:`functions
+<gloss-function>`, or dialect improvements, let us know on `Github`_! We are
+always improving and extending CrateDB and would love to hear your feedback.
 
 
 .. _Github: https://github.com/crate/crate

--- a/docs/appendices/glossary.rst
+++ b/docs/appendices/glossary.rst
@@ -1,3 +1,5 @@
+.. highlight:: psql
+
 .. _appendix-glossary:
 
 ========
@@ -42,6 +44,41 @@ C
 .. _gloss-f:
 
 
+F
+-
+
+.. _gloss-function:
+
+**Function**
+    A token (e.g., :ref:`replace <scalar-replace>`) that takes zero or more
+    arguments (e.g., three :ref:`strings <character-data-types>`), performs a
+    specific task, and may return one or more values (e.g., a modified
+    string). Functions that return more than one value are called
+    :ref:`multi-valued functions <gloss-multi-valued-functions>`.
+
+    Functions may be :ref:`called <sql-function-call>` in an SQL statement,
+    like so::
+
+        cr> SELECT replace('Hello world!', 'world', 'friend') as result;
+        +---------------+
+        | result        |
+        +---------------+
+        | Hello friend! |
+        +---------------+
+        SELECT 1 row in set (... sec)
+
+    .. SEEALSO::
+
+        :ref:`scalar-functions`
+
+        :ref:`aggregation-functions`
+
+        :ref:`table-functions`
+
+        :ref:`window-functions`
+
+        :ref:`user-defined-functions`
+
 .. _gloss-g:
 
 
@@ -76,6 +113,16 @@ M
 
          :ref:`Cluster configuration: Metadata gateway <metadata_gateway>`
 
+.. _gloss-multi-valued-functions:
+
+**Multi-valued function**
+    A :ref:`function <gloss-function>` that returns two or more values.
+
+    .. SEEALSO::
+
+        :ref:`table-functions`
+
+        :ref:`window-functions`
 
 .. _gloss-n:
 
@@ -226,7 +273,7 @@ R
         :ref:`Storage and consistency: Addressing documents
         <concepts_addressing_documents>`
 
-        :ref:`Sharding: Routing <routing>`
+        :ref:`Sharding: Routing <sharding-routing>`
 
         :ref:`CREATE TABLE: CLUSTERED clause <sql-create-table-clustered>`
 
@@ -266,7 +313,7 @@ S
 
         :ref:`Cluster configuration: Routing allocation <conf_routing>`
 
-        :ref:`Sharding: Number of shards <number-of-shards>`
+        :ref:`Sharding: Number of shards <sharding-number>`
 
         :ref:`Altering tables: Changing the number of shards
         <alter-shard-number>`

--- a/docs/appendices/release-notes/1.0.0.rst
+++ b/docs/appendices/release-notes/1.0.0.rst
@@ -8,11 +8,11 @@ Released on 2016/12/05.
 
 .. NOTE::
 
-    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or higher
-    before you upgrade to 1.0.0.
+    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or
+    higher before you upgrade to 1.0.0.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
 .. WARNING::
 
@@ -27,116 +27,121 @@ Released on 2016/12/05.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
 
- - Removed ``schema_name`` from ``information_schema.tables``,
-   ``information_schema.columns``, and ``information_schema.table_constraints``
-   in favour of ``table_schema``.
+- Removed ``schema_name`` from ``information_schema.tables``,
+  ``information_schema.columns``, and ``information_schema.table_constraints``
+  in favour of ``table_schema``.
 
- - Possibly BREAKING blob storage changes:
+- Possibly BREAKING blob storage changes:
 
-   - Changed blob storage to utilize all paths listed under ``path.data``.
+- Changed blob storage to utilize all paths listed under ``path.data``.
 
-   - Changed the directory layout in case a custom ``blobs.path`` is
-     configured. This allows running two nodes on the same machine pointing to
-     the same ``blobs.path`` without conflicts.
+  - Changed the directory layout in case a custom ``blobs.path`` is
+    configured. This allows running two nodes on the same machine pointing to
+    the same ``blobs.path`` without conflicts.
 
-   These changes require a manual migration for users who have blob tables and
-   either had:
+    These changes require a manual migration for users who have blob tables and
+    either had:
 
      - Multiple paths configured under ``path.data``
 
      - A custom ``blobs.path`` set either globally or per table.
 
-   Please run the `migration script`_ provided **before** updating to examine
-   whether you are affected by these changes. The migration script will tell
-   you what has to be done.
+  Please run the `migration script`_ provided **before** updating to examine
+  whether you are affected by these changes. The migration script will tell you
+  what has to be done.
+
 
 Changes
 -------
 
- - Removed the ``client`` package which contained the deprecated
-   ``crate-client``. You should start using the PostgreSQL JDBC driver instead.
+- Removed the ``client`` package which contained the deprecated
+  ``crate-client``. You should start using the PostgreSQL JDBC driver instead.
 
- - Removed Java 7 support
+- Removed Java 7 support
 
- - Optimize execution of joins by ordering the join relations based on
-   join/where conditions.
+- Optimize execution of joins by ordering the join relations based on
+  join/where conditions.
 
- - Improved error message if function is unsupported with ``distinct``.
+- Improved error message if a :ref:`function <gloss-function>` is unsupported
+  with ``distinct``.
 
- - Nested numeric factors do not require brackets any more; e.g. ``SELECT + -
-   10`` is now supported.
+- Nested numeric factors do not require brackets any more; e.g. ``SELECT + -
+  10`` is now supported.
 
- - Added subscript support for ``cast`` and ``try_cast`` expressions. e.g.:
-   ``select cast(coordinates as array(double))[1] from sys.summits`` is now
-   possible
+- Added subscript support for ``cast`` and ``try_cast`` expressions. e.g.:
+  ``select cast(coordinates as array(double))[1] from sys.summits`` is now
+  possible
 
- - Upgraded Elasticsearch to 2.4.2.
+- Upgraded Elasticsearch to 2.4.2.
 
- - Added scalar functions ``latitude`` and ``longitude`` to extract latitude
-   and longitude of a ``geo_point``.
+- Added scalar functions ``latitude`` and ``longitude`` to extract latitude and
+  longitude of a ``geo_point``.
 
- - Improved performance of ``array_cat`` and ``array_difference`` scalar
-   functions if the array contains function expressions.
+- Improved performance of ``array_cat`` and ``array_difference`` scalar
+  functions if the array contains function expressions.
 
- - New setting ``stats.service.interval`` which allows to control the refresh
-   interval of the table statistics used to create optimal query execution
-   plans.
+- New setting ``stats.service.interval`` which allows to control the refresh
+  interval of the table statistics used to create optimal query execution
+  plans.
 
- - Added support for global aggregations on subselects.
+- Added support for global aggregations on subselects.
 
- - Added the ``-C`` option for providing CrateDB settings and deprecated usage
-   of the ``.es`` prefix with ``-D`` option.
+- Added the ``-C`` option for providing CrateDB settings and deprecated usage
+  of the ``.es`` prefix with ``-D`` option.
 
- - Added support for global aggregations on joins
+- Added support for global aggregations on joins
 
- - Log unhandled HTTP related exceptions as ``debug`` instead of ``error``.
+- Log unhandled HTTP related exceptions as ``debug`` instead of ``error``.
 
- - Implemented ``if`` conditional function.
+- Implemented ``if`` conditional function.
 
- - F261/F262: Implemented ``CASE`` expression support.
+- F261/F262: Implemented ``CASE`` expression support.
 
- - Removed the duplicate ``rowcount`` field from the HTTP response.
+- Removed the duplicate ``rowcount`` field from the HTTP response.
 
- - Added the ``search_path`` session setting parameter. The default table
-   schema can be set with ``SET SESSION search_path = schema_name``.
+- Added the ``search_path`` session setting parameter. The default table schema
+  can be set with ``SET SESSION search_path = schema_name``.
 
- - Updated crate-admin to 1.0.1 which includes the following changes:
+- Updated crate-admin to 1.0.1 which includes the following changes:
 
-    - Fixed an issue that caused incorrect URL paths if the project gets built.
+  - Fixed an issue that caused incorrect URL paths if the project gets built.
 
-    - Implemented new layout for the admin-ui.
+    Implemented new layout for the admin-ui.
 
-    - Local development: do not store ``base_uri`` permanently in localStorage
-      but keep it in URL.
+  - Local development: do not store ``base_uri`` permanently in localStorage
+    but keep it in URL.
 
-    - Added Pepper contact widget which displays various Crate.io support
-      Channels in a user friendly way.
+  - Added Pepper contact widget which displays various Crate.io support
+    Channels in a user friendly way.
 
-    - The first node in the node list is selected by default.
+  - The first node in the node list is selected by default.
 
-    - The first table in the table list is selected by default.
+  - The first table in the table list is selected by default.
 
-    - Developer news from Crate.io website are now loaded correctly into
-      newsfeed.
+  - Developer news from Crate.io website are now loaded correctly into
+    newsfeed.
 
- - Updated Crash to 0.20.0 which includes the following change:
+- Updated Crash to 0.20.0 which includes the following change:
 
-    - Updated information_schema metadata queries to reflect the current state
-      of CrateDB.
+- Updated information_schema metadata queries to reflect the current state of
+  CrateDB.
 
 Fixes
 -----
 
- - Fixed issue in joins with 3 or more tables where limit was applied before
-   ``WHERE`` clause filtering which produced  wrong results.
+- Fixed issue in joins with 3 or more tables where limit was applied before
+  ``WHERE`` clause filtering which produced wrong results.
 
- - Fixed issue which causes ``BETWEEN`` to return a wrong result if ``min`` or
-   ``max`` is null.
+- Fixed issue which causes ``BETWEEN`` to return a wrong result if ``min`` or
+  ``max`` is null.
+
 
 .. _migration script: https://github.com/crate/crate-utils/tree/master/migrations/pre-1.0

--- a/docs/appendices/release-notes/1.0.1.rst
+++ b/docs/appendices/release-notes/1.0.1.rst
@@ -8,13 +8,14 @@ Released on 2016/12/12.
 
 .. NOTE::
 
-    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or higher
-    before you upgrade to 1.0.1.
+    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or
+    higher before you upgrade to 1.0.1.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_1.0.0`. If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_1.0.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_1.0.0`, and will require a `full restart
+    upgrade`_.
 
 .. WARNING::
 
@@ -39,33 +40,34 @@ Changes
 
  - Updated crate-admin to 1.0.2 which includes the following changes:
 
-    - Removed pepper widget, support links are now in a Help section along with
-      the Get Started tutorial.
+   - Removed pepper widget, support links are now in a Help section along with
+     the Get Started tutorial.
 
-    - Changed read notification behaviour so that all items are marked as read
-      upon opening the settings.
+   - Changed read notification behaviour so that all items are marked as read
+     upon opening the settings.
 
-    - Lowered opacity of placeholder query in the console.
+   - Lowered opacity of placeholder query in the console.
 
-    - Fix intercom support that disappeared during the implementation of the
-      new admin-ui layout.
+   - Fix intercom support that disappeared during the implementation of the new
+     admin-ui layout.
 
-    - Fix Radio button position in load overview.
+   - Fix Radio button position in load overview.
 
-    - Made schema tabs more distinguishable from tables in the table list.
+   - Made schema tabs more distinguishable from tables in the table list.
 
-    - Updated link to support website in contact widget.
+   - Updated link to support website in contact widget.
+
 
 Fixes
 -----
 
- - Fixed scalar signature registration, NULL literals are now supported.
+ - Fixed scalar signature registration, ``NULL`` literals are now supported.
 
- - Fixed usage of aggregations with NULL values, no exception will be thrown
-   anymore but instead NULL values are properly processed.
+ - Fixed usage of aggregations with ``NULL`` values, no exception will be
+   thrown anymore but instead ``NULL`` values are properly processed.
 
- - The ``chunk_size`` and ``buffer_size`` settings for creating repositories
-   of type ``S3`` are now parsed correctly.
+ - The ``chunk_size`` and ``buffer_size`` settings for creating repositories of
+   type ``S3`` are now parsed correctly.
 
  - CrateDB no longer throws an error when ``ANY`` or ``ALL`` array comparison
    expressions are used in ``SELECT`` list. e.g.::
@@ -73,7 +75,8 @@ Fixes
        select 'foo' = any(some_array)
 
  - Fixed an issue that could lead to incorrect results if the ``WHERE`` clause
-   contains primary key comparisons together with other functions like match.
+   contains primary key comparisons together with other :ref:`functions
+   <gloss-function>` like match.
 
  - Fixed an issue that caused select queries with bulk arguments to hang
    instead of throwing the proper error.

--- a/docs/appendices/release-notes/1.0.2.rst
+++ b/docs/appendices/release-notes/1.0.2.rst
@@ -8,12 +8,12 @@ Released on 2017/01/09.
 
 .. NOTE::
 
-    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or higher
-    before you upgrade to 1.0.2.
+    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or
+    higher before you upgrade to 1.0.2.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
-    number must be :ref:`version_1.0.0` or higher. If you want to upgrade from a
-    version prior to this, the upgrade will introduce all of the breaking
+    number must be :ref:`version_1.0.0` or higher. If you want to upgrade from
+    a version prior to this, the upgrade will introduce all of the breaking
     changes listed for :ref:`version_1.0.0`, and will require a `full restart
     upgrade`_.
 
@@ -30,64 +30,67 @@ Released on 2017/01/09.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
- - Do not display current statement in ``sys.jobs`` that disabled stats.
+- Do not display current statement in ``sys.jobs`` that disabled stats.
 
- - It is not possible any more to circumvent ``NOT NULL`` column constraint by
-   omitting the column in the ``INSERT`` statement.
+- It is not possible any more to circumvent ``NOT NULL`` column constraint by
+  omitting the column in the ``INSERT`` statement.
 
- - Updated crate-admin to 1.0.3 which includes the following change:
+- Updated crate-admin to 1.0.3 which includes the following change:
 
-    - Added compatibility with future CrateDB versions which will serve the
-      admin-ui from ``/admin/`` instead of ``/_plugins/crate-admin/``.
+  - Added compatibility with future CrateDB versions which will serve the
+    admin-ui from ``/admin/`` instead of ``/_plugins/crate-admin/``.
+
 
 Fixes
 -----
 
- - Fixed a NPE when using a ``percentile`` aggregation in a multi-node
-   environment.
+- Fixed a NPE when using a ``percentile`` aggregation in a multi-node
+  environment.
 
- - Fixed ``INDEX`` constraint validation. Defining it on complex data types
-   like e.g. ``object`` was silently ignored instead of throwing an error.
+- Fixed ``INDEX`` constraint validation. Defining it on complex data types like
+  e.g. ``object`` was silently ignored instead of throwing an error.
 
- - Fixed an issue that causes ``UnsupportedFeatureException`` for operations on
-   a table where array access is used inside generated columns. e.g.::
+- Fixed an issue that causes ``UnsupportedFeatureException`` for operations on
+  a table where array access is used inside generated columns. e.g.::
 
-       CREATE TABLE t1 (cola string, gencola AS (a[1]))
+      CREATE TABLE t1 (cola string, gencola AS (a[1]))
 
-   Error thrown when: ``SELECT * from t1``, ``DROP TABLE t1``, etc.
+  Error thrown when: ``SELECT * from t1``, ``DROP TABLE t1``, etc.
 
- - Fixed an issue that causes hanging queries if a data node disconnects from
-   the cluster.
+- Fixed an issue that causes hanging queries if a data node disconnects from
+  the cluster.
 
- - CrateDB now throws a correct error if a user tries to create a table
-   starting with ``_``.
+- CrateDB now throws a correct error if a user tries to create a table starting
+  with ``_``.
 
- - Fixed an issue that causes ``UnhandledServerException`` on joins when
-   ``WHERE`` clause contains conditions on columns of array type of both tables
-   which are separated with the ``OR`` :ref:`operator <gloss-operator>`. e.g.::
+- Fixed an issue that causes ``UnhandledServerException`` on joins when
+  ``WHERE`` clause contains conditions on columns of array type of both tables
+  which are separated with the ``OR`` :ref:`operator <gloss-operator>`. e.g.::
 
-       SELECT * FROM t1 join t2 ON t1.id = t2.id
-       WHERE 'foo' = ANY(a.strArray) OR 'bar' = ANY(b.strArray)
+      SELECT * FROM t1 join t2 ON t1.id = t2.id
+      WHERE 'foo' = ANY(a.strArray) OR 'bar' = ANY(b.strArray)
 
- - Scalar functions ``longitude`` and ``latitude`` no longer show misleading
-   results.
+- :ref:`Scalar functions <scalar-functions>` ``longitude`` and ``latitude`` no
+  longer show misleading results.
 
- - Fixed an issue that causes ``ClassCastException`` on outer joins when
-   ``WHERE`` clause contains a condition that prevents null values on the
-   relation that may produce nulls. e.g.::
+- Fixed an issue that causes ``ClassCastException`` on outer joins when
+  ``WHERE`` clause contains a condition that prevents null values on the
+  relation that may produce nulls. e.g.::
 
-       SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id WHERE t2.txt = 'foo'
+      SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id WHERE t2.txt = 'foo'
 
- - Fixed NPE that occurred when an ``UPDATE`` statement inserted ``NULL`` value
-   into a column that did not exist before.
+- Fixed NPE that occurred when an ``UPDATE`` statement inserted ``NULL`` value
+  into a column that did not exist before.
 
- - Fixed an issue that causes an error to be thrown if nested method calls are
-   used in ``HAVING`` clause. e.g.::
+- Fixed an issue that causes an error to be thrown if nested method calls are
+  used in ``HAVING`` clause. e.g.::
 
-       having sum(power(power(id, id), id)) > 1
+      having sum(power(power(id, id), id)) > 1

--- a/docs/appendices/release-notes/1.0.3.rst
+++ b/docs/appendices/release-notes/1.0.3.rst
@@ -8,12 +8,12 @@ Released on 2017/02/10.
 
 .. NOTE::
 
-    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or higher
-    before you upgrade to 1.0.3.
+    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or
+    higher before you upgrade to 1.0.3.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
-    number must be :ref:`version_1.0.0` or higher. If you want to upgrade from a
-    version prior to this, the upgrade will introduce all of the breaking
+    number must be :ref:`version_1.0.0` or higher. If you want to upgrade from
+    a version prior to this, the upgrade will introduce all of the breaking
     changes listed for :ref:`version_1.0.0`, and will require a `full restart
     upgrade`_.
 
@@ -30,61 +30,65 @@ Released on 2017/02/10.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Deprecations
 ------------
 
- - Multicast discovery has been deprecated in this release, and will be removed
-   in the 1.1 release. Multicast discovery is disabled by default.
+- Multicast discovery has been deprecated in this release, and will be removed
+  in the 1.1 release. Multicast discovery is disabled by default.
+
 
 Changes
 -------
 
- - Return correct affected row count instead of throwing an exception when
-   trying to bulk insert values that don't match the column type(s).
+- Return correct affected row count instead of throwing an exception when
+  trying to bulk insert values that don't match the column type(s).
 
- - Removed ``OVER`` support from SQL parser because the clause was completely
-   ignored when executing the query which led to misleading results.
+- Removed ``OVER`` support from SQL parser because the clause was completely
+  ignored when executing the query which led to misleading results.
 
- - Queries with ``_doc`` reference comparison (e.g. ``_doc['name'] = 'foo'``)
-   in the ``WHERE`` clause return the correct results instead of empty result.
+- Queries with ``_doc`` reference comparison (e.g. ``_doc['name'] = 'foo'``) in
+  the ``WHERE`` clause return the correct results instead of empty result.
 
- - Dynamically added string columns now have exactly the same characteristics
-   as string columns created via ``CREATE TABLE`` or ``ALTER TABLE ADD COLUMN``
+- Dynamically added string columns now have exactly the same characteristics as
+  string columns created via ``CREATE TABLE`` or ``ALTER TABLE ADD COLUMN``
 
- - Updated crate-admin to ``1.0.4`` which includes the following change:
+- Updated crate-admin to ``1.0.4`` which includes the following change:
 
-     - Fixed getting started display issue on very wide screens.
+  - Fixed getting started display issue on very wide screens.
+
 
 Fixes
 -----
 
- - Scalar functions are now allowed on the ``HAVING`` clause if the scalar
-   function is used as a ``GROUP BY`` symbol.
+- Scalar :ref:`functions <gloss-function>` are now allowed on the ``HAVING``
+  clause if the :ref:`scalar function <scalar-functions>` is used as a ``GROUP
+  BY`` symbol.
 
- - Fixed an issue in the PostgreSQL protocol that could cause a
-   ``StackOverflow`` exception due to connection errors or malfunctioning
-   clients.
+- Fixed an issue in the PostgreSQL protocol that could cause a
+  ``StackOverflow`` exception due to connection errors or malfunctioning
+  clients.
 
- - Closing a connection via the PostgreSQL Wire Protocol now correctly closes
-   the internal resources.
+- Closing a connection via the PostgreSQL Wire Protocol now correctly closes
+  the internal resources.
 
- - Fixed issue that led to casting exception when comparing an object column
-   with an object literal that contains a string value.
+- Fixed issue that led to casting exception when comparing an object column
+  with an object literal that contains a string value.
 
- - Fixed and issue that caused ``UPDATE`` statement on an empty partitioned
-   table to throw ``UnsupportedOperationException``.
+- Fixed and issue that caused ``UPDATE`` statement on an empty partitioned
+  table to throw ``UnsupportedOperationException``.
 
- - Fixed an issue that caused fulltext search with ``fuzziness='AUTO'`` to
-   throw ``NumberFormatException``.
+- Fixed an issue that caused fulltext search with ``fuzziness='AUTO'`` to throw
+  ``NumberFormatException``.
 
- - Fixed an issue in the ``LIKE`` predicate which prevented from using escaped
-   backslash before the wildcard.
+- Fixed an issue in the ``LIKE`` predicate which prevented from using escaped
+  backslash before the wildcard.
 
- - Fixed an issue that caused ``ORDER BY`` clause to be ignored if used in
-   combination with ``GROUP BY`` in subselects. e.g.::
+- Fixed an issue that caused ``ORDER BY`` clause to be ignored if used in
+  combination with ``GROUP BY`` in subselects. e.g.::
 
-       SELECT x from (SELECT * from t1) as tt
-       GROUP BY x ORDER BY x
+       SELECT x from (SELECT * from t1) as tt GROUP BY x ORDER BY x

--- a/docs/appendices/release-notes/1.1.0.rst
+++ b/docs/appendices/release-notes/1.1.0.rst
@@ -20,8 +20,10 @@ Released on 2017/03/21.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
@@ -39,6 +41,7 @@ Breaking Changes
  - Removed deprecated setting ``indices.fielddata.breaker`` that have been used
    as an alias for ``indices.breaker.fielddata``.
 
+
 Changes
 -------
 
@@ -49,8 +52,8 @@ Changes
  - Added cluster checks that warn if some tables need to be recreated or
    upgraded for compatibility with future versions of CrateDB.
 
- - Added functionality to monitor query runtime statistics via JMX. This feature
-   can only be used with an enterprise license.
+ - Added functionality to monitor query runtime statistics via JMX. This
+   feature can only be used with an enterprise license.
 
  - Added a new parameter ``upgrade_segments`` to the ``OPTIMIZE`` statement
    which enables the upgrade of tables and tables partitions to the current
@@ -73,14 +76,14 @@ Changes
    of each node clock at the time of collecting the metric instead of the
    timestamp on the handler node.
 
- - Added scalar function ``geohash`` that returns a GeoHash representation of
-   a ``geo_point``
+ - Added :ref:`scalar function <scalar-functions>` ``geohash`` that returns a
+   GeoHash representation of a ``geo_point``
 
  - Added support for casting JSON strings to object columns.
 
  - The array comparison no longer requires extra parentheses for subselects.
-   Now it's possible to use `` = ANY (SELECT ...)`` instead of
-   `` = ANY ((SELECT ...))``.
+   Now it's possible to use ``= ANY (SELECT ...)`` instead of ``= ANY ((SELECT
+   ...))``.
 
  - Allow semi-colon (``;``) in the end of simple SQL statements.
 
@@ -96,8 +99,8 @@ Changes
 
  - Added monitoring plugin for the Enterprise edition in the admin UI.
 
- - Added Lazy loading of the stylesheet and plugins depending on the
-   Enterprise settings.
+ - Added Lazy loading of the stylesheet and plugins depending on the Enterprise
+   settings.
 
  - Added buttons to collapse and expand all schemas in the tables view.
 
@@ -121,6 +124,7 @@ Changes
    human-readable timestamps, Google Maps link on geo-point results & lazy
    loading on result sets larger than 100 rows.
 
+
 Fixes
 -----
 
@@ -138,8 +142,8 @@ Fixes
  - Fixed a console results issue that caused the results table not to be
    visible after horizontal scrolling.
 
- - Fixed styling issue that caused the last element in the side bar list to
-   be hidden.
+ - Fixed styling issue that caused the last element in the side bar list to be
+   hidden.
 
  - Fixed an issue that caused the notification date to be ``null`` in Safari.
 
@@ -148,5 +152,5 @@ Fixes
 
  - Fixed an issue that caused the admin UI to load only one plugin.
 
- - Display warning in the console view when the query result contains an
-   unsafe integer.
+ - Display warning in the console view when the query result contains an unsafe
+   integer.

--- a/docs/appendices/release-notes/1.1.3.rst
+++ b/docs/appendices/release-notes/1.1.3.rst
@@ -8,12 +8,12 @@ Released on 2017/05/09.
 
 .. NOTE::
 
-    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or higher
-    before you upgrade to 1.1.3.
+    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or
+    higher before you upgrade to 1.1.3.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
-    number must be :ref:`version_1.1.1` or higher. If you want to upgrade from a
-    version prior to this, the upgrade will introduce all of the breaking
+    number must be :ref:`version_1.1.1` or higher. If you want to upgrade from
+    a version prior to this, the upgrade will introduce all of the breaking
     changes listed for :ref:`version_1.1.0`, and will require a `full restart
     upgrade`_.
 
@@ -38,9 +38,8 @@ Fixes
 
  - Admin UI improvements.
 
- - Improved the accuracy of results if  :ref:`arithmetic operators
-   <arithmetic>` +,-,*,/ are used in expressions that contain only float-type
-   values.
+ - Improved the accuracy of results if :ref:`arithmetic operators <arithmetic>`
+   ``+,-,*,/`` are used in expressions that contain only float-type values.
 
  - Fixed ``COPY FROM`` to be able to copy data into a partitioned table with a
    generated column as both the primary key and a :ref:`partition column
@@ -54,8 +53,8 @@ Fixes
    more than 2 tables.
 
  - Fixed issue which lead to an object's column policy being changed to the
-   default ``DYNAMIC`` when adding a nested object column using the
-   ``ALTER TABLE`` statement.
+   default ``DYNAMIC`` when adding a nested object column using the ``ALTER
+   TABLE`` statement.
 
  - Fixed an issue with ``regexp_replace``: In some cases it used the third
    argument as flags parameter instead of the fourth argument.

--- a/docs/appendices/release-notes/1.1.5.rst
+++ b/docs/appendices/release-notes/1.1.5.rst
@@ -8,12 +8,12 @@ Released on 2017/06/12.
 
 .. NOTE::
 
-    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or higher
-    before you upgrade to 1.1.5.
+    If you are upgrading a cluster, you must be running CrateDB 0.57.0 or
+    higher before you upgrade to 1.1.5.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
-    number must be :ref:`version_1.1.1` or higher. If you want to upgrade from a
-    version prior to this, the upgrade will introduce all of the breaking
+    number must be :ref:`version_1.1.1` or higher. If you want to upgrade from
+    a version prior to this, the upgrade will introduce all of the breaking
     changes listed for :ref:`version_1.1.0`, and will require a `full restart
     upgrade`_.
 
@@ -30,20 +30,23 @@ Released on 2017/06/12.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
 
  - Fixed an issue that leads to an exception if the statement evaluates on
-   arrays that are provided in an aggregation function.
+   arrays that are provided in an :ref:`aggregation function
+   <aggregation-functions>`.
 
- - Fixed a performance regression that could cause JOIN queries to execute
+ - Fixed a performance regression that could cause ``JOIN`` queries to execute
    slower than they used to.
 
- - Return proper exception when group by is used on scalar functions that are
-   applied to an aggregation.
+ - Return proper exception when group by is used on :ref:`scalar functions
+   <scalar-functions>` that are applied to an aggregation.
 
  - Fixed an issue that causes aliases used in the select list to get lost on
    subselect queries.

--- a/docs/appendices/release-notes/2.0.0.rst
+++ b/docs/appendices/release-notes/2.0.0.rst
@@ -8,8 +8,8 @@ Released on 2017/05/16.
 
 .. WARNING::
 
-    CrateDB 2.x versions prior 2.0.4 (including this version) contain a critical
-    bug which leads to deletion of blob data upon node shutdown. It is
+    CrateDB 2.x versions prior 2.0.4 (including this version) contain a
+    critical bug which leads to deletion of blob data upon node shutdown. It is
     recommended to not install those versions.
 
 .. rubric:: Table of contents
@@ -17,15 +17,17 @@ Released on 2017/05/16.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
 
- - To accommodate user-defined functions, some new reserved keywords have been
-   added to the CrateDB SQL dialect: ``RETURNS``, ``CALLED``, ``REPLACE``,
-   ``FUNCTION``, ``LANGUAGE``, ``INPUT``
+ - To accommodate :ref:`user-defined functions <user-defined-functions>`, some
+   new reserved keywords have been added to the CrateDB SQL dialect:
+   ``RETURNS``, ``CALLED``, ``REPLACE``, ``FUNCTION``, ``LANGUAGE``, ``INPUT``
 
  - The ``license.enterprise`` setting is set to ``true`` by default. This
    enables the CrateDB Enterprise Edition.
@@ -51,8 +53,8 @@ Breaking Changes
    multiple nodes and ended up thinking they have lost data because the second
    node will start with an empty directory.
 
-   Running multiple nodes on the same data path tends to be an exception,
-   so this is a safer default.
+   Running multiple nodes on the same data path tends to be an exception, so
+   this is a safer default.
 
  - Parsing support of time values has been changed:
 
@@ -127,8 +129,8 @@ Breaking Changes
    snapshots.
 
  - Changed default bind and publish address from ``0.0.0.0`` to the system
-   ``loopback`` addresses which will result in CrateDB listening only to
-   local ports.
+   ``loopback`` addresses which will result in CrateDB listening only to local
+   ports.
 
  - The ``discovery.ec2.ping_timeout`` setting has been removed and the
    ``discovery.zen.ping_timeout`` setting is now also used for EC2 discovery.
@@ -142,8 +144,10 @@ Breaking Changes
 
      - ``indices.recovery.retry_internal_action_timeout`` has been renamed to
        ``indices.recovery.internal_action_timeout``
+
      - ``indices.recovery.retry_internal_long_action_timeout`` has been renamed
        to ``indices.recovery.internal_action_long_timeout``
+
      - ``indices.recovery.retry_activity_timeout`` has been renamed to
        ``indices.recovery.recovery_activity_timeout``
 
@@ -155,14 +159,13 @@ Breaking Changes
 
  - The blobs data directory layout has changed.
 
+
 Changes
 -------
 
- - Extended the subselect support. See :ref:`SELECT Reference
-   <sql_reference_subselect>` for details.
+ - Extended the :ref:`sub-select <sql-select-sub-select>` support.
 
- - Added support for host based authentication (HBA).
-   Please see :ref:`Host Based Authentication <admin_hba>`.
+ - Added support for :ref:`host based authentication <admin_hba>` (HBA).
 
  - Added support for renaming tables using the ``ALTER ... RENAME TO ...``
    statement.
@@ -184,16 +187,16 @@ Changes
 
      SELECT x, COUNT(*) FROM (SELECT x FROM t LIMIT 1) AS tt GROUP BY x;
 
- - Implemented hash sum scalar functions (MD5, SHA1).
+ - Implemented hash sum :ref:`scalar functions <scalar-functions>` (MD5, SHA1).
    Please see :ref:`sha1 <sha1>`.
 
  - Various admin UI improvements.
 
  - Added support for ``GROUP BY`` on joins.
 
- - Added support for user-defined functions.
+ - Added support for :ref:`user-defined functions <user-defined-functions>`.
 
- - Added JavaScript language for functions.
+ - Added JavaScript language for user-defined functions.
 
  - Added cluster check and warning for unlicensed usage of CrateDB Enterprise.
 
@@ -207,8 +210,7 @@ Changes
  - Improved performance of blob stats computation by calculating them in an
    incremental manner.
 
- - Optimized performance of negation queries on ``NOT NULL`` columns.
-   E.g.::
+ - Optimized performance of negation queries on ``NOT NULL`` columns.  E.g.::
 
      SELECT * FROM t WHERE not_null_col != 10
 
@@ -227,6 +229,7 @@ Changes
  - Added validation that ``ORDER BY`` symbols are included in the ``SELECT``
    list when ``DISTINCT`` is used.
 
+
 Fixes
 -----
 
@@ -239,10 +242,12 @@ Fixes
  - Fixed that ``sys.snapshot`` queries hung instead of throwing an error if
    something went wrong.
 
+
 .. _version_2.0.0_upgrade_notes:
 
 Upgrade Notes
 =============
+
 
 Daemon User
 -----------
@@ -250,11 +255,13 @@ Daemon User
 You can no longer run CrateDB as the superuser on Unix-like systems. You should
 create a new ``crate`` user for running the CrateDB daemon.
 
+
 Logging
 -------
 
 The ``logging.yml`` has been removed. You must migrate your :ref:`conf-logging`
 configuration to the new ``log4j2.properties`` file.
+
 
 System Properties
 -----------------
@@ -274,6 +281,7 @@ You can continue to use the ``JAVA_OPTIONS`` and ``CRATE_JAVA_OPTS``
 environment variables to set general JVM properties and CrateDB specific JVM
 properties, respectively.
 
+
 Configuration Changes
 ---------------------
 
@@ -281,12 +289,14 @@ Many configuration settings and files have been renamed or removed. You must
 review the `Breaking Changes`_ section above and update your setup as
 necessary.
 
+
 SQL Changes
 -----------
 
 Several breaking changes were made to CrateDB's SQL. This includes changes to
 time parsing, syntax changes, and new reserved keywords. You must review the
 `Breaking Changes`_ section above and update your client code as necessary.
+
 
 Bind Address
 ------------
@@ -296,8 +306,7 @@ address (meaning it will only be accessible on ``localhost``). See
 :ref:`conf_hosts` for more.
 
 If you want to keep the original behaviour (i.e. bind to every available
-network interface) you must add the following line to your
-:ref:`config` file::
+network interface) you must add the following line to your :ref:`config` file::
 
     network.host: 0.0.0.0
 
@@ -307,6 +316,7 @@ network interface) you must add the following line to your
    instructions in the new `bootstrap checks`_ guide.
 
 .. _bootstrap checks: https://crate.io/docs/crate/howtos/en/latest/admin/bootstrap-checks.html
+
 
 Heap Size
 ---------
@@ -318,6 +328,7 @@ with a single variable ``CRATE_HEAP_SIZE``. The :ref:`CRATE_HEAP_SIZE
 allocate, and should be set to whatever your previous ``CRATE_MAX_MEM`` was set
 to.
 
+
 Cluster name in path data
 -------------------------
 
@@ -325,12 +336,13 @@ The computation of the effective data directory path has changed in a way that
 the cluster name is not part of the path anymore. In previous versions it was
 ``$PATH_DATA_DIR/$CLUSTER_NAME/nodes/`` and now it is
 ``$PATH_DATA_DIR/nodes/``. There's a fallback that still accepts the old data
-structure, which will be removed in future versions of CrateDB.
-It will be required that the data directory is either moved to the new location
-or the ``path.data`` setting gets changed to point to the old location by
-appending the clustername to it (e.g ``/data/`` becomes
+structure, which will be removed in future versions of CrateDB.  It will be
+required that the data directory is either moved to the new location or the
+``path.data`` setting gets changed to point to the old location by appending
+the clustername to it (e.g ``/data/`` becomes
 ``/data/yourclustername``). Therefore it's not possible anymore for multiple
 clusters to share the exact same ``path.data`` directory.
+
 
 Boolean Data Type
 -----------------

--- a/docs/appendices/release-notes/2.0.4.rst
+++ b/docs/appendices/release-notes/2.0.4.rst
@@ -13,8 +13,9 @@ Released on 2017/07/06.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.0.0`. If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.0.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.0.0`, and will require a `full restart
+    upgrade`_.
 
     Consult the upgrade notes for :ref:`Version 2.0.0
     <version_2.0.0_upgrade_notes>` when upgrading.
@@ -35,6 +36,7 @@ Released on 2017/07/06.
 .. contents::
    :local:
 
+
 Upgrade Notes
 =============
 
@@ -48,14 +50,17 @@ before continuing.
 
 Only then you may upgrade one node after each other.
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
  - The ``recovery_after_time`` node check now fails if it would prevent the
    ``gateway.expected_nodes`` setting from having any effect.
+
 
 Fixes
 -----
@@ -65,13 +70,14 @@ Fixes
 
  - Fixed an issue that caused blob data to be deleted upon node shutdown.
 
- - Fix thread-safety issue for scalar functions ``md5`` and ``sha1``.
+ - Fix thread-safety issue for :ref:`scalar functions <scalar-functions>`
+   ``md5`` and ``sha1``.
 
  - ``information.schema.tables`` now returns the default routing hash function
    if none is present in the table metadata.
 
- - Fixed an issue that caused an exception to be thrown when using
-   ``COUNT(*)`` with subselects that return one row, e.g.::
+ - Fixed an issue that caused an exception to be thrown when using ``COUNT(*)``
+   with subselects that return one row, e.g.::
 
      SELECT count(*) FROM t1 WHERE id > (SELECT max(col1) FROM t2)
 

--- a/docs/appendices/release-notes/2.0.5.rst
+++ b/docs/appendices/release-notes/2.0.5.rst
@@ -13,8 +13,9 @@ Released on 2017/07/11.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.0.0`. If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.0.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.0.0`, and will require a `full restart
+    upgrade`_.
 
     Consult the upgrade notes for :ref:`Version 2.0.0
     <version_2.0.0_upgrade_notes>` when upgrading.
@@ -35,6 +36,7 @@ Released on 2017/07/11.
 .. contents::
    :local:
 
+
 Upgrade Notes
 =============
 
@@ -43,22 +45,24 @@ data, it is necessary to perform a `rolling upgrade`_ if you're running a
 version >= 2.0.0 and < 2.0.4 and using BLOB tables.
 
 Additionally, the number of replicas needs to be set to at least ``1`` for
-**all** blob tables and you need to make sure that data is fully replicated
+*all* blob tables and you need to make sure that data is fully replicated
 before continuing.
 
 Only then you may upgrade one node after each other.
 
+
 Changelog
 =========
+
 
 Fixes
 -----
 
- - Fixed an issue that caused an exception to be thrown when using
-   ``COUNT(*)`` with a ``JOIN`` on 3 or more tables.
+ - Fixed an issue that caused an exception to be thrown when using ``COUNT(*)``
+   with a ``JOIN`` on 3 or more tables.
 
- - Fixed a regression that caused queries with a ``GROUP BY`` on array-columns,
-   which are wrapped in a scalar function, to fail.
+ - Fixed a regression that caused queries with a ``GROUP BY`` on array columns,
+   which are wrapped in a :ref:`scalar function <scalar-functions>` to fail.
 
  - Fixed an issue that caused an exception if a table that has been created
    with CrateDB version <= 1.1 is modified using ``ALTER TABLE``.

--- a/docs/appendices/release-notes/2.0.6.rst
+++ b/docs/appendices/release-notes/2.0.6.rst
@@ -13,8 +13,9 @@ Released on 2017/07/19.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.0.0`.  If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.0.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.0.0`, and will require a `full restart
+    upgrade`_.
 
     Consult the upgrade notes for :ref:`Version 2.0.0
     <version_2.0.0_upgrade_notes>` when upgrading.
@@ -35,6 +36,7 @@ Released on 2017/07/19.
 .. contents::
    :local:
 
+
 Upgrade Notes
 =============
 
@@ -43,18 +45,20 @@ data, it is necessary to perform a `rolling upgrade`_ if you're running a
 version >= 2.0.0 and < 2.0.4 and using BLOB tables.
 
 Additionally, the number of replicas needs to be set to at least ``1`` for
-**all** blob tables and you need to make sure that data is fully replicated
+*all* blob tables and you need to make sure that data is fully replicated
 before continuing.
 
 Only then you may upgrade one node after each other.
 
+
 Changelog
 =========
+
 
 Fixes
 -----
 
- - Allow ``GROUP BY`` on any scalar functions, e.g.::
+ - Allow ``GROUP BY`` on any :ref:`scalar functions <scalar-functions>`, e.g.::
 
      SELECT id + 1 FROM t GROUP BY id
 

--- a/docs/appendices/release-notes/2.0.7.rst
+++ b/docs/appendices/release-notes/2.0.7.rst
@@ -13,8 +13,9 @@ Released on 2017/08/08.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.0.0`.  If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.0.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.0.0`, and will require a `full restart
+    upgrade`_.
 
     Consult the upgrade notes for :ref:`Version 2.0.0
     <version_2.0.0_upgrade_notes>` when upgrading.
@@ -35,6 +36,7 @@ Released on 2017/08/08.
 .. contents::
    :local:
 
+
 Upgrade Notes
 =============
 
@@ -42,28 +44,31 @@ Due to a bug introduced in :ref:`version_2.0.0` that can cause loss of BLOB
 data, it is necessary to perform a `rolling upgrade`_ if you're running a
 version >= 2.0.0 and < 2.0.4 and using BLOB tables.
 
-Additionally, the number of replicas needs to be set to a t least ``1`` for
-**all** blob tables and you need to make sure that data is fully replicated
+Additionally, the number of replicas needs to be set to at least ``1`` for
+*all* blob tables and you need to make sure that data is fully replicated
 before continuing.
 
 Only then you may upgrade one node after each other.
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
  - Enabled ``mapping.total_fields.limit`` setting for tables in order to be
-   able to increase the maximum number of columns higher than the default
-   of ``1000``.
+   able to increase the maximum number of columns higher than the default of
+   ``1000``.
+
 
 Fixes
 -----
 
- - Fixed an issue where ``COPY FROM``, ``INSERT-BY-SUBQUERY`` or bulk ``INSERT``
-   statements could not be killed when high pressure is put on data node thread
-   pools.
+ - Fixed an issue where ``COPY FROM``, ``INSERT-BY-SUBQUERY`` or bulk
+   ``INSERT`` statements could not be killed when high pressure is put on data
+   node thread pools.
 
  - Fixed the error message to be more descriptive when the condition in a
    ``CASE/WHEN`` expression is not a boolean.
@@ -72,19 +77,19 @@ Fixes
    statement that uses the ``ANY (array_expression)`` :ref:`operator
    <gloss-operator>`.
 
- - Allow support of conditional expressions with different return types that can
-   be converted to a single return type.
+ - Allow support of conditional expressions with different return types that
+   can be converted to a single return type.
 
  - Fixed support for negate on null in conditional expressions.
 
  - Fixed support for setting ``write.wait_for_active_shards`` on a partitioned
    table.
 
- - Optimized the algorithm that determines the best ordering of the tables in
-   a ``JOIN``.
+ - Optimized the algorithm that determines the best ordering of the tables in a
+   ``JOIN``.
 
  - Fixed a regression causing incorrect results for queries with ``DISTINCT``
-   on scalar functions. E.g.::
+   on :ref:`scalar functions <scalar-functions>`. E.g.::
 
      SELECT DISTINCT upper(name) FROM t
 

--- a/docs/appendices/release-notes/2.1.0.rst
+++ b/docs/appendices/release-notes/2.1.0.rst
@@ -11,8 +11,8 @@ Released on 2017/07/11.
     If you are upgrading a cluster, you must be running CrateDB
     :ref:`version_1.1.3` or higher before you upgrade to 2.1.0.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
     Consult the upgrade notes for :ref:`Version 2.1.0
     <version_2.1.0_upgrade_notes>` when upgrading.
@@ -30,95 +30,100 @@ Released on 2017/07/11.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
 
- - ``CURRENT_USER``, ``USER`` and ``SESSION_USER`` are now reserved words as we
-   introduced them as system functions. These terms will not be available to
-   be used as table, and column names and for already existing entities they
-   will have to be quoted when referenced (otherwise the terms will be treated
-   as function calls).
+- ``CURRENT_USER``, ``USER`` and ``SESSION_USER`` are now reserved words as we
+  introduced them as :ref:`system functions <scalar-sysinfo>`. These terms will
+  not be available to be used as table, and column names and for already
+  existing entities they will have to be quoted when referenced (otherwise the
+  terms will be treated as :ref:`function calls <sql-function-call>`).
 
- - ``SELECT`` statements without any ``FROM`` items are no longer executed
-   against the ``sys.cluster`` table, but against a virtual table with no
-   columns. Queries including ``sys.cluster`` columns but no explicit ``FROM``
-   item will now result in a ``ColumnUnknownException``.
+- ``SELECT`` statements without any ``FROM`` items are no longer executed
+  against the ``sys.cluster`` table, but against a virtual table with no
+  columns. Queries including ``sys.cluster`` columns but no explicit ``FROM``
+  item will now result in a ``ColumnUnknownException``.
 
- - The ``onModule()`` method had been removed from ``io.crate.Plugin``
-   interface; ``createGuiceModules()`` must be used instead.
+- The ``onModule()`` method had been removed from ``io.crate.Plugin``
+  interface; ``createGuiceModules()`` must be used instead.
 
- - ``srv`` and ``azure`` are no longer valid configuration options for
-   ``discovery.type``. Instead there is a new ``discovery.zen.hosts_provider``
-   settings which can be set to either ``srv`` or ``azure``.
+- ``srv`` and ``azure`` are no longer valid configuration options for
+  ``discovery.type``. Instead there is a new ``discovery.zen.hosts_provider``
+  settings which can be set to either ``srv`` or ``azure``.
 
- - Duplicate definition of settings is neither allowed in the ``crate.yml``
-   file nor as command line options. However, settings provided via command
-   line arguments can still override the settings defined in th ``crate.yml``
-   file.
+- Duplicate definition of settings is neither allowed in the ``crate.yml`` file
+  nor as command line options. However, settings provided via command line
+  arguments can still override the settings defined in th ``crate.yml`` file.
 
- - The syntax for creating columns on ``Create Table`` and ``Alter Table`` has
-   become more strict.
+- The syntax for creating columns on ``Create Table`` and ``Alter Table`` has
+  become more strict.
 
- - The sigar jar and object files have been moved from ``plugins/sigar`` to
-   ``lib/sigar``.
+- The sigar jar and object files have been moved from ``plugins/sigar`` to
+  ``lib/sigar``.
+
 
 Changes
 -------
 
- - Updated Elasticsearch to ``5.2.2``.
+- Updated Elasticsearch to ``5.2.2``.
 
- - Updated Crash to ``0.21.3``.
+- Updated Crash to ``0.21.3``.
 
- - Updated the Admin UI to ``1.4.1``.
+- Updated the Admin UI to ``1.4.1``.
 
- - The table setting ``recovery.initial_shards`` has been deprecated. You may
-   set ``gateway.local.initial_shards`` per node instead.
-   CrateDB will continue to read the old setting but applications should be
-   migrated to the new setting.
+- The table setting ``recovery.initial_shards`` has been deprecated. You may
+  set ``gateway.local.initial_shards`` per node instead.
+  CrateDB will continue to read the old setting but applications should be
+  migrated to the new setting.
 
- - Added support for ``GRANT`` and ``REVOKE`` privileges for accessing the
-   cluster. Currently supported privilege types: ``DQL``, ``DML`` and ``DDL``.
+- Added support for ``GRANT`` and ``REVOKE`` privileges for accessing the
+  cluster. Currently supported privilege types: ``DQL``, ``DML`` and ``DDL``.
 
- - Added support for ``GRANT``, ``DENY`` and ``REVOKE`` privileges for
-   accessing the tables and schemas.
+- Added support for ``GRANT``, ``DENY`` and ``REVOKE`` privileges for
+  accessing the tables and schemas.
 
- - Added column ``username`` to ``sys.jobs`` and ``sys.jobs_log`` that contains
-   the username under which the job was invoked.
+- Added column ``username`` to ``sys.jobs`` and ``sys.jobs_log`` that contains
+  the username under which the job was invoked.
 
- - Added SSL/TLS support for HTTP endpoints.
+- Added SSL/TLS support for HTTP endpoints.
 
- - Added SSL/TLS support for PostgreSQL Wire Protocol.
+- Added SSL/TLS support for PostgreSQL Wire Protocol.
 
- - Added new HBA setting ``ssl`` which allows to control whether
-   users have to connect with ssl enabled or disabled.
+- Added new HBA setting ``ssl`` which allows to control whether
+  users have to connect with ssl enabled or disabled.
 
- - Added support for client certificate authentication via HBA.
+- Added support for client certificate authentication via HBA.
 
- - Added support for joins on virtual tables.
+- Added support for joins on virtual tables.
 
- - Queries which contain a correlated subquery will now result in an error
-   stating that correlated subqueries are not supported, instead of a more
-   confusing error indicating that a relation is unknown.
+- Queries which contain a correlated subquery will now result in an error
+  stating that correlated subqueries are not supported, instead of a more
+  confusing error indicating that a relation is unknown.
 
- - Extended the output of the ``EXPLAIN`` statement.
+- Extended the output of the ``EXPLAIN`` statement.
+
 
 .. _version_2.1.0_upgrade_notes:
 
 Upgrade Notes
 =============
 
+
 Database User
 -------------
 
 Clients that use the `PostgreSQL Wire Protocol`_ need to connect with a valid
-database user to get access to the server. See the official `Crate JDBC Driver`_
-documentation for further information.
+database user to get access to the server. See the official `Crate JDBC
+Driver`_ documentation for further information.
 
 .. _PostgreSQL Wire Protocol: https://crate.io/docs/crate/reference/en/latest/protocols/postgres.html
 .. _Crate JDBC Driver: https://crate.io/docs/clients/jdbc/
+
 
 Upgrading from version 2.0.x
 ----------------------------
@@ -128,18 +133,20 @@ If you're using CrateDB's BLOB storage and you need to run at least version
 
 Please consult the :ref:`version_2.0.4` release notes for further details.
 
+
 Create columns syntax strictness
 ................................
 
 The syntax strictness when creating new columns has been increased:
 
- - Columns cannot contain a dot when using alter table. Instead, you can still
-   use the subscript pattern to add an object column.
+- Columns cannot contain a dot when using alter table. Instead, you can still
+  use the subscript pattern to add an object column.
 
- - The use of references as a key of a subscript is not possible anymore. E.g.
-   instead of ``col_name[index]``, you'll need to use ``col_name['index']``. Be
-   aware that the use of single quotes will cause the index to be case
-   sensitive.
+- The use of references as a key of a subscript is not possible anymore. E.g.
+  instead of ``col_name[index]``, you'll need to use ``col_name['index']``. Be
+  aware that the use of single quotes will cause the index to be case
+  sensitive.
+
 
 Upgrading from versions prior to 2.0.0
 --------------------------------------

--- a/docs/appendices/release-notes/2.1.1.rst
+++ b/docs/appendices/release-notes/2.1.1.rst
@@ -13,8 +13,9 @@ Released on 2017/08/04.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.1.0`.  If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.1.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.1.0`, and will require a `full restart
+    upgrade`_.
 
     Consult the upgrade notes for :ref:`Version 2.1.0
     <version_2.1.0_upgrade_notes>` when upgrading.
@@ -32,43 +33,44 @@ Released on 2017/08/04.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
- - Made the help messages of ``bin/crate`` and the Java code consistent. This
-   change also removes the undocumented ``-E`` command line option which makes
-   ``-C`` the only valid option for passing settings to CrateDB.
+- Made the help messages of ``bin/crate`` and the Java code consistent. This
+  change also removes the undocumented ``-E`` command line option which makes
+  ``-C`` the only valid option for passing settings to CrateDB.
 
- - Changed the Enterprise License missing check message, as well as lowering
-   the severity from ``HIGH`` to ``LOW``.
+- Changed the Enterprise License missing check message, as well as lowering the
+  severity from ``HIGH`` to ``LOW``.
 
- - Added a warning message to the log if the Unofficial Elasticsearch HTTP
-   REST API is enabled via ``es.api.enabled`` setting.
+- Added a warning message to the log if the unofficial Elasticsearch HTTP REST
+  API is enabled via ``es.api.enabled`` setting.
 
- - Updated Elasticsearch to v5.4.3.
+- Updated Elasticsearch to v5.4.3.
 
- - Enabled ``mapping.total_fields.limit`` setting for tables in order to be
-   able to increase maximum number of columns higher than the default of
-   ``1000``.
+- Enabled ``mapping.total_fields.limit`` setting for tables in order to be able
+  to increase maximum number of columns higher than the default of ``1000``.
 
- - Table functions now support value expressions as arguments.
+- :ref:Table functions <table-functions>` now support value expressions as
+  arguments.
 
 Fixes
 -----
 
- - Fixed an issue when using dots in an identifier for column creation in alter
-   table, where they were interpreted as sub-fields of an object. The usage of
-   dots as part of a column name is prohibited.
+- Fixed an issue when using dots in an identifier for column creation in alter
+  table, where they were interpreted as sub-fields of an object. The usage of
+  dots as part of a column name is prohibited.
 
- - Fixed an issue that prevented CrateDB from starting when ``path.home`` was
-   set via command line argument.
+- Fixed an issue that prevented CrateDB from starting when ``path.home`` was
+  set via command line argument.
 
- - Fixed an issue causing ``JOINs`` on virtual tables (sub-selects) which
-   contain ``LIMIT`` and/or ``OFFSET`` to return incorrect results.
-   E.g.::
+- Fixed an issue causing ``JOINs`` on virtual tables (sub-selects) which
+  contain ``LIMIT`` and/or ``OFFSET`` to return incorrect results.  E.g.::
 
       SELECT * FROM
         (SELECT * FROM t1 ORDER BY a LIMIT 5) t1,
@@ -76,90 +78,90 @@ Fixes
         (SELECT * FROM t2 ORDER BY b OFFSET 2) t2
       ON t1.a = t2.max
 
- - Fixed an issue causing ``JOINs`` with aggregations on virtual tables
-   (sub-selects) which also contain aggregations to return incorrect results.
-   E.g.::
+- Fixed an issue causing ``JOINs`` with aggregations on virtual tables
+  (sub-selects) which also contain aggregations to return incorrect results.
+  E.g.::
 
-     SELECT t1.a, COUNT(*) FROM t1
-     JOIN (SELECT b, max(i) as max FROM t2 GROUP BY b) t2
-     ON t1.a = t2.max
-     GROUP BY t1.id
+      SELECT t1.a, COUNT(*) FROM t1
+      JOIN (SELECT b, max(i) as max FROM t2 GROUP BY b) t2
+      ON t1.a = t2.max
+      GROUP BY t1.id
 
- - Fixed the error message to be more descriptive when the condition in a
-   ``CASE/WHEN`` expression is not a boolean.
+- Fixed the error message to be more descriptive when the condition in a
+  ``CASE/WHEN`` expression is not a boolean.
 
- - Fixed an issue which caused an exception if ``EXPLAIN`` is used on a
-   statement that uses the ``ANY (array_expression)`` :ref:`operators
-   <gloss-operator>`.
+- Fixed an issue which caused an exception if ``EXPLAIN`` is used on a
+  statement that uses the ``ANY (array_expression)`` :ref:`operators
+  <gloss-operator>`.
 
- - Allow support of conditional expression with different return types that can
-   be converted to a single return type.
+- Allow support of conditional expression with different return types that can
+  be converted to a single return type.
 
- - Fixed support for negate on null in conditional expression.
+- Fixed support for negate on null in conditional expression.
 
- - Fixed support for setting ``write.wait_for_active_shards`` on a partitioned
-   table.
+- Fixed support for setting ``write.wait_for_active_shards`` on a partitioned
+  table.
 
- - Added missing documentation about the default value of the table setting
-   ``write.wait_for_active_shards``.
+- Added missing documentation about the default value of the table setting
+  ``write.wait_for_active_shards``.
 
- - Improved user privileges matching to constant time complexity.
+- Improved user privileges matching to constant time complexity.
 
- - Improved the error message if an invalid table column reference is used in
-   ``INSERT`` statements.
+- Improved the error message if an invalid table column reference is used in
+  ``INSERT`` statements.
 
- - Optimized the algorithm that determines the best ordering of the tables in
-   a ``JOIN``.
+- Optimized the algorithm that determines the best ordering of the tables in a
+  ``JOIN``.
 
- - Updated Crash to ``0.21.4`` which fixes an issue with ``\verbose`` command
-   not working correctly when Crash is started without ``--verbose``.
+- Updated Crash to ``0.21.4`` which fixes an issue with ``\verbose`` command
+  not working correctly when Crash is started without ``--verbose``.
 
- - Implemented flexible return type of sum-function depending on the input
-   types, which was previously only double.
+- Implemented flexible return type of ``sum`` function depending on the input
+  types, which was previously only double.
 
- - Fixed a regression causing incorrect results for queries with ``DISTINCT``
-   on scalar functions. E.g.::
+- Fixed a regression causing incorrect results for queries with ``DISTINCT`` on
+  :ref:`scalar functions <scalar-functions>`. E.g.::
 
-     SELECT DISTINCT upper(name) FROM t
+      SELECT DISTINCT upper(name) FROM t
 
- - Fixed a race condition which made it possible to create new columns in a
-   partition of a partitioned table that didn't match the type of the same
-   column of sibling partitions.
+- Fixed a race condition which made it possible to create new columns in a
+  partition of a partitioned table that didn't match the type of the same
+  column of sibling partitions.
 
- - Upgraded Admin UI version to fix an issue with the Twitter tutorial.
+- Upgraded Admin UI version to fix an issue with the Twitter tutorial.
 
- - Fixed a NPE when running ``select port from sys.nodes`` and
-   ``psql.enabled: false`` was set.
+- Fixed a NPE when running ``select port from sys.nodes`` and ``psql.enabled:
+  false`` was set.
 
- - Fixed an issue where the user that gets provided by the client on connect is
-   not always used as current user if host based authentication is disabled.
+- Fixed an issue where the user that gets provided by the client on connect is
+  not always used as current user if host based authentication is disabled.
 
- - Corrected the documentation of the ``version`` column of the ``sys.snapshots``
-   table. It was described as the CrateDB version whereas it's an internal
-   version instead.
+- Corrected the documentation of the ``version`` column of the
+  ``sys.snapshots`` table. It was described as the CrateDB version whereas it's
+  an internal version instead.
 
- - Dropping an empty partitioned table now drops the related table privileges.
+- Dropping an empty partitioned table now drops the related table privileges.
 
- - Implemented ``NOT NULL`` constraint validation for nested object columns,
-   which was previously ignored. E.g.::
+- Implemented ``NOT NULL`` constraint validation for nested object columns,
+  which was previously ignored. E.g.::
 
-     CREATE TABLE test (
-       stuff object(dynamic) AS (
-         level1 object(dynamic) AS (
-           level2 string not null
-         ) NOT NULL
-       ) NOT NULL
-     )
+      CREATE TABLE test (
+        stuff object(dynamic) AS (
+          level1 object(dynamic) AS (
+            level2 string not null
+          ) NOT NULL
+        ) NOT NULL
+      )
 
- - Internal system queries are now executed under the ``crate`` superuser if user
-   management is enabled.
+- Internal system queries are now executed under the ``crate`` superuser if
+  user management is enabled.
 
- - ``!= ANY()`` could not operate on arrays with more than 1024 elements. This
-   limit has been increased by default to 8192. A new node setting:
-   ``indices.query.bool.max_clause_count`` has been exposed to allow
-   configuration of this limit.
+- ``!= ANY()`` could not operate on arrays with more than 1024 elements. This
+  limit has been increased by default to 8192. A new node setting:
+  ``indices.query.bool.max_clause_count`` has been exposed to allow
+  configuration of this limit.
 
- - Fixed an issue which caused unrelated table privileges to be lost after a
-   table was renamed.
+- Fixed an issue which caused unrelated table privileges to be lost after a
+  table was renamed.
 
- - Fixed an issue that prevents CrateDB from bootstrapping on Windows hosts.
+- Fixed an issue that prevents CrateDB from bootstrapping on Windows hosts.

--- a/docs/appendices/release-notes/2.1.2.rst
+++ b/docs/appendices/release-notes/2.1.2.rst
@@ -13,8 +13,9 @@ Released on 2017/08/08.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.1.0`.  If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.1.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.1.0`, and will require a `full restart
+    upgrade`_.
 
     Consult the upgrade notes for :ref:`Version 2.1.0
     <version_2.1.0_upgrade_notes>` when upgrading.
@@ -32,11 +33,13 @@ Released on 2017/08/08.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
 
- - Fixed an issue where user defined functions were not persisted across node
-   restarts.
+- Fixed an issue where :ref:`user-defined functions <user-defined-functions>`
+  were not persisted across node restarts.

--- a/docs/appendices/release-notes/2.2.6.rst
+++ b/docs/appendices/release-notes/2.2.6.rst
@@ -13,8 +13,9 @@ Released on 2018/01/17.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.2.0`.  If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.2.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.2.0`, and will require a `full restart
+    upgrade`_.
 
 .. WARNING::
 
@@ -29,16 +30,18 @@ Released on 2018/01/17.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
 
 - Fixed a race condition that caused ``DELETE`` or ``UPDATE`` statements to
-  result in an error if a shard was being relocated or in a `RECOVERY` state.
+  result in an error if a shard was being relocated or in a ``RECOVERY`` state.
 
-- Improved error message when using the `DISTINCT` clause on unsupported data
+- Improved error message when using the ``DISTINCT`` clause on unsupported data
   types. Also improved documentation to note the data type restriction.
 
 - Fix log verbosity by only logging the HTTP SSL enabled/disabled message once
@@ -48,15 +51,16 @@ Fixes
   tables to not work correctly. This only occurred if a ``query`` instead of
   the ``VALUES`` clause was used.
 
-- Fixed the evaluation of JavaScript user defined functions that caused CrateDB
-  to crash because of an unhandled assertion when providing the UDF with
-  EcmaScript 6 arrow function syntax (``var f = (x) => x;``).
+- Fixed the evaluation of JavaScript :ref:`user-defined functions
+  <user-defined-functions>` that caused CrateDB to crash because of an
+  unhandled assertion when providing the UDF with EcmaScript 6 arrow function
+  syntax (``var f = (x) => x;``).
 
 - Fixed an issue where batch operations executed using the PosgreSQL wire
   protocol returned 0 as row count, even though the actual row count was
   different.
 
-- Fixed a bug which could cause job entries in `sys.jobs` not being removed
+- Fixed a bug which could cause job entries in ``sys.jobs`` not being removed
   when a connection error occurred while sending the results of the job
   execution to the client.
 

--- a/docs/appendices/release-notes/2.3.0.rst
+++ b/docs/appendices/release-notes/2.3.0.rst
@@ -11,8 +11,8 @@ Released on 2017/12/22.
     If you are upgrading a cluster, you must be running CrateDB
     :ref:`version_1.1.3` or higher before you upgrade to 2.3.0.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
 .. WARNING::
 
@@ -27,8 +27,10 @@ Released on 2017/12/22.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
@@ -52,31 +54,34 @@ Breaking Changes
   without breaking exising HBA configurations.
 
   An implication of these settings is that whenever Enterprise is enabled
-  (default behaviour) connections from remote hosts *always* require
-  password authentication. Note, that when running CrateDB in Docker, the host
-  of the Docker container is also considered a remote host.
+  (default behaviour) connections from remote hosts *always* require password
+  authentication. Note, that when running CrateDB in Docker, the host of the
+  Docker container is also considered a remote host.
 
 - Columns aren't implicitly cast to a type anymore. Whenever columns are
   compared to Literals (e.g. 'string', 1, 1.2), these literals will be
   converted to the column type but not vice-versa. The column can still be
-  manually cast to a type by using a cast function.
+  manually cast to a type by using a :ref:`cast function <type_cast>`.
 
 - Table ``information_schema.table_constraints`` is now returning
   ``constraint_name`` as type string instead of type array. Constraint type
   ``PRIMARY_KEY`` has been changed to ``PRIMARY KEY``. Also PRIMARY KEY
   constraint is not returned when not explicitly defined.
 
-- Scalar functions are resolved more strictly based on the argument types. This
-  means that built-in functions with the same name as user defined functions
-  will always "hide" the latter, even if the UDF has a different set of
-  arguments. Using the same name as a built-in function for a user defined
-  function is considered bad practice.
+- :ref:Scalar functions <scalar-functions>` are resolved more strictly based on
+  the argument types. This means that built-in functions with the same name as
+  :ref:`user-defined functions <user-defined-functions>` will always "hide" the
+  latter, even if the UDF has a different set of arguments. Using the same name
+  as a built-in function for a user defined function is considered bad
+  practice.
+
 
 Changes
 -------
 
-- Added the ``hyperloglog_distinct`` aggregation function. This feature is only
-  available in the Enterprise Edition.
+- Added the ``hyperloglog_distinct`` :ref:`aggregation function
+  <aggregation-functions>`. This feature is only available in the Enterprise
+  Edition.
 
 - Added a ``os['cpu']['used']`` column to the ``sys.nodes`` table. This
   replaces the deprecated system/user/idle/stolen values.
@@ -134,8 +139,8 @@ Changes
 - Table ``information_schema.table_constraints`` is now also returning the
   ``NOT_NULL`` constraint.
 
-- Added new cluster setting ``routing.rebalance.enable`` that allows to
-  enable or disable shard rebalancing on the cluster.
+- Added new cluster setting ``routing.rebalance.enable`` that allows to enable
+  or disable shard rebalancing on the cluster.
 
 - Added support to manually control the :ref:`allocation of shards
   <gloss-shard-allocation>` using ``ALTER TABLE REROUTE``. Supported
@@ -150,12 +155,13 @@ Changes
 - Added new system table ``sys.allocations`` which lists shards and their
   allocation state including the reasoning why they are in a certain state.
 
-- Function arguments are now linked to each other, where possible. This enables
-  type inference between arguments such that arguments can be converted to
-  match a function's signature. For example, ``coalesce(integer, long)`` would
-  have resulted in an "unknown function" message. We now convert this call into
-  ``coalesce(long, long)``. The conversion is possible through a type
-  precedence list and convertibility checks on the data types.
+- :ref:`Function <gloss-function>` arguments are now linked to each other,
+  where possible. This enables type inference between arguments such that
+  arguments can be converted to match a function's signature. For example,
+  ``coalesce(integer, long)`` would have resulted in an "unknown function"
+  message. We now convert this call into ``coalesce(long, long)``. The
+  conversion is possible through a type precedence list and convertibility
+  checks on the data types.
 
 - Functions which accept regular expression flags now throw an error when
   invalid flags are provided.
@@ -167,7 +173,8 @@ Changes
 - Added the ``typtype`` column to ``pg_catalog.pg_type`` for better
   compatibility with certain PostgreSQL client libraries.
 
-- Added the ``pg_backend_pid()`` function for enhanced PostgreSQL compatibility.
+- Added the ``pg_backend_pid()`` function for enhanced PostgreSQL
+  compatibility.
 
 - Added support for the PSQL ParameterDescription message which allows to get
   the parameter types in prepared statements up front without specifying the
@@ -176,10 +183,14 @@ Changes
 
 - Upgraded Elasticsearch to version 5.6.3.
 
-- Updated the CrateDB command line shell (crash) to version 0.23.0, which added
-  support for password authentication and pasting multiple statements at once.
+- Updated the `CrateDB command line shell`_ (Crash) to version 0.23.0, which
+  added support for password authentication and pasting multiple statements at
+  once.
 
 - Update the Admin UI to use new CPU metrics for its graphs.
 
 - Hadoop2 dependencies for the HDFS repository plugin have been upgraded to
   version 2.8.1.
+
+
+.. _CrateDB command line shell: https://crate.io/docs/crate/crash/en/latest/

--- a/docs/appendices/release-notes/2.3.1.rst
+++ b/docs/appendices/release-notes/2.3.1.rst
@@ -28,8 +28,10 @@ Released on 2018/01/22.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Changes
 -------
@@ -38,14 +40,15 @@ Changes
   that are part of a composite primary key to the ``WHERE`` clause in order to
   get an execution plan with real-time semantics.
 
-- Greatly improved performance of queries that uses scalar functions inside the
-  ``WHERE`` clause.
+- Greatly improved performance of queries that uses :ref:`scalar functions
+  <scalar-functions>` inside the ``WHERE`` clause.
+
 
 Fixes
 -----
 
-- Avoid downcasts in function expressions which could lead to reduced
-  precision. For example ::
+- Avoid downcasts in :ref:`function expressions <sql-function-call>` which
+  could lead to reduced precision. For example ::
 
     SELECT round(float_col) + 1.1 would result in
       SELECT round(float_col) + 1
@@ -54,8 +57,8 @@ Fixes
 
 - Ensured natural order of config keys for Host Based Authentication.
 
-- Fixed encoding/decoding of ``Timestamp`` type for PostgreSQL wire protocol
-  to support Golang psql drivers.
+- Fixed encoding/decoding of ``Timestamp`` type for PostgreSQL wire protocol to
+  support Golang psql drivers.
 
 - Fixed an Admin UI issue that caused the ``Cluster`` tab to not be loaded
   correctly.

--- a/docs/appendices/release-notes/2.3.4.rst
+++ b/docs/appendices/release-notes/2.3.4.rst
@@ -28,19 +28,22 @@ Released on 2018/03/06.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
 - Updated Elasticsearch to v5.6.8.
 
+
 Fixes
 -----
 
-- Fixed the URL linking to stats collection documentation in the monitoring
-  tab of the Admin UI.
+- Fixed the URL linking to stats collection documentation in the monitoring tab
+  of the Admin UI.
 
 - Updated the table list search field to filter tables only by table name and
   table schema in the Admin UI.
@@ -49,8 +52,9 @@ Fixes
   results.
 
 - Re-enable implicit casting for columns whenever columns are used on both
-  sides of an :ref:`operator <gloss-operator>` or function. The implicit cast
-  will obey the type precedence (eg. long > integer).
+  sides of an :ref:`operator <gloss-operator>` or :ref:`function
+  <gloss-function>`. The implicit cast will obey the type precedence (eg. long
+  > integer).
 
 - Fixed an issue that caused incorrect results to be returned when a ``WHERE``
   clause filters on a :ref:`partition column <gloss-partition-column>` and a

--- a/docs/appendices/release-notes/2.3.7.rst
+++ b/docs/appendices/release-notes/2.3.7.rst
@@ -28,14 +28,17 @@ Released on 2018/05/03.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
-- Table functions no longer require any permissions to be used. (Enterprise
-  only.)
+- :ref:`Table functions <table-functions>` no longer require any permissions to
+  be used. (Enterprise only.)
+
 
 Fixes
 -----
@@ -48,17 +51,17 @@ Fixes
   an unnecessary stacktrace.
 
 - Fixed a performance regression which occurred in queries where a literal was
-  compared against an array column of a different type. For example:
-  ``SELECT * FROM t1 WHERE 1 = ANY(int_arr_column)``
-  The array column would have been converted to long although the literal on
-  the left could have been converted to integer.
+  compared against an array column of a different type. For example: ``SELECT *
+  FROM t1 WHERE 1 = ANY(int_arr_column)`` The array column would have been
+  converted to long although the literal on the left could have been converted
+  to integer.
 
 - Fixed an issue where the order of the relations in a ``FROM`` clause would
   expose fields between the relations. An error was thrown during execution of
   the statements.
 
 - Fixed incorrect HTTP responses on the BLOB API of subsequent requests after
-  an error response occurred, e.g. 404 Not Found.
+  an error response occurred, e.g., ``404 Not Found``.
 
 - Fixed an issue that caused ``ANY`` to not work correctly on nested arrays.
 

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -14,8 +14,8 @@ Released on 2018/05/16.
     We recommend that you upgrade to the latest 2.3 release before moving to
     3.0.0.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
     When restarting, CrateDB will migrate indexes to a newer format. Depending
     on the amount of data, this may delay node start-up time.
@@ -41,8 +41,10 @@ Released on 2018/05/16.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
@@ -83,7 +85,7 @@ Breaking Changes
 - EC2 ``cloud.aws.*`` settings have been renamed to ``discovery.ec2.*``.
 
 - The setting that controls system call filters ``bootstrap.seccomp`` has been
-  has been renamed to  ``bootstrap.system_call_filter``.
+  has been renamed to ``bootstrap.system_call_filter``.
 
 - The columns ``number_of_shards``, ``number_of_replicas``, and
   ``self_referencing_column_name`` in ``information_schema.tables`` changed to
@@ -104,6 +106,7 @@ Breaking Changes
   renamed to ``node``, is now visible by default and has been trimmed to only
   include ``node['id']`` and ``node['name']``. In order to get all information
   a join query can be used with ``sys.nodes``.
+
 
 Changes
 -------
@@ -139,11 +142,11 @@ Changes
 - Added support for ``INSERT INTO ... ON CONFLICT DO NOTHING``. The statement
   ignores insert values which would cause duplicate keys.
 
-- Added support for ON CONFLICT clause in insert statements.  ``INSERT INTO ...
-  ON CONFLICT (pk_col) DO UPDATE SET col = val`` is identical to ``INSERT INTO
-  ... ON DUPLICATE KEY UPDATE col = val``.  The special EXCLUDED table can be
-  used to refer to the insert values: ``INSERT INTO ... ON CONFLICT (pk_col) DO
-  UPDATE SET col = EXCLUDED.col``
+- Added support for ``ON CONFLICT`` clause in insert statements.  ``INSERT INTO
+  ...  ON CONFLICT (pk_col) DO UPDATE SET col = val`` is identical to ``INSERT
+  INTO ... ON DUPLICATE KEY UPDATE col = val``.  The special ``EXCLUDED`` table
+  can be used to refer to the insert values: ``INSERT INTO ... ON CONFLICT
+  (pk_col) DO UPDATE SET col = EXCLUDED.col``
 
 - DEPRECATED: The ``ON DUPLICATE KEY UPDATE`` clause has been deprecated in
   favor of the ``ON CONFLICT DO UPDATE SET`` clause.
@@ -199,8 +202,8 @@ Changes
 - Changed ``BEGIN`` and ``SET SESSION`` to no longer require ``DQL``
   permissions on the ``CLUSTER`` level.
 
-- Added ``epoch`` argument to the extract function which returns the number of
-  seconds since Jan 1, 1970. For example: ``extract(epoch from
+- Added ``epoch`` argument to the ``EXTRACT`` function which returns the number
+  of seconds since Jan 1, 1970. For example: ``extract(epoch from
   '1970-01-01T00:00:01')`` returns ``1.0`` seconds.
 
 - Enable logging of JVM garbage collection times that help to debug memory
@@ -230,16 +233,19 @@ Changes
 - The first argument (``field``) of the ``EXTRACT`` function has been limited
   to string literals and identifiers, as it was documented.
 
+
 .. _version_3.0.0_upgrade_notes:
 
 Upgrade Notes
 =============
+
 
 Configuration Changes
 ---------------------
 
 There are a few configuration changes that you should be aware of before
 restarting the nodes.
+
 
 Removed Settings
 ................
@@ -250,32 +256,35 @@ Removed Settings
 - Similarly, the ``recovery.initial_shards`` configuration option has been
   removed, and should also be removed from your configuration.
 
+
 Renamed Settings
 ................
 
 - The ``discovery.type`` setting which was previously used to specify whether a
-  cluster should use DNS discovery or the EC2 API, has been removed. Configuring
-  the use of the EC2 API has now been moved to the
+  cluster should use DNS discovery or the EC2 API, has been
+  removed. Configuring the use of the EC2 API has now been moved to the
   ``discovery.zen.hosts_provider`` setting.
 
 - The ``bootstrap.seccomp`` setting, which controls system call filters, has
   been renamed to ``bootstrap.system_call_filter``.
 
+
 Altered Settings
 ................
 
-- The ``path.data`` setting specifies the path or paths where the
-  CrateDB node should store its table data and cluster metadata.
+- The ``path.data`` setting specifies the path or paths where the CrateDB node
+  should store its table data and cluster metadata.
 
-  In CrateDB 3.0.0 and later, this path must *not* contain the cluster name
-  as a directory. For example, if you have set ``cluster.name: abcdef``,
-  the setting ``path.data: /mnt/abcdef/data`` would be incompatible. Moving
-  or renaming the directory, such as to ``/mnt/data``, and altering your
+  In CrateDB 3.0.0 and later, this path must *not* contain the cluster name as
+  a directory. For example, if you have set ``cluster.name: abcdef``, the
+  setting ``path.data: /mnt/abcdef/data`` would be incompatible. Moving or
+  renaming the directory, such as to ``/mnt/data``, and altering your
   ``path.data`` setting accordingly will allow you to continue using the node's
   data.
 
   Data paths that are incompatible with 3.0.0 will be indicated visually in the
   `admin UI`_ if you are running the latest 2.2.x or 2.3.x release.
+
 
 Other Changes
 -------------
@@ -293,7 +302,7 @@ Other Changes
   This head is now deprecated in favour of the standard `HTTP Authorization
   header`_.
 
-- The ``_node`` column in  the ``sys.shards`` and ``sys.operations`` tables has
+- The ``_node`` column in the ``sys.shards`` and ``sys.operations`` tables has
   been renamed to ``node``.
 
   Additionally, ``node`` object now only includes ``id`` and ``name`` of the
@@ -301,6 +310,7 @@ Other Changes
 
   To get the full node information, use ``node['id']`` to join the
   ``sys.nodes`` table.
+
 
 .. _admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
 .. _backup: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html

--- a/docs/appendices/release-notes/3.0.1.rst
+++ b/docs/appendices/release-notes/3.0.1.rst
@@ -43,8 +43,10 @@ Released on 2018/05/30.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----

--- a/docs/appendices/release-notes/3.0.2.rst
+++ b/docs/appendices/release-notes/3.0.2.rst
@@ -43,15 +43,17 @@ Released on 2018/06/12.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
 
-- Fixed an issue that caused an UnsupportedFeatureException to be thrown for
-  queries with a ``WHERE`` clause which contains an equality comparison that
-  references a table column in both sides. E.g.::
+- Fixed an issue that caused an ``UnsupportedFeatureException`` to be thrown
+  for queries with a ``WHERE`` clause which contains an equality comparison
+  that references a table column in both sides. E.g.::
 
     SELECT * FROM t
     WHERE t.i = abs(t.i)

--- a/docs/appendices/release-notes/3.0.3.rst
+++ b/docs/appendices/release-notes/3.0.3.rst
@@ -45,16 +45,18 @@ Released on 2018/06/29.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
 - Added settings ``s3.client.default.access_key`` and
   ``s3.client.default.secret_key`` which can be used to set default credentials
-  for s3 repositories, if they are not passed as parameters to the
-  ``CREATE REPOSITORY`` SQL statement.
+  for s3 repositories, if they are not passed as parameters to the ``CREATE
+  REPOSITORY`` SQL statement.
 
 - Implemented a thread-utilization down-scaling logic which dynamically adapts
   the number of threads used for ``SELECT`` queries to avoid running into
@@ -66,6 +68,7 @@ Changes
   subset of the rows and avoid ``CircuitBreakingException`` errors. But it
   might result in a slight performance decrease if queries match all or almost
   all records.
+
 
 Fixes
 -----
@@ -92,5 +95,5 @@ Fixes
 - Fixed an issue that would cause a ``CAST`` from ``TIMESTAMP`` to ``LONG`` to
   be ignored.
 
-- Handle ``STRING_ARRAY`` as argument type for user-defined functions correctly
-  to prevent an ``ArrayStoreException``.
+- Handle ``STRING_ARRAY`` as argument type for :ref:`user-defined functions
+  <user-defined-functions>` correctly to prevent an ``ArrayStoreException``.

--- a/docs/appendices/release-notes/3.0.6.rst
+++ b/docs/appendices/release-notes/3.0.6.rst
@@ -45,8 +45,10 @@ Released on 2018/08/28.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----

--- a/docs/appendices/release-notes/3.0.7.rst
+++ b/docs/appendices/release-notes/3.0.7.rst
@@ -45,8 +45,10 @@ Released on 2018/09/25.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
@@ -59,11 +61,13 @@ Breaking Changes
   This bug has been fixed in 3.0.7. Due to this, ``CREATE REPOSITORY`` queries
   that were accepted (erroneously) in 3.0.6 may no longer work in 3.0.7.
 
+
 Fixes
 -----
 
-- Calling an unknown user defined function now results in an appropriate error
-  message instead of a ``NullPointerException``.
+- Calling an unknown :ref:`user-defined function <user-defined-functions>` now
+  results in an appropriate error message instead of a
+  ``NullPointerException``.
 
 - Trying to create a table with a generated column inside an object column now
   results in a friendly error message instead of a ``NullPointerException``.

--- a/docs/appendices/release-notes/3.1.0.rst
+++ b/docs/appendices/release-notes/3.1.0.rst
@@ -14,8 +14,8 @@ Released on 2018/08/28.
     We recommend that you upgrade to the latest 3.0 release before moving to
     3.1.0.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
     When restarting, CrateDB will migrate indexes to a newer format. Depending
     on the amount of data, this may delay node start-up time.
@@ -35,19 +35,21 @@ Released on 2018/08/28.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
 
-- ``crash`` is no longer bundled with the ``CrateDB`` tarball distribution.
+- `Crash`_ is no longer bundled with the ``CrateDB`` tarball distribution.
+
 
 Changes
 -------
@@ -55,16 +57,16 @@ Changes
 - Improved performance and memory utilisation for queries against the ``sys``
   tables.
 
-- Improved performance and memory utilisation for unsorted distributed
-  ``GROUP BY`` and aggregations statements by executing the reduce operation
-  in an incremental way.
+- Improved performance and memory utilisation for unsorted distributed ``GROUP
+  BY`` and aggregations statements by executing the reduce operation in an
+  incremental way.
 
 - Improved performance and memory utilisation of ``GROUP BY`` statements when
   the key column is a single ``string``, ``byte``, ``short``, ``int`` or
   ``long``.
 
-- Added a new ``CircuitBreakers`` MXBean for JMX which exposes statistics of all
-  availabel circuit breakers.
+- Added a new ``CircuitBreakers`` MXBean for JMX which exposes statistics of
+  all availabel circuit breakers.
 
 - Exposed the cluster state version in the ``sys.nodes`` table under the
   ``cluster_state_version`` column and under the ``NodeInfo`` MXBean in JMX.
@@ -81,8 +83,8 @@ Changes
 - Improved performance of queries using an array access inside the ``WHERE``
   clause. E.g.::
 
-    SELECT * FROM t
-    WHERE int_array_col[1] = 123
+      SELECT * FROM t
+      WHERE int_array_col[1] = 123
 
 - Added the full PostgreSQL syntax of the ``BEGIN`` statement and the
   ``COMMIT`` statement. This improves the support for clients that are based on
@@ -90,14 +92,14 @@ Changes
   clients. The ``BEGIN`` and ``COMMIT`` statements and any of their parameters
   are simply ignored.
 
-- Added a new scalar function ``ignore3vl`` which eliminates the 3-valued logic
-  of null handling for every logical expression beneath it. If 3-valued logic
-  is not required, the use of this function in the ``WHERE`` clause beneath a
-  ``NOT`` :ref:`operator <gloss-operator>` can boost the query performance
-  significantly. E.g.::
+- Added a new :ref:`scalar function <scalar-functions>` ``ignore3vl`` which
+  eliminates the 3-valued logic of null handling for every logical expression
+  beneath it. If 3-valued logic is not required, the use of this :ref:`function
+  <gloss-function>` in the ``WHERE`` clause beneath a ``NOT`` :ref:`operator
+  <gloss-operator>` can boost the query performance significantly. E.g.::
 
-    SELECT * FROM t
-    WHERE NOT IGNORE3VL(5 = ANY(t.int_array_col))
+      SELECT * FROM t
+      WHERE NOT IGNORE3VL(5 = ANY(t.int_array_col))
 
 - Added a new ``Connections`` MBean for JMX which exposes the number of open
   connections per protocol.
@@ -110,8 +112,8 @@ Changes
   set with detailed error reporting of imported rows.
 
 - Added a new ``stats.jobs_log_filter`` setting which can be used to control
-  what kind of entries are recorded into the ``sys.jobs_log`` table.
-  In addition there is a new ``stats.jobs_log_persistent_filter`` setting which
+  what kind of entries are recorded into the ``sys.jobs_log`` table.  In
+  addition there is a new ``stats.jobs_log_persistent_filter`` setting which
   can be used to record entries also in the regular CrateDB log file.
 
 - Exposed statement classification in ``sys.jobs_log`` table.
@@ -120,8 +122,8 @@ Changes
 
 - The setting ``es.api.enabled`` has been marked as deprecated and will be
   removed in a future version. Once removed it will no longer be possible to
-  use the ES API. Please create a feature request if you're using the ES API and
-  cannot use the SQL interface as substitute.
+  use the Elasticsearch API. Please create a feature request if you're using
+  the ES API and cannot use the SQL interface as substitute.
 
 - Introduced the ``EXPLAIN ANALYZE`` statement for query profiling.
 
@@ -129,7 +131,10 @@ Changes
 
 - Added support for the ``SHOW TRANSACTION_ISOLATION`` statement.
 
-- Added TimeZone parameter response to PostgreSQL Wire Protocol.
+- Added ``TimeZone`` parameter response to PostgreSQL Wire Protocol.
 
 - Extended syntax support for certain ``ALTER BLOB TABLE RENAME``, ``REROUTE``
   and ``OPEN/CLOSE`` queries.
+
+
+.. _Crash: https://crate.io/docs/crate/crash/en/latest/

--- a/docs/appendices/release-notes/3.1.1.rst
+++ b/docs/appendices/release-notes/3.1.1.rst
@@ -14,8 +14,8 @@ Released on 2018/09/25.
     We recommend that you upgrade to the latest 3.0 release before moving to
     3.1.1.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
     When restarting, CrateDB will migrate indexes to a newer format. Depending
     on the amount of data, this may delay node start-up time.
@@ -35,25 +35,28 @@ Released on 2018/09/25.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Changes
 -------
 
 - Added support for using generated columns inside object columns.
 
+
 Fixes
 -----
 
-- Calling an unknown user defined function now results in an appropriate error
-  message instead of a ``NullPointerException``.
+- Calling an unknown :ref:`user-defined function <user-defined-functions>` now
+  results in an appropriate error message instead of a
+  ``NullPointerException``.
 
 - Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
   repository parameters.

--- a/docs/appendices/release-notes/3.1.2.rst
+++ b/docs/appendices/release-notes/3.1.2.rst
@@ -33,11 +33,11 @@ Released on 2018/10/18.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
 
 Changelog
 =========

--- a/docs/appendices/release-notes/3.1.3.rst
+++ b/docs/appendices/release-notes/3.1.3.rst
@@ -33,7 +33,6 @@ Released on 2018/11/19.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
@@ -59,10 +58,11 @@ Fixes
 - Fixed a race condition that could allow the creation of partitions with a
   different schema than other partitions within the same partitioned table.
 
-- Changed the ``user`` hdfs repository parameter to ``security.principal``, as that is
-  the parameter used by the underlying repository-hdfs plugin.
+- Changed the ``user`` hdfs repository parameter to ``security.principal``, as
+  that is the parameter used by the underlying repository-hdfs plugin.
 
-- Removed the ``conf_location`` hdfs repository parameter as it is no longer used.
+- Removed the ``conf_location`` hdfs repository parameter as it is no longer
+  used.
 
 - Fixed an issue that caused zombie entries in ``sys.jobs`` if the
   ``fetchSize`` functionality of PostgreSQL wire protocol based clients is

--- a/docs/appendices/release-notes/3.1.4.rst
+++ b/docs/appendices/release-notes/3.1.4.rst
@@ -33,7 +33,6 @@ Released on 2018/12/19.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::

--- a/docs/appendices/release-notes/3.1.5.rst
+++ b/docs/appendices/release-notes/3.1.5.rst
@@ -57,8 +57,8 @@ Fixes
 
 - The type of parameter placeholders in sub-queries in the FROM clause of a
   query can now be resolved to support PostgreSQL clients relying on the
-  ``ParameterDescription`` message. This enables queries like ``select *
-  from (select $1::int + $2) t``
+  ``ParameterDescription`` message. This enables queries like ``select * from
+  (select $1::int + $2) t``
 
 - Fixed error readability of certain ``ALTER TABLE`` operations.
 

--- a/docs/appendices/release-notes/3.1.6.rst
+++ b/docs/appendices/release-notes/3.1.6.rst
@@ -33,11 +33,11 @@ Released on 2019/02/05.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
 
 Changelog
 =========
@@ -54,5 +54,6 @@ Fixes
   larger than the available rows would result in ``OutOfMemoryError`` even
   though the number of available rows could fit in memory.
 
-- Fixed a ``NullPointerException`` that occurs on ``OUTER`` joins which can
-  be rewritten to ``INNER`` joins and uses a function as a select item.
+- Fixed a ``NullPointerException`` that occurs on ``OUTER`` joins which can be
+  rewritten to ``INNER`` joins and uses a :ref:`function <gloss-function>` as a
+  select item.

--- a/docs/appendices/release-notes/3.2.0.rst
+++ b/docs/appendices/release-notes/3.2.0.rst
@@ -14,8 +14,8 @@ Released on 2018/12/19.
     We recommend that you upgrade to the latest 3.1 release before moving to
     3.2.0.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
     When restarting, CrateDB will migrate indexes to a newer format. Depending
     on the amount of data, this may delay node start-up time.
@@ -37,16 +37,17 @@ Released on 2018/12/19.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 .. _version_3.2.0_upgrade_notes:
 
 Upgrade Notes
 =============
+
 
 Logging Configuration Changes
 -----------------------------
@@ -56,10 +57,11 @@ changed. If you have customised this :ref:`logging configuration
 <conf-logging-log4j>`, you should replace the ``$marker`` entry with
 ``[%node_name] %marker``.
 
+
 Deprecated Settings and Features
 --------------------------------
 
-In previous versions, the CrateDB license was set via the `license.ident`
+In previous versions, the CrateDB license was set via the ``license.ident``
 configuration setting. This has now been deprecated, and going forward the
 CrateDB license should be set using the :ref:`ref-set-license` statement.
 
@@ -73,28 +75,32 @@ The ``delimited_payload_filter`` built-in token filter for fulltext analyzers
 has been renamed to ``delimited_payload``. The ``delimited_payload_filter``
 name can still be used, but is deprecated, and will be removed in the future.
 
+
 Changelog
 =========
+
 
 Breaking Changes
 ----------------
 
-- The ``*`` of ``SELECT *`` statements in the query clause of
-  :ref:`view definitions <views>`
-  is no longer expanded at view creation time but lazy whenever a view is
-  evaluated. That means columns added to a table after the views initial
-  creation will show up in queries on the view. It is generally recommended to
-  avoid using ``*`` in views but always specify columns explicitly.
+- The ``*`` of ``SELECT *`` statements in the query clause of :ref:`view
+  definitions <ddl-views>` is no longer expanded at view creation time but lazy
+  whenever a view is evaluated. That means columns added to a table after the
+  views initial creation will show up in queries on the view. It is generally
+  recommended to avoid using ``*`` in views but always specify columns
+  explicitly.
+
 
 Changes
 -------
 
+
 New Features
 ~~~~~~~~~~~~
 
-- Added support for executing existing aggregation functions as
-  :ref:`window functions <window-functions>` using the
-  :ref:`OVER <over>` clause.
+- Added support for executing existing :ref:`aggregation functions
+  <aggregation-functions>` as :ref:`window functions <window-functions>` using
+  the :ref:`OVER <sql-select-over>` clause.
 
 - Added support for CrateDB license management enabling users to trial the
   enterprise-features, set a production enterprise license, or continue using
@@ -102,51 +108,52 @@ New Features
   <ref-set-license>` statement has been added for license registration, and the
   ``license.ident`` setting has become ``@deprecated``.
 
+
 SQL Improvements
 ~~~~~~~~~~~~~~~~
 
-- Added the :ref:`REPLACE <scalar-replace>` scalar function replacing
-  substrings in a string with another string.
+- Added the :ref:`REPLACE <scalar-replace>` :ref:`scalar function
+  <scalar-functions>` replacing substrings in a string with another string.
 
-- Added the
-  :ref:`GENERATE_SERIES(start, stop [, step ]) <table-functions-generate-series>`
-  table function which can generate a series of numbers.
+- Added the :ref:`GENERATE_SERIES(start, stop [, step ])
+  <table-functions-generate-series>` :ref:`table function <table-functions>`
+  which can generate a series of numbers.
 
 - Implemented the :ref:`ARRAY_UPPER <scalar-array-upper>`, :ref:`ARRAY_LENGTH
   <scalar-array-length>` and :ref:`ARRAY_LOWER <scalar-array-lower>` scalar
   functions that return the upper and respectively lower bound of a given array
   dimension.
 
-- Added support for the
-  :ref:`ARRAY(subquery) <sql_expressions_array_subquery>` expression,
-  which can turn the result from a subquery into an array.
+- Added support for the :ref:`ARRAY(subquery) <sql_expressions_array_subquery>`
+  expression, which can turn the result from a subquery into an array.
 
 - The :ref:`= ANY <sql_dql_any_array>` :ref:`operator <gloss-operator>` now
   also supports operations on object arrays or nested arrays. This enables
   queries like ``WHERE ['foo', 'bar'] = ANY(object_array(string_array))``.
 
-- Added support for :ref:`SHOW parameter_name | ALL <ref-show>` to retrieve
-  one or all session setting value(s).
+- Added support for :ref:`SHOW parameter_name | ALL <ref-show>` to retrieve one
+  or all session setting value(s).
 
-- Added support for :ref:`INITCAP(string) <scalar-initcap>` which
-  capitalizes the first letter of every word while turning all others into
-  lowercase.
+- Added support for :ref:`INITCAP(string) <scalar-initcap>` which capitalizes
+  the first letter of every word while turning all others into lowercase.
 
 - Added the scalar expression :ref:`CURRENT_DATABASE <scalar_current_database>`
   which returns the current database.
 
-- Functions like :ref:`CURRENT_SCHEMA <scalar_current_schema>` and
-  :ref:`CURRENT_USER <current_user>` which depend on the active session can now
-  be used as :ref:`generated columns <ddl-generated-columns>`.
+- :ref:`Functions <gloss-function>` like :ref:`CURRENT_SCHEMA
+  <scalar_current_schema>` and :ref:`CURRENT_USER <current_user>` which depend
+  on the active session can now be used as :ref:`generated columns
+  <ddl-generated-columns>`.
 
-- Added support for using :ref:`table functions <ref-table-functions>` in the
+- Added support for using :ref:`table functions <table-functions>` in the
   select list of a query.
 
 - :ref:`geo_shape <geo_shape_data_type>` columns can now be casted to
   ``object`` with ``cast`` in addition to ``try_cast``.
 
-- Improved the handling of function expressions inside subscripts used on
-  object columns. This allows expressions like ``obj['x' || 'x']`` to be used.
+- Improved the handling of :ref:`function expressions <sql-function-call>`
+  inside subscripts used on object columns. This allows expressions like
+  ``obj['x' || 'x']`` to be used.
 
 - ``<object_column> = <object_literal>`` comparisons now try to utilize the
   index for the objects contents and can therefore run much faster.
@@ -156,7 +163,8 @@ SQL Improvements
   since epoch and byte size values are treat as bytes.
 
 - Added support of using units inside byte-size or time bases statement
-  parameters values. E.g. '1mb' for 1 MegaByte or '1s' for 1 Second.
+  parameters values. E.g. ``1mb`` for one megabyte or ``1s`` for one Second.
+
 
 PostgreSQL Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -164,9 +172,8 @@ PostgreSQL Compatibility
 - Added the :ref:`pg_catalog.pg_database <postgres_pg_catalog>` table.
 
 - Added ``pg_class``, ``pg_namespace``, ``pg_attribute``, ``pg_attrdef``,
-  ``pg_index`` and ``pg_constraint`` tables to the
-  :ref:`pg_catalog <postgres_pg_catalog>` schema for
-  improved compatibility with PostgreSQL.
+  ``pg_index`` and ``pg_constraint`` tables to the :ref:`pg_catalog
+  <postgres_pg_catalog>` schema for improved compatibility with PostgreSQL.
 
 - Improved the compatibility with PostgreSQL clients that use the ``text`` type
   for parameter encoding.
@@ -175,12 +182,12 @@ PostgreSQL Compatibility
 
 - Added some type aliases for improved compatibility with PostgreSQL.
 
-- Expand the :ref:`search_path <conf-session-search-path>` setting to
-  accept a list of schemas that will be
-  searched when a relation (table, view or user defined function) is referenced
-  without specifying a schema. The system
-  :ref:`pg_catalog <postgres_pg_catalog>` schema is implicitly
-  included as the first one in the path.
+- Expand the :ref:`search_path <conf-session-search-path>` setting to accept a
+  list of schemas that will be searched when a relation (table, view or
+  :ref:`user-defined function <user-defined-functions>`) is referenced without
+  specifying a schema. The system :ref:`pg_catalog <postgres_pg_catalog>`
+  schema is implicitly included as the first one in the path.
+
 
 Database Administration
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -192,8 +199,8 @@ Database Administration
 - Improved resiliency of the :ref:`ALTER TABLE: RENAME TO
   <sql-alter-table-rename-to>` operation by making it an atomic operation.
 
-- Added an :ref:`ALTER CLUSTER SWAP TABLE <alter_cluster_swap_table>`
-  statement that can be used to switch the names of two tables.
+- Added an :ref:`ALTER CLUSTER SWAP TABLE <alter_cluster_swap_table>` statement
+  that can be used to switch the names of two tables.
 
 - Added a :ref:`ALTER CLUSTER GC DANGLING ARTIFACTS
   <alter_cluster_gc_dangling_artifacts>` statement that can be used to clean up
@@ -203,12 +210,13 @@ Database Administration
 - Added support for per-table :ref:`shard allocation filtering
   <ddl_shard_allocation>`.
 
+
 Admin UI Upgrade to 1.11.3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Changed the license information (ident) to be taken from the
-  `sys.cluster.licence` attribute instead of the `license.ident` setting,
-  which is ``@deprecated``.
+  `sys.cluster.licence` attribute instead of the `license.ident` setting, which
+  is ``@deprecated``.
 
 - Addition of French language files and menu options.
 
@@ -218,6 +226,7 @@ Admin UI Upgrade to 1.11.3
 
 - Various other improvements.
 
+
 Deprecations
 ~~~~~~~~~~~~
 
@@ -226,23 +235,23 @@ Deprecations
 
 - Deprecated the ``http.enabled`` setting which will be always on in future.
 
+
 Other
 ~~~~~
 
 - Upgraded to Elasticsearch 6.5.1, which includes changes to the default
   logging configuration.
 
-- Added a :ref:`remove_duplicates <analyzers_remove_duplicates>` token
-  filter.
+- Added a :ref:`remove_duplicates <analyzers_remove_duplicates>` token filter.
 
 - Added a :ref:`char_group <analyzers_char_group>` tokenizer.
 
 - Renamed the ``delimited_payload_filter`` token filter to
-  :ref:`delimited_payload <delimited_payload-tokenfilter>`. The old name
-  can still be used, but is deprecated.
+  :ref:`delimited_payload <delimited_payload-tokenfilter>`. The old name can
+  still be used, but is deprecated.
 
-For further information on CrateDB 3.2.0 see our
-`announcement blogpost <blogpost_>`__.
+For further information on CrateDB 3.2.0 see our `announcement blogpost
+<blogpost_>`__.
 
 
 .. _blogpost: https://crate.io/a/cratedb-3-2-stable-available-now/

--- a/docs/appendices/release-notes/3.2.1.rst
+++ b/docs/appendices/release-notes/3.2.1.rst
@@ -38,14 +38,15 @@ Released on 2019/01/14.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
@@ -55,8 +56,8 @@ Fixes
 - Fixed a race condition that could lead to stuck queries, for example if a
   node was stopped or crashed.
 
-- Fixed an issue that prevented queries on table functions from working if the
-  cluster contains an expired license.
+- Fixed an issue that prevented queries on :ref:`table functions
+  <table-functions>` from working if the cluster contains an expired license.
 
 - Casts to nested arrays are now properly supported.
 

--- a/docs/appendices/release-notes/3.2.2.rst
+++ b/docs/appendices/release-notes/3.2.2.rst
@@ -44,8 +44,10 @@ Released on 2019/01/22.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
@@ -53,5 +55,5 @@ Fixes
 - Fixed a ``NullPointerException`` that could occur on queries on the
   ``information_schema.tables`` table.
 
-- Fixed a ``NullPointerException`` that occurs on ``OUTER`` joins which can
-  be rewritten to ``INNER`` joins and uses a function as a select item.
+- Fixed a ``NullPointerException`` that occurs on ``OUTER`` joins which can be
+  rewritten to ``INNER`` joins and uses a function as a select item.

--- a/docs/appendices/release-notes/3.2.3.rst
+++ b/docs/appendices/release-notes/3.2.3.rst
@@ -44,8 +44,10 @@ Released on 2019/02/07.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----

--- a/docs/appendices/release-notes/3.2.4.rst
+++ b/docs/appendices/release-notes/3.2.4.rst
@@ -38,22 +38,22 @@ Released on 2019/02/25.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
 
 - Fixed an issue that would cause the results of a nested loop join statement
-  ordered by fields from a single relation, in the form of
-  ``SELECT t1.x, t2.x FROM t2 INNER JOIN t1 ON t1.x = t2.x ORDER BY t2.y``, to
-  be out of order.
+  ordered by fields from a single relation, in the form of ``SELECT t1.x, t2.x
+  FROM t2 INNER JOIN t1 ON t1.x = t2.x ORDER BY t2.y``, to be out of order.
 
 - Fixed an issue that caused the Admin UI monitoring graphs to be cut off.
 

--- a/docs/appendices/release-notes/3.2.5.rst
+++ b/docs/appendices/release-notes/3.2.5.rst
@@ -38,14 +38,15 @@ Released on 2019/03/11.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----

--- a/docs/appendices/release-notes/3.2.6.rst
+++ b/docs/appendices/release-notes/3.2.6.rst
@@ -55,12 +55,12 @@ Fixes
   in a ``JOIN`` statement.
 
 - Fixed an issue which caused a ``NullPointerException`` when executing a
-  :ref:`window function <window-functions>` over an ordered window which
-  contained null values under the ordered column.
+  window function over an ordered window which contained null values under the
+  ordered column.
 
 - Fixed an issue which causes sub-select queries with certain ``ORDER BY``
   constructs to fail.
 
-- Fixed circuit breaker memory accounting of window functions to prevent Out Of
-  Memory exceptions.
+- Fixed circuit breaker memory accounting of window functions to prevent *Out
+  Of Memory* exceptions.
 

--- a/docs/appendices/release-notes/3.2.7.rst
+++ b/docs/appendices/release-notes/3.2.7.rst
@@ -50,8 +50,9 @@ Changelog
 Fixes
 -----
 
-- Fixed an issue that could cause window functions to compute incorrect results
-  if multiple window functions with different window definitions were used.
+- Fixed an issue that could cause :ref:`window functions <window-functions>` to
+  compute incorrect results if multiple window functions with different window
+  definitions were used.
 
 - Fixed an issue that could cause a query with window functions and limit to
   return too few rows or have the window functions compute wrong results.

--- a/docs/appendices/release-notes/3.2.8.rst
+++ b/docs/appendices/release-notes/3.2.8.rst
@@ -53,14 +53,13 @@ Fixes
 - Fixed the processing of ``LIMIT`` clauses within queries in the :ref:`INSERT
   INTO <ref-insert>` statement. A query like ``INSERT INTO target (SELECT *
   FROM (SELECT * FROM source LIMIT 10) t)`` could insert more than 10 rows if
-  there is more than 1 node in the cluster.
-  In addition, using ``LIMIT`` in the top level query of the ``INSERT INTO``
-  statement is now no longer prohibited. So the query can be written as
-  follows: ``INSERT INTO target (SELECT * FROM source LIMIT 10)``.
+  there is more than 1 node in the cluster.  In addition, using ``LIMIT`` in
+  the top level query of the ``INSERT INTO`` statement is now no longer
+  prohibited. So the query can be written as follows: ``INSERT INTO target
+  (SELECT * FROM source LIMIT 10)``.
 
-- Fixed an issue that would cause the wrong evaluation of nested sub-queries
-  in cases where the inner sub-query returns a multi-value and the outer returns
-  a single value result. For instance, the assignment sub-query expression in
-  the following update statement
-  ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE x IN (SELECT x FROM t3))")``
-  might have produced an incorrect result.
+- Fixed an issue that would cause the wrong evaluation of nested sub-queries in
+  cases where the inner sub-query returns a multi-value and the outer returns a
+  single value result. For instance, the assignment sub-query expression in the
+  following update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE
+  x IN (SELECT x FROM t3))")`` might have produced an incorrect result.

--- a/docs/appendices/release-notes/3.3.0.rst
+++ b/docs/appendices/release-notes/3.3.0.rst
@@ -14,8 +14,8 @@ Released on 2019/03/27.
     We recommend that you upgrade to the latest 3.2 release before moving to
     3.3.0.
 
-    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
-    version will require a `full restart upgrade`_.
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to
+    this version will require a `full restart upgrade`_.
 
     When restarting, CrateDB will migrate indexes to a newer format. Depending
     on the amount of data, this may delay node start-up time.
@@ -37,35 +37,36 @@ Released on 2019/03/27.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
 
 .. _version_3.3.0_upgrade_notes:
 
 Upgrade Notes
 =============
 
+
 Deprecated Settings and Features
 --------------------------------
 
-The query frequency and average duration :ref:`query_stats_mbean` metrics
-has now been deprecated, in favour of the new total count and sum of durations
+The query frequency and average duration :ref:`query_stats_mbean` metrics has
+now been deprecated, in favour of the new total count and sum of durations
 metrics.
 
 The ``cluster.graceful_stop.reallocate`` setting has been marked as deprecated.
-This setting was already being ignored, and setting the value to ``false``
-had no effect.
+This setting was already being ignored, and setting the value to ``false`` had
+no effect.
 
 The node decommission using the ``USR2`` :ref:`signals <cli-crate-signals>` has
 now been deprecated in favour of the :ref:`ALTER CLUSTER DECOMMISSION
 <alter_cluster_decommission>` statement.
 
-The ``CREATE INGEST`` and ``DROP INGEST`` rules have been marked
-as deprecated. Given that the only implementation (MQTT) was deprecated
-and will be removed, the framework itself will also be removed.
+The ``CREATE INGEST`` and ``DROP INGEST`` rules have been marked as
+deprecated. Given that the only implementation (MQTT) was deprecated and will
+be removed, the framework itself will also be removed.
 
 
 Changelog
@@ -85,17 +86,18 @@ New Features
   statement type under the ``sum_of_durations``, ``total_count`` and
   ``failed_count`` columns, respectively, in the :ref:`sys-jobs-metrics` table.
 
+
 SQL Improvements
 ~~~~~~~~~~~~~~~~
 
-- Added ``current_schemas(boolean)`` scalar function which will return the
-  names of schemas in the ``search_path``.
+- Added ``current_schemas(boolean)`` :ref:`scalar function <scalar-functions>`
+  which will return the names of schemas in the ``search_path``.
 
 - Added support for the ``first_value``, ``last_value``, and ``nth_value``
-  window functions as enterprise features.
+  :ref:`window functions <window-functions>` as enterprise features.
 
-- Added the ``DROP ANALYZER`` statement to support removal of custom
-  analyzer definitions from the cluster.
+- Added the ``DROP ANALYZER`` statement to support removal of custom analyzer
+  definitions from the cluster.
 
 - Output the custom analyzer, tokenizer, token_filter, and char_filter
   definition inside the ``information_schema.routines.routine_definition``
@@ -108,18 +110,20 @@ SQL Improvements
 - Fix quoting of identifiers that contain leading digits or spaces when
   printing relation or column names.
 
+
 PostgreSQL Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Added ``pg_type`` columns: ``typlen``, ``typarray``, ``typnotnull``,
-  and ``typnamespace`` for improved PostgreSQL compatibility.
+- Added ``pg_type`` columns: ``typlen``, ``typarray``, ``typnotnull``, and
+  ``typnamespace`` for improved PostgreSQL compatibility.
 
 - Added a ``pg_description`` table to the ``pg_catalog`` schema for improved
   PostgreSQL compatibility.
 
-- Fixed function resolution for PostgreSQL functions ``pg_backend_pid``,
-  ``pg_get_expr``, and ``current_database`` when the schema prefix
-  ``pg_catalog`` is included.
+- Fixed :ref:`function <gloss-function>` resolution for PostgreSQL functions
+  ``pg_backend_pid``, ``pg_get_expr``, and ``current_database`` when the schema
+  prefix ``pg_catalog`` is included.
+
 
 Database Administration
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -138,23 +142,24 @@ Database Administration
 Deprecations
 ~~~~~~~~~~~~
 
-- The query frequency and average duration :ref:`query_stats_mbean` metrics
-  has been deprecated in favour of the new total count and sum of durations
+- The query frequency and average duration :ref:`query_stats_mbean` metrics has
+  been deprecated in favour of the new total count and sum of durations
   metrics.
 
-- Marked the ``cluster.graceful_stop.reallocate`` setting as deprecated.
-  This setting was already being ignored, setting the value to ``false`` has no effect.
+- Marked the ``cluster.graceful_stop.reallocate`` setting as deprecated.  This
+  setting was already being ignored, setting the value to ``false`` has no
+  effect.
 
 - The node decommission using the ``USR2`` :ref:`signal <cli-crate-signals>`
   has been deprecated in favour of the :ref:`ALTER CLUSTER DECOMMISSION
   <alter_cluster_decommission>` statement.
 
-- Marked ``CREATE INGEST`` and ``DROP INGEST`` as deprecated.
-  Given that the only implementation (MQTT) was deprecated and will be removed,
-  the framework itself will also be removed.
+- Marked ``CREATE INGEST`` and ``DROP INGEST`` as deprecated.  Given that the
+  only implementation (MQTT) was deprecated and will be removed, the framework
+  itself will also be removed.
 
 Other
 ~~~~~
 
-- Buffer the file output of ``COPY TO`` operations to improve performance by not
-  writing to disk on every row.
+- Buffer the file output of ``COPY TO`` operations to improve performance by
+  not writing to disk on every row.

--- a/docs/appendices/release-notes/3.3.1.rst
+++ b/docs/appendices/release-notes/3.3.1.rst
@@ -44,8 +44,10 @@ Released on 2019/04/09.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
@@ -53,8 +55,9 @@ Fixes
 - Fixed a ``ClassCastException`` which could occur when selecting
   ``pg_catalog.pg_type.typlen``.
 
-- Fixed an issue that could cause window functions to compute incorrect results
-  if multiple window functions with different window definitions were used.
+- Fixed an issue that could cause :ref:`window functions <window-functions>` to
+  compute incorrect results if multiple window functions with different window
+  definitions were used.
 
 - Fixed an issue that could cause a query with window functions and limit to
   return too few rows or have the window functions compute wrong results.

--- a/docs/appendices/release-notes/3.3.2.rst
+++ b/docs/appendices/release-notes/3.3.2.rst
@@ -38,14 +38,15 @@ Released on 2019/04/17.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
@@ -53,14 +54,13 @@ Fixes
 - Fixed the processing of ``LIMIT`` clauses within queries in the :ref:`INSERT
   INTO <ref-insert>` statement. A query like ``INSERT INTO target (SELECT *
   FROM (SELECT * FROM source LIMIT 10) t)`` could insert more than 10 rows if
-  there is more than 1 node in the cluster.
-  In addition, using ``LIMIT`` in the top level query of the ``INSERT INTO``
-  statement is now no longer prohibited. So the query can be written as
-  follows: ``INSERT INTO target (SELECT * FROM source LIMIT 10)``.
+  there is more than 1 node in the cluster.  In addition, using ``LIMIT`` in
+  the top level query of the ``INSERT INTO`` statement is now no longer
+  prohibited. So the query can be written as follows: ``INSERT INTO target
+  (SELECT * FROM source LIMIT 10)``.
 
-- Fixed an issue that would cause the wrong evaluation of nested sub-queries
-  in cases where the inner sub-query returns a multi-value and the outer returns
-  a single value result. For instance, the assignment sub-query expression in
-  the following update statement
-  ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE x IN (SELECT x FROM t3))")``
-  might have produced an incorrect result.
+- Fixed an issue that would cause the wrong evaluation of nested sub-queries in
+  cases where the inner sub-query returns a multi-value and the outer returns a
+  single value result. For instance, the assignment sub-query expression in the
+  following update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE
+  x IN (SELECT x FROM t3))")`` might have produced an incorrect result.

--- a/docs/appendices/release-notes/3.3.3.rst
+++ b/docs/appendices/release-notes/3.3.3.rst
@@ -38,14 +38,15 @@ Released on 2019/05/23.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
@@ -79,5 +80,6 @@ Fixes
   startup while a trial license is generated concurrently and such may used
   instead of the user given license.
 
-- Improve error message for the unsupported :ref:`window-definition` ordered or
-  partitioned by an array column type in the context of :ref:`window-functions`
+- Improve error message for the unsupported :ref:`window definition
+  <window-definition>` ordered or partitioned by an array column type in the
+  context of :ref:`window functions <window-functions>`

--- a/docs/appendices/release-notes/3.3.4.rst
+++ b/docs/appendices/release-notes/3.3.4.rst
@@ -44,8 +44,10 @@ Released on 2019/06/19.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
@@ -68,10 +70,10 @@ Fixes
   return the results over ``JDBC``. ``collection_count`` and ``collection_avg``
   are also changed to receive ``arrays`` as arguments, instead of ``sets``.
 
-- Fixed an issue that caused an error when trying to create a table with
-  a column definition that contains a predefined array data type and generated
-  expression. For instance, a statement like
-  ``CREATE TABLE foo (col ARRAY(TEXT) AS ['bar'])`` would fail.
+- Fixed an issue that caused an error when trying to create a table with a
+  column definition that contains a predefined array data type and generated
+  expression. For instance, a statement like ``CREATE TABLE foo (col
+  ARRAY(TEXT) AS ['bar'])`` would fail.
 
-- Fixed a bug that led to failures of group by a single text column queries
-  on columns with the cardinality ration lower than ``0.5``.
+- Fixed a bug that led to failures of group by a single text column queries on
+  columns with the cardinality ration lower than ``0.5``.

--- a/docs/appendices/release-notes/3.3.5.rst
+++ b/docs/appendices/release-notes/3.3.5.rst
@@ -44,8 +44,10 @@ Released on 2019/07/08.
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----
@@ -54,10 +56,11 @@ Fixes
   to be recreated in preparation for a CrateDB upgrade towards the next major
   version of CrateDB.
 
-- The values provided in INSERT or UPDATE statements for object columns which
-  contain generated expressions are now validated. The computed expression must
-  match the provided value. This makes the behavior consistent with how top
-  level columns of a table are treated.
+- The values provided in ``INSERT`` or ``UPDATE`` statements for object columns
+  which contain generated expressions are now validated. The computed
+  expression must match the provided value. This makes the behavior consistent
+  with how top level columns of a table are treated.
 
 - Fixed support for ordering by literal constants.
+
   Example: ``SELECT 1, * FROM t ORDER BY 1"``

--- a/docs/appendices/release-notes/3.3.6.rst
+++ b/docs/appendices/release-notes/3.3.6.rst
@@ -38,14 +38,15 @@ Released on 2019/09/27.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
 
+
 Changelog
 =========
+
 
 Fixes
 -----

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -23,8 +23,8 @@ Released on 2019/06/25.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -35,16 +35,17 @@ Released on 2019/06/25.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
 
+
 .. _version_4.0.0_upgrade_notes:
 
 Upgrade Notes
 =============
+
 
 .. _discovery-changes:
 
@@ -52,16 +53,18 @@ Discovery Changes
 -----------------
 
 This version of CrateDB uses a new cluster coordination (discovery)
-implementation which improves resiliency and master election times.
-A new voting mechanism is used when a node is removed or added which makes the
-system capable of automatically maintaining an optimal level of fault
-tolerance even in situations of network partitions.
+implementation which improves resiliency and master election times.  A new
+voting mechanism is used when a node is removed or added which makes the system
+capable of automatically maintaining an optimal level of fault tolerance even
+in situations of network partitions.
+
 This eliminates the need of the easily miss configured ``minimum_master_nodes``
 setting.
+
 Additionally a rare resiliency failure, recorded as :ref:`Repeated cluster
 partitions can cause cluster state updates to be lost
-<resiliency_cluster_partitions_cause_lost_cluster_updates>`
-can no longer occur.
+<resiliency_cluster_partitions_cause_lost_cluster_updates>` can no longer
+occur.
 
 Due to this some discovery settings are added, renamed and removed.
 
@@ -94,10 +97,10 @@ Due to this some discovery settings are added, renamed and removed.
 
 .. NOTE::
 
-   Only a single port value is allowed for each ``discovery.seed_hosts`` setting
-   entry. Defining a port range as it was allowed but ignored in previous
-   versions under the old setting name ``discovery.zen.ping.unicast.hosts``,
-   will be rejected.
+   Only a single port value is allowed for each ``discovery.seed_hosts``
+   setting entry. Defining a port range as it was allowed but ignored in
+   previous versions under the old setting name
+   ``discovery.zen.ping.unicast.hosts``, will be rejected.
 
 .. NOTE::
 
@@ -109,28 +112,29 @@ Due to this some discovery settings are added, renamed and removed.
 Breaking Changes
 ================
 
+
 General
 -------
 
 - Renamed CrateDB data types to the corresponding PostgreSQL data types.
 
-+---------------+------------------------------+
-| Current Name  | New Name                     |
-+===============+==============================+
-| ``short``     | ``smallint``                 |
-+---------------+------------------------------+
-| ``long``      | ``bigint``                   |
-+---------------+------------------------------+
-| ``float``     | ``real``                     |
-+---------------+------------------------------+
-| ``double``    | ``double precision``         |
-+---------------+------------------------------+
-| ``byte``      | ``char``                     |
-+---------------+------------------------------+
-| ``string``    | ``text``                     |
-+---------------+------------------------------+
-| ``timestamp`` | ``timestamp with time zone`` |
-+---------------+------------------------------+
+  +---------------+------------------------------+
+  | Current Name  | New Name                     |
+  +===============+==============================+
+  | ``short``     | ``smallint``                 |
+  +---------------+------------------------------+
+  | ``long``      | ``bigint``                   |
+  +---------------+------------------------------+
+  | ``float``     | ``real``                     |
+  +---------------+------------------------------+
+  | ``double``    | ``double precision``         |
+  +---------------+------------------------------+
+  | ``byte``      | ``char``                     |
+  +---------------+------------------------------+
+  | ``string``    | ``text``                     |
+  +---------------+------------------------------+
+  | ``timestamp`` | ``timestamp with time zone`` |
+  +---------------+------------------------------+
 
   See :ref:`data-types` for more detailed information. The old data type names,
   are registered as aliases for backward comparability.
@@ -147,6 +151,7 @@ General
   ``HTTP``.
 
 - Dropped support for Java versions < 11
+
 
 Removed Settings
 ----------------
@@ -166,14 +171,15 @@ Removed Settings
   to false, this execution strategy cannot be used anymore.
 
 - Removed the possibility of configuring the AWS S3 repository client via the
-  ``crate.yaml`` configuration file and command line arguments. Please, use
-  the :ref:`ref-create-repository` statement parameters for this purpose.
+  ``crate.yaml`` configuration file and command line arguments. Please, use the
+  :ref:`ref-create-repository` statement parameters for this purpose.
 
 - Removed :ref:`HDFS repository setting<ref-create-repository-types-hdfs>`:
   ``concurrent_streams`` as it is no longer supported.
 
 - The ``zen1`` related discovery settings mentioned in
   :ref:`discovery-changes`.
+
 
 System table changes
 --------------------
@@ -186,38 +192,38 @@ System table changes
 
 - Removed deprecated metrics from :ref:`sys.nodes <sys-nodes>`:
 
-+--------------------------------+
-| Metric name                    |
-+================================+
-|``fs['disks']['reads']``        |
-+--------------------------------+
-|``fs['disks']['bytes_read']``   |
-+--------------------------------+
-|``fs['disks']['writes']``       |
-+--------------------------------+
-|``fs['disks']['bytes_written']``|
-+--------------------------------+
-|``os['cpu']['system']``         |
-+--------------------------------+
-|``os['cpu']['user']``           |
-+--------------------------------+
-|``os['cpu']['idle']``           |
-+--------------------------------+
-|``os['cpu']['stolen']``         |
-+--------------------------------+
-|``process['cpu']['user']``      |
-+--------------------------------+
-|``process['cpu']['system']``    |
-+--------------------------------+
+  +--------------------------------+
+  | Metric name                    |
+  +================================+
+  |``fs['disks']['reads']``        |
+  +--------------------------------+
+  |``fs['disks']['bytes_read']``   |
+  +--------------------------------+
+  |``fs['disks']['writes']``       |
+  +--------------------------------+
+  |``fs['disks']['bytes_written']``|
+  +--------------------------------+
+  |``os['cpu']['system']``         |
+  +--------------------------------+
+  |``os['cpu']['user']``           |
+  +--------------------------------+
+  |``os['cpu']['idle']``           |
+  +--------------------------------+
+  |``os['cpu']['stolen']``         |
+  +--------------------------------+
+  |``process['cpu']['user']``      |
+  +--------------------------------+
+  |``process['cpu']['system']``    |
+  +--------------------------------+
 
-- Renamed column `information_schema.table_partitions.schema_name` to
-  `table_schema`.
+- Renamed column ``information_schema.table_partitions.schema_name`` to
+  ``table_schema``.
 
 - Renamed ``information_schema.columns.user_defined_type_*`` columns to
   ``information_schema_columns.udt_*`` for SQL standard compatibility.
 
-- Changed type of column ``information_schema.columns.is_generated`` to ``STRING``
-  with value ``NEVER`` or ``ALWAYS`` for SQL standard compatibility.
+- Changed type of column ``information_schema.columns.is_generated`` to
+  ``STRING`` with value ``NEVER`` or ``ALWAYS`` for SQL standard compatibility.
 
 
 Removed Functionality
@@ -262,18 +268,19 @@ Deprecations
   columns.
 
 - Deprecate the usage of the :ref:`TIMESTAMP <data-type-aliases>` data type as
-  a timestamp with time zone, use
-  :ref:`TIMESTAMP WITH TIME ZONE <datetime-with-time-zone>` or
-  :ref:`TIMESTAMPTZ <data-type-aliases>` instead. The ``TIMESTAMP`` data type
-  will be an equivalent to data type without time zone in future ``CrateDB``
-  releases.
+  a timestamp with time zone, use :ref:`TIMESTAMP WITH TIME ZONE
+  <datetime-with-time-zone>` or :ref:`TIMESTAMPTZ <data-type-aliases>`
+  instead. The ``TIMESTAMP`` data type will be an equivalent to data type
+  without time zone in future ``CrateDB`` releases.
 
 - Marked SynonymFilter tokenizer as deprecated.
 
 - Marked LowerCase tokenizer as deprecated.
 
+
 Changes
 =======
+
 
 SQL Standard and PostgreSQL compatibility improvements
 ------------------------------------------------------
@@ -284,18 +291,19 @@ SQL Standard and PostgreSQL compatibility improvements
 - Added support for column :ref:`sql-create-table-default-clause` for
   :ref:`sql-create-table`.
 
-- Extended the support for window functions. The ``PARTITION BY`` definition
-  and the ``CURRENT ROW -> UNBOUNDED FOLLOWING`` frame definitions are now
-  supported. See :ref:`window-functions`.
+- Extended the support for :ref:`window functions <window-functions>`. The
+  ``PARTITION BY`` definition and the ``CURRENT ROW -> UNBOUNDED FOLLOWING``
+  frame definitions are now supported.
 
-- Added the :ref:`aggregation-string-agg` aggregation function.
+- Added the :ref:`aggregation-string-agg` :ref:`aggregation function
+  <aggregation-functions>`.
 
 - Added support for `SQL Standard Timestamp Format
   <https://crate.io/docs/sql-99/en/latest/chapters/08.html#timestamp-literal>`_
   to the :ref:`date-time-types`.
 
-- Added the :ref:`TIMESTAMP WITHOUT TIME ZONE <datetime-without-time-zone>` data
-  type.
+- Added the :ref:`TIMESTAMP WITHOUT TIME ZONE <datetime-without-time-zone>`
+  data type.
 
 - Added the :ref:`TIMESTAMPTZ <data-type-aliases>` alias for the
   :ref:`TIMESTAMP WITH TIME ZONE <datetime-with-time-zone>` data type.
@@ -304,11 +312,11 @@ SQL Standard and PostgreSQL compatibility improvements
   cast :ref:`operator <gloss-operator>`, which is used to initialize a constant
   of an arbitrary type.
 
-- Added the :ref:`pg_get_userbyid` scalar function to enhance PostgreSQL
-  compatibility.
+- Added the :ref:`pg_get_userbyid` :ref:`scalar function <scalar-functions>` to
+  enhance PostgreSQL compatibility.
 
-- Enabled Scalar function evaluation when used :ref:`in the query FROM
-  clause in place of a relation<table-functions-scalar>`.
+- Enabled scalar function evaluation when used :ref:`in the query FROM clause
+  in place of a relation<table-functions-scalar>`.
 
 - Show the session setting description in the output of the ``SHOW ALL``
   statement.
@@ -321,36 +329,35 @@ SQL Standard and PostgreSQL compatibility improvements
 
 - Added support for :ref:`sql_escape_string_literals`.
 
-- Added :ref:`trim <scalar-trim>` scalar string function that trims
-  the (leading, trailing or both) set of characters from an input string.
+- Added :ref:`trim <scalar-trim>` scalar function that trims the (leading,
+  trailing or both) set of characters from an input string.
 
-- Added :ref:`string_to_array <scalar-string-to-array>` scalar array function
-  that splits an input string into an array of string elements using a
-  separator and a null-string.
+- Added :ref:`string_to_array <scalar-string-to-array>` scalar function that
+  splits an input string into an array of string elements using a separator and
+  a null-string.
 
 - Added missing PostgreSQL type mapping for the ``array(ip)`` collection type.
 
 - Added :ref:`current_setting <scalar_current_setting>` system information
   scalar function that yields the current value of the setting.
 
-- Allow :ref:`sql_administration_udf` to be registered against the
+- Allow :ref:`user-defined-functions` to be registered against the
   ``pg_catalog`` schema. This also extends :ref:`scalar_current_schema` to be
   addressable with ``pg_catalog`` included.
 
-- Added :ref:`quote_ident <scalar-quote-ident>` scalar string function that
-  quotes a string if it is needed.
+- Added :ref:`quote_ident <scalar-quote-ident>` scalar function that quotes a
+  string if it is needed.
 
 
 Users and Access Control
 ------------------------
 
-- Mask sensitive user account information in
-  :ref:`sys.repositories <sys-repositories>` for repository types:
-  ``azure``, ``s3``.
+- Mask sensitive user account information in :ref:`sys.repositories
+  <sys-repositories>` for repository types: ``azure``, ``s3``.
 
 - Restrict access to log entries in :ref:`sys.jobs <sys-jobs>` and
-  :ref:`sys.jobs_log <sys-logs>` to the current user.
-  This doesn't apply to superusers.
+  :ref:`sys.jobs_log <sys-logs>` to the current user.  This doesn't apply to
+  superusers.
 
 - Added a new ``Administration Language (AL)`` privilege type which allows
   users to manage other users and use ``SET GLOBAL``. See
@@ -360,12 +367,12 @@ Users and Access Control
 Repositories and Snapshots
 --------------------------
 
-- Added support for the
-  :ref:`Azure Storage repositories <ref-create-repository-types-azure>`.
+- Added support for the :ref:`Azure Storage repositories
+  <ref-create-repository-types-azure>`.
 
-- Changed the default value of the ``fs`` repository type setting
-  ``compress``, to ``true``. See
-  :ref:`fs repository parameters<ref-create-repository-types-fs>`.
+- Changed the default value of the ``fs`` repository type setting ``compress``,
+  to ``true``. See :ref:`fs repository
+  parameters<ref-create-repository-types-fs>`.
 
 - Improved resiliency of the :ref:`sql-create-snapshot` operation.
 
@@ -375,10 +382,10 @@ Performance and resiliency improvements
 
 - Exposed the :ref:`_seq_no <sql_administration_system_columns_seq_no>` and
   :ref:`_primary_term <sql_administration_system_columns_primary_term>` system
-  columns which can be used for :ref:`sql_occ`.
-  By introducing :ref:`_seq_no <sql_administration_system_columns_seq_no>` and
-  :ref:`_primary_term <sql_administration_system_columns_primary_term>`, the
-  following resiliency issues were fixed:
+  columns which can be used for :ref:`sql_occ`.  By introducing :ref:`_seq_no
+  <sql_administration_system_columns_seq_no>` and :ref:`_primary_term
+  <sql_administration_system_columns_primary_term>`, the following resiliency
+  issues were fixed:
 
    - :ref:`Version Number Representing Ambiguous Row Versions
      <resiliency_ambiguous_row_versions>`
@@ -386,10 +393,10 @@ Performance and resiliency improvements
    - :ref:`Replicas can fall out of sync when a primary shard fails
      <resiliency_replicas_fall_out_of_sync>`
 
-- Predicates like ``abs(x) = 1`` which require a scalar function evaluation and
-  cannot operate on table indices directly are now candidates for the query
-  cache. This can result in order of magnitude performance increases on
-  subsequent queries.
+- Predicates like ``abs(x) = 1`` which require a :ref:`scalar function
+  <scalar-functions>` evaluation and cannot operate on table indices directly
+  are now candidates for the query cache. This can result in order of magnitude
+  performance increases on subsequent queries.
 
 - Routing awareness attributes are now also taken into consideration for
   primary key lookups. (Queries like ``SELECT * FROM t WHERE pk = 1``)
@@ -405,13 +412,13 @@ Performance and resiliency improvements
 Others
 ------
 
-- Added support for dynamical reloading of SSL certificates.
-  See :ref:`ssl_configure_keystore`.
+- Added support for dynamical reloading of SSL certificates.  See
+  :ref:`ssl_configure_keystore`.
 
-- Added `minimum_index_compatibility_version` and
-  `minimum_wire_compatibility_version` to  :ref:`sys.version <sys-versions>`
-  to expose the current state of the node's index and wire protocol version
-  as part of the :ref:`sys.nodes <sys-nodes>` table.
+- Added ``minimum_index_compatibility_version`` and
+  ``minimum_wire_compatibility_version`` to :ref:`sys.version <sys-versions>` to
+  expose the current state of the node's index and wire protocol version as
+  part of the :ref:`sys.nodes <sys-nodes>` table.
 
 - Upgraded to Lucene 8.0.0, and as part of this the BM25 scoring has changed.
   The order of the scores remain the same, but the values of the scores differ.
@@ -420,6 +427,7 @@ Others
 - Added a new ``_docid`` :ref:`system column
   <sql_administration_system_columns>`.
 
-- Added support for subscript expressions on an object column of a sub-relation.
-  Examples: ``select a['b'] from (select a from t1)`` or ``select a['b'] from
-  my_view`` where ``my_view`` is defined as ``select a from t1``.
+- Added support for subscript expressions on an object column of a
+  sub-relation.  Examples: ``select a['b'] from (select a from t1)`` or
+  ``select a['b'] from my_view`` where ``my_view`` is defined as ``select a
+  from t1``.

--- a/docs/appendices/release-notes/4.0.1.rst
+++ b/docs/appendices/release-notes/4.0.1.rst
@@ -20,8 +20,8 @@ Released on 2019/07/08.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -38,7 +38,6 @@ Released on 2019/07/08.
 .. contents::
    :local:
 
-
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
 
@@ -53,13 +52,13 @@ Fixes
   to be recreated in preparation for a CrateDB upgrade towards the next major
   version of CrateDB.
 
-- Fixed an issue that led to DEFAULT constraints of inner columns of object
+- Fixed an issue that led to ``DEFAULT`` constraints of inner columns of object
   columns to be ignored.
 
-- The values provided in INSERT or UPDATE statements for object columns which
-  contain generated expressions are now validated. The computed expression must
-  match the provided value. This makes the behavior consistent with how top
-  level columns of a table are treated.
+- The values provided in ``INSERT`` or ``UPDATE`` statements for object columns
+  which contain generated expressions are now validated. The computed
+  expression must match the provided value. This makes the behavior consistent
+  with how top level columns of a table are treated.
 
-- Fixed support for ordering by literal constants.
-  Example: ``SELECT 1, * FROM t ORDER BY 1"``
+- Fixed support for ordering by literal constants.  Example: ``SELECT 1, * FROM
+  t ORDER BY 1"``

--- a/docs/appendices/release-notes/4.0.10.rst
+++ b/docs/appendices/release-notes/4.0.10.rst
@@ -9,9 +9,8 @@ Released on 2019/12/10.
 .. NOTE::
 
     Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
-    CrateDB 3.x or earlier.
-    Before upgrading to 4.0.10 you should be running a CrateDB cluster that is
-    at least on 3.0.7.
+    CrateDB 3.x or earlier.  Before upgrading to 4.0.10 you should be running a
+    CrateDB cluster that is at least on 3.0.7.
 
     We recommend that you upgrade to the latest 3.3 release before moving to
     4.0.10.
@@ -25,8 +24,8 @@ Released on 2019/12/10.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -44,15 +43,15 @@ Released on 2019/12/10.
 .. contents::
    :local:
 
-
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
+
 
 Fixes
 =====
 
-- Fixed an issue that would lead to incorrect behaviour of the insert from
-  sub query statement for the scenario when the target table contains a
+- Fixed an issue that would lead to incorrect behaviour of the insert from sub
+  query statement for the scenario when the target table contains a
   :ref:`generated column <ddl-generated-columns>` with the
   :ref:`not_null_constraint` constraint and a value for the :ref:`generated
   column <ddl-generated-columns>` is not provided explicitly. For example, the
@@ -69,15 +68,15 @@ Fixes
 - Improved snapshot error handling by assuring a snapshot is declared as failed
   when a shard or node failure happens during the snapshot process.
 
-- Fixed an issue which may result in an ``ArrayIndexOutOfBoundsException`` while
-  altering an empty partitioned table.
+- Fixed an issue which may result in an ``ArrayIndexOutOfBoundsException``
+  while altering an empty partitioned table.
 
 - Fixed a regression introduced in ``2.3.2`` which optimizes subqueries when
-  used inside multi-value producing functions and :ref:`operators
-  <gloss-operator>` like ``IN()``, ``ANY()`` or ``ARRAY()`` by applying an
-  implicit ordering. When using data types (e.g. like an object: ``select
-  array(select {a = col} from test)`` which do not support ordering, an NPE was
-  raised.
+  used inside :ref:`multi-valued functions <gloss-multi-valued-functions>` and
+  :ref:`operators <gloss-operator>` like ``IN()``, ``ANY()`` or ``ARRAY()`` by
+  applying an implicit ordering. When using data types (e.g. like an object:
+  ``select array(select {a = col} from test)`` which do not support ordering,
+  an NPE was raised.
 
 - Fixed a possible OutOfMemory issue which may happen on ``GROUP BY`` statement
   using a group key of type ``TEXT`` on tables containing at least one shard
@@ -87,11 +86,12 @@ Fixes
   table which contains nested primary key columns.
 
 - Fixed an issue where values of type ``array(varchar)`` were decoded
-  incorrectly if they contained a ``,`` character. This occurred when
-  the PostgreSQL wire protocol was used in ``text`` mode.
+  incorrectly if they contained a ``,`` character. This occurred when the
+  PostgreSQL wire protocol was used in ``text`` mode.
 
-- Improved performance of snapshot finalization as https://github.com/crate/crate/pull/9327
-  introduced a performance regression on the snapshot process.
+- Improved performance of snapshot finalization as
+  https://github.com/crate/crate/pull/9327 introduced a performance regression
+  on the snapshot process.
 
 - Fixed a ``ClassCastException`` that could occur when using ``unnest`` on
   multi dimensional arrays.

--- a/docs/appendices/release-notes/4.0.2.rst
+++ b/docs/appendices/release-notes/4.0.2.rst
@@ -20,8 +20,8 @@ Released on 2019/07/12.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -32,12 +32,10 @@ Released on 2019/07/12.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
-
 
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
@@ -53,5 +51,5 @@ Fixes
   future versions of CrateDB.
 
 - Arithmetic operations now work on expressions of type :ref:`timestamp without
-  time zone <date-time-types>`, to make it consistent with ``timestamp with time
-  zone``.
+  time zone <date-time-types>`, to make it consistent with ``timestamp with
+  time zone``.

--- a/docs/appendices/release-notes/4.0.3.rst
+++ b/docs/appendices/release-notes/4.0.3.rst
@@ -12,7 +12,8 @@ Released on 2019/08/06.
     Before upgrading to 4.0.3 you should be running a CrateDB cluster that is
     at least on 3.0.7.
 
-    We recommend that you upgrade to the latest 3.3 release before moving to 4.0.3.
+    We recommend that you upgrade to the latest 3.3 release before moving to
+    4.0.3.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be at least :ref:`version_4.0.2`. Any upgrade from a version
@@ -23,8 +24,8 @@ Released on 2019/08/06.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -36,12 +37,10 @@ Released on 2019/08/06.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
-
 
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
@@ -51,14 +50,16 @@ Fixes
 =====
 
 - Fixed an issue with using the same column under a different name/alias inside
-  more complex queries. Example:
-  ``SELECT count(*), t.x, t.x AS tx FROM t GROUP BY t.x``
+  more complex queries. Example: ``SELECT count(*), t.x, t.x AS tx FROM t GROUP
+  BY t.x``
 
 - Fixed an issue with the ``collect_set`` function. It could compute an
-  incorrect result if used as a window function with shrinking window frames.
+  incorrect result if used as a :ref:`window function <window-functions>` with
+  shrinking window frames.
 
 - Fixed an issue with the version payload returned by HTTP, which resulted in
-  falsely displaying CrateDB's version as a ``-SNAPSHOT`` version at the AdminUI.
+  falsely displaying CrateDB's version as a ``-SNAPSHOT`` version at the
+  AdminUI.
 
 - Fixed parsing of timestamps with a time zone offset of ``+0000``.
 

--- a/docs/appendices/release-notes/4.0.4.rst
+++ b/docs/appendices/release-notes/4.0.4.rst
@@ -9,11 +9,11 @@ Released on 2019/08/21.
 .. NOTE::
 
     Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
-    CrateDB 3.x or earlier.
-    Before upgrading to 4.0.4 you should be running a CrateDB cluster that is
-    at least on 3.0.7.
+    CrateDB 3.x or earlier.  Before upgrading to 4.0.4 you should be running a
+    CrateDB cluster that is at least on 3.0.7.
 
-    We recommend that you upgrade to the latest 3.3 release before moving to 4.0.4.
+    We recommend that you upgrade to the latest 3.3 release before moving to
+    4.0.4.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be at least :ref:`version_4.0.2`. Any upgrade from a version
@@ -24,8 +24,8 @@ Released on 2019/08/21.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -51,17 +51,17 @@ See the :ref:`version_4.0.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue that would lead :ref:`ref-explain` of invalid statements
-  to stuck instead of fail.
+- Fixed an issue that would lead :ref:`ref-explain` of invalid statements to
+  stuck instead of fail.
 
 - Fixed a regression introduced in 4.0 that broke the ``MATCH`` predicate if
   used on aliased relations.
 
-- Improved error handling if an argument of a window function is not used as a
-  grouping symbol.
+- Improved error handling if an argument of a :ref:`window function
+  <window-functions>` is not used as a grouping symbol.
 
-- Fixed an ``OUTER JOIN`` issue resulting in an ``ArrayOutOfBoundException``
-  if the gap between matching rows of the tables was growing to big numbers.
+- Fixed an ``OUTER JOIN`` issue resulting in an ``ArrayOutOfBoundException`` if
+  the gap between matching rows of the tables was growing to big numbers.
 
 - Fixed serialization issue that might occur in distributed queries that
   contain window function calls with the partition by clause in the select

--- a/docs/appendices/release-notes/4.0.5.rst
+++ b/docs/appendices/release-notes/4.0.5.rst
@@ -9,11 +9,11 @@ Released on 2019/09/19.
 .. NOTE::
 
     Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
-    CrateDB 3.x or earlier.
-    Before upgrading to 4.0.5 you should be running a CrateDB cluster that is
-    at least on 3.0.7.
+    CrateDB 3.x or earlier.  Before upgrading to 4.0.5 you should be running a
+    CrateDB cluster that is at least on 3.0.7.
 
-    We recommend that you upgrade to the latest 3.3 release before moving to 4.0.5.
+    We recommend that you upgrade to the latest 3.3 release before moving to
+    4.0.5.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be at least :ref:`version_4.0.2`. Any upgrade from a version
@@ -24,8 +24,8 @@ Released on 2019/09/19.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -56,7 +56,7 @@ Fixes
   generated columns in the table/column view section.
 
 - Fixed an issue introduced in CrateDB 4.0 resulting in dysfunctional
-  disk-based :ref:`allocation <gloss-shard-allocation>`  thresholds.
+  disk-based :ref:`allocation <gloss-shard-allocation>` thresholds.
 
 - Fixed an issue resulting in ``pg_catalog.pg_attribute.attnum`` and
   ``information_schema.columns.ordinal_position`` being ``NULL`` on tables

--- a/docs/appendices/release-notes/4.0.6.rst
+++ b/docs/appendices/release-notes/4.0.6.rst
@@ -9,11 +9,11 @@ Released on 2019/10/03.
 .. NOTE::
 
     Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
-    CrateDB 3.x or earlier.
-    Before upgrading to 4.0.6 you should be running a CrateDB cluster that is
-    at least on 3.0.7.
+    CrateDB 3.x or earlier.  Before upgrading to 4.0.6 you should be running a
+    CrateDB cluster that is at least on 3.0.7.
 
-    We recommend that you upgrade to the latest 3.3 release before moving to 4.0.6.
+    We recommend that you upgrade to the latest 3.3 release before moving to
+    4.0.6.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be at least :ref:`version_4.0.2`. Any upgrade from a version
@@ -24,8 +24,8 @@ Released on 2019/10/03.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -37,7 +37,6 @@ Released on 2019/10/03.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
@@ -46,6 +45,7 @@ Released on 2019/10/03.
 
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
+
 
 Fixes
 =====
@@ -64,8 +64,8 @@ Fixes
   after the login redirect in the CrateDB Admin UI.
 
 - Fixed an issue that prevented subqueries from being used in select item
-  expressions that also contain a reference accessed via a relation alias.
-  For example: ``SELECT t.y IN (SELECT x FROM t2) FROM t1 t``
+  expressions that also contain a reference accessed via a relation alias.  For
+  example: ``SELECT t.y IN (SELECT x FROM t2) FROM t1 t``
 
 - Fail the storage engine if indexing on a replica shard fails after it was
   successfully done on a primary shard. It prevents replica and primary shards

--- a/docs/appendices/release-notes/4.0.7.rst
+++ b/docs/appendices/release-notes/4.0.7.rst
@@ -9,11 +9,11 @@ Released on 2019/10/24.
 .. NOTE::
 
     Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
-    CrateDB 3.x or earlier.
-    Before upgrading to 4.0.7 you should be running a CrateDB cluster that is
-    at least on 3.0.7.
+    CrateDB 3.x or earlier.  Before upgrading to 4.0.7 you should be running a
+    CrateDB cluster that is at least on 3.0.7.
 
-    We recommend that you upgrade to the latest 3.3 release before moving to 4.0.7.
+    We recommend that you upgrade to the latest 3.3 release before moving to
+    4.0.7.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be at least :ref:`version_4.0.2`. Any upgrade from a version
@@ -24,8 +24,8 @@ Released on 2019/10/24.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -37,12 +37,10 @@ Released on 2019/10/24.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
-
 
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
@@ -56,13 +54,12 @@ Fixes
   now no longer cause a ``NullPointerException`` but instead advice users to
   use ``RESET GLOBAL`` to reset settings to their default value.
 
-- Fixed evaluation of generated columns when they are based on columns
-  with default constraints and no user given values. Default
-  contraints where not taken into account before.
+- Fixed evaluation of generated columns when they are based on columns with
+  default constraints and no user given values. Default contraints where not
+  taken into account before.
 
-- Fixed an issue when using ``try_cast('invalid-ts' as timestamp)``
-  which resulted in a parsing exception instead of an expected
-  ``NULL`` value.
+- Fixed an issue when using ``try_cast('invalid-ts' as timestamp)`` which
+  resulted in a parsing exception instead of an expected ``NULL`` value.
 
 - Tuned the circuit breaker mechanism to reduce the chance of it rejecting
   queries under low cluster load.
@@ -78,7 +75,7 @@ Fixes
 - Improved the migration logic for partitioned tables which have been created
   in CrateDB 2.x. If all current partitions of a partitioned tables have been
   created in CrateDB 3.x, the table won't have to be re-indexed anymore to
-  upgrade to CrateDB 4.0+. 
+  upgrade to CrateDB 4.0+.
 
 - Changed the error message returned when a :ref:`CREATE REPOSITORY
   <ref-create-repository>` statement fails so that it includes more information

--- a/docs/appendices/release-notes/4.0.8.rst
+++ b/docs/appendices/release-notes/4.0.8.rst
@@ -9,11 +9,11 @@ Released on 2019/11/07.
 .. NOTE::
 
     Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
-    CrateDB 3.x or earlier.
-    Before upgrading to 4.0.8 you should be running a CrateDB cluster that is
-    at least on 3.0.7.
+    CrateDB 3.x or earlier.  Before upgrading to 4.0.8 you should be running a
+    CrateDB cluster that is at least on 3.0.7.
 
-    We recommend that you upgrade to the latest 3.3 release before moving to 4.0.8.
+    We recommend that you upgrade to the latest 3.3 release before moving to
+    4.0.8.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be at least :ref:`version_4.0.2`. Any upgrade from a version
@@ -24,8 +24,8 @@ Released on 2019/11/07.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -37,12 +37,10 @@ Released on 2019/11/07.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
-
 
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
@@ -66,4 +64,5 @@ Fixes
 
 - Fixed an issue resulting in a parsing exception on ``SHOW TABLE`` statements
   when a default expression is implicitly cast to the related column type and
-  the column type contains a ``SPACE`` character (like e.g. ``double precision``).
+  the column type contains a ``SPACE`` character (like e.g. ``double
+  precision``).

--- a/docs/appendices/release-notes/4.0.9.rst
+++ b/docs/appendices/release-notes/4.0.9.rst
@@ -9,11 +9,11 @@ Released on 2019/11/25.
 .. NOTE::
 
     Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
-    CrateDB 3.x or earlier.
-    Before upgrading to 4.0.9 you should be running a CrateDB cluster that is
-    at least on 3.0.7.
+    CrateDB 3.x or earlier.  Before upgrading to 4.0.9 you should be running a
+    CrateDB cluster that is at least on 3.0.7.
 
-    We recommend that you upgrade to the latest 3.3 release before moving to 4.0.9.
+    We recommend that you upgrade to the latest 3.3 release before moving to
+    4.0.9.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be at least :ref:`version_4.0.2`. Any upgrade from a version
@@ -24,8 +24,8 @@ Released on 2019/11/25.
 
 .. WARNING::
 
-    Tables that were created prior CrateDB 3.x will not function with 4.x
-    and must be recreated before moving to 4.x.x.
+    Tables that were created prior CrateDB 3.x will not function with 4.x and
+    must be recreated before moving to 4.x.x.
 
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
@@ -37,12 +37,10 @@ Released on 2019/11/25.
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
-
 
 See the :ref:`version_4.0.0` release notes for a full list of changes in the
 4.0 series.
@@ -68,4 +66,5 @@ Fixes
 - Fixed an resiliency issue on snapshot creation while dynamic columns are
   created concurrently which may result in incompatibility problems on restore.
 
-- Fixed case sensitivity of unquoted column names inside ``ON CONFLICT`` clauses.
+- Fixed case sensitivity of unquoted column names inside ``ON CONFLICT``
+  clauses.

--- a/docs/appendices/release-notes/4.1.0.rst
+++ b/docs/appendices/release-notes/4.1.0.rst
@@ -31,8 +31,8 @@ Breaking Changes
 ================
 
 - Changed :ref:`arithmetic operations <arithmetic>` ``*``, ``+``, and ``-`` of
-  types ``integer`` and ``bigint`` to throw an exception instead of rolling over
-  from positive to negative or the other way around.
+  types ``integer`` and ``bigint`` to throw an exception instead of rolling
+  over from positive to negative or the other way around.
 
 - Changed how columns of type :ref:`geo_point_data_type` are being communicated
   to PostgreSQL clients.
@@ -92,18 +92,17 @@ Performance improvements
   rows returned by various parts of a query plan. This should result in more
   efficient execution plans for joins.
 
-- Reduced recovery time by sending file-chunks concurrently. This change
-  only applies when transport communication is secured or compressed. The
-  number of chunks is controlled by the
-  :ref:`indices.recovery.max_concurrent_file_chunks
+- Reduced recovery time by sending file-chunks concurrently. This change only
+  applies when transport communication is secured or compressed. The number of
+  chunks is controlled by the :ref:`indices.recovery.max_concurrent_file_chunks
   <indices.recovery.max_concurrent_file_chunks>` setting.
 
 - Added an optimization that allows ``WHERE`` clauses on top of derived tables
-  containing :ref:`table functions <ref-table-functions>` to run more
-  efficiently in some cases.
+  containing :ref:`table functions <table-functions>` to run more efficiently
+  in some cases.
 
-- Allow user to control how table data is stored and accessed on a disk
-  via the :ref:`store.type <sql-create-table-store-type>` table parameter and
+- Allow user to control how table data is stored and accessed on a disk via the
+  :ref:`store.type <sql-create-table-store-type>` table parameter and
   :ref:`node.store.allow_mmap <node.store_allow_mmap>` node setting.
 
 - Changed the default table data store type from ``mmapfs`` to ``hybridfs``.
@@ -116,19 +115,19 @@ SQL Standard and PostgreSQL compatibility improvements
 Window function extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Added support for the :ref:`lag <window-function-lag>` and :ref:`lead
-  <window-function-lead>` window functions as enterprise features.
+- Added support for the :ref:`lag <window-functions-lag>` and :ref:`lead
+  <window-functions-lead>` window functions as enterprise features.
 
 - Added support for ``ROWS`` frame definitions in the context of window
   functions :ref:`window definitions <window-definition>`.
 
-- Added support for the :ref:`named window definition <named-windows>`.
-  This change allows a user to define a list of window definitions in the
-  :ref:`sql_reference_window` clause that can be referenced in :ref:`over`
-  clauses.
+- Added support for the :ref:`named window definition
+  <window-definition-named-windows>`.  This change allows a user to define a
+  list of window definitions in the :ref:`WINDOW <sql-select-window>` clause
+  that can be referenced in :ref:`OVER <sql-select-over>` clauses.
 
-- Added support for ``offset PRECEDING`` and ``offset FOLLOWING``
-  :ref:`window definitions <window-definition>`.
+- Added support for ``offset PRECEDING`` and ``offset FOLLOWING`` :ref:`window
+  definitions <window-definition>`.
 
 
 Functions and operators
@@ -177,9 +176,9 @@ Functions and operators
 - Added support for CIDR notation comparisons through special purpose
   :ref:`operator <gloss-operator>` ``<<`` associated with type IP.
 
-  Statements like ``192.168.0.0 << 192.168.0.1/24`` evaluate as true,
-  meaning ``SELECT ip FROM ips_table WHERE ip << 192.168.0.1/24`` returns
-  matching :ref:`ip <ip-type>` addresses.
+  Statements like ``192.168.0.0 << 192.168.0.1/24`` evaluate as true, meaning
+  ``SELECT ip FROM ips_table WHERE ip << 192.168.0.1/24`` returns matching
+  :ref:`ip <ip-type>` addresses.
 
 
 New statements and clauses
@@ -192,10 +191,9 @@ New statements and clauses
 - Added a :ref:`PROMOTE REPLICA <sql-alter-table-reroute>` sub command to
   :ref:`sql-alter-table`.
 
-- Added support for the filter clause in
-  :ref:`aggregate expressions <aggregation-expressions>` and
-  :ref:`window functions <window-function-call>` that are
-  :ref:`aggregates <aggregation>`.
+- Added support for the filter clause in :ref:`aggregate expressions
+  <aggregation-expressions>` and :ref:`window functions <window-function-call>`
+  that are :ref:`aggregates <aggregation>`.
 
 - Added support for using :ref:`ref-values` as a top-level relation.
 
@@ -221,8 +219,9 @@ Observability improvements
 
 - Added a ``node`` column to :ref:`sys.jobs_log <sys-logs>`.
 
-- Statements containing limits, filters, window functions, or table functions
-  will now be labelled accordingly in :ref:`sys-jobs-metrics`.
+- Statements containing limits, filters, :ref:`window functions
+  <window-functions>`, or :ref:`table functions <table-functions>` will now be
+  labelled accordingly in :ref:`sys-jobs-metrics`.
 
 
 Others
@@ -245,9 +244,9 @@ Others
   in the WHERE clause which involve partitioned columns led to a query that
   can't be executed``.
 
-- Support implicit object creation in update statements. For example,
-  ``UPDATE t SET obj['x'] = 10`` will now implicitly set ``obj`` to
-  ``{obj: {x: 10}}`` on rows where ``obj`` was ``null``.
+- Support implicit object creation in update statements. For example, ``UPDATE
+  t SET obj['x'] = 10`` will now implicitly set ``obj`` to ``{obj: {x: 10}}``
+  on rows where ``obj`` was ``null``.
 
 - Added the :ref:`sql-create-table-codec` parameter to :ref:`sql-create-table`
   to control the compression algorithm used to store data.

--- a/docs/appendices/release-notes/4.1.4.rst
+++ b/docs/appendices/release-notes/4.1.4.rst
@@ -34,8 +34,8 @@ See the :ref:`version_4.1.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Improved the resiliency of ``INSERT INTO ..`` queries that have a table
-  function like ``generate_series`` as a source.
+- Improved the resiliency of ``INSERT INTO ..`` queries that have a :ref:`table
+  function <table-functions>` like ``generate_series`` as a source.
 
 - Fixed a regression introduced in 4.1 that led to a ``ClassCastException``
   running queries with ``GROUP BY``, no aggregations, and a ``LIMIT`` clause.

--- a/docs/appendices/release-notes/4.1.5.rst
+++ b/docs/appendices/release-notes/4.1.5.rst
@@ -46,7 +46,7 @@ Fixes
   incorrectly.
 
 - Fixed an issue that could lead to incorrect ordering if using ``ORDER BY`` on
-  a column of type ``IP`` or on a scalar function.
+  a column of type ``IP`` or on a :ref:`scalar function <scalar-functions>`.
 
 - Fixed an issue that caused a ``NullPointerException`` if using ``COPY TO``
   with a ``WHERE`` clause with filters on primary key columns.

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -20,8 +20,6 @@ Released on 2020-07-07.
 
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
-
-
 .. rubric:: Table of Contents
 
 .. contents::
@@ -31,9 +29,9 @@ Released on 2020-07-07.
 Breaking Changes
 ================
 
-- Changed the logic how the ``array_unique`` scalar function infers the
-  argument types.  Previously if the arguments had a different type it used the
-  type of the first argument. For example::
+- Changed the logic how the ``array_unique`` :ref:`scalar function
+  <scalar-functions>` infers the argument types.  Previously if the arguments
+  had a different type it used the type of the first argument. For example::
 
     cr> select array_unique(['1'], [1.0, 2.0]);
     +---------------------------------+
@@ -43,7 +41,7 @@ Breaking Changes
     +---------------------------------+
 
   This logic has been changed to instead use a type precedence logic to be
-  consistent with how other functions behave::
+  consistent with how other :ref:`functions <gloss-function>` behave::
 
     cr> select array_unique(['1'], [1.0, 2.0]);
     +------------+
@@ -55,17 +53,17 @@ Breaking Changes
 - Remap CrateDB :ref:`object_data_type` array data type from the PostgreSQL
   JSON to JSON array type. That might effect some drivers that use the
   PostgreSQL wire protocol to insert data into tables with object array typed
-  columns. For instance,  when using the ``Npgsql`` driver, it is not longer
-  possible to insert an array of objects into a column of the object array
-  data type by using the parameter of a SQL statement that has the JSON data
-  type and an array of CLR as its value. Instead, use a string array with JSON
-  strings that represent the objects. See the ``Npgsql`` documentation for
-  more details.
+  columns. For instance, when using the ``Npgsql`` driver, it is not longer
+  possible to insert an array of objects into a column of the object array data
+  type by using the parameter of a SQL statement that has the JSON data type
+  and an array of CLR as its value. Instead, use a string array with JSON
+  strings that represent the objects. See the ``Npgsql`` documentation for more
+  details.
 
 - Bulk ``INSERT INTO ... VALUES (...)`` statements do not throw an exception
-  any longer when one of the bulk operations fails. The result of the
-  execution is only available via the ``results`` array represented by a
-  row count for each bulk operation.
+  any longer when one of the bulk operations fails. The result of the execution
+  is only available via the ``results`` array represented by a row count for
+  each bulk operation.
 
 - Numeric literals fitting into the ``integer`` range are now treated as
   ``integer`` literals instead of ``bigint`` literals. Thus a statement like
@@ -89,6 +87,7 @@ Breaking Changes
   explicit ``rollback`` call in a client library will result in an unsupported
   ``ROLLBACK`` statement.
 
+
 Deprecations
 ============
 
@@ -103,11 +102,11 @@ Changes
 Administration
 --------------
 
-- The JavaScript user defined function language is now enabled by default in
-  the CrateDB enterprise edition.
+- The JavaScript :ref:`user-defined function <user-defined-functions>` language
+  is now enabled by default in the CrateDB enterprise edition.
 
-- Added the :ref:`optimizer <conf-session-optimizer>` session setting
-  to configure query optimizer rules.
+- Added the :ref:`optimizer <conf-session-optimizer>` session setting to
+  configure query optimizer rules.
 
 - Include the bundled version of ``OpenJDK`` (14.0.1+7) into the ``CrateDB``
   built. It means that ``CrateDB`` doesn't rely on ``JAVA_HOME`` of the host
@@ -120,28 +119,28 @@ Administration
   which lists the fully qualified name of all tables contained within the
   snapshot.
 
-- Limit the output of COPY FROM RETURN SUMMARY in the presence of errors to
-  display up to 50 ``line_numbers`` to avoid buffer pressure at clients and
-  to improve readability.
+- Limit the output of ``COPY FROM RETURN SUMMARY`` in the presence of errors to
+  display up to 50 ``line_numbers`` to avoid buffer pressure at clients and to
+  improve readability.
 
 
 SQL Standard and PostgreSQL compatibility improvements
 ------------------------------------------------------
 
-- Added scalar function :ref:`CURRENT_TIME <current_time>`, that returns
-  the system's time as microseconds since midnight UTC, at the time the SQL
-  statement is handled. The actual return type is the new data type
-  :ref:`timetz <time-data-type>`.
+- Added :ref:`scalar function <scalar-functions>` :ref:`CURRENT_TIME
+  <current_time>`, that returns the system's time as microseconds since
+  midnight UTC, at the time the SQL statement is handled. The actual return
+  type is the new data type :ref:`timetz <time-data-type>`.
 
-- Added new type :ref:`time with time zone <time-data-type>`, a.k.a `timetz`,
-  which is to be used as return type for time related functions such as the
-  future `current_time`.
+- Added new type :ref:`time with time zone <time-data-type>`, a.k.a ``timetz``,
+  which is to be used as return type for :ref:`time related functions
+  <scalar-date-time>` such as the future ``current_time``.
 
 - Added the :ref:`oidvector_type` data type which is used in some
   :ref:`postgres_pg_catalog` tables.
 
 - Added the :ref:`oid_regproc` alias data type that is used to reference
-  functions in the :ref:`postgres_pg_catalog` tables.
+  :ref:`functions <gloss-function>` in the :ref:`postgres_pg_catalog` tables.
 
 - Added the :ref:`varchar(n) and character varying(n) <data-type-varchar>`
   types, where ``n`` is an optional length limit.
@@ -159,9 +158,9 @@ SQL Standard and PostgreSQL compatibility improvements
 - Added the :ref:`information_schema.character_sets <character_sets>` table.
 
 - Added :ref:`postgres_pg_type` columns: ``typbyval``, ``typcategory``,
-  ``typowner``, ``typisdefined``, ``typrelid``, ``typndims``,
-  ``typcollation``, ``typinput``, ``typoutput``, and ``typndefault`` for improved
-  PostgreSQL compatibility.
+  ``typowner``, ``typisdefined``, ``typrelid``, ``typndims``, ``typcollation``,
+  ``typinput``, ``typoutput``, and ``typndefault`` for improved PostgreSQL
+  compatibility.
 
 - Added support for ``JOIN USING``, e.g. ``SELECT * FROM t1 JOIN t2 USING
   (col)``, an alternative to ``JOIN ON``, when the column name(s) are the same
@@ -186,6 +185,7 @@ SQL Standard and PostgreSQL compatibility improvements
 - Added support for ``GROUP BY`` operations on analysed columns of type
   ``text``.
 
+
 Functions and operators
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -194,15 +194,16 @@ Functions and operators
   return type.
 
 - Replaced the ``Nashorn`` JavaScript engine with ``GraalVM`` for JavaScript
-  :ref:`user-defined functions <sql_administration_udf>`. This change upgrades
+  :ref:`user-defined functions <user-defined-functions>`. This change upgrades
   ``ECMAScript`` support from ``5.1`` to ``10.0``.
 
-- Added the :ref:`chr <scalar_chr>` scalar function.
+- Added the :ref:`chr <scalar_chr>` :ref:`scalar function <scalar-functions>`.
 
-- Added :ref:`length <scalar-length>` and :ref:`repeat <scalar-repeat>`
-  scalar functions.
+- Added :ref:`length <scalar-length>` and :ref:`repeat <scalar-repeat>` scalar
+  functions.
 
-- Added the :ref:`array_agg <aggregation-array-agg>` aggregation function.
+- Added the :ref:`array_agg <aggregation-array-agg>` :ref:`aggregation function
+  <aggregation-functions>`.
 
 - Added the :ref:`trunc <scalar-trunc>` scalar function.
 
@@ -218,8 +219,8 @@ Functions and operators
 - Added the :ref:`degrees <scalar-degrees>` and :ref:`radians <scalar-radians>`
   scalar functions.
 
-- Added support for using :ref:`table functions <ref-table-functions>` with
-  more than one column within the select list part of a SELECT statement.
+- Added support for using :ref:`table functions <table-functions>` with more
+  than one column within the select list part of a ``SELECT`` statement.
 
 - Added the :ref:`cot <scalar-cot>` trigonometric scalar function.
 
@@ -229,17 +230,17 @@ Functions and operators
   improved PostgreSQL compatibility.
 
 - Added the :ref:`encode(bytea, format) <scalar-encode>` and :ref:`decode(text,
-  format) <scalar-decode>` string functions.
+  format) <scalar-decode>` scalar functions.
 
 - Added the :ref:`ascii <scalar_ascii>` scalar function.
 
 - Added the :ref:`obj_description(integer, text) <obj_description>` scalar
   function for improved PostgreSQL compatibility.
 
-- Added the :ref:`format_type(integer, integer) <format_type>` scalar
-  function for improved PostgreSQL compatibility.
+- Added the :ref:`format_type(integer, integer) <format_type>` scalar function
+  for improved PostgreSQL compatibility.
 
-- Added the :ref:`version() <version>` system information function.
+- Added the :ref:`version() <version>` system information scalar function.
 
 
 New statements and clauses
@@ -258,8 +259,8 @@ New statements and clauses
   and :ref:`UPDATE <ref-update>` to return specified values from each row
   written.
 
+
 Performance improvements
 ------------------------
 
-- Optimized `<column> IS NOT NULL` queries.
-
+- Optimized ``<column> IS NOT NULL`` queries.

--- a/docs/appendices/release-notes/4.2.1.rst
+++ b/docs/appendices/release-notes/4.2.1.rst
@@ -20,13 +20,10 @@ Released on 2020-07-14.
 
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
-
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
-
 
 See the :ref:`version_4.2.0` release notes for a full list of changes in the
 4.2 series.
@@ -35,9 +32,9 @@ See the :ref:`version_4.2.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue with the :ref:`quote_ident <scalar-quote-ident>` scalar
-  function that caused it to quote subscript expressions like ``"col['x']"``
-  instead of ``"col"['x']``.
+- Fixed an issue with the :ref:`quote_ident <scalar-quote-ident>` :ref:`scalar
+  function <scalar-functions>` that caused it to quote subscript expressions
+  like ``"col['x']"`` instead of ``"col"['x']``.
 
 - Fixed an issue that prevented the use of subscript expressions as conflict
   target in ``ON CONFLICT`` clauses of ``INSERT`` statements.
@@ -47,4 +44,4 @@ Fixes
   all the related data.
 
 - Fixed an issue that could lead to a ``Field is not streamable`` error message
-  when using window functions.
+  when using :ref:`window functions <window-functions>`.

--- a/docs/appendices/release-notes/4.2.4.rst
+++ b/docs/appendices/release-notes/4.2.4.rst
@@ -20,13 +20,10 @@ Released on 2020-08-26.
 
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 
-
-
 .. rubric:: Table of Contents
 
 .. contents::
    :local:
-
 
 See the :ref:`version_4.2.0` release notes for a full list of changes in the
 4.2 series.
@@ -36,7 +33,7 @@ Fixes
 =====
 
 - Fixed a performance regression that caused ``SELECT`` statements on tables
-  with generated :ref:`partition columns  <gloss-partition-column>` and a
+  with generated :ref:`partition columns <gloss-partition-column>` and a
   predicate that uses a column used to compute the partition column to hit all
   partitions instead of only a subset.
 
@@ -49,16 +46,18 @@ Fixes
 - Fixed an issue that prevented the ``MATCH`` predicate from working in mixed
   clusters running 4.1.8 and 4.2.
 
-- Fixed an issue that prevented user defined functions in a custom schema from
-  working if used in a generated column expression.
+- Fixed an issue that prevented :ref:`user-defined functions
+  <user-defined-functions>` in a custom schema from working if used in a
+  generated column expression.
 
-- Fixed an issue that allowed users to use a function in a generated column
-  that didn't fully match the given arguments, leading to a subsequent runtime
-  failure when trying to access tables.
+- Fixed an issue that allowed users to use a :ref:`function <gloss-function>`
+  in a generated column that didn't fully match the given arguments, leading to
+  a subsequent runtime failure when trying to access tables.
 
 - Fixed exposure of the full qualified name of a sub-script column in
   `information_schema.tables.partitioned_by` and
-  `pg_catalog.pg_attribute.attname` to use the CrateDB SQL compatible identifier.
+  `pg_catalog.pg_attribute.attname` to use the CrateDB SQL compatible
+  identifier.
 
 - Fixed an issue that led to a ``Message not fully read`` error when trying to
   decommission a node using ``ALTER CLUSTER DECOMMISSION``.

--- a/docs/appendices/release-notes/4.2.5.rst
+++ b/docs/appendices/release-notes/4.2.5.rst
@@ -38,8 +38,9 @@ Fixes
 - Fixed an issue that caused the IP restriction in the host based
   authentication to not work correctly in all cases
 
-- Fixed a BWC issue with aggregation function resolving in a mixed version
-  cluster where at least one node is on version < 4.2.
+- Fixed a BWC issue with :ref:`aggregation functions <aggregation-functions>`
+  resolving in a mixed version cluster where at least one node is on version <
+  4.2.
 
 - Improved the throttling behavior of ``INSERT INTO .. <query>``, it is now
   more aggressive to reduce the amount of memory used by a ``INSERT INTO``

--- a/docs/appendices/release-notes/4.2.6.rst
+++ b/docs/appendices/release-notes/4.2.6.rst
@@ -43,11 +43,12 @@ Fixes
   the minimal supported ``REAL`` number ``-3.4028235e38``.
 
 - Fixed an issue that prevented an access to the properties of object type
-  arguments in JavaScript user defined functions.
+  arguments in JavaScript :ref:`user-defined functions
+  <user-defined-functions>`.
 
 - Fixed a regression introduced in 4.2 that could cause subscript expressions
-  to fail with a ``Base argument to subscript must be an object, not null``
-  or ``Can't handle Symbol`` error.
+  to fail with a ``Base argument to subscript must be an object, not null`` or
+  ``Can't handle Symbol`` error.
 
 - Fixed an issue causing a node crash due to OOM when running the ``analyze``
   on large tables.

--- a/docs/appendices/release-notes/4.3.0.rst
+++ b/docs/appendices/release-notes/4.3.0.rst
@@ -31,10 +31,10 @@ Released on 2020-10-16.
 Breaking Changes
 ================
 
-- Added support for flag ``g`` to function
-  :ref:`regexp_matches <table-functions-regexp-matches>` and changed
-  its type from ``scalar`` to ``table`` type. It now returns a table where each
-  row contains a single column ``groups`` of type ``array(text)``.
+- Added support for the ``g`` flag to function :ref:`regexp_matches
+  <table-functions-regexp-matches>` and changed its type from :ref:`scalar
+  <scalar-functions>` to :ref:`table <table-functions>`. It now returns a table
+  where each row contains a single column ``groups`` of type ``array(text)``.
 
 - Changed values of ``information_schema.columns.ordinal_position`` and
   ``pg_catalog.pg_attribute.attnum`` for ``object`` data type sub-columns from
@@ -57,6 +57,7 @@ Deprecations
 
 Changes
 =======
+
 
 Performance improvements
 ------------------------
@@ -82,7 +83,8 @@ SQL Standard and PostgreSQL compatibility improvements
 
 - Added scalar function :ref:`pg_function_is_visible <pg_function_is_visible>`.
 
-- Added table function :ref:`generate_subscripts <table-functions-generate-subscripts>`
+- Added table function :ref:`generate_subscripts
+  <table-functions-generate-subscripts>`
 
 - Added the `pg_catalog.pg_roles table <postgres_pg_catalog>`
 
@@ -133,8 +135,8 @@ Error handling improvements
   - a relation does not exist to ``42P01`` ``undefined_table``
   - a document exists already to ``23505`` ``unique_violation``
 
-- Changed the error code for dropping a missing view from the undefined 4040
-  to 4041.
+- Changed the error code for dropping a missing view from the undefined 4040 to
+  4041.
 
 - Changed the error handling so it returns the error message and the related
   exception without being wrapped in a ``SqlActionException``. Error codes

--- a/docs/appendices/release-notes/4.3.2.rst
+++ b/docs/appendices/release-notes/4.3.2.rst
@@ -64,5 +64,5 @@ Fixes
   Can't handle Symbol [ParameterSymbol: $1]`` if using ``INSERT INTO`` with a
   query that contains parameter place holders and a ``LIMIT`` clause.
 
-- Fixed an issue that led to an error when nesting multiple table
-  functions.
+- Fixed an issue that led to an error when nesting multiple :ref:`table
+  functions <table-functions>`.

--- a/docs/appendices/release-notes/4.4.0.rst
+++ b/docs/appendices/release-notes/4.4.0.rst
@@ -31,12 +31,15 @@ Released on 2021-01-19.
 Deprecations
 ============
 
-- The settings ``discovery.zen.publish_timeout``, ``discovery.zen.commit_timeout``,
-  ``discovery.zen.no_master_block``, ``discovery.zen.publish_diff.enable``
-  have been marked as deprecated and will be removed in a future version.
+- The settings ``discovery.zen.publish_timeout``,
+  ``discovery.zen.commit_timeout``, ``discovery.zen.no_master_block``,
+  ``discovery.zen.publish_diff.enable`` have been marked as deprecated and will
+  be removed in a future version.
+
 
 Changes
 =======
+
 
 Performance improvements
 ------------------------
@@ -53,6 +56,7 @@ Performance improvements
 - Improved the performance for queries which select a subset of the columns
   available in a wide table.
 
+
 SQL and PostgreSQL compatibility improvements
 ---------------------------------------------
 
@@ -60,8 +64,8 @@ SQL and PostgreSQL compatibility improvements
   <numeric_type>` type.
 
 - Added support for the :ref:`numeric <numeric_type>` data type and allow the
-  ``sum`` aggregation on the :ref:`numeric <numeric_type>` type.
-  Note that the storage of the ``numeric`` data type is not supported.
+  ``sum`` aggregation on the :ref:`numeric <numeric_type>` type.  Note that the
+  storage of the ``numeric`` data type is not supported.
 
 - Extended the ``RowDescription`` message that can be sent while communicating
   with PostgreSQL clients to include a ``table_oid`` and a ``attr_num`` based
@@ -99,8 +103,8 @@ New scalar and window functions
 
 - Added the :ref:`split_part <scalar-split_part>` scalar function.
 
-- Added the :ref:`dense_rank <window-function-dense_rank>` window function,
+- Added the :ref:`dense_rank <window-functions-dense-rank>` window function,
   which is available as an enterprise feature.
 
-- Added the :ref:`rank <window-function-rank>` window function, which is
+- Added the :ref:`rank <window-functions-rank>` window function, which is
   available as an enterprise feature.

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -89,7 +89,8 @@ Changes
 
 - Added support for the :ref:`CREATE TABLE AS <ref-create-table-as>` statement.
 
-- Added :ref:`CURDATE` and :ref:`CURRENT_DATE` :ref:`scalar` functions.
+- Added :ref:`CURDATE` and :ref:`CURRENT_DATE` :ref:`scalar functions
+  <scalar-functions>`.
 
 Fixes
 =====

--- a/docs/concepts/storage-consistency.rst
+++ b/docs/concepts/storage-consistency.rst
@@ -107,13 +107,14 @@ Every document has an `internal identifier`_. By default this identifier
 is derived from the primary key. Documents living in tables without a primary
 key are assigned a unique auto-generated ID automatically when created.
 
-Each document is :ref:`routed <routing>` to one specific shard according to the
-:ref:`routing column <gloss-routing-column>`. All rows that have the same
-routing column row value are stored in the same shard. The routing column can
-be specified with the :ref:`CLUSTERED <sql-create-table-clustered>` clause when
-creating the table. If a :ref:`primary key <primary_key_constraint>` has been
-defined, it will be used as the default routing column, otherwise the
-:ref:`internal document ID <sql_administration_system_column_id>` is used.
+Each document is :ref:`routed <sharding-routing>` to one specific shard
+according to the :ref:`routing column <gloss-routing-column>`. All rows that
+have the same routing column row value are stored in the same shard. The
+routing column can be specified with the :ref:`CLUSTERED
+<sql-create-table-clustered>` clause when creating the table. If a
+:ref:`primary key <primary_key_constraint>` has been defined, it will be used
+as the default routing column, otherwise the :ref:`internal document ID
+<sql_administration_system_column_id>` is used.
 
 While transparent to the user, internally there are two ways how CrateDB
 accesses documents:

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -743,7 +743,7 @@ Queries
 
 .. _conf-node-lang-js:
 
-Javascript language
+JavaScript language
 ===================
 
 .. _lang.js.enabled:
@@ -752,7 +752,7 @@ Javascript language
   | *Default:*  ``true``
   | *Runtime:*  ``no``
 
-  Setting to enable or disable :ref:`JavaScript UDF support <udf_lang_js>`.
+  Setting to enable or disable :ref:`JavaScript UDF <udf-js>` support.
 
 
 .. _conf-node-attributes:

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -11,11 +11,12 @@ Session settings
 
 Session settings only apply to the currently connected client session.
 
+
 Usage
 =====
 
-To configure a modifiable session setting, use :ref:`SET <ref-set>`,
-for example:
+To configure a modifiable session setting, use :ref:`SET <ref-set>`, for
+example:
 
 .. code-block:: sql
 
@@ -29,7 +30,7 @@ eg:
   SHOW search_path;
 
 Besides using ``SHOW``, it is also possible to use the :ref:`current_setting
-<scalar_current_setting>` scalar function.
+<scalar_current_setting>` :ref:`scalar function <scalar-functions>`.
 
 
 Supported session settings
@@ -55,7 +56,8 @@ Supported session settings
 
      Some :ref:`PostgreSQL clients <postgres_wire_protocol>` require access to
      various tables in the ``pg_catalog`` schema. Usually, this is to extract
-     information about built-in data types or functions.
+     information about built-in data types or :ref:`functions
+     <gloss-function>`.
 
      CrateDB implements the system ``pg_catalog`` schema and it automatically
      includes it in the ``search_path`` *before* the configured schemas, unless
@@ -74,10 +76,9 @@ Supported session settings
   .. NOTE::
 
      It is not always possible or efficient to use the ``HashJoin``
-     implementation. Having this setting enabled, will only add the
-     option of considering it, it will not guaranty it.
-     See also the :ref:`available join algorithms
-     <available-join-algo>` for more insights on this topic.
+     implementation. Having this setting enabled, will only add the option of
+     considering it, it will not guarantee it.  See also the :ref:`available
+     join algorithms <available-join-algo>` for more insights on this topic.
 
 .. _conf-session-max_index_keys:
 
@@ -120,15 +121,16 @@ Supported session settings
   setting e.g. ``SET optimizer_rewrite_collect_to_get = false``.
 
   .. NOTE::
+
    The optimizer setting is for advanced use only and can significantly impact
    the performance behavior of the queries.
-
 
 .. _experimental-warning:
 
 .. WARNING::
 
-  Experimental session settings might be removed in the future
-  even in minor feature releases.
+  Experimental session settings might be removed in the future even in minor
+  feature releases.
+
 
 .. _search_path: https://www.postgresql.org/docs/10/static/ddl-schemas.html#DDL-SCHEMAS-PATH

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -22,9 +22,9 @@ For example::
 Here, the :ref:`count(*) <aggregation-count-star>` function computes the result
 across all rows.
 
-Aggregate functions can be used with the :ref:`sql_dql_group_by` clause. When
-used like this, an aggregate function returns a single summary value for each
-grouped collection of column values.
+Aggregate :ref:`functions <gloss-function>` can be used with the
+:ref:`sql_dql_group_by` clause. When used like this, an aggregate function
+returns a single summary value for each grouped collection of column values.
 
 For example::
 
@@ -56,18 +56,19 @@ For example::
 Aggregate expressions
 =====================
 
-An *aggregate expression* represents the application of an aggregate function
-across rows selected by a query. Besides the function signature, expressions
-might contain supplementary clauses and keywords.
+An *aggregate expression* represents the application of an :ref:`aggregate
+function <aggregation-functions>` across rows selected by a query. Besides the
+function signature, expressions might contain supplementary clauses and
+keywords.
 
 The synopsis of an aggregate expression is one of the following::
 
    aggregate_function ( * ) [ FILTER ( WHERE condition ) ]
    aggregate_function ( [ DISTINCT ] expression [ , ... ] ) [ FILTER ( WHERE condition ) ]
 
-Here, ``aggregate_function`` is a name of an :ref:`aggregate function
-<aggregation-functions>` and ``expression`` is a column reference, scalar
-function or literal.
+Here, ``aggregate_function`` is a name of an aggregate function and
+``expression`` is a column reference, :ref:`scalar function <scalar-functions>`
+or literal.
 
 If ``FILTER`` is specified, then only the rows that met the
 :ref:`sql_dql_where_clause` condition are supplied to the aggregate function.
@@ -280,11 +281,10 @@ number of distinct values in this column that are not ``NULL``::
 ``count(*)``
 ~~~~~~~~~~~~
 
-This aggregate function simply returns the number of rows that match the
-query.
+This aggregate function simply returns the number of rows that match the query.
 
-``count(columName)`` is also possible, but currently only works on a primary key
-column. The semantics are the same.
+``count(columName)`` is also possible, but currently only works on a primary
+key column. The semantics are the same.
 
 The return value is always of type ``bigint``.
 
@@ -569,12 +569,13 @@ of the observed values. The result is defined and computed as an interpolated
 weighted average. According to that it allows the median of the input data to
 be defined conveniently as the 50th percentile.
 
-The function expects a single fraction or an array of fractions and a column
-name. Independent of the input column data type the result of ``percentile``
-always returns a ``double precision``. If the value at the specified column is
-``null`` the row is ignored. Fractions must be double precision values between
-0 and 1. When supplied a single fraction, the function will return a single
-value corresponding to the percentile of the specified fraction::
+The :ref:`function <gloss-function>` expects a single fraction or an array of
+fractions and a column name. Independent of the input column data type the
+result of ``percentile`` always returns a ``double precision``. If the value at
+the specified column is ``null`` the row is ignored. Fractions must be double
+precision values between 0 and 1. When supplied a single fraction, the function
+will return a single value corresponding to the percentile of the specified
+fraction::
 
     cr> select percentile(position, 0.95), kind from locations
     ... group by kind order by kind;
@@ -624,7 +625,7 @@ Depending on the argument type a suitable return type is chosen. For ``real``
 and ``double precison`` argument types the return type is equal to the argument
 type. For ``char``, ``smallint``, ``integer`` and ``bigint`` the return type
 changes to ``bigint``. If the range of ``bigint`` values (-2^64 to 2^64-1) gets
-exceeded an `ArithmeticException` will be raised.
+exceeded an ``ArithmeticException`` will be raised.
 
 ::
 
@@ -656,8 +657,8 @@ exceeded an `ArithmeticException` will be raised.
 
 If the ``sum`` aggregation on a numeric data type with the fixed length can
 potentially exceed its range it is possible to handle the overflow by casting
-the function argument to the :ref:`numeric type <numeric_type>` with an
-arbitrary precision.
+the :ref:`function <gloss-function>` argument to the :ref:`numeric type
+<numeric_type>` with an arbitrary precision.
 
 .. Hidden: create user visits table
 
@@ -740,10 +741,10 @@ Limitations
 ===========
 
  - ``DISTINCT`` is not supported with aggregations on :ref:`sql_joins`.
- - Aggregate functions can only be applied to columns with a plain index,
-   which is the default for all :ref:`primitive type
-   <sql_ddl_datatypes_primitives>` columns. For more information, please refer
-   to :ref:`sql_ddl_index_plain`.
+
+ - Aggregate functions can only be applied to columns with a :ref:`plain index
+   <sql_ddl_index_plain>`, which is the default for all :ref:`primitive type
+   <sql_ddl_datatypes_primitives>` columns.
 
 
 .. _Aggregate function: https://en.wikipedia.org/wiki/Aggregate_function

--- a/docs/general/builtins/arithmetic.rst
+++ b/docs/general/builtins/arithmetic.rst
@@ -45,6 +45,5 @@ be an integer with the fractional part truncated::
 
 .. NOTE::
 
-    The same restrictions that apply to :ref:`scalar functions <scalar>` also
-    apply to arithmetic operators.
-
+    The same restrictions that apply to :ref:`scalar functions
+    <scalar-functions>` also apply to arithmetic operators.

--- a/docs/general/builtins/array-comparisons.rst
+++ b/docs/general/builtins/array-comparisons.rst
@@ -96,7 +96,7 @@ The operator returns ``NULL`` if:
     When doing ``NOT <value> = ANY(<array_col>)``, query performance may be
     degraded because special handling is required to implement the `3-valued
     logic`_. To achieve better performance, consider using the :ref:`ignore3vl
-    function<ignore3vl>`.
+    function <ignore3vl>`.
 
 
 .. _all_array_comparison:

--- a/docs/general/builtins/comparison-operators.rst
+++ b/docs/general/builtins/comparison-operators.rst
@@ -71,9 +71,10 @@ When comparing dates, `ISO date formats`_ can be used::
 .. TIP::
 
     Comparison operators are commonly used to filter rows (e.g., in the
-    ``WHERE`` and ``HAVING`` clauses of a :ref:`sql_reference_select`
-    statement). However, basic comparison operators can be used as :ref:`value
-    expressions <sql-operator-invocation>` in any context. For example::
+    :ref:`WHERE <sql-select-where>` and :ref:`HAVING <sql-select-having>`
+    clauses of a :ref:`SELECT <sql-select>` statement). However, basic
+    comparison operators can be used as :ref:`value expressions
+    <sql-operator-invocation>` in any context. For example::
 
         cr> SELECT 1 < 10 as my_column;
         +--------------+

--- a/docs/general/builtins/index.rst
+++ b/docs/general/builtins/index.rst
@@ -1,20 +1,20 @@
 .. highlight:: psql
 
-.. _sql-functions-operators:
+.. _builtins:
 
 ================================
 Built-in functions and operators
 ================================
 
-This chapter provides an overview of built-in functions and :ref:`operators
-<gloss-operator>`.
+This chapter provides an overview of built-in :ref:`functions <gloss-function>`
+and :ref:`operators <gloss-operator>`.
 
 .. rubric:: Table of contents
 
 .. toctree::
   :maxdepth: 2
 
-  scalar
+  scalar-functions
   aggregation
   arithmetic
   table-functions

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1,16 +1,19 @@
 .. highlight:: psql
-.. _scalar:
+
+.. _scalar-functions:
 
 ================
 Scalar functions
 ================
 
-Scalar functions return :ref:`scalars <gloss-scalar>`.
+Scalar functions are :ref:`functions <gloss-function>` that return
+:ref:`scalars <gloss-scalar>`.
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
 
 String functions
 ================
@@ -701,6 +704,8 @@ Example::
    SELECT 1 row in set (... sec)
 
 
+.. _scalar-date-time:
+
 Date and time functions
 =======================
 
@@ -736,8 +741,8 @@ Valid values for ``timezone`` are either the name of a time zone (for example
 get a complete overview of all possible values take a look at the `available
 time zones`_ supported by `Joda-Time`_.
 
-The following example shows how to use the date_trunc function to generate a
-day based histogram in the ``Europe/Moscow`` timezone::
+The following example shows how to use the ``date_trunc`` function to generate
+a day based histogram in the ``Europe/Moscow`` timezone::
 
     cr> select
     ... date_trunc('day', 'Europe/Moscow', date) as day,
@@ -1309,7 +1314,6 @@ specified interval added to the timestamp of ``0000/01/01 00:00:00``:
     SELECT 1 row in set (... sec)
 
 
-
 Geo functions
 =============
 
@@ -1344,14 +1348,14 @@ the other argument must be a column reference.
 
 .. NOTE::
 
-   The algorithm of the calculation which is used when the distance
-   function is used as part of the result column list has a different
-   precision than what is stored inside the index which is utilized if
-   the distance function is part of a WHERE clause.
+   The algorithm of the calculation which is used when the distance function is
+   used as part of the result column list has a different precision than what
+   is stored inside the index which is utilized if the distance function is
+   part of a WHERE clause.
 
-   For example if ``select distance(...)`` returns 0.0 an equality check
-   with ``where distance(...) = 0`` might not yield anything at all due
-   to the precision difference.
+   For example if ``select distance(...)`` returns 0.0 an equality check with
+   ``where distance(...) = 0`` might not yield anything at all due to the
+   precision difference.
 
 .. _scalar_within:
 
@@ -1366,8 +1370,8 @@ that is not the case false is returned.
 ``shape1`` can either be a ``geo_shape`` or a ``geo_point``. ``shape2`` must be
 a ``geo_shape``.
 
-Below is an example of the within function which makes use of the implicit type
-casting from strings to geo point and geo shapes::
+Below is an example of the ``within`` function which makes use of the implicit
+type casting from strings in WKT representation to geo point and geo shapes::
 
     cr> select within(
     ...   'POINT (10 10)',
@@ -1419,7 +1423,7 @@ Example::
     SELECT 1 row in set (... sec)
 
 Due to a limitation on the :ref:`geo_shape_data_type` datatype this function
-cannot be used in the :ref:`sql_reference_order_by`.
+cannot be used in the :ref:`ORDER BY <sql-select-order-by>` clause.
 
 ``latitude(geo_point)`` and ``longitude(geo_point)``
 ----------------------------------------------------
@@ -2243,8 +2247,8 @@ It can be used to remove elements from array fields.
 ``array(subquery)``
 -------------------
 
-The ``array(subquery)`` expression is an array constructor function
-which operates on the result of the ``subquery``.
+The ``array(subquery)`` expression is an array constructor function which
+operates on the result of the ``subquery``.
 
 Returns: ``array``
 
@@ -2256,6 +2260,7 @@ Returns: ``array``
 
 ``array_upper(anyarray, dimension)``
 ------------------------------------
+
 The ``array_upper`` function returns the number of elements in the requested
 array dimension (the upper bound of the dimension).
 
@@ -2295,6 +2300,7 @@ Returns: ``integer``
 
 ``array_lower(anyarray, dimension)``
 ------------------------------------
+
 The ``array_lower`` function returns the lower bound of the requested array
 dimension (which is ``1`` if the dimension is valid and has at least one
 element).
@@ -3076,10 +3082,9 @@ Returns: ``boolean``
 .. NOTE::
 
     The main usage of the ``ignore3vl`` function is in the ``WHERE`` clause
-    when a ``NOT`` operator is involved. Such filtering, with
-    `3-valued logic`_, cannot be translated to an optimized query in the
-    internal storage engine, and therefore can result into slow performance.
-    E.g.::
+    when a ``NOT`` operator is involved. Such filtering, with `3-valued
+    logic`_, cannot be translated to an optimized query in the internal storage
+    engine, and therefore can degrade performance. E.g.::
 
       SELECT * FROM t
       WHERE NOT 5 = ANY(t.int_array_col);
@@ -3091,33 +3096,33 @@ Returns: ``boolean``
 
     which will yield better performance (in execution time) than before.
 
-    .. CAUTION::
+.. CAUTION::
 
-      If there are NULL values in the `long_array_col`, in the case that
-      `5 = ANY(t.long_array_col)` evaluates to ``NULL``, without the
-      ``ignore3vl``, it would be evaluated as ``NOT NULL`` => ``NULL``,
-      resulting to zero matched rows. With the ``IGNORE3VL`` in place it will
-      be evaluated as ``NOT FALSE`` => ``TRUE`` resulting to all rows matching
-      the filter. E.g::
+    If there are ``NULL`` values in the ``long_array_col``, in the case that
+    ``5 = ANY(t.long_array_col)`` evaluates to ``NULL``, without the
+    ``ignore3vl``, it would be evaluated as ``NOT NULL`` => ``NULL``,
+    resulting to zero matched rows. With the ``IGNORE3VL`` in place it will
+    be evaluated as ``NOT FALSE`` => ``TRUE`` resulting to all rows matching
+    the filter. E.g::
 
-        cr> SELECT * FROM t
-        ... WHERE NOT 5 = ANY(t.int_array_col);
-        +---------------+
-        | int_array_col |
-        +---------------+
-        +---------------+
-        SELECT 0 rows in set (... sec)
+      cr> SELECT * FROM t
+      ... WHERE NOT 5 = ANY(t.int_array_col);
+      +---------------+
+      | int_array_col |
+      +---------------+
+      +---------------+
+      SELECT 0 rows in set (... sec)
 
-      ::
+    ::
 
-        cr> SELECT * FROM t
-        ... WHERE NOT IGNORE3VL(5 = ANY(t.int_array_col));
-        +-----------------+
-        | int_array_col   |
-        +-----------------+
-        | [1, 2, 3, null] |
-        +-----------------+
-        SELECT 1 row in set (... sec)
+      cr> SELECT * FROM t
+      ... WHERE NOT IGNORE3VL(5 = ANY(t.int_array_col));
+      +-----------------+
+      | int_array_col   |
+      +-----------------+
+      | [1, 2, 3, null] |
+      +-----------------+
+      SELECT 1 row in set (... sec)
 
 .. hide:
 
@@ -3143,11 +3148,12 @@ Example::
 
 .. [#MySQL-Docs] https://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format
 
-.. _`formatter`: https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html
-.. _Java Regular Expressions: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
-.. _`MySQL date_format`: https://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format
-.. _`Haversine formula`: https://en.wikipedia.org/wiki/Haversine_formula
-.. _`CrateDB PDO`: https://crate.io/docs/pdo/en/latest/connect.html
+
 .. _`3-valued logic`: https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)
+.. _`CrateDB PDO`: https://crate.io/docs/pdo/en/latest/connect.html
+.. _`formatter`: https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html
+.. _`Haversine formula`: https://en.wikipedia.org/wiki/Haversine_formula
+.. _`MySQL date_format`: https://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format
 .. _Java DateTimeFormatter: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 .. _Java DecimalFormat: https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html
+.. _Java Regular Expressions: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html

--- a/docs/general/builtins/table-functions.rst
+++ b/docs/general/builtins/table-functions.rst
@@ -1,20 +1,20 @@
 .. highlight:: psql
 
-.. _ref-table-functions:
+.. _table-functions:
 
 ===============
 Table functions
 ===============
 
-Table functions are functions that produce a set of rows.  They can either be
-used in place of a relation in the ``FROM`` clause, or within the select list
-of a query.
+Table functions are :ref:`functions <gloss-function>` that produce a set of
+rows. They can either be used in place of a relation in the ``FROM`` clause, or
+within the select list of a query.
 
-If used within the select list, the table functions will be evaluated
-per row of the relations in the ``FROM`` clause,
-generating one or more rows which are appended to the result set.
-If multiple table functions with different amount of rows are used, ``null``
-values will be returned for the functions that are exhausted. An example::
+If used within the select list, the table functions will be evaluated per row
+of the relations in the ``FROM`` clause, generating one or more rows which are
+appended to the result set.  If multiple table functions with different amounts
+of rows are used, ``null`` values will be returned for the functions that are
+exhausted. An example::
 
 
     cr> select unnest([1, 2, 3]), unnest([1, 2]);
@@ -40,14 +40,15 @@ values will be returned for the functions that are exhausted. An example::
 .. contents::
    :local:
 
+
 .. _table-functions-scalar:
 
 Scalar functions
 ================
 
-:ref:`A scalar function <scalar>`, when used in the ``FROM`` clause in place of
-a relation, will result in a table of one row and one column, containing the
-:ref:`scalar value <gloss-scalar>` returned from the function.
+A :ref:`scalar function <scalar-functions>`, when used in the ``FROM`` clause
+in place of a relation, will result in a table of one row and one column,
+containing the :ref:`scalar value <gloss-scalar>` returned from the function.
 
 ::
 
@@ -62,6 +63,7 @@ a relation, will result in a table of one row and one column, containing the
 
 ``empty_row( )``
 ================
+
 empty_row doesn't take any argument and produces a table with an empty row and
 no column.
 
@@ -140,6 +142,7 @@ The return value always matches the ``start`` / ``stop`` types.
     +---------------+-----------------------------------+
     SELECT 3 rows in set (... sec)
 
+
 .. _table-functions-generate-subscripts:
 
 ``pg_catalog.generate_subscripts(array, dim, [reverse])``
@@ -198,6 +201,7 @@ arrays within the same level.
     +---+
     SELECT 2 rows in set (... sec)
 
+
 .. _table-functions-regexp-matches:
 
 ``regexp_matches(source, pattern [, flags])``
@@ -234,7 +238,8 @@ For example matching the regular expression ``([Aa](.+)z)`` against
  * group 1: ``alcatraz`` (from first to last parenthesis or whole pattern)
  * group 2: ``lcatra`` (beginning at second parenthesis)
 
-The ``regexp_matches`` function will return all groups as a ``text`` array::
+The ``regexp_matches`` :ref:`function <gloss-function>` will return all groups
+as a ``text`` array::
 
     cr> select regexp_matches('alcatraz', '(a(.+)z)') as matched;
     +------------------------+
@@ -266,6 +271,7 @@ See :ref:`sql_dql_object_arrays` for details.
     | lcatra       |
     +--------------+
     SELECT 1 row in set (... sec)
+
 
 .. _table-functions-regexp-matches-flags:
 
@@ -342,8 +348,8 @@ arrays, each containing two entries:
     +------------------+
     SELECT 2 rows in set (... sec)
 
-.. _pg_catalog.pg_get_keywords:
 
+.. _pg_catalog.pg_get_keywords:
 
 ``pg_catalog.pg_get_keywords()``
 ================================

--- a/docs/general/builtins/window-functions.rst
+++ b/docs/general/builtins/window-functions.rst
@@ -1,27 +1,30 @@
 .. highlight:: psql
+
 .. _window-functions:
 
 ================
 Window functions
 ================
 
+Window functions are :ref:`functions <gloss-function>` which perform a
+computation across a set of rows which are related to the current row. This is
+comparable to :ref:`aggregation functions <aggregation-functions>`, but window
+functions do not cause multiple rows to be grouped into a single row.
+
+
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
-Introduction
-============
-
-Window functions are functions which perform a computation across a set of rows
-which are related to the current row. This is comparable to aggregation
-functions, but window functions do not cause multiple rows to be grouped
-into a single row.
 
 .. _window-function-call:
 
-Window Function Call
+Window function call
 ====================
+
+
+.. _window-call-synopsis:
 
 Synopsis
 --------
@@ -35,30 +38,35 @@ The synopsis of a window function call is one of the following
                  over_clause
    function_name ( * ) [ FILTER ( WHERE condition ) ] over_clause
 
-where ``function_name`` is a name of
-a :ref:`general-purpose window <general-purpose-window-functions>` or
-:ref:`aggregate <aggregation-functions>` function
-and ``expression`` is a column reference, scalar function or literal.
+where ``function_name`` is a name of a :ref:`general-purpose window
+<window-functions-general-purpose>` or :ref:`aggregate <aggregation-functions>`
+function and ``expression`` is a column reference, scalar function or literal.
 
-If ``FILTER`` is specified, then only the rows that met the
-:ref:`sql_dql_where_clause` condition are supplied to the window
-function. Only window functions that are :ref:`aggregates <aggregation>`
-accept the ``FILTER`` clause.
+If ``FILTER`` is specified, then only the rows that met the :ref:`WHERE
+<sql-select-where>` condition are supplied to the window function. Only window
+functions that are :ref:`aggregates <aggregation>` accept the ``FILTER``
+clause.
 
-The :ref:`over` clause is what declares a function to be a window function.
+The :ref:`window-definition-over` clause is what declares a function to be a
+window function.
 
-The window function call that uses a ``wildcard`` instead of an ``expression`` as
-a function argument is supported only by the ``count(*)`` aggregate function.
+The window function call that uses a ``wildcard`` instead of an ``expression``
+as a function argument is supported only by the ``count(*)`` aggregate
+function.
+
 
 .. _window-definition:
 
-Window Definition
+Window definition
 =================
 
-.. _over:
+
+.. _window-definition-over:
 
 OVER
 ----
+
+.. _window-definition-over-synopsis:
 
 Synopsis
 ........
@@ -78,7 +86,7 @@ where ``window_definition`` has the syntax
       [ { RANGE | ROWS } BETWEEN frame_start AND frame_end ]
 
 The ``window_name`` refers to ``window_definition`` defined in the
-:ref:`sql_reference_window` clause.
+:ref:`WINDOW <sql-select-window>` clause.
 
 The ``frame_start`` and ``frame_end`` can be one of
 
@@ -106,21 +114,21 @@ In ``ROWS`` mode ``CURRENT_ROW`` means the current row.
 The ``offset PRECEDING`` and ``offset FOLLOWING`` options vary in meaning
 depending on the frame mode. In ``ROWS`` mode, the ``offset`` is an integer
 indicating that the frame start or end is offsetted by that many rows before or
-after the current row. In ``RANGE`` mode, the use of a custom ``offset``
-option requires that there is exactly one ``ORDER BY`` column in the window
+after the current row. In ``RANGE`` mode, the use of a custom ``offset`` option
+requires that there is exactly one ``ORDER BY`` column in the window
 definition. The frame contains those rows whose ordering column value is no
-more than ``offset`` minus (for PRECEDING) or plus (for FOLLOWING) the current
-row's ordering column value. Because the value of ``offset`` is substracted/added
-to the values of the ordering column, only type combinations that support
-addition/substraction operations are allowed. For instance, when the ordering
-column is of type :ref:`timestamp <timestamp_data_type>`, the ``offset``
-expression can be an :ref:`interval <interval_data_type>`.
+more than ``offset`` minus (for ``PRECEDING``) or plus (for ``FOLLOWING``) the
+current row's ordering column value. Because the value of ``offset`` is
+substracted/added to the values of the ordering column, only type combinations
+that support addition/substraction operations are allowed. For instance, when
+the ordering column is of type :ref:`timestamp <timestamp_data_type>`, the
+``offset`` expression can be an :ref:`interval <interval_data_type>`.
 
-The ``OVER`` clause defines the ``window`` containing the appropriate rows
-which will take part in the ``window function`` computation.
+The :ref:`window-definition-over` clause defines the ``window`` containing the
+appropriate rows which will take part in the ``window function`` computation.
 
-An empty ``OVER`` clause defines a ``window`` containing all the rows in the
-result set.
+An empty :ref:`window-definition-over` clause defines a ``window`` containing
+all the rows in the result set.
 
 Example::
 
@@ -219,17 +227,19 @@ Example::
    +---------+-----+-----+
    SELECT 18 rows in set (... sec)
 
-.. note::
+.. NOTE::
 
    Taking into account the ``peers`` concept mentioned above, for an empty
-   ``OVER`` clause all the rows in the result set are ``peers``.
+   :ref:`window-definition-over` clause all the rows in the result set are
+   ``peers``.
 
-.. note::
+.. NOTE::
 
-   :ref:`Aggregation functions <aggregation>` will be treated as
-   ``window functions`` when used in conjunction with the ``OVER`` clause.
+   :ref:`Aggregation functions <aggregation>` will be treated as ``window
+   functions`` when used in conjunction with the :ref:`window-definition-over`
+   clause.
 
-.. note::
+.. NOTE::
 
    Window definitions order or partitioned by an array column type are
    currently not supported.
@@ -276,17 +286,18 @@ Example::
    +---------+-----+---------------------------+
    SELECT 18 rows in set (... sec)
 
-.. _named-windows:
+
+.. _window-definition-named-windows:
 
 Named windows
 -------------
 
 It is possible to define a list of named window definitions that can be
-referenced in :ref:`over` clauses. To do this, use the
-:ref:`sql_reference_window` clause in the :ref:`sql_reference_select` clause.
+referenced in :ref:`window-definition-over` clauses. To do this, use the
+:ref:`sql-select-window` clause in the :ref:`sql-select` clause.
 
 Named windows are particularly useful when the same window definition
-could be used in multiple :ref:`over` clauses. For instance
+could be used in multiple :ref:`window-definition-over` clauses. For instance
 
 ::
 
@@ -306,13 +317,15 @@ could be used in multiple :ref:`over` clauses. For instance
    +---+-------+------+
    SELECT 4 rows in set (... sec)
 
-If a ``window_name`` is specified in the window definition of the :ref:`over`
-clause, then there must be a named window entry that matches the ``window_name``
-in the window definition list of the :ref:`sql_reference_window` clause.
+If a ``window_name`` is specified in the window definition of the
+:ref:`window-definition-over` clause, then there must be a named window entry
+that matches the ``window_name`` in the window definition list of the
+:ref:`sql-select-window` clause.
 
-If the :ref:`over` clause has its own non-empty window definition and
-references a window definition from the :ref:`sql_reference_window` clause,
-then it can only add clauses from the referenced window, but not overwrite them.
+If the :ref:`window-definition-over` clause has its own non-empty window
+definition and references a window definition from the :ref:`sql-select-window`
+clause, then it can only add clauses from the referenced window, but not
+overwrite them.
 
 ::
 
@@ -335,8 +348,9 @@ then it can only add clauses from the referenced window, but not overwrite them.
    +---+---+
    SELECT 4 rows in set (... sec)
 
-Otherwise, an attempt to override the clauses of the referenced window
-by the window definition of the :ref:`OVER` clause will result in failure.
+Otherwise, an attempt to override the clauses of the referenced window by the
+window definition of the :ref:`window-definition-over` clause will result in
+failure.
 
 ::
 
@@ -347,18 +361,19 @@ by the window definition of the :ref:`OVER` clause will result in failure.
    SQLParseException[Cannot override ORDER BY clause of window w]
 
 It is not possible to define the ``PARTITION BY`` clause in the window
-definition of the :ref:`OVER` clause if it references a window definition
-from the :ref:`sql_reference_window` clause.
+definition of the :ref:`window-definition-over` clause if it references a
+window definition from the :ref:`sql-select-window` clause.
 
-The window definitions in the :ref:`sql_reference_window` clause cannot define
+The window definitions in the :ref:`sql-select-window` clause cannot define
 its own window frames, if they are referenced by non-empty window definitions
-of the :ref:`OVER` clauses.
+of the :ref:`window-definition-over` clauses.
 
-The definition of the named window can itself begin with a ``window_name``.
-In this case all the elements of inter-connected named windows will be copied
-to the window definition of the :ref:`OVER` clause if it references the named
-window definition that has subsequent window references. The window definitions
-in the ``WINDOW`` clause permits only backward references.
+The definition of the named window can itself begin with a ``window_name``.  In
+this case all the elements of interconnected named windows will be copied to
+the window definition of the :ref:`window-definition-over` clause if it
+references the named window definition that has subsequent window
+references. The window definitions in the ``WINDOW`` clause permits only
+backward references.
 
 ::
 
@@ -380,10 +395,12 @@ in the ``WINDOW`` clause permits only backward references.
    +---+---+
    SELECT 3 rows in set (... sec)
 
-.. _general-purpose-window-functions:
 
-General-Purpose Window Functions
+.. _window-functions-general-purpose:
+
+General-purpose window functions
 ================================
+
 
 ``row_number()``
 ----------------
@@ -405,7 +422,8 @@ Example::
    +------+---------+
    SELECT 3 rows in set (... sec)
 
-.. _window-function-firstvalue:
+
+.. _window-functions-first-value:
 
 ``first_value(arg)``
 --------------------
@@ -430,7 +448,8 @@ Example::
    +------+-------+
    SELECT 4 rows in set (... sec)
 
-.. _window-function-lastvalue:
+
+.. _window-functions-last-value:
 
 ``last_value(arg)``
 -------------------
@@ -455,7 +474,8 @@ Example::
    +------+-------+
    SELECT 4 rows in set (... sec)
 
-.. _window-function-nthvalue:
+
+.. _window-functions-nth-value:
 
 ``nth_value(arg, number)``
 --------------------------
@@ -481,11 +501,14 @@ Example::
    +------+------+
    SELECT 4 rows in set (... sec)
 
-.. _window-function-lag:
+
+.. _window-functions-lag:
 
 ``lag(arg [, offset [, default] ])``
 ------------------------------------
 
+
+.. _window-functions-lag-synopsis:
 
 Synopsis
 ........
@@ -531,11 +554,14 @@ Example::
    +---------+------+--------+-------------+
    SELECT 5 rows in set (... sec)
 
-.. _window-function-lead:
+
+.. _window-functions-lead:
 
 ``lead(arg [, offset [, default] ])``
 -------------------------------------
 
+
+.. _window-functions-lead-synopsis:
 
 Synopsis
 ........
@@ -544,13 +570,13 @@ Synopsis
 
    lead(argument any [, offset integer [, default any]])
 
-The ``lead`` function is the counterpart of the
-:ref:`lag window function <window-function-lag>` as it allows the evaluation of
-the argument at rows that follow the current row. ``lead`` returns the argument
-value evaluated at the row that follows the current row by the offset within
-the partition. If there is no such row, the return value is ``default``.
-If ``offset`` or ``default`` arguments are missing, they default to ``1`` and
-``null``, respectively.
+The ``lead`` function is the counterpart of the :ref:`lag window function
+<window-functions-lag>` as it allows the evaluation of the argument at rows
+that follow the current row. ``lead`` returns the argument value evaluated at
+the row that follows the current row by the offset within the partition. If
+there is no such row, the return value is ``default``.  If ``offset`` or
+``default`` arguments are missing, they default to ``1`` and ``null``,
+respectively.
 
 Both ``offset`` and ``default`` are evaluated with respect to the current row.
 
@@ -585,11 +611,13 @@ Example::
    SELECT 5 rows in set (... sec)
 
 
-.. _window-function-rank:
+.. _window-functions-rank:
 
 ``rank()``
 ----------
 
+
+.. _window-functions-rank-synopsis:
 
 Synopsis
 ........
@@ -632,11 +660,13 @@ Example::
     SELECT 6 rows in set (... sec)
 
 
-.. _window-function-dense_rank:
+.. _window-functions-dense-rank:
 
 ``dense_rank()``
 ----------------
 
+
+.. _window-functions-dense-rank-synopsis:
 
 Synopsis
 ........
@@ -680,7 +710,9 @@ Example::
     SELECT 6 rows in set (... sec)
 
 
-Aggregate Window Functions
+.. _window-aggregate-functions:
+
+Aggregate window functions
 ==========================
 
 See :ref:`aggregation`.

--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -153,7 +153,7 @@ Advanced use
 Tables can be:
 
 - :ref:`Clustered <sql-create-table-clustered>` into multiple :ref:`shards
-  <sql_ddl_sharding>`
+  <ddl-sharding>`
 - :ref:`sql-create-table-partitioned-by` one or more columns (to create
   :ref:`partitioned tables <partitioned-tables>`)
 - Fine-tuned with :ref:`table paramaters <sql-create-table-with>` (e.g., to

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -89,7 +89,7 @@ A basic boolean type. Accepting ``true`` and ``false`` as values. Example::
 Character types
 ===============
 
-These are general purpose character data types available in CrateDB.
+Character types are general purpose strings of character data.
 
 Only character data types without specified length can be analyzed.
 By default the :ref:`plain <plain-analyzer>` analyzer is used. See
@@ -237,14 +237,22 @@ CrateDB supports a set of the following numeric data types:
 Floating-Point Types
 --------------------
 
-The ``real`` and ``double precision`` data types are inexact, variable-precision
-numeric types. It means that these types are stored as an approximation.
-Therefore, storage, calculation, and retrieval of the value will not always
-result in an exact representation of the actual floating-point value.
+The ``real`` and ``double precision`` data types are inexact,
+variable-precision numeric types. It means that these types are stored as an
+approximation.  Therefore, storage, calculation, and retrieval of the value
+will not always result in an exact representation of the actual floating-point
+value.
 
-For instance, the result of applying ``sum`` or ``avg`` aggregate functions may
-slightly vary between query executions or comparing floating-point values for
-equality might not always be correct.
+For instance, the result of applying ``sum`` or ``avg`` :ref:`aggregate
+functions <aggregation-functions>` may slightly vary between query executions
+or comparing floating-point values for equality might not always match.
+
+.. SEEALSO::
+
+    `Wikipedia: Single-precision floating-point format`_
+
+    `Wikipedia: Double-precision floating-point format`_
+
 
 Special floating point values
 .............................
@@ -332,9 +340,9 @@ more detailed information about its behaviour, see `BigDecimal documentation`_.
 ``ip``
 ======
 
-The ``ip`` type allows to store IPv4 and IPv6 addresses by inserting their string
-representation. Internally ips are stored as ``bigint`` allowing expected sorting,
-filtering and aggregation.
+The ``ip`` type allows to store IPv4 and IPv6 addresses by inserting their
+string representation. Internally IP addresses are stored as ``bigint``
+allowing expected sorting, filtering and aggregation.
 
 Example::
 
@@ -509,8 +517,9 @@ time zone. It has the following variants:
 In these expressions, the desired time zone is specified as a string
 (e.g., 'Europe/Madrid', '+02:00'). See :ref:`Timezone <date-format-timezone>`.
 
-The scalar function :ref:`TIMEZONE <scalar-timezone>` (zone, timestamp) is
-equivalent to the SQL-conforming construct timestamp AT TIME ZONE zone.
+The :ref:`scalar function <scalar-functions>` :ref:`TIMEZONE <scalar-timezone>`
+(zone, timestamp) is equivalent to the SQL-conforming construct timestamp ``AT
+TIME ZONE zone``.
 
 .. _time-data-type:
 
@@ -535,8 +544,8 @@ and a cast. The syntax for string literal is as follows:
     geo-region:   As defined by ISO 8601.
 
 
-Where `time-only` can contain optional seconds, or optional minutes and seconds,
-and can use `:` as a separator optionally.
+Where ``time-only`` can contain optional seconds, or optional minutes and
+seconds, and can use ``:`` as a separator optionally.
 
 `fraction` accepts up to 6 digits, as precision is in micro seconds.
 
@@ -728,7 +737,8 @@ For example::
 PostgreSQL format
 """""""""""""""""
 
-The ``PostgreSQL`` format describes a duration of time using the `PostgreSQL interval format`_ syntax.
+The ``PostgreSQL`` format describes a duration of time using the `PostgreSQL
+interval format`_ syntax.
 
 For example::
 
@@ -1062,10 +1072,10 @@ subcolumns. One can retrieve them, sort by them and use them in where clauses.
 The third option is ``ignored``. Explicitly defined columns within an
 ``ignored`` object behave the same as those within object columns declared as
 ``dynamic`` or ``strict`` (e.g., column constraints are still enforced, columns
-that would be indexed are still indexed, and so on). The difference is that with
-``ignored``, dynamically added columns do not result in a schema update and the
-values won't be indexed. This allows you to store values with a mixed type under
-the same key.
+that would be indexed are still indexed, and so on). The difference is that
+with ``ignored``, dynamically added columns do not result in a schema update
+and the values won't be indexed. This allows you to store values with a mixed
+type under the same key.
 
 An example:
 ::
@@ -1166,8 +1176,8 @@ Synopsis::
 
 Here, ``ident`` is the key and ``expr`` is the value. The key must be a
 lowercase column identifier or a quoted mixed-case column identifier. The value
-must be a value literal (object literals are permitted and can be nested in this
-way).
+must be a value literal (object literals are permitted and can be nested in
+this way).
 
 Empty object literal::
 
@@ -1392,12 +1402,12 @@ Object Identifier Types
 Regproc
 -------
 
-The object identifier alias type that is used in the
-:ref:`postgres_pg_catalog` tables for referencing functions.
-For more information, see PostgreSQL :ref:`postgres_pg_oid`.
+The object identifier alias type that is used in the :ref:`postgres_pg_catalog`
+tables for referencing :ref:`functions <user-defined-functions>`.  For more
+information, see PostgreSQL :ref:`postgres_pg_oid`.
 
-Casting a column of the ``regproc`` alias data type to ``text`` or
-``integer`` results in a function name or its ``oid``, respectively.
+Casting a column of the ``regproc`` alias data type to ``text`` or ``integer``
+results in a function name or its ``oid``, respectively.
 
 
 .. _oid_regclass:
@@ -1419,8 +1429,9 @@ oidvector
 
 This is a system type used to represent one or more OID values.
 
-It looks similar to an array of integers, but doesn't support any of the scalar
-functions or expressions that can be used on regular arrays.
+It looks similar to an array of integers, but doesn't support any of the
+:ref:`scalar functions <scalar-functions>` or expressions that can be used on
+regular arrays.
 
 
 .. _type_conversion:
@@ -1616,21 +1627,23 @@ See the table below for a full list of aliases:
 
 .. NOTE::
 
-   The :ref:`PG_TYPEOF <pg_typeof>` system function can be used to resolve the
-   data type of any expression.
+   The :ref:`PG_TYPEOF <pg_typeof>` system :ref:`function <gloss-function>` can
+   be used to resolve the data type of any expression.
 
-.. _pattern letters and symbols:
-    https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/time/format/DateTimeFormatter.html
-.. _WKT: https://en.wikipedia.org/wiki/Well-known_text
-.. _GeoJSON: https://geojson.org/
-.. _GeoJSON geometry objects: https://tools.ietf.org/html/rfc7946#section-3.1
+
+.. _BigDecimal documentation: https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/math/BigDecimal.html
+.. _CIDR notation: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
 .. _Geohash: https://en.wikipedia.org/wiki/Geohash
+.. _GeoJSON geometry objects: https://tools.ietf.org/html/rfc7946#section-3.1
+.. _GeoJSON: https://geojson.org/
+.. _IEEE 754: https://ieeexplore.ieee.org/document/30711/?arnumber=30711&filter=AND(p_Publication_Number:2355)
+.. _ISO 8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+.. _ISO 8601 time zone designators: https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
+.. _pattern letters and symbols: https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/time/format/DateTimeFormatter.html
+.. _PostgreSQL interval format: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
 .. _Quadtree: https://en.wikipedia.org/wiki/Quadtree
 .. _Trie: https://en.wikipedia.org/wiki/Trie
 .. _Tries: https://en.wikipedia.org/wiki/Trie
-.. _IEEE 754: https://ieeexplore.ieee.org/document/30711/?arnumber=30711&filter=AND(p_Publication_Number:2355)
-.. _PostgreSQL interval format: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
-.. _ISO 8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
-.. _CIDR notation: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
-.. _ISO 8601 time zone designators: https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
-.. _BigDecimal documentation: https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/math/BigDecimal.html
+.. _Wikipedia\: Double-precision floating-point format: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+.. _Wikipedia\: Single-precision floating-point format: https://en.wikipedia.org/wiki/Single-precision_floating-point_format
+.. _WKT: https://en.wikipedia.org/wiki/Well-known_text

--- a/docs/general/ddl/sharding.rst
+++ b/docs/general/ddl/sharding.rst
@@ -1,4 +1,4 @@
-.. _sql_ddl_sharding:
+.. _ddl-sharding:
 
 ========
 Sharding
@@ -9,18 +9,21 @@ Sharding
 .. contents::
    :local:
 
+
+.. _sharding-intro:
+
 Introduction
 ============
 
-Every table partition (see :ref:`partitioned-tables`) is split into a
-configured number of shards. Shards are then distributed across the cluster. As
-nodes are added to the cluster, CrateDB will move shards around to achieve
-maximum possible distribution.
+Every :ref:`table partition <partitioned-tables>` is split into a configured
+number of shards. Shards are then distributed across the cluster. As nodes are
+added to the cluster, CrateDB will move shards around to achieve maximum
+possible distribution.
 
 .. TIP::
 
-   Non-partitioned tables function as a single partition, so non-partitioned tables
-   are still split into the configured number of shards.
+   Non-partitioned tables function as a single partition, so non-partitioned
+   tables are still split into the configured number of shards.
 
 Shards are transparent at the table-level. You do not need to know about or
 think about shards when querying a table.
@@ -29,7 +32,7 @@ Read requests are broken down and executed in parallel across multiple shards
 on multiple nodes, massively improving read performance.
 
 
-.. _number-of-shards:
+.. _sharding-number:
 
 Number of shards
 ================
@@ -45,7 +48,11 @@ Example::
     CREATE OK, 1 row affected (... sec)
 
 If the number of shards is not defined explicitly, the sensible default value
-is applied, (see :ref:`sql-create-table-clustered`).
+is applied.
+
+.. SEEALSO::
+
+    :ref:`CREATE TABLE: CLUSTERED <sql-create-table-clustered>`
 
 .. NOTE::
 
@@ -57,14 +64,12 @@ is applied, (see :ref:`sql-create-table-clustered`).
 
 .. CAUTION::
 
-   Well tuned :ref:`shard allocation <sql_ddl_sharding>` is vital. Read the
+   Well tuned :ref:`shard allocation <ddl_shard_allocation>` is vital. Read the
    `Sharding Guide`_ to make sure you're getting the best performance out ot
    CrateDB.
 
-.. _Sharding Guide: https://crate.io/docs/crate/howtos/en/latest/performance/sharding.html
 
-
-.. _routing:
+.. _sharding-routing:
 
 Routing
 =======
@@ -116,3 +121,6 @@ Example for combining custom routing and shard definition::
     ...   third_column text
     ... ) clustered by (first_column) into 10 shards;
     CREATE OK, 1 row affected (... sec)
+
+
+.. _Sharding Guide: https://crate.io/docs/crate/howtos/en/latest/performance/sharding.html

--- a/docs/general/ddl/views.rst
+++ b/docs/general/ddl/views.rst
@@ -1,4 +1,4 @@
-.. _views:
+.. _ddl-views:
 
 =====
 Views
@@ -18,7 +18,7 @@ Creating views
 Views are stored named queries which can be used in place of table names.
 They're resolved at runtime and can be used to simplify common queries.
 
-Views are created using the :ref:`CREATE VIEW statement <ref-create-view>`
+Views are created using the :ref:`CREATE VIEW statement <sql-create-view>`
 
 For example, a common use case is to create a view which queries a table with a
 pre-defined filter::
@@ -75,7 +75,7 @@ be able to query it.
 Dropping views
 ==============
 
-Views can be dropped using the :ref:`DROP VIEW statement <ref-drop-view>`::
+Views can be dropped using the :ref:`DROP VIEW statement <sql-drop-view>`::
 
     cr> DROP VIEW big_mountains;
     DROP OK, 1 row affected (... sec)

--- a/docs/general/dql/geo.rst
+++ b/docs/general/dql/geo.rst
@@ -1,4 +1,5 @@
 .. highlight:: psql
+
 .. _sql_dql_geo_search:
 
 ==========
@@ -9,6 +10,7 @@ Geo search
 
 .. contents::
    :local:
+
 
 Introduction
 ============
@@ -21,7 +23,7 @@ and so on, making it possible to create apps and services with rich
 geographical features.
 
 :ref:`Geographic shapes <geo_shape_data_type>` are stored using special
-indices. ref:`Geographic points <geo_point_data_type>` are represented by
+indices. :ref:`Geographic points <geo_point_data_type>` are represented by
 their coordinates. They are represented as columns of the respective datatypes.
 
 Geographic indices for :ref:`geo_shape <geo_shape_data_type>` columns are used
@@ -91,11 +93,10 @@ Let's insert Austria::
 
 .. NOTE::
 
-   When using a polygon shape that resembles a rectangle, and that
-   rectangle is wider than 180 degrees the CrateDB geoshape validator
-   will convert it into a multipolygon consisting of 2 rectangular
-   shapes covering the narrower area between the 4 original points split
-   by the dateline (+/- 180deg).
+   When using a polygon shape that resembles a rectangle, and that rectangle is
+   wider than 180 degrees, the CrateDB geoshape validator will convert it into
+   a multipolygon consisting of 2 rectangular shapes covering the narrower area
+   between the 4 original points split by the dateline (+/- 180deg).
 
    This is due to CrateDB operating in the geospatial context of the earth.
 
@@ -104,8 +105,9 @@ Let's insert Austria::
    cr> REFRESH TABLE countries;
    REFRESH OK, 1 row affected  (... sec)
 
-:ref:`Geographic points <geo_point_data_type>` can be inserted as a
-``double precision`` array with lon and lat as seen above or as `WKT`_ string.
+:ref:`Geographic points <geo_point_data_type>` can be inserted as a ``double
+precision`` array with longitude and latitude values as seen above or by using
+a `WKT`_ string.
 
 :ref:`Geographic shapes <geo_shape_data_type>` can be inserted as `GeoJSON`_
 :ref:`object literal <data-type-object-literals>` or parameter as seen above
@@ -117,49 +119,49 @@ CrateDB supports different kinds of geographic queries.
 Fast queries that leverage the geographic index are done using the
 :ref:`sql_dql_geo_match`:
 
+
 .. _sql_dql_geo_match:
 
-Match Predicate
-===============
+``MATCH`` predicate
+===================
 
 The ``MATCH`` predicate can be used to perform multiple kinds of searches on
-indices or indexed columns. While it can be used to perform
-:ref:`fulltext searches <sql_dql_fulltext_search>` on analyzed indices of
-type :ref:`data-type-text`, it is also handy for operating on geographic
-indices, querying for relations between geographical shapes and points.
+indices or indexed columns. While it can be used to perform :ref:`fulltext
+searches <sql_dql_fulltext_search>` on analyzed indices of type
+:ref:`data-type-text`, it is also handy for operating on geographic indices,
+querying for relations between geographical shapes and points.
 
 ::
 
      MATCH (column_ident, query_term) [ using match_type ]
 
-The Match predicate for geographical search supports a single ``column_ident``
-of a geo_shape indexed column as first argument.
+The ``MATCH`` predicate for geographical search supports a single
+``column_ident`` of a ``geo_shape`` indexed column as first argument.
 
 The second argument, the ``query_term`` is taken to match against the indexed
-geo_shape.
+``geo_shape``.
 
 The matching operation is determined by the ``match_type`` which determines the
 spatial relation we want to match. Available ``match_types`` are:
 
 :intersects:
   (Default) If the two shapes share some points and/or area, they are
-  intersecting and considered matching using this ``match_type``. This
-  also precludes containment or complete equality.
+  intersecting and considered matching using this ``match_type``. This also
+  precludes containment or complete equality.
 
 :disjoint:
-  If the two shapes share no single point and not area, they are
-  disjoint. This is the opposite of ``intersects``.
+  If the two shapes share no single point or area, they are disjoint. This is
+  the opposite of ``intersects``.
 
 :within:
-  If the indexed ``column_ident`` shape is completely inside the
-  ``query_term`` shape they are considered matching using this
-  ``match_type``.
+  If the indexed ``column_ident`` shape is completely inside the ``query_term``
+  shape, they are considered matching using this ``match_type``.
 
 .. NOTE::
 
    The ``MATCH`` predicate can only be used in the :ref:`sql_dql_where_clause`
-   and on user-created tables. Using the ``MATCH`` predicate on system
-   tables is not supported.
+   and on user-created tables. Using the ``MATCH`` predicate on system tables
+   is not supported.
 
    One ``MATCH`` predicate cannot combine columns of both relations of a join.
 
@@ -179,8 +181,8 @@ spatial relation we want to match. Available ``match_types`` are:
        WHERE match(t1.shape, 'POINT(1.1 2.2)')
           OR match(t2.shape, 'POINT(3.3 4.4)')``
 
-Having a table ``countries`` with a ``GEO_SHAPE`` column "geo" indexed using
-``geohash`` you can query that column using the ``MATCH`` predicate with
+Having a table ``countries`` with a ``GEO_SHAPE`` column ``geo``, indexed using
+``geohash``, you can query that column using the ``MATCH`` predicate with
 different match types as described above::
 
     cr> SELECT name from countries
@@ -211,13 +213,17 @@ different match types as described above::
     +--------------+
     SELECT 4 rows in set (... sec)
 
-Exact Queries
+
+Exact queries
 =============
 
-*Exact* queries are done using the following scalar functions:
+*Exact* queries are done using the following :ref:`scalar functions
+<scalar-functions>`:
 
  * :ref:`scalar_intersects`
+
  * :ref:`scalar_within`
+
  * :ref:`scalar_distance`
 
 They are exact, but this comes at the price of performance.
@@ -275,6 +281,7 @@ into your geographic data::
 
 Nonetheless these :ref:`scalars <gloss-scalar>` can be used everywhere in a SQL
 query where scalar functions are allowed.
+
 
 .. _GeoJSON: https://geojson.org/
 .. _WKT: https://en.wikipedia.org/wiki/Well-known_text

--- a/docs/general/dql/index.rst
+++ b/docs/general/dql/index.rst
@@ -1,9 +1,9 @@
 .. highlight:: psql
 .. _sql_dql:
 
-==============
-Querying Crate
-==============
+========
+Querying
+========
 
 This section provides an overview on how to query documents using SQL.  See
 :ref:`sql_ddl` for information about `Table creation` and other Data Definition

--- a/docs/general/dql/joins.rst
+++ b/docs/general/dql/joins.rst
@@ -1,11 +1,12 @@
 .. highlight:: psql
+
 .. _sql_joins:
 
 Joins
 =====
 
 When selecting data from CrateDB, you can :ref:`join
-<sql_reference_joined_tables>` one or more relations (e.g., tables) to combine
+<sql-select-joined-relation>` one or more relations (e.g., tables) to combine
 columns into one result set.
 
 .. SEEALSO::
@@ -16,6 +17,7 @@ columns into one result set.
 
 .. contents::
    :local:
+
 
 .. _cross-joins:
 
@@ -47,7 +49,7 @@ query operation on it (``WHERE`` clause, ``SELECT`` list, ``ORDER BY`` clause,
     +------------------------------+---------------+----------+
     SELECT 8 rows in set (... sec)
 
-Cross Joins can be done explicitly using the ``CROSS JOIN`` statement as shown
+Cross joins can be done explicitly using the ``CROSS JOIN`` statement as shown
 in the example above, or implicitly by just specifying two or more tables in
 the ``FROM`` list::
 
@@ -69,10 +71,13 @@ the ``FROM`` list::
     +------------------------------+---------------+----------+
     SELECT 8 rows in set (... sec)
 
+
+.. _inner-joins:
+
 Inner joins
 -----------
 
-Inner Joins require each record of one table to have matching records on the
+Inner joins require each record of one table to have matching records on the
 other table::
 
     cr> select s.id, s.table_name, t.number_of_shards
@@ -90,13 +95,20 @@ other table::
     +----+------------+------------------+
     SELECT 4 rows in set (... sec)
 
-Left outer joins
-----------------
 
-**Left** outer join returns tuples for all matching records of the *left* and
-*right* relation like **Inner** join. Additionally it returns tuples for all
-other records from *left* that don't match any record on the *right* by using
-null values for the columns of the *right* relation::
+.. _outer-joins:
+
+Outer joins
+-----------
+
+
+Left outer joins
+................
+
+Left outer join returns tuples for all matching records of the *left* and
+*right* relation like :ref:`inner joins <inner-joins>`. Additionally it returns
+*tuples* for all other records from *left* that don't match any record on the
+*right* by using null values for the columns of the *right* relation::
 
     cr> select e.name || ' ' || e.surname as employee, coalesce(d.name, '') as manager_of_department
     ... from employees e left join departments d
@@ -126,13 +138,14 @@ null values for the columns of the *right* relation::
     +--------------------+-----------------------+
     SELECT 18 rows in set (... sec)
 
-Right outer joins
------------------
 
-**Right** outer join returns tuples for all matching records of the *right* and
-*left* relation like **Inner** join. Additionally it returns tuples for all
-other records from *right* that don't match any record on the *left* by using
-null values for the columns of the *left* relation::
+Right outer joins
+.................
+
+Right outer join returns tuples for all matching records of the *right* and
+*left* relation like :ref:`inner joins <inner-joins>`. Additionally it returns
+tuples for all other records from *right* that don't match any record on the
+*left* by using null values for the columns of the *left* relation::
 
     cr> select e.name || ' ' || e.surname as employee, d.name as manager_of_department
     ... from employees e right join departments d
@@ -150,15 +163,17 @@ null values for the columns of the *left* relation::
     +-------------+-----------------------+
     SELECT 6 rows in set (... sec)
 
-Full outer joins
-----------------
 
-**Full** outer join returns tuples for all matching records of the *left* and
-*right* relation like **Inner** join. Additionally it returns tuples for all
-other records from *left* that don't match any record on the *right* by using
-null values for the columns of the *right* relation. Additionally it returns
-tuples for all other records from *right* that don't match any record on the
-*left* by using null values for the columns of the *left* relation::
+Full outer joins
+................
+
+Full outer join returns tuples for all matching records of the *left* and
+*right* relation like :ref:`inner joins <inner-joins>`. Additionally it returns
+tuples for all other records from *left* that don't match any record on the
+*right* by using null values for the columns of the *right*
+relation. Additionally it returns tuples for all other records from *right*
+that don't match any record on the *left* by using null values for the columns
+of the *left* relation::
 
     cr> select e.name || ' ' || e.surname as employee, coalesce(d.name, '') as manager_of_department
     ... from employees e full join departments d
@@ -189,11 +204,12 @@ tuples for all other records from *right* that don't match any record on the
     +--------------------+-----------------------+
     SELECT 19 rows in set (... sec)
 
+
 Join conditions
 ---------------
 
-CrateDB supports all :ref:`operators <gloss-operator>` and scalar functions as
-join conditions in the ``WHERE`` clause.
+CrateDB supports all :ref:`operators <gloss-operator>` and :ref:`scalar
+functions <scalar-functions>` as join conditions in the ``WHERE`` clause.
 
 Example with ``within`` scalar function::
 
@@ -209,10 +225,12 @@ Example with ``within`` scalar function::
     +--------------+---------+
     SELECT 2 rows in set (... sec)
 
+
 .. _available-join-algo:
 
 Available join algorithms
 -------------------------
+
 
 Nested loop join algorithm
 ..........................
@@ -224,31 +242,35 @@ in the left table.
 
 This is the default algorithm used for all types of joins.
 
+
 Block hash join algorithm
 .........................
 
-The performance of `Equi-Joins`_  is substantially improved by using the
-`Hash Join`_ algorithm. At first one relation is scanned and loaded into a hash
-table using the attributes of the join conditions as hash keys. Once the hash
-table is build, the second relation is scanned and the join condition values of
-every row are hashed and matched against the hash table.
+The performance of `Equi-Joins`_ is substantially improved by using the `Hash
+Join`_ algorithm. At first one relation is scanned and loaded into a hash table
+using the attributes of the join conditions as hash keys. Once the hash table
+is build, the second relation is scanned and the join condition values of every
+row are hashed and matched against the hash table.
 
 In order to built a hash table even if the first relation wouldn't fit into the
-available memory, only a certain block size of a relation is loaded at once. The
-whole operation will be repeated with the next block of the first relation once
-scanning the second relation has finished.
+available memory, only a certain block size of a relation is loaded at
+once. The whole operation will be repeated with the next block of the first
+relation once scanning the second relation has finished.
 
 This optimisation cannot be applied unless the join is an ``INNER`` join and
 the join condition satisfies the following rules:
 
   - Contains at least one ``EQUAL`` :ref:`operator <gloss-operator>`
+
   - Contains no ``OR`` operator
+
   - Every argument of a ``EQUAL`` operator can only references fields from one
     relation
 
 The `Hash Join`_ algorithm is faster but has a bigger memory footprint. As such
-it can explicitly be disabled on demand when memory is scarce using the
-session setting :ref:`enable_hashjoin <conf-session-enable-hashjoin>`::
+it can explicitly be disabled on demand when memory is scarce using the session
+setting :ref:`enable_hashjoin <conf-session-enable-hashjoin>`::
+
 
   SET enable_hashjoin=false
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -6,13 +6,9 @@ Selecting data
 ==============
 
 Selecting (i.e., retrieving) data from CrateDB can be done by using an SQL
-:ref:`SELECT <sql_reference_select>` statement. The response to a ``SELECT``
-query includes the column names of the result, the result rows as a
-two-dimensional array of values, the row count, and the execution time.
-
-.. SEEALSO::
-
-    :ref:`SELECT syntax <sql_reference_select>`
+:ref:`SELECT <sql-select>` statement. The response to a ``SELECT`` query
+includes the column names of the result, the result rows as a two-dimensional
+array of values, the row count, and the execution time.
 
 .. rubric:: Table of contents
 
@@ -58,6 +54,7 @@ Aliases can be used to change the output name of the columns::
     +-------------------+
     SELECT 1 row in set (... sec)
 
+
 .. _sql_dql_from_clause:
 
 ``FROM`` clause
@@ -65,7 +62,7 @@ Aliases can be used to change the output name of the columns::
 
 The ``FROM`` clause is used to reference the relation this select query is
 based upon. Can be a single table, many tables, a view, a :ref:`JOIN
-<sql_joins>` or another :ref:`SELECT <sql_reference_select>` statement.
+<sql-select-joined-relation>` or another :ref:`SELECT <sql-select>` statement.
 
 Tables and views are referenced by schema and table name and can optionally be
 aliased.  If the relation ``t`` is only referenced by name, CrateDB assumes the
@@ -107,6 +104,7 @@ A table can be aliased for the sake of brevity too::
     +-------------------+
     SELECT 1 row in set (... sec)
 
+
 .. _sql_dql_joins:
 
 Joins
@@ -118,13 +116,14 @@ Joins
 
     See the :ref:`sql_joins` for current state.
 
+
 .. _sql_dql_distinct_clause:
 
 ``DISTINCT`` clause
 ===================
 
-If DISTINCT is specified, one unique row is kept. All other duplicate rows are
-removed from the result set::
+If ``DISTINCT`` is specified, one unique row is kept. All other duplicate rows
+are removed from the result set::
 
     cr> select distinct date from locations order by date;
     +---------------+
@@ -138,7 +137,8 @@ removed from the result set::
 
 .. note::
 
-   Using `DISTINCT` is only supported on :ref:`sql_ddl_datatypes_primitives`.
+   Using ``DISTINCT`` is only supported on :ref:`sql_ddl_datatypes_primitives`.
+
 
 .. _sql_dql_where_clause:
 
@@ -165,6 +165,7 @@ Comparison operators
 CrateDB supports a variety of :ref:`comparison operators
 <comparison-operators>` (including basic operators such as ``=``, ``<``, ``>``,
 and so on).
+
 
 .. _sql_ddl_regexp:
 
@@ -221,7 +222,7 @@ expression matching on Lucene terms.
 
 `Lucene Regular Expressions`_ are basically `POSIX Extended Regular
 Expressions`_ without the character classes and with some extensions, like a
-metacharacter ``#``  for the empty string or ``~`` for negation and others. By
+metacharacter ``#`` for the empty string or ``~`` for negation and others. By
 default all Lucene extensions are enabled. See the Lucene documentation for
 more details.
 
@@ -278,8 +279,8 @@ These operators can be used to query for rows where only part of a columns
 value should match something. The only difference is that, in the case of
 ``ILIKE``, the matching is case insensitive.
 
-For example to get all locations where the name starts with 'Ar' the following
-queries can be used::
+For example to get all locations where the name starts with ``Ar`` the
+following queries can be used::
 
     cr> select name from locations where name like 'Ar%' order by name asc;
     +-------------------+
@@ -364,11 +365,11 @@ null        null
 
    CrateDB handles the case of ``NOT (NULL)`` inconsistently. The above is only
    true when the ``NOT`` appears in a ``SELECT`` clause or a ``WHERE`` clause
-   that operates on system tables. The result of ``NOT (NULL)`` in a
-   ``WHERE`` clause that operates on user tables will produce
-   inconsistent but deterministic results (``NULL`` or ``TRUE``)
-   depending on the specifics of the clause. This does not adhere to
-   standard SQL three-valued-logic and will be fixed in a future release.
+   that operates on system tables. The result of ``NOT (NULL)`` in a ``WHERE``
+   clause that operates on user tables will produce inconsistent but
+   deterministic results (``NULL`` or ``TRUE``) depending on the specifics of
+   the clause. This does not adhere to standard SQL three-valued-logic and will
+   be fixed in a future release.
 
 
 .. _sql_dql_is_null:
@@ -587,8 +588,8 @@ element that is not ``netball``::
 
 .. NOTE::
 
-    When using the  ``!= ANY(<array_col>))`` syntax, the default maximum size
-    of the array can be 8192. To be use larger arrays, you must configure the
+    When using the ``!= ANY(<array_col>))`` syntax, the default maximum size of
+    the array can be 8192. To use larger arrays, you must configure the
     :ref:`indices.query.bool.max_clause_count
     <indices.query.bool.max_clause_count>` setting as appropriate on each node.
 
@@ -617,9 +618,9 @@ This behaviour applies to:
     logic`_. For better performance, consider using the :ref:`ignore3vl
     <ignore3vl>` function.
 
-    Additionally, When using ``NOT`` with ``LIKE ANY`` or ``NOT LIKE ANY``,
-    the default maximum size of the array can be 8192. To be use larger arrays,
-    you must configure the :ref:`indices.query.bool.max_clause_count
+    Additionally, When using ``NOT`` with ``LIKE ANY`` or ``NOT LIKE ANY``, the
+    default maximum size of the array can be 8192. To use larger arrays, you
+    must configure the :ref:`indices.query.bool.max_clause_count
     <indices.query.bool.max_clause_count>` setting as appropriate on each node.
 
 
@@ -783,11 +784,11 @@ The query above includes:
 .. rst-class:: open
 
 * An array nested within an object. Specifically, the ``inhabitants`` column
-  contains an *parent object* with an ``interests`` property set to an *child
+  contains an *parent object* with an ``interests`` property set to a *child
   array* of strings (e.g., ``lettuce``).
 
 * Objects nested within an array. Specifically, the ``information`` column
-  contains an *parent array* with two *child objects* (e.g.,
+  contains a *parent array* with two *child objects* (e.g.,
   ``{evolution_level=42, population=1}``).
 
 
@@ -868,9 +869,9 @@ There are two limitations to be aware of:
        ``foo[n1]['bar']``) to a string using the ``<expression>::text`` syntax,
        which is equivalent to ``cast(<expression> as text)``
 
-    2. Creating an temporary :ref:`array <data-type-array>` (in-memory and
-       addressable)  from that string using the ``<expression>[]`` syntax,
-       which is equivalent to ``array(expression``)
+    2. Creating a temporary :ref:`array <data-type-array>` (in-memory and
+       addressable) from that string using the ``<expression>[]`` syntax, which
+       is equivalent to ``array(expression``)
 
     *Note: Because this syntax effectively circumvents the index, it may
     considerably degrade query performance.*
@@ -1059,11 +1060,12 @@ Some examples::
     +---------------+-------------+
     SELECT 3 rows in set (... sec)
 
+
 Window functions
 ================
 
-CrateDB supports the :ref:`OVER <over>` clause to enable the execution of
-:ref:`window functions <window-functions>`::
+CrateDB supports the :ref:`OVER <window-definition-over>` clause to enable the
+execution of :ref:`window functions <window-functions>`::
 
     cr> select sum(position) OVER() AS pos_sum, name from locations order by name;
     +---------+------------------------------------+
@@ -1088,16 +1090,18 @@ CrateDB supports the :ref:`OVER <over>` clause to enable the execution of
     +---------+------------------------------------+
     SELECT 16 rows in set (... sec)
 
+
 .. _sql_dql_group_by:
 
 ``GROUP BY``
 ============
 
-CrateDB supports the ``group by`` clause. This clause can be used to group the
+CrateDB supports the ``GROUP BY`` clause. This clause can be used to group the
 resulting rows by the value(s) of one or more columns. That means that rows
 that contain duplicate values will be merged.
 
-This is useful if used in conjunction with aggregation functions::
+This is useful if used in conjunction with :ref:`aggregation functions
+<aggregation-functions>`::
 
     cr> select count(*), kind from locations
     ... group by kind order by count(*) desc, kind asc;
@@ -1120,18 +1124,19 @@ This is useful if used in conjunction with aggregation functions::
    shadow the table columns are used.
 
    Grouping on array columns doesn't work, but arrays can be unnested in a
-   subquery using :ref:`unnest`, it is then possible to use GROUP BY on the
-   subquery.
+   subquery using :ref:`unnest <unnest>`, it is then possible to use ``GROUP
+   BY`` on the subquery.
+
 
 .. _sql_dql_having:
 
 ``HAVING``
 ----------
 
-The having clause is the equivalent to the where clause for the resulting rows
-of a group by clause.
+The ``HAVING`` clause is the equivalent to the ``WHERE`` clause for the
+resulting rows of a ``GROUP BY`` clause.
 
-A simple having clause example using an equality :ref:`operator
+A simple ``HAVING`` clause example using an equality :ref:`operator
 <gloss-operator>`::
 
     cr> select count(*), kind from locations
@@ -1143,11 +1148,11 @@ A simple having clause example using an equality :ref:`operator
     +----------+--------+
     SELECT 1 row in set (... sec)
 
-The condition of the having clause can refer to the resulting columns of the
-group by clause.
+The condition of the ``HAVING`` clause can refer to the resulting columns of
+the ``GROUP BY`` clause.
 
-It is also possible to use aggregates in the having clause just like in the
-result columns::
+It is also possible to use :ref:`aggregate functions <aggregation-functions>`
+in the ``HAVING`` clause, like in the result columns::
 
     cr> select count(*), kind from locations
     ... group by kind having min(name) = 'Aldebaran';
@@ -1171,7 +1176,8 @@ result columns::
 
 .. NOTE::
 
-   Aliases are not supported in the having clause.
+   Aliases are not supported in the ``HAVING`` clause.
+
 
 .. _`3-valued logic`: https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)
 .. _Lucene Regular Expressions: http://lucene.apache.org/core/4_9_0/core/org/apache/lucene/util/automaton/RegExp.html

--- a/docs/general/dql/union.rst
+++ b/docs/general/dql/union.rst
@@ -1,12 +1,14 @@
 .. highlight:: psql
+
 .. _sql_union:
 
 =========
 Union All
 =========
 
-UNION ALL can be used to combine results from multiple ``SELECT`` statements.
-For further information on the syntax and usages see :ref:`sql_reference_union`.
+:ref:`UNION ALL <sql-select-union-all>` can be used to combine results from
+multiple :ref:`SELECT <sql-select>` statements.
+
 ::
 
     cr> select name from photos

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -160,7 +160,7 @@ The table also contains additional information such as the specified
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``reference_generation``         | Specifies how values in the self-referencing column are generated                  | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
-| ``routing_hash_function``        | The name of the hash function used for internal :ref:`routing <routing>`           | ``TEXT``    |
+| ``routing_hash_function``        | The name of the hash function used for internal :ref:`routing <sharding-routing>`  | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | ``self_referencing_column_name`` | The name of the column that uniquely identifies each row (always ``_id``)          | ``TEXT``    |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
@@ -602,8 +602,8 @@ instead of ``4``::
 
 The routines table contains tokenizers, token-filters, char-filters, custom
 analyzers created by ``CREATE ANALYZER`` statements (see
-:ref:`sql-ddl-custom-analyzer`), and functions created by ``CREATE FUNCTION``
-statements::
+:ref:`sql-ddl-custom-analyzer`), and :ref:`functions <user-defined-functions>`
+created by ``CREATE FUNCTION`` statements::
 
     cr> select routine_name, routine_type
     ... from information_schema.routines

--- a/docs/general/user-defined-functions.rst
+++ b/docs/general/user-defined-functions.rst
@@ -1,4 +1,4 @@
-.. _sql_administration_udf:
+.. _user-defined-functions:
 
 ======================
 User-defined functions
@@ -9,11 +9,14 @@ User-defined functions
 .. contents::
    :local:
 
+
+.. _udf-create-replace:
+
 ``CREATE OR REPLACE``
 =====================
 
-CrateDB supports user-defined functions. See :ref:`ref-create-function` for a
-full syntax description.
+CrateDB supports user-defined :ref:`functions <gloss-function>`. See
+:ref:`ref-create-function` for a full syntax description.
 
 ``CREATE FUNCTION`` defines a new function::
 
@@ -102,18 +105,24 @@ schema, the current session schema is used::
    :ref:`snapshot-restore` can't be used to backup functions, because snapshots
    contain table data only.
 
+
+.. _udf-supported-types:
+
 Supported types
 ===============
 
-Function arguments and return values can be any supported :ref:`data-types`.
-The values passed into a function must strictly correspond to the specified
-argument data types.
+Function arguments and return values can be any of the supported :ref:`data
+types <data-types>`. The values passed into a function must strictly
+correspond to the specified argument data types.
 
 .. NOTE::
 
     The value returned by the function will be casted to the return type
     provided in the definition if required. An exception will be thrown if the
     cast is not successful.
+
+
+.. _udf-overloading:
 
 Overloading
 ===========
@@ -160,6 +169,8 @@ This would overload the ``my_multiply`` function with more arguments::
     arguments!** However, such functions can still be called if the schema name
     is explicitly provided.
 
+.. _udf-determinism:
+
 Determinism
 ===========
 
@@ -169,6 +180,9 @@ Determinism
     always return the same result value when called with the same argument
     values, because CrateDB might cache the returned values and reuse the value
     if the function is called multiple times with the same arguments.
+
+
+.. _udf-drop-function:
 
 ``DROP FUNCTION``
 =================
@@ -194,12 +208,16 @@ Optionally, you can provide a schema::
      cr> DROP FUNCTION my_schema.log10(bigint);
      DROP OK, 1 row affected  (... sec)
 
+
+.. _udf-supported-languages:
+
 Supported languages
 ===================
 
-CrateDB currently only supports the ``JavaScript`` user-defined functions.
+Currently, CrateDB only supports JavaScript for user-defined functions.
 
-.. _udf_lang_js:
+
+.. _udf-js:
 
 JavaScript
 ----------
@@ -230,8 +248,10 @@ JavaScript, objects that are normally accessible with a web browser
 (e.g. ``window``, ``console``, and so on) are not available.
 
 
-Supported Types
-...............
+.. _udf-js-supported-types:
+
+JavaScript supported types
+..........................
 
 JavaScript functions can handle all CrateDB data types. However, for some
 return types the function output must correspond to the certain format.
@@ -283,8 +303,11 @@ the JavaScript function should return a ``GeoJson`` object or ``WKT`` string::
    If the return value of the JavaScript function is ``undefined``, it is
    converted to ``NULL``.
 
+
+.. _udf-js-numbers:
+
 Working with ``NUMBERS``
-------------------------
+........................
 
 The JavaScript engine interprets numbers as ``java.lang.Double``,
 ``java.lang.Long``, or ``java.lang.Integer``, depending on the computation
@@ -374,13 +397,17 @@ is returned::
     cr> DROP FUNCTION utc(bigint, bigint, bigint);
     DROP OK, 1 row affected  (... sec)
 
+
+.. _udf-js-array-methods:
+
 Working with ``Array`` methods
-------------------------------
+..............................
 
 The JavaScript ``Array`` object has a number of prototype methods you can
 use, such as `join`_, `map`_, `sort`_, `slice`_, `reduce`_, and so on.
 
-Normally, you can call these methods directly from an ``Array`` object, like so:
+Normally, you can call these methods directly from an ``Array`` object, like
+so:
 
 .. code-block:: js
 
@@ -401,14 +428,14 @@ You must do it like this because arguments are not passed as ``Array`` objects,
 and so do not have the associated prototype methods available. Arguments are instead
 passed as array-like objects.
 
-.. _join: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join
-.. _map: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
-.. _sort: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-.. _slice: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
-.. _reduce: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
 
 .. _ECMAScript 2019: https://262.ecma-international.org/10.0/index.html
 .. _GraalVM JavaScript: https://www.graalvm.org/docs/reference-manual/languages/js/
 .. _GraalVM Polyglot API: https://www.graalvm.org/docs/reference-manual/polyglot/
-.. _stock host Java VM JIT compilers: https://www.graalvm.org/reference-manual/js/RunOnJDK/
 .. _GraalVM Security Guide: https://www.graalvm.org/docs/security-guide/
+.. _join: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join
+.. _map: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
+.. _reduce: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
+.. _slice: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
+.. _sort: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+.. _stock host Java VM JIT compilers: https://www.graalvm.org/reference-manual/js/RunOnJDK/

--- a/docs/interfaces/http.rst
+++ b/docs/interfaces/http.rst
@@ -458,7 +458,7 @@ Code   Error
 ------ ---------------------------------------------------------------------
 4048   Unknown Snapshot.
 ------ ---------------------------------------------------------------------
-4049   Unknown user-defined function.
+4049   Unknown :ref:`user-defined function <user-defined-functions>`.
 ------ ---------------------------------------------------------------------
 40410  Unknown user.
 ------ ---------------------------------------------------------------------
@@ -529,5 +529,6 @@ error::
    Every bulk operation will be executed, independent if one of the operation
    fails.
 
-.. _prepared statement: https://en.wikipedia.org/wiki/Prepared_statement
+
 .. _here documents: https://en.wikipedia.org/wiki/Here_document
+.. _prepared statement: https://en.wikipedia.org/wiki/Prepared_statement

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -4,14 +4,6 @@
 PostgreSQL wire protocol
 ========================
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-Introduction
-============
-
 CrateDB contains support for the `PostgreSQL wire protocol v3`_.
 
 If a node is started with postgres support enabled it will bind to port
@@ -31,12 +23,16 @@ which is why clients should generally enable ``autocommit``.
     The client will utilize the fetchSize on SELECT statements and only load up
     to fetchSize rows into memory.
 
-    See `PostgreSQL JDBC Query docs
-    <https://jdbc.postgresql.org/documentation/head/query.html>` for more
-    information.
+    See the `PostgreSQL JDBC Query docs`_ for more information.
 
     Write operations will still behave as if autocommit was enabled and commit
     or rollback calls are ignored.
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
 
 Server compatibility and implementation status
 ==============================================
@@ -75,8 +71,8 @@ Database selection
 
 Since CrateDB uses schemas instead of databases, the ``database`` parameter
 sets the default schema name for future queries. If no schema is specified, the
-schema ``doc`` will be used as default. Additionally, the only supported charset
-is ``UTF8``.
+schema ``doc`` will be used as default. Additionally, the only supported
+charset is ``UTF8``.
 
 Query Modes
 -----------
@@ -84,12 +80,13 @@ Query Modes
 Simple query
 ............
 
-The `Simple Query`_ protocol mode is fully implemented.
+The `PostgreSQL simple query`_ protocol mode is fully implemented.
 
 Extended query
 ..............
 
-The `Extended Query`_ protocol mode is implemented with the following limitations:
+The `PostgreSQL extended query`_ protocol mode is implemented with the
+following limitations:
 
 - The ``ParameterDescription`` message works for the most common use cases
   except for DDL statements.
@@ -105,7 +102,8 @@ CrateDB does not support the ``COPY`` sub-protocol.
 Function call
 -------------
 
-The function call sub-protocol is not supported since it's a legacy feature.
+The :ref:`function call <sql-function-call>` sub-protocol is not supported
+since it's a legacy feature.
 
 Canceling requests
 ------------------
@@ -231,13 +229,13 @@ The ``oid`` type might have the following type aliases:
 .. NOTE::
 
    Currently, casting a string or integer literal to the ``regproc`` type
-   wouldn't result in a function lookup.  Instead, casting the string
-   literal to the ``regproc`` type results in an object of the ``regproc``
-   type that has a name that corresponds to the string literal and the ``oid``
-   hash of the literal as ``oid`` and casting an integer literal to the
-   ``regproc`` type results in an object of the ``regproc`` type that has a
-   name that corresponds to the string representation of the literal and the
-   literal value as ``oid``.
+   wouldn't result in a :ref:`function <user-defined-functions>` lookup.
+   Instead, casting the string literal to the ``regproc`` type results in an
+   object of the ``regproc`` type that has a name that corresponds to the
+   string literal and the ``oid`` hash of the literal as ``oid``. Casting an
+   integer literal to the ``regproc`` type results in an object of the
+   ``regproc`` type that has a name that corresponds to the string
+   representation of the literal and the literal value as ``oid``.
 
 Show transaction isolation
 --------------------------
@@ -386,20 +384,23 @@ Accessing arrays
 ................
 
 Fetching arbitrary rectangular slices of an array using
-``lower-bound:upper-bound`` expression (see `Arrays`_) in the array subscript
-is not supported.
+``lower-bound:upper-bound`` expression in the array subscript is not supported.
+
+.. SEEALSO::
+
+    `PostgreSQL Arrays`_
 
 Text search functions and operators
 -----------------------------------
 
-The functions and :ref:`operators <gloss-operator>` provided by PostgreSQL for
-full-text search (see `PostgreSQL Fulltext Search`_) are not compatible with
-those provided by CrateDB. For more information about the built-in full-text
-search in CrateDB refer to :ref:`sql_dql_fulltext_search`.
+The :ref:`functions <gloss-function>` and :ref:`operators <gloss-operator>`
+provided by PostgreSQL for :ref:`full-text search <sql_dql_fulltext_search>`
+(see `PostgreSQL Fulltext Search`_) are not compatible with those provided by
+CrateDB.
 
 If you are missing features, functions or dialect improvements and have a great
-use case for it, let us know on `Github`_. We're always improving and extending
-CrateDB, and we love to hear feedback.
+use case for it, let us know on `GitHub`_. We're always improving and extending
+CrateDB and we love to hear feedback.
 
 Expression evaluation
 ---------------------
@@ -407,9 +408,7 @@ Expression evaluation
 Unlike PostgreSQL, expressions are not evaluated if the query results in 0 rows
 either because of the table is empty or by a not matching where clause.
 
-.. _Arrays: https://www.postgresql.org/docs/current/static/arrays.html
-.. _Extended Query: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-.. _Github: https://github.com/crate/crate
+.. _GitHub: https://github.com/crate/crate
 .. _pg_am: https://www.postgresql.org/docs/10/catalog-pg-am.html
 .. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html
 .. _pg_enum: https://www.postgresql.org/docs/10/catalog-pg-enum.html
@@ -427,8 +426,11 @@ either because of the table is empty or by a not matching where clause.
 .. _pgsql_pg_proc: https://www.postgresql.org/docs/10/static/catalog-pg-proc.html
 .. _pgsql_pg_settings: https://www.postgresql.org/docs/10/view-pg-settings.html
 .. _pgsql_pg_type: https://www.postgresql.org/docs/10/static/catalog-pg-type.html
+.. _PostgreSQL Arrays: https://www.postgresql.org/docs/current/static/arrays.html
+.. _PostgreSQL extended query: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 .. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/current/static/functions-textsearch.html
 .. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/head/connect.html#connection-failover
+.. _PostgreSQL JDBC Query docs: https://jdbc.postgresql.org/documentation/head/query.html
+.. _PostgreSQL simple query: https://www.postgresql.org/docs/current/static/protocol-flow.html#id-1.10.5.7.4
 .. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/current/static/protocol.html
-.. _Simple Query: https://www.postgresql.org/docs/current/static/protocol-flow.html#id-1.10.5.7.4
 .. _Value Expressions: https://www.postgresql.org/docs/current/static/sql-expressions.html

--- a/docs/sql/general/constraints.rst
+++ b/docs/sql/general/constraints.rst
@@ -10,26 +10,28 @@ Constraints
 .. contents::
    :local:
 
-Tables Constraints
-==================
+
+Table constraints
+=================
 
 Table constraints are constraints that are applied to the table as a whole.
+
 
 .. _primary_key_constraint:
 
 ``PRIMARY KEY``
 ---------------
 
-The PRIMARY KEY constraint specifies that a column or columns of a table can
-contain only unique (non-duplicate), non-null values.
+The ``PRIMARY KEY`` constraint specifies that a column or columns of a table
+can contain only unique (non-duplicate), non-null values.
 
 Using columns of type ``object``, ``geo_point``, ``geo_shape`` or ``array`` as
-PRIMARY KEY is not supported.
+``PRIMARY KEY`` is not supported.
 
-To use a whole ``object`` as PRIMARY KEY each column within the ``object`` can
-be declared as PRIMARY KEY instead.
+To use a whole ``object`` as ``PRIMARY KEY`` each column within the ``object``
+can be declared as ``PRIMARY KEY`` instead.
 
-Adding a PRIMARY KEY column is only possible if the table is empty.
+Adding a ``PRIMARY KEY`` column is only possible if the table is empty.
 
 .. WARNING::
 
@@ -38,38 +40,43 @@ Adding a PRIMARY KEY column is only possible if the table is empty.
     that isn't empty.
 
     If that is the case queries that contain the primary key columns in the
-    WHERE clause will not behave as expected.
+    ``WHERE`` clause will not behave as expected.
+
 
 .. _index-constraint:
 
 ``INDEX``
 ---------
 
-The INDEX constraint specifies a specific index method on one or more columns.
+The ``INDEX`` constraint specifies a specific index method on one or more
+columns.
 
 It is possible to define more than one index per table, whether as a column
 constraint or a table constraint.
 
-For further details about the meaning of the options see
-:ref:`indices_and_fulltext`.
+.. SEEALSO::
+
+    :ref:`indices_and_fulltext`
+
 
 .. _check_constraint:
 
 ``CHECK``
 ---------
 
-The CHECK constraint specifies that the values of certain columns must satisfy
-a boolean expression on insert and update.
+The ``CHECK`` constraint specifies that the values of certain columns must
+satisfy a boolean expression on insert and update.
 
 Syntax::
 
   [CONSTRAINT check_name>] CHECK (boolean_expression)
 
-If `CONSTAINT check_name` is omitted, CrateDB generates a unique name automatically.
-This name is visible in :ref:`information_schema_table_constraints` and can be
-used to :ref:`drop-constraint` a constraint.
+If ``CONSTAINT check_name`` is omitted, CrateDB generates a unique name
+automatically.  This name is visible in
+:ref:`information_schema_table_constraints`. This name can be used with
+:ref:`DROP CONSTRAINT <drop-constraint>` to remove the constraint.
 
-The CONSTRAINT definition can either be inline with a column, like this::
+The ``CONSTRAINT`` definition can either be inline with a column, like this::
 
     cr> CREATE TABLE metrics1 (
     ...     weight REAL CONSTRAINT weight_is_positive CHECK (weight >= 0),
@@ -116,15 +123,14 @@ Multiple columns can be referenced::
 
 .. WARNING::
 
-   CHECK constraint conditions must be deterministic, always yielding the same
-   result for the same input.
-   A way to break this is to reference a user-defined function in a CHECK
-   expression, and then change the behavior of that function. Some existing
-   rows in the table could now violate the CHECK constraint. That would
-   cause a subsequent database dump and reload to fail.
+   The ``CHECK`` constraint conditions must be deterministic, always yielding
+   the same result for the same input.
 
-CHECK constaints can be removed :ref:`drop-constraint`.
-
+   A way to break this is to reference a :ref:`user-defined function
+   <user-defined-functions>` in a ``CHECK`` expression, and then change the
+   behavior of that function. Some existing rows in the table could now violate
+   the ``CHECK`` constraint. That would cause a subsequent database dump and
+   reload to fail.
 
 .. hide:
 
@@ -141,9 +147,10 @@ CHECK constaints can be removed :ref:`drop-constraint`.
    cr> drop table metrics6;
    DROP OK, 1 row affected (... sec)
 
+
 .. _column_constraints:
 
-Column Constraints
+Column constraints
 ==================
 
 Column constraints are constraints that are applied on each column of the table
@@ -151,17 +158,20 @@ separately.
 
 The supported column constraints are:
 
- * :ref:`not_null_constraint`
- * :ref:`primary_key_constraint`
- * :ref:`check_constraint`
+- :ref:`not_null_constraint`
+
+- :ref:`primary_key_constraint`
+
+- :ref:`check_constraint`
+
 
 .. _not_null_constraint:
 
 ``NOT NULL``
 ------------
 
-The NOT NULL constraint specifies that a column of a table can contain only
+The ``NOT NULL`` constraint specifies that a column of a table can contain only
 non-null values.
 
-The columns that are part of the primary key of a table are NOT NULL by
+The columns that are part of the primary key of a table are ``NOT NULL`` by
 default.

--- a/docs/sql/general/lexical-structure.rst
+++ b/docs/sql/general/lexical-structure.rst
@@ -1,4 +1,5 @@
 .. highlight:: psql
+
 .. _sql_lexical:
 
 =================
@@ -17,6 +18,7 @@ character symbol.
 .. contents::
    :local:
 
+
 .. _string_literal:
 
 String literal
@@ -26,18 +28,20 @@ String literals are defined as an arbitrary sequence of characters that are
 delimited with single quotes ``'`` as defined in ANSI SQL, for example
 ``'This is a string'``.
 
+
 Escape strings
 --------------
 
 The escape character in CrateDB is the single-quote ``'``. A character gets
 escaped when adding a single-quote before it. For example a single quote
 character within a string literal can be included by writing two adjacent
-single quotes, e.g. ``'Jack''s car'``.
+single quotes, e.g., ``'Jack''s car'``.
 
 .. NOTE::
 
    Two adjacent single quotes are **not** equivalent to the double-quote
    character ``"``.
+
 
 .. _sql_escape_string_literals:
 
@@ -62,8 +66,9 @@ Escape Sequence                                       Interpretation
 ``\uxxxx``, ``\Uxxxxxxxx`` (``x`` = [0-9,A-F,a-f])    16 or 32-bit hexadecimal Unicode character value
 ==================================================   ================
 
-For instance, the escape string literal ``e'\u0061\x61\141'``
-is equivalent to the ``'aaa'`` string literal.
+For instance, the escape string literal ``e'\u0061\x61\141'`` is equivalent to
+the ``'aaa'`` string literal.
+
 ::
 
     cr> select e'\u0061\x61\141' as col1;
@@ -77,6 +82,7 @@ is equivalent to the ``'aaa'`` string literal.
 Any other character following a backslash is taken literally. Thus, to include
 a backslash character ``\``, two adjacent backslashes need to be used
 (i.e. ``\\``).
+
 ::
 
     cr> select e'aa\\nbb' as col1;
@@ -87,9 +93,10 @@ a backslash character ``\``, two adjacent backslashes need to be used
     +--------+
     SELECT 1 row in set (... sec)
 
-Finally, a single quote can be included in an escape string literal
-by also using the escape backslash character: ``\'``, in addition to the
-single-quote described in :ref:`String Literals <string_literal>`.
+Finally, a single quote can be included in an escape string literal by also
+using the escape backslash character: ``\'``, in addition to the single-quote
+described in the :ref:`string literals <string_literal>` section.
+
 ::
 
     cr> select e'aa\'bb' as col1;
@@ -100,12 +107,13 @@ single-quote described in :ref:`String Literals <string_literal>`.
     +-------+
     SELECT 1 row in set (... sec)
 
+
 .. _sql_lexical_keywords_identifiers:
 
 Key words and identifiers
 =========================
 
-The table bellow lists all **reserved key words** in CrateDB. These need to be
+The table below lists all *reserved key words* in CrateDB. These need to be
 quoted if used as identifiers::
 
     cr> SELECT word FROM pg_catalog.pg_get_keywords() WHERE catcode = 'R' ORDER BY 1;
@@ -210,10 +218,9 @@ quoted if used as identifiers::
     +-------------------+
     SELECT 95 rows in set (... sec)
 
-
 Tokens such as ``my_table``, ``id``, ``name``, or ``data`` in the example below
-are **identifiers**, which identify names of tables, columns, and other
-database objects.
+are *identifiers*, which identify names of tables, columns, and other database
+objects.
 
 Example::
 
@@ -254,6 +261,7 @@ Quoted identifiers can contain an arbitrary sequence of characters enclosed by
 double quotes (``"``). Quoted identifiers are never keywords, so you can use
 ``"update"`` as a table or column name.
 
+
 .. _sql_lexical_special_chars:
 
 Special characters
@@ -278,12 +286,14 @@ described.
 
 :Asterisk:
     The asterisk (``*``) is used in some contexts to denote all columns of a
-    table. As an argument in global aggregate functions it has the meaning of
-    *any field*, e.g. ``COUNT(*)``.
+    table. As an argument in global :ref:`aggregate functions
+    <aggregation-functions>` it has the meaning of *any field*,
+    e.g. ``COUNT(*)``.
 
 :Period:
     The period (``.``) is used for numeric values and to separate schema and
     table names, e.g. ``blob.my_blob_table``.
+
 
 .. _sql_lexical_comments:
 
@@ -302,5 +312,3 @@ Example::
   SELECT *
     FROM information_schema.tables
     WHERE table_schema = 'doc'; -- query information schema for doc tables
-
-.. _`crash`: https://github.com/crate/crash/

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -171,17 +171,12 @@ an identifier that must refer to a field of the record.
 Function call
 =============
 
-A function is declared by its name followed by its arguments enclosed in
-parentheses::
+A :ref:`function <gloss-function>` can be invoked with a *function call* (a
+process better known as *calling the function*). The corresponding syntax is
+the function name optionally followed by zero or more arguments (in the form of
+:ref:`value expressions <sql-value-expressions>`) enclosed by parentheses::
 
-    function_name([expression [, expression ... ]])
-      [OVER( [PARTITION BY expression [, ...] ] [ORDER BY expression [, ...] ]) ]
-
-.. SEEALSO::
-
-    - :ref:`scalar`
-    - :ref:`aggregation`
-    - :ref:`window-functions`
+    function_name[([expression [, expression ... ]])]
 
 
 .. _sql-type-cast:
@@ -239,7 +234,7 @@ optionally prefixed with ``ARRAY``::
 .. _sql_expressions_array_subquery:
 
 Another way to construct an array is by using an ``ARRAY(subquery)`` expression
-as part of the :ref:`Select list <sql_reference_select_list>` of a ``SELECT``
+as part of the :ref:`SELECT list <sql-select-list>` of a ``SELECT``
 statement::
 
     ARRAY '(' subquery ')'
@@ -278,6 +273,6 @@ stating that the column is unknown.
 
 .. NOTE::
 
-    Scalar subqueries are restricted to :ref:`SELECT <sql_reference_select>`,
-    :ref:`DELETE <sql_reference_delete>` and :ref:`UPDATE <ref-update>`
-    statements and cannot be used in other statements.
+    Scalar subqueries are restricted to :ref:`SELECT <sql-select>`, :ref:`DELETE
+    <sql_reference_delete>` and :ref:`UPDATE <ref-update>` statements and
+    cannot be used in other statements.

--- a/docs/sql/statements/create-function.rst
+++ b/docs/sql/statements/create-function.rst
@@ -1,16 +1,18 @@
 .. highlight:: psql
+
 .. _ref-create-function:
 
 ===================
 ``CREATE FUNCTION``
 ===================
 
-Create a new function.
+Create a new :ref:`function <user-defined-functions>`.
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
 
 Synopsis
 ========
@@ -23,10 +25,12 @@ Synopsis
     LANGUAGE language_name
     AS 'definition'
 
+
 Description
 ===========
 
-``CREATE FUNCTION`` creates a new user defined function.
+``CREATE FUNCTION`` creates a new :ref:`user-defined function
+<user-defined-functions>`.
 
 ``CREATE OR REPLACE FUNCTION`` will either create a new function, or replace an
 existing function.
@@ -37,6 +41,7 @@ arguments.
 You can overload functions by defining two functions of the same name, but with
 a different set of input arguments.
 
+
 Parameters
 ==========
 
@@ -44,15 +49,11 @@ Parameters
   The name of the function to create.
 
 :arg_name:
-  The optional name given to an argument. Function arguments do not
-  retain names, but you can name them in your query for documentation
-  purposes.
+  The optional name given to an argument. Function arguments do not retain
+  names, but you can name them in your query for documentation purposes.
 
 :arg_type:
-  The data type of a given argument.
-
-  See :ref:`data-types` for more detailed information about the
-  supported types.
+  The :ref:`data type <data-types>` of a given argument.
 
 :return_type:
   The returned data type of the function. The return type can be any
@@ -62,6 +63,4 @@ Parameters
   The registered language which should be used for the function.
 
 :definition:
-  A string defining the body of the function.
-
-  See :ref:`string_literal` for more details.
+  A :ref:`string <string_literal>` defining the body of the function.

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -93,7 +93,7 @@ use when the constraint only affects one column.
 
 .. SEEALSO::
 
-    :ref:`sql_ddl_create`
+    :ref:`Data definition: Creating tables <sql_ddl_create>`
 
 
 .. _sql-create-table-elements:
@@ -147,7 +147,7 @@ The ``GENERATED ALWAYS`` part of the syntax is optional.
 
 .. SEEALSO::
 
-   For more information, see :ref:`ddl-generated-columns`.
+    :ref:`Data definition: Generated columns <ddl-generated-columns>`
 
 
 .. _sql-create-table-table-constraints:
@@ -158,7 +158,9 @@ Table constraints
 Table constraints are constraints that are applied to more than one column or
 to the table as a whole.
 
-For further details see :ref:`table_constraints`.
+.. SEEALSO::
+
+    :ref:`General SQL: Table constraints <table_constraints>`
 
 
 .. _sql-create-table-column-constraints:
@@ -169,7 +171,9 @@ Column constraints
 Column constraints are constraints that are applied on each column of the table
 separately.
 
-For further details see :ref:`column_constraints`.
+.. SEEALSO::
+
+    :ref:`General SQL: Column constraints <column_constraints>`
 
 
 .. _sql-create-table-storage-options:
@@ -179,7 +183,9 @@ Storage options
 
 Storage options can be applied on each column of the table separately.
 
-For further details and available options see :ref:`ddl-storage`.
+.. SEEALSO::
+
+    :ref:`Data definition: Storage <ddl-storage>`
 
 
 .. _sql-create-table-parameters:
@@ -194,15 +200,15 @@ Parameters
   The name of a column to be created in the new table.
 
 :data_type:
-  The data type of the column. This can include array and object specifiers. For
-  more information on the data types supported by CrateDB see :ref:`data-types`.
+  The :ref:`data type <data-types>` of the column. This can include array and
+  object specifiers.
 
 :generation_expression:
-  An expression (usually a function call) that is applied in the context
-  of the current row. As such it can reference other base columns of the
-  table. Referencing other generated columns (including itself) is not
-  supported. The generation expression is evaluated each time a row is
-  inserted or the referenced base columns are updated.
+  An expression (usually a :ref:`function call <sql-function-call>`) that is
+  applied in the context of the current row. As such it can reference other
+  base columns of the table. Referencing other generated columns (including
+  itself) is not supported. The generation expression is evaluated each time a
+  row is inserted or the referenced base columns are updated.
 
 
 .. _sql-create-table-if-not-exists:
@@ -210,8 +216,8 @@ Parameters
 ``IF NOT EXISTS``
 =================
 
-If the optional IF NOT EXISTS clause is used this statement won't do anything
-if the table exists already.
+If the optional ``IF NOT EXISTS`` clause is used, this statement won't do
+anything if the table exists already.
 
 
 .. _sql-create-table-clustered:
@@ -219,7 +225,7 @@ if the table exists already.
 ``CLUSTERED``
 =============
 
-The optional CLUSTERED clause specifies how a table should be distributed
+The optional ``CLUSTERED`` clause specifies how a table should be distributed
 accross a cluster.
 
 ::
@@ -227,7 +233,7 @@ accross a cluster.
     [ CLUSTERED [ BY (routing_column) ] INTO num_shards SHARDS ]
 
 :num_shards:
-  Specifies the number of :ref:`shards <sql_ddl_sharding>` a table is stored
+  Specifies the number of :ref:`shards <ddl-sharding>` a table is stored
   in. Must be greater than 0. If not provided, the number of shards is
   calculated based on the number of currently active data nodes with the
   following formula::
@@ -242,7 +248,7 @@ accross a cluster.
 
 :routing_column:
   Specify a :ref:`routing column <gloss-routing-column>` that :ref:`determines
-  <routing>` how rows are sharded.
+  <sharding-routing>` how rows are sharded.
 
   All rows that have the same ``routing_column`` row value are stored in the
   same shard. If a :ref:`primary key <primary_key_constraint>` has been
@@ -251,7 +257,7 @@ accross a cluster.
 
 .. SEEALSO::
 
-    :ref:`sql_ddl_sharding`
+    :ref:`Data definition: Sharding <ddl-sharding>`
 
 
 .. _sql-create-table-partitioned-by:
@@ -274,14 +280,18 @@ values in the specified :ref:`partition columns <gloss-partition-column>`.
 
 The following restrictions apply:
 
-* Partition columns may not be part of the :ref:`sql-create-table-clustered`
+- Partition columns may not be part of the :ref:`sql-create-table-clustered`
   clause
-* Partition columns must only contain :ref:`primitive types
+
+- Partition columns must only contain :ref:`primitive types
   <sql_ddl_datatypes_primitives>`
-* Partition columns may not be inside an object array
-* Partition columns may not be indexed with a :ref:`fulltext index with
+
+- Partition columns may not be inside an object array
+
+- Partition columns may not be indexed with a :ref:`fulltext index with
   analyzer <sql_ddl_index_fulltext>`
-* If the table has a :ref:`primary_key_constraint` constraint, all of the
+
+- If the table has a :ref:`primary_key_constraint` constraint, all of the
   partition columns must be included in the primary key definition
 
 .. CAUTION::
@@ -295,7 +305,7 @@ The following restrictions apply:
 ``WITH``
 ========
 
-The optional WITH clause can specify parameters for tables.
+The optional ``WITH`` clause can specify parameters for tables.
 
 ::
 
@@ -335,11 +345,13 @@ The number of replicas is defined like this::
 :max_replicas:
   The maximum number of replicas.
 
-  The actual maximum number of replicas is max(num_replicas, N-1), where
-  N is the number of data nodes in the cluster. If ``max_replicas`` is
-  the string ``all`` then it will always be N.
+  The actual maximum number of replicas is max(num_replicas, N-1), where N is
+  the number of data nodes in the cluster. If ``max_replicas`` is the string
+  ``all`` then it will always be N.
 
-For further details and examples see :ref:`replication`.
+.. SEEALSO::
+
+    :ref:`replication`
 
 
 .. _sql-create-table-number-of-routing-shards:
@@ -363,9 +375,9 @@ Specifies the refresh interval of a shard in milliseconds. The default is set
 to 1000 milliseconds.
 
 :value:
-  The refresh interval in milliseconds. A value of smaller or equal than
-  0 turns off the automatic refresh. A value of greater than 0 schedules
-  a periodic refresh of the table.
+  The refresh interval in milliseconds. A value of smaller or equal than 0
+  turns off the automatic refresh. A value of greater than 0 schedules a
+  periodic refresh of the table.
 
 .. NOTE::
 
@@ -373,7 +385,11 @@ to 1000 milliseconds.
    visible to subsequent reads. Only the periodic refresh is disabled. There
    are other internal factors that might trigger a refresh.
 
-For further details see :ref:`refresh_data` or :ref:`sql-refresh`.
+.. SEEALSO::
+
+    :ref:`Querying: Refresh <refresh_data>`
+
+    :ref:`SQL syntax: REFRESH <sql-refresh>`
 
 
 .. _sql-create-table-write-wait:
@@ -388,8 +404,9 @@ operations to proceed. If less shard copies are active the operation must wait
 and retry for up to 30s before timing out.
 
 :value:
-  ``all`` or a positive integer up to the total number of configured shard copies
-  (``number_of_replicas + 1``).
+  ``all`` or a positive integer up to the total number of configured shard
+  copies (``number_of_replicas + 1``).
+
   A value of ``1`` means only the primary has to be active. A value of ``2``
   means the primary plus one replica shard has to be active, and so on.
 
@@ -397,7 +414,6 @@ and retry for up to 30s before timing out.
 
   ``all`` is a special value that means all shards (primary + replicas) must be
   active for write operations to proceed.
-
 
 Increasing the number of shard copies to wait for improves the resiliency of
 the system. It reduces the chance of write operations not writing to the
@@ -434,8 +450,8 @@ enough.
 Allows to have a read only table.
 
 :value:
-  Table is read only if value set to ``true``. Allows writes and table
-  settings changes if set to ``false``.
+  Table is read only if value set to ``true``. Allows writes and table settings
+  changes if set to ``false``.
 
 
 .. _sql-create-table-blocks-read-only-allow-delete:
@@ -457,7 +473,8 @@ Allows to have a read only table that additionally can be deleted.
 
 .. SEEALSO::
 
-    :ref:`Disk-based shard allocation <cluster.routing.allocation.disk>`
+    :ref:`Cluster-wide settings: Disk-based shard allocation
+    <cluster.routing.allocation.disk>`
 
 
 .. _sql-create-table-blocks-read:
@@ -468,8 +485,8 @@ Allows to have a read only table that additionally can be deleted.
 ``disable``/``enable`` all the read operations
 
 :value:
-  Set to ``true`` to disable all read operations for a table, otherwise
-  set ``false``.
+  Set to ``true`` to disable all read operations for a table, otherwise set
+  ``false``.
 
 
 .. _sql-create-table-blocks-write:
@@ -492,8 +509,8 @@ Allows to have a read only table that additionally can be deleted.
 ``disable``/``enable`` the table settings modifications.
 
 :values:
-  Disables the table settings modifications if set to ``true``, if set
-  to ``false`` — table settings modifications are enabled.
+  Disables the table settings modifications if set to ``true``. If set to
+  ``false``, table settings modifications are enabled.
 
 
 .. _sql-create-table-soft-deletes:
@@ -582,37 +599,37 @@ the expense of slower column value lookups.
 ``store.type``
 --------------
 
-The store type setting allows you to control how data is stored
-and accessed on disk. The following storage types are supported:
+The store type setting allows you to control how data is stored and accessed on
+disk. The following storage types are supported:
 
 :fs:
   Default file system implementation. It will pick the best implementation
-  depending on the operating environment, which is currently ``hybridfs``
-  on all supported systems but is subject to change.
+  depending on the operating environment, which is currently ``hybridfs`` on
+  all supported systems but is subject to change.
 
 :simplefs:
-  The ``Simple FS`` type is an implementation of file system storage
-  (Lucene ``SimpleFsDirectory``) using a random access file.
-  This implementation has poor concurrent performance. It is usually
-  better to use the ``niofs`` when you need index persistence.
+  The ``Simple FS`` type is an implementation of file system storage (Lucene
+  ``SimpleFsDirectory``) using a random access file.  This implementation has
+  poor concurrent performance. It is usually better to use the ``niofs`` when
+  you need index persistence.
 
 :niofs:
-  The ``NIO FS`` type stores the shard index on the file system
-  (Lucene ``NIOFSDirectory``) using NIO. It allows multiple threads
-  to read from the same file concurrently.
+  The ``NIO FS`` type stores the shard index on the file system (Lucene
+  ``NIOFSDirectory``) using NIO. It allows multiple threads to read from the
+  same file concurrently.
 
 :mmapfs:
-  The ``MMap FS`` type stores the shard index on the file system
-  (Lucene ``MMapDirectory``) by mapping a file into memory (mmap).
-  Memory mapping uses up a portion of the virtual memory address space
-  in your process equal to the size of the file being mapped. Before
-  using this type, be sure you have allowed plenty of virtual address space.
+  The ``MMap FS`` type stores the shard index on the file system (Lucene
+  ``MMapDirectory``) by mapping a file into memory (mmap).  Memory mapping uses
+  up a portion of the virtual memory address space in your process equal to the
+  size of the file being mapped. Before using this type, be sure you have
+  allowed plenty of virtual address space.
 
 :hybridfs:
-  The ``hybridfs`` type is a hybrid of ``niofs`` and ``mmapfs``, which
-  chooses the best file system type for each type of file based on the
-  read access pattern. Similarly to ``mmapfs`` be sure you have allowed
-  plenty of virtual address space.
+  The ``hybridfs`` type is a hybrid of ``niofs`` and ``mmapfs``, which chooses
+  the best file system type for each type of file based on the read access
+  pattern. Similarly to ``mmapfs`` be sure you have allowed plenty of virtual
+  address space.
 
 It is possible to restrict the use of the ``mmapfs`` and ``hybridfs`` store
 type via the :ref:`node.store.allow_mmap <node.store_allow_mmap>` node setting.
@@ -625,11 +642,12 @@ type via the :ref:`node.store.allow_mmap <node.store_allow_mmap>` node setting.
 ``mapping.total_fields.limit``
 ------------------------------
 
-Sets the maximum number of columns that is allowed for a table. Default is ``1000``.
+Sets the maximum number of columns that is allowed for a table. Default is
+``1000``.
 
 :value:
-  Maximum amount of fields in the Lucene index mapping. This includes
-  both the user facing mapping (columns) and internal fields.
+  Maximum amount of fields in the Lucene index mapping. This includes both the
+  user facing mapping (columns) and internal fields.
 
 
 .. _sql-create-table-translog:
@@ -676,11 +694,11 @@ Sets frequency of flush necessity check.
 ``translog.sync_interval``
 --------------------------
 
-How often the translog is fsynced to disk. Defaults to 5s.
-When setting this interval, please keep in mind that changes logged
-during this interval and not synced to disk may get lost in case of a
-failure. This setting only takes effect if :ref:`translog.durability
-<sql-create-table-translog-durability>` is set to ``ASYNC``.
+How often the translog is fsynced to disk. Defaults to 5s.  When setting this
+interval, please keep in mind that changes logged during this interval and not
+synced to disk may get lost in case of a failure. This setting only takes
+effect if :ref:`translog.durability <sql-create-table-translog-durability>` is
+set to ``ASYNC``.
 
 :value:
   Interval in milliseconds.
@@ -759,7 +777,7 @@ comma-separated values.
 
 .. SEEALSO::
 
-    :ref:`ddl_shard_allocation`
+    :ref:`Data definition: Shard allocation filtering <ddl_shard_allocation>`
 
 
 .. _sql-create-table-routing-allocation-require:
@@ -772,7 +790,7 @@ values.
 
 .. SEEALSO::
 
-    :ref:`ddl_shard_allocation`
+    :ref:`Data definition: Shard allocation filtering <ddl_shard_allocation>`
 
 
 .. _sql-create-table-routing-allocation-exclude:
@@ -785,7 +803,7 @@ comma-separated values.
 
 .. SEEALSO::
 
-    :ref:`ddl_shard_allocation`
+    :ref:`Data definition: Shard allocation filtering <ddl_shard_allocation>`
 
 
 .. _sql-create-table-unassigned:
@@ -818,16 +836,20 @@ The column policy is defined like this::
     WITH ( column_policy = {'dynamic' | 'strict'} )
 
 :strict:
-  Rejecting any column on insert, update or copy from which is not
-  defined in the schema
+  Rejecting any column on insert, update or copy from which is not defined in
+  the schema
 
 :dynamic:
-  New columns can be added using insert, update or copy from. New
+  New columns can be added using ``INSERT``, ``UPDATE`` or ``COPY FROM``. New
   columns added to ``dynamic`` tables are, once added, usable as usual
-  columns. One can retrieve them, sort by them and use them in where
+  columns. One can retrieve them, sort by them and use them in ``WHERE``
   clauses.
 
-For further details and examples see :ref:`column_policy` or :ref:`config`.
+.. SEEALSO::
+
+    :ref:`Data definition: Column policy <column_policy>`
+
+    :ref:`config`
 
 
 .. _sql-create-table-max-ngram-diff:
@@ -835,8 +857,8 @@ For further details and examples see :ref:`column_policy` or :ref:`config`.
 ``max_ngram_diff``
 ------------------
 
-Specifies the maximum difference between max_ngram and min_ngram when using
-the NGramTokenizer or the NGramTokenFilter. The default is 1.
+Specifies the maximum difference between ``max_ngram`` and ``min_ngram`` when
+using the ``NGramTokenizer`` or the ``NGramTokenFilter``. The default is 1.
 
 
 .. _sql-create-table-max-shingle-diff:
@@ -844,8 +866,8 @@ the NGramTokenizer or the NGramTokenFilter. The default is 1.
 ``max_shingle_diff``
 --------------------
 
-Specifies the maximum difference between min_shingle_size and max_shingle_size
-when using the ShingleTokenFilter. The default is 3.
+Specifies the maximum difference between ``min_shingle_size`` and
+``max_shingle_size`` when using the ``ShingleTokenFilter``. The default is 3.
 
 
 .. _sql-create-table-merge:
@@ -858,6 +880,7 @@ when using the ShingleTokenFilter. The default is 3.
 ------------------------------------
 
 The maximum number of threads on a single shard that may be merging at once.
-Defaults to ``Math.max(1, Math.min(4, Runtime.getRuntime().availableProcessors() / 2))``
-which works well for a good solid-state-disk (SSD). If your index is on
-spinning platter drives instead, decrease this to 1.
+Defaults to ``Math.max(1, Math.min(4,
+Runtime.getRuntime().availableProcessors() / 2))`` which works well for a good
+solid-state-disk (SSD). If your index is on spinning platter drives instead,
+decrease this to 1.

--- a/docs/sql/statements/create-view.rst
+++ b/docs/sql/statements/create-view.rst
@@ -1,16 +1,18 @@
 .. highlight:: psql
-.. _ref-create-view:
+
+.. _sql-create-view:
 
 ===============
 ``CREATE VIEW``
 ===============
 
-Define a new view.
+Define a new :ref:`view <ddl-views>`.
 
 .. rubric:: Table of contents
 
 .. contents::
     :local:
+
 
 Synopsis
 ========
@@ -20,13 +22,13 @@ Synopsis
     CREATE [ OR REPLACE ] VIEW view_ident AS query
 
 
-Where ``query`` is a :ref:`SELECT statement <sql_reference_select>`.
+Where ``query`` is a :ref:`SELECT <sql-select>` statement.
 
 
 Description
 ===========
 
-CREATE VIEW creates a named definition of a query. This name can be used in
+``CREATE VIEW`` creates a named definition of a query. This name can be used in
 other statements instead of a table name to reference the saved query
 definition. A view is not materialized, instead the query is run every time a
 view is referenced in a query.
@@ -45,7 +47,7 @@ operations.
 
 .. SEEALSO::
 
-    :ref:`ref-drop-view`
+    :ref:`SQL syntax: DROP VIEW <sql-drop-view>`
 
 .. NOTE::
 

--- a/docs/sql/statements/drop-function.rst
+++ b/docs/sql/statements/drop-function.rst
@@ -1,16 +1,18 @@
 .. highlight:: psql
+
 .. _ref-drop-function:
 
 =================
 ``DROP FUNCTION``
 =================
 
-Drop a function.
+Drop a :ref:`function <user-defined-functions>`.
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
 
 Synopsis
 ========
@@ -20,11 +22,14 @@ Synopsis
     DROP FUNCTION [ IF EXISTS ] function_name
         ( [ [ arg_name ] arg_type [, ...] ] )
 
+
 Description
 ===========
 
-``DROP FUNCTION`` drops a function. A function name and argument types must be
-specified.
+``DROP FUNCTION`` drops a :ref:`user-defined function
+<user-defined-functions>`. The ``function_name`` and respective ``arg_type``
+variables must be specified.
+
 
 Parameters
 ==========
@@ -38,12 +43,10 @@ Parameters
 :arg_name:
   The name given to an argument.
 
-  Function arguments do not retain names, but you can name them in your
-  query for documentation purposes. Note that ``DROP FUNCTION`` will
-  ignore argument names, since only the argument data types are needed
-  to identify the function.
+  Function arguments do not retain names, but you can name them in your query
+  for documentation purposes. Note that ``DROP FUNCTION`` will ignore argument
+  names, since only the argument data types are needed to identify the
+  function.
 
 :arg_type:
-  The data type of an argument, if any.
-
-  See :ref:`data-types` for more information about the supported types.
+  The :ref:`data type <data-types>` of an argument, if any.

--- a/docs/sql/statements/drop-view.rst
+++ b/docs/sql/statements/drop-view.rst
@@ -1,16 +1,18 @@
 .. highlight:: psql
-.. _ref-drop-view:
+
+.. _sql-drop-view:
 
 =============
 ``DROP VIEW``
 =============
 
-Drop one or more views.
+Drop one or more :ref:`views <ddl-views>`.
 
 .. rubric:: Table of contents
 
 .. contents::
     :local:
+
 
 Synopsis
 ========
@@ -23,11 +25,11 @@ Synopsis
 Description
 ===========
 
-Drop view drops one or more existing views.
+``DROP VIEW`` drops one or more existing views.
 
 If a view doesn't exist an error will be returned, unless ``IF EXISTS`` is
 used, in which case all matching existing views will be dropped.
 
 .. SEEALSO::
 
-    :ref:`ref-create-view`
+    :ref:`SQL syntax: CREATE VIEW <sql-create-view>`

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _sql_reference_select:
+
+.. _sql-select:
 
 ==========
 ``SELECT``
@@ -11,6 +12,9 @@ Retrieve rows from a table.
 
 .. contents::
    :local:
+
+
+.. _sql-select-synopsis:
 
 Synopsis
 ========
@@ -32,75 +36,91 @@ where ``relation`` is::
 
     relation_reference | joined_relation | table_function | sub_select
 
+
+.. _sql-select-description:
+
 Description
 ===========
 
-SELECT retrieves rows from a table. The general processing of SELECT is as
-follows:
+``SELECT`` retrieves rows from a table. The general processing of ``SELECT`` is
+as follows:
 
-- The FROM item points to the table where the data should be retrieved from. If
-  no FROM item is specified, the query is executed against a virtual table with
-  no columns.
+- The :ref:`FROM <sql-select-from>` item points to the table where the data
+  should be retrieved from. If no ``FROM`` item is specified, the query is
+  executed against a virtual table with no columns.
 
-- If the WHERE clause is specified, all rows that do not satisfy the condition
-  are eliminated from the output. (See WHERE Clause below.)
+- If the :ref:`WHERE <sql-select-where>` clause is specified, all rows that do
+  not satisfy the condition are eliminated from the output.
 
-- If the GROUP BY clause is specified, the output is combined into groups of
-  rows that match on one or more values.
+- If the :ref:`GROUP BY <sql-select-group-by>` clause is specified, the output
+  is combined into groups of rows that match on one or more values.
 
-- The actual output rows are computed using the SELECT output expressions for
-  each selected row or row group.
+- The actual output rows are computed using the ``SELECT`` output expressions
+  for each selected row or row group.
 
-- If the ORDER BY clause is specified, the returned rows are sorted in the
-  specified order. If ORDER BY is not given, the rows are returned in whatever
-  order the system finds fastest to produce.
+- If the :ref:`ORDER BY <sql-select-order-by>` clause is specified, the
+  returned rows are sorted in the specified order. If ``ORDER BY`` is not
+  given, the rows are returned in whatever order the system finds fastest to
+  produce.
 
-- If DISTINCT is specified, one unique row is kept. All other duplicate rows
-  are removed from the result set.
+- If :ref:`DISTINCT <sql-select-list>` is specified, one unique row is
+  kept. All other duplicate rows are removed from the result set.
 
-- If the LIMIT or OFFSET clause is specified, the SELECT statement only returns
-  a subset of the result rows.
+- If the :ref:`LIMIT <sql-select-limit>` or :ref:`OFFSET <sql-select-offset>`
+  clause is specified, the ``SELECT`` statement only returns a subset of the
+  result rows.
+
+
+.. _sql-select-parameters:
 
 Parameters
 ==========
 
-.. _sql_reference_select_list:
+
+.. _sql-select-list:
 
 The ``SELECT`` List
 -------------------
 
-The SELECT list specifies expressions that form the output rows of the SELECT
-statement. The expressions can (and usually do) refer to columns computed in
-the FROM clause.
+The ``SELECT`` list specifies expressions that form the output rows of the
+``SELECT`` statement. The expressions can (and usually do) refer to columns
+computed in the ``FROM`` clause.
 
 ::
 
     SELECT [ ALL | DISTINCT ] * | expression [ [ AS ] output_name ] [, ...]
 
-Just as in a table, every output column of a SELECT has a name. In a simple
-SELECT this name is just used to label the column for display. To specify the
-name to use for an output column, write AS ``output_name`` after the column's
-``expression``. (You can omit AS, but only if the desired output name does not
-match any reserved keyword. For protection against possible future keyword
-additions, it is recommended that you always either write AS or double-quote
-the output name.) If you do not specify a column name, a name is chosen
-automatically by CrateDB. If the column's expression is a simple column
-reference then the chosen name is the same as that column's name. In more
-complex cases a function or type name may be used, or the system may fall back
-on a generated name.
+Just as in a table, every output column of a ``SELECT`` has a name. In a simple
+``SELECT``, this name is just used to label the column for display. To specify
+the name to use for an output column, write ``AS output_name`` after the
+column's ``expression``. (You can omit ``AS``, but only if the desired output
+name does not match any reserved keyword. For protection against possible
+future keyword additions, it is recommended that you always either write ``AS``
+or double-quote the output name.) If you do not specify a column name, a name
+is chosen automatically by CrateDB. If the column's expression is a simple
+column reference, then the chosen name is the same as that column's name. In
+more complex cases, a :ref:`function <gloss-function>` or type name may be
+used, or the system may fall back on a generated name.
 
-An output column's name can be used to refer to the column's value in ORDER BY
-and GROUP BY clauses, but not in the WHERE clause; there you must write out the
-expression instead.
+An output column's name can be used to refer to the column's value in
+:ref:`ORDER BY <sql-select-order-by>` and :ref:`GROUP BY <sql-select-group-by>`
+clauses, but not in the :ref:`WHERE <sql-select-where>` clause; there you must
+write out the expression instead.
 
 Instead of an expression, ``*`` can be written in the output list as a
 shorthand for all the columns of the selected rows. Also, you can write
-table_name.* as a shorthand for the columns coming from just that table. In
-these cases it is not possible to specify new names with AS; the output column
-names will be the same as the table columns' names.
+``table_name.*`` as a shorthand for the columns coming from just that table. In
+these cases it is not possible to specify new names with ``AS``; the output
+column names will be the same as the table columns' names.
+
+
+.. _sql-select-clauses:
 
 Clauses
 -------
+
+
+.. _sql-select-over:
 
 ``OVER``
 ........
@@ -111,18 +131,27 @@ The ``OVER`` clause defines a window.
 
    OVER ( window_definition )
 
-The ``window_definition`` determines the partitioning and ordering of
-rows before the window function is applied. For detailed information,
-see :ref:`window-definition`.
+The ``window_definition`` determines the partitioning and ordering of rows
+before the :ref:`window function <window-functions>` is applied.
+
+.. SEEALSO::
+
+    :ref:`Window functions: Window definition <window-definition>`
+
+
+.. _sql-select-from:
 
 ``FROM``
 ........
 
-The FROM clause specifies the source relation for the SELECT::
+The ``FROM`` clause specifies the source relation for the ``SELECT``::
 
     FROM relation
 
 The relation can be any of the following relations.
+
+
+.. _sql-select-relation-reference:
 
 Relation reference
 ''''''''''''''''''
@@ -138,65 +167,75 @@ view with an optional alias::
 .. _sql_reference_relation_alias:
 
 :alias:
-  A substitute name for the FROM item containing the alias.
+  A substitute name for the ``FROM`` item containing the alias.
 
   An alias is used for brevity. When an alias is provided, it completely hides
   the actual name of the relation. For example given ``FROM foo AS f``, the
-  remainder of the SELECT must refer to this ``FROM`` item as ``f`` not
+  remainder of the ``SELECT`` must refer to this ``FROM`` item as ``f`` not
   ``foo``.
 
 .. SEEALSO::
 
-    :ref:`sql-create-table`
+    :ref:`SQL syntax: CREATE TABLE <sql-create-table>`
 
-    :ref:`ref-create-view`
+    :ref:`SQL syntax: CREATE VIEW <sql-create-view>`
 
-.. _sql_reference_joined_tables:
+
+.. _sql-select-joined-relation:
 
 Joined relation
 '''''''''''''''
 
-A ``joined_relation`` is a relation which joins two relations together. See
-:ref:`sql_dql_joins` ::
+A ``joined_relation`` is a relation which :ref:`joins <sql_dql_joins>` two
+relations together.
+
+::
 
     relation { , | join_type JOIN } relation [ { ON join_condition  |  USING (col_names) } ]
 
 :join_type:
-  ``LEFT [OUTER]``, ``RIGHT [OUTER]``, ``FULL [OUTER]``, ``CROSS`` or ``INNER``.
+  ``LEFT [OUTER]``, ``RIGHT [OUTER]``, ``FULL [OUTER]``, ``CROSS`` or
+  ``INNER``.
 
 :join_condition:
   An expression which specifies which rows in a join are considered a
   match.
 
-  The join_condition is not applicable for joins of type CROSS and must
+  The ``join_condition`` is not applicable for joins of type ``CROSS`` and must
   have a returning value of type ``boolean``.
 
 :col_names:
   A comma-separated list of column names. The joined relations need to contain
   the specified columns.
 
+
+.. _sql-select-table-function:
+
 Table function
 ''''''''''''''
 
-``table_function`` is a function that produces a set of rows and has columns.
+``table_function`` is a :ref:`function <gloss-function>` that produces a set of
+rows and has columns.
 
 ::
 
     function_call
 
 :function_call:
-  The call declaration of the function. Usually in the form of ``function_name
-  ( [ args ] )``.
+  The :ref:`call declaration <sql-function-call>` of the function. Usually in
+  the form of ``function_name ( [ args ] )``.
 
-  Depending on the function the parenthesis and arguments are either
-  optional or required.
+  Depending on the function the parenthesis and arguments are either optional
+  or required.
 
-Available functions are documented in the :ref:`table functions
-<ref-table-functions>` section.
+.. SEEALSO::
 
-.. _sql_reference_subselect:
+    :ref:`Built-ins: Table functions <table-functions>`
 
-Sub select
+
+.. _sql-select-sub-select:
+
+Sub-select
 ''''''''''
 
 A ``sub_select`` is another ``SELECT`` statement surrounded by parentheses with
@@ -211,15 +250,18 @@ clauses of the surrounding ``SELECT`` statements are applied on the result of
 the inner ``SELECT`` statement.
 
 :select_stmt:
-  A :ref:`SELECT <sql_reference_select>` statement.
+  A ``SELECT`` statement.
 
 :alias:
-  An :ref:`alias <sql_reference_relation_alias>` for the sub select.
+  An :ref:`alias <sql_reference_relation_alias>` for the sub-select.
+
+
+.. _sql-select-where:
 
 ``WHERE``
 .........
 
-The optional WHERE clause defines the condition to be met for a row to be
+The optional ``WHERE`` clause defines the condition to be met for a row to be
 returned::
 
     WHERE condition
@@ -228,98 +270,107 @@ returned::
   A where condition is any expression that evaluates to a result of type
   boolean.
 
-  Any row that does not satisfy this condition will be eliminated from
-  the output. A row satisfies the condition if it returns true when the
-  actual row values are substituted for any variable references.
+  Any row that does not satisfy this condition will be eliminated from the
+  output. A row satisfies the condition if it returns true when the actual row
+  values are substituted for any variable references.
 
-.. _sql_reference_group_by:
+
+.. _sql-select-group-by:
 
 ``GROUP BY``
 ............
 
-The optional GROUP BY clause will condense into a single row all selected rows
-that share the same values for the grouped expressions.
+The optional ``GROUP BY`` clause will condense all selected rows that share the
+same values for the grouped expression into a single row.
 
-Aggregate expressions, if any are used, are computed across all rows making up
-each group, producing a separate value for each group.
+:ref:`Aggregate expressions <aggregation-expressions>`, if any are used, are
+computed across all rows making up each group, producing a separate value for
+each group.
 
 ::
 
     GROUP BY expression [, ...] [HAVING condition]
 
 :expression:
-  An arbitrary expression formed from column references of the queried
-  relation that are also present in the result column list. Numeric
-  literals are interpreted as ordinals referencing an output column from
-  the select list.
+  An arbitrary :ref:`expression <sql-value-expressions>` formed from column
+  references of the queried relation that are also present in the result column
+  list. Numeric literals are interpreted as ordinals referencing an output
+  column from the select list.
 
   It can also reference output columns by name.
 
-  In case of ambiguity, a GROUP BY name will be interpreted as a name of
-  a column from the queried relation rather than an output column name.
+  In case of ambiguity, a ``GROUP BY`` name will be interpreted as a name of a
+  column from the queried relation rather than an output column name.
 
-.. _sql_reference_having:
+
+.. _sql-select-having:
 
 ``HAVING``
 ''''''''''
 
-The optional HAVING clause defines the condition to be met for values whitin a
-resulting row of a group by clause.
+The optional ``HAVING`` clause defines the condition to be met for values
+within a resulting row of a ``GROUP BY`` clause.
 
 :condition:
-  A having condition is any expression that evaluates to a result of
-  type boolean. Every row for which the condition is not satisfied will
-  be eliminated from the output.
+  A ``HAVING`` condition is any expression that evaluates to a result of type
+  boolean. Every row for which the condition is not satisfied will be
+  eliminated from the output.
 
 .. NOTE::
 
-   When GROUP BY is present, it is not valid for the SELECT list expressions to
-   refer to ungrouped columns except within aggregate functions, since there
-   would otherwise be more than one possible value to return for an ungrouped
-   column.
+   When ``GROUP BY`` is present, it is not valid for the ``SELECT`` list
+   expressions to refer to ungrouped columns except within :ref:`aggregate
+   functions <aggregation-functions>`, since there would otherwise be more than
+   one possible value to return for an ungrouped column.
 
-   Additionally, grouping can only be applied on indexed fields. For more
-   information, please refer to :ref:`sql_ddl_index_off`.
+   Additionally, grouping can only be applied on indexed fields.
 
-.. _sql_reference_union:
+.. SEEALSO::
+
+    :ref:`Fulltext indices : Disable indexing <sql_ddl_index_off>`
+
+
+.. _sql-select-union-all:
 
 UNION ALL
 .........
 
-The UNION ALL :ref:`operator <gloss-operator>` combines the result sets of two
-or more SELECT statements. The two SELECT statements that represent the direct
-:ref:`operands <gloss-operand>` of the UNION ALL must produce the same number
-of columns, and corresponding columns must be of the same data types. The
-result of UNION ALL may contain duplicate rows. You can find :ref:`here
-<sql_union>` sample usage of UNION ALL.
+The ``UNION ALL`` :ref:`operator <gloss-operator>` combines the result sets of
+two or more ``SELECT`` statements. The two ``SELECT`` statements that represent
+the direct :ref:`operands <gloss-operand>` of the ``UNION ALL`` must produce
+the same number of columns, and corresponding columns must be of the same data
+types. The result of ``UNION ALL`` may contain duplicate rows. You can find
+:ref:`here <sql_union>` sample usage of ``UNION ALL``.
 
 ::
 
     UNION ALL query_specification
 
 :query_specification:
-  Can be any SELECT statement.
+  Can be any ``SELECT`` statement.
+
+``ORDER BY``, ``LIMIT``, and ``OFFSET`` can only be applied after the last
+``SELECT`` statement of the ``UNION ALL``, as they are applied to the complete
+result of the ``UNION`` operation. In order to apply an ``ORDER BY`` and/or
+``LIMIT`` and/or ``OFFSET`` to any of the partial ``SELECT`` statements, those
+statements need to become subqueries.
+
+Column names used in ``ORDER BY`` must be position numbers or refer to the
+outputs of the first ``SELECT`` statement, and no :ref:`functions
+<gloss-function>` can be applied on top of the ``ORDER BY`` symbols. To achieve
+more complex ordering, ``UNION ALL`` must become a subselect and the more
+complex ``ORDER BY`` should be applied on the outer ``SELECT`` wrapping the
+``UNION ALL`` subselect.
+
+The ordering of the outcome is not guaranteed unless ``ORDER BY`` is used.
 
 
-ORDER BY, LIMIT and OFFSET can only be applied after the last SELECT statement
-of the UNION ALL, as they are applied to the complete result of the UNION
-operation. In order to apply an ORDER BY and/or LIMIT and/or OFFSET to any of
-the partial SELECT statements, those statements need to become subqueries.
-
-Column names used in ORDER BY must be position numbers or refer to the outputs
-of the first SELECT statement, and no functions can be applied on top of the
-ORDER BY symbols. To achieve more complex ordering UNION ALL must become a
-subselect and the more complex ORDER BY should be applied on the outer SELECT
-wrapping the UNION ALL subselect.
-
-Ordering of the outcome is not guaranteed unless ORDER BY is used.
-
-.. _sql_reference_order_by:
+.. _sql-select-order-by:
 
 ``ORDER BY``
 ............
 
-The ORDER BY clause causes the result rows to be sorted according to the
+The ``ORDER BY`` clause causes the result rows to be sorted according to the
 specified expression(s).
 
 ::
@@ -330,14 +381,15 @@ specified expression(s).
   Can be the name or ordinal number of an output column, or it can be an
   arbitrary expression formed from input-column values.
 
-The optional keyword ASC (ascending) or DESC (descending) after any expression
-allows to define the direction in which values have are sorted. The default is
-ascending.
+The optional keyword ``ASC`` (ascending) or ``DESC`` (descending) after any
+expression allows to define the direction in which values are sorted. The
+default is ascending.
 
-If NULLS FIRST is specified, null values sort before non null values. If NULLS
-LAST is specified null values sort after non null values.  If neither is
-specified nulls are considered larger than any value. That means the default
-for ASC is NULLS LAST and the default for DESC is NULLS FIRST.
+If ``NULLS FIRST`` is specified, null values sort before non-null values. If
+``NULLS LAST`` is specified, null values sort after non-null values.  If
+neither is specified nulls are considered larger than any value. That means the
+default for ``ASC`` is ``NULLS LAST`` and the default for ``DESC`` is ``NULLS
+FIRST``.
 
 If two rows are equal according to the leftmost expression, they are compared
 according to the next expression and so on. If they are equal according to all
@@ -347,38 +399,48 @@ Character-string data is sorted by its UTF-8 representation.
 
 .. NOTE::
 
-    Sorting can only be applied on indexed fields. For more information, please
-    refer to :ref:`sql_ddl_index_off`.
-
+    Sorting can only be applied on indexed fields.
 
     Additionally, sorting on :ref:`geo_point_data_type`,
     :ref:`geo_shape_data_type`, :ref:`data-type-array`, and
     :ref:`object_data_type` is not supported.
 
-.. _sql_reference_window:
+.. SEEALSO::
+
+    :ref:`Fulltext indices : Disable indexing <sql_ddl_index_off>`
+
+
+.. _sql-select-window:
 
 ``WINDOW``
 ..........
 
-The optional WINDOW clause has a form:
+The optional ``WINDOW`` clause has a form:
 
 ::
 
    WINDOW window_name AS ( window_definition ) [, ...]
 
-The ``window_name`` is a name that can be referenced from ``OVER`` clauses
-or subsequent window definitions.
+The ``window_name`` is a name that can be referenced from ``OVER`` clauses or
+subsequent window definitions.
 
-The ``window_definition`` determines the partitioning and ordering of
-rows before the window function is applied. For detailed information,
-see :ref:`window-definition`.
+The ``window_definition`` determines the partitioning and ordering of rows
+before the :ref:`window function <window-functions>` is applied.
 
-See also, :ref:`named-windows`.
+.. SEEALSO::
+
+    :ref:`Window functions: Window definition <window-definition>`
+
+    :ref:`Window functions: Named windows <window-definition-named-windows>`
+
+
+.. _sql-select-limit:
 
 ``LIMIT``
 .........
 
-The optional LIMIT Clause allows to limit the number or retured result rows::
+The optional ``LIMIT`` clause allows to limit the number of returned result
+rows::
 
     LIMIT num_results
 
@@ -387,14 +449,17 @@ The optional LIMIT Clause allows to limit the number or retured result rows::
 
 .. NOTE::
 
-   It is possible for repeated executions of the same LIMIT query to return
-   different subsets of the rows of a table, if there is not an ORDER BY to
+   It is possible for repeated executions of the same ``LIMIT`` query to return
+   different subsets of the rows of a table, if there is not an ``ORDER BY`` to
    enforce selection of a deterministic subset.
+
+
+.. _sql-select-offset:
 
 ``OFFSET``
 ..........
 
-The optional OFFSET Clause allows to skip result rows at the beginning::
+The optional ``OFFSET`` clause allows to skip result rows at the beginning::
 
     OFFSET start
 


### PR DESCRIPTION
added "function" to the glossary. we have a bunch of documentation for specific types of function. the bulk of the cross-references adds links to these function-specific docs (instead of the glossary)

the commit message has more details

where I added cross-references, I ended up reformatting the RST for line-length reasons. I took the opportunity to add a lot of related RST improvements

this is a BIG changeset because there were so many function-related terms to cross-reference and so many RST problems. I think could have improved things if I made one commit per specific function type

if you would like, I think I could probably decompose the changes into three commits:

- one for changes to the glossary
- one for changes to the main docs
- one for changes to the release notes

feedback is welcome for how I can improve my commit strategy for follow-up glossary terms. part of the problem is that adding links to existing paragraphs necessitates re-wrapping and this re-wrapping is what generates most of the diff noise

---

*Edit: for nomi/gloss-20210302-03 I am taking the approach outlined above: splitting things up into glossary additions and separate commits for each term-related main docs changes*