### PR TITLE
WIP: Try to fix self-sign certificate issue with JDK 16

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -13,7 +13,7 @@ elasticsearchhadoop=2.4.0
 slf4j_log4j12=1.7.10
 jaxb_api=2.2.2
 jopt_simple=5.0.2
-
+bouncycastle=1.68
 
 jackson=2.11.0
 jackson_jaxrs=1.9.13

--- a/plugins/azure-discovery/build.gradle
+++ b/plugins/azure-discovery/build.gradle
@@ -42,6 +42,7 @@ dependencies {
         exclude group: 'commons-codec', module: 'commons-codec'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+        exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
     }
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.apache.lucene:lucene-test-framework:${versions.lucene}"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     }
 
     // Required to use SelfSignedCertificate from netty
-    testCompile "org.bouncycastle:bcpkix-jdk15on:1.68"
+    testCompile "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
 }
 
 //noinspection GroovyAssignabilityCheck


### PR DESCRIPTION
We added the bouncy castle lib which is used by netty as a fallback
if jdk internal modules are not exposed.
JDK 16 blocks illegal access now, see https://openjdk.java.net/jeps/396.

The Azure discovery plugin uses a azure sdk which also has a test
dependency to bouncy castle but different version.
This dependency is excluded now to fix possible version conflicts.

Should fix https://github.com/crate/crate/pull/11149/checks?check_run_id=2134101368#step:4:174.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
