### PR TITLE
Deprecate translog.retention.age and translog.retention.size settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -191,7 +191,7 @@ public final class IndexSettings {
     public static final Setting<TimeValue> INDEX_TRANSLOG_RETENTION_AGE_SETTING =
         Setting.timeSetting("index.translog.retention.age",
             settings -> shouldDisableTranslogRetention(settings) ? TimeValue.MINUS_ONE : TimeValue.timeValueHours(12),
-            TimeValue.MINUS_ONE, Property.Dynamic, Property.IndexScope);
+            TimeValue.MINUS_ONE, Property.Dynamic, Property.IndexScope, Property.Deprecated);
 
     /**
      * Controls how many translog files that are no longer needed for persistence reasons
@@ -202,7 +202,7 @@ public final class IndexSettings {
     public static final Setting<ByteSizeValue> INDEX_TRANSLOG_RETENTION_SIZE_SETTING =
         Setting.byteSizeSetting("index.translog.retention.size",
             settings -> shouldDisableTranslogRetention(settings) ? "-1" : "512MB",
-            Property.Dynamic, Property.IndexScope);
+            Property.Dynamic, Property.IndexScope, Property.Deprecated);
 
     /**
      * Controls the number of translog files that are no longer needed for persistence reasons will be kept around before being deleted.

--- a/server/src/test/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/test/java/org/elasticsearch/test/ESTestCase.java
@@ -388,10 +388,16 @@ public abstract class ESTestCase extends LuceneTestCase {
                 DeprecationLogger.getRecentWarnings(),
                 anyOf(
                     Matchers.emptyIterable(),
-                    // As long as index.soft_deletes.enabled settings are deprecated but still used in
+                    // As long as these settings are deprecated but still used in
                     // tests we need to exclude them from the warning here.
                     hasItem(
                         containsString(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey())
+                    ),
+                    hasItem(
+                        containsString(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey())
+                    ),
+                    hasItem(
+                        containsString(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey())
                     )
                 )
             );


### PR DESCRIPTION
These settings wil become obsolete once soft-deletes are becoming
default. Recovery will then soley use soft-deletes.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
