### PR TITLE
[Tests] Fix self-signed SSL Certification generation

### DIFF
--- a/server/src/test/java/io/crate/auth/HostBasedAuthenticationTest.java
+++ b/server/src/test/java/io/crate/auth/HostBasedAuthenticationTest.java
@@ -23,7 +23,6 @@
 package io.crate.auth;
 
 import io.crate.protocols.postgres.ConnectionProperties;
-import org.elasticsearch.test.ESTestCase;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -31,7 +30,9 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -40,6 +41,7 @@ import java.net.InetAddress;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -81,6 +83,15 @@ public class HostBasedAuthenticationTest extends ESTestCase {
     private static final InetAddress LOCALHOST = InetAddresses.forString("127.0.0.1");
 
     private SSLSession sslSession;
+
+    @BeforeClass
+    public static void ensureEnglishLocale() {
+        // BouncyCastle is parsing date objects with the system locale while creating self-signed SSL certs
+        // This fails for certain locales, e.g. 'ks'.
+        // Until this is fixed, we force the english locale.
+        // See also https://github.com/bcgit/bc-java/issues/405 (different topic, but same root cause)
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Before
     private void setUpTest() throws Exception {

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -38,12 +38,14 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.elasticsearch.common.settings.Settings;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.net.ssl.SSLSession;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.EnumSet;
+import java.util.Locale;
 
 import static io.crate.auth.HttpAuthUpstreamHandler.WWW_AUTHENTICATE_REALM_MESSAGE;
 import static org.hamcrest.core.Is.is;
@@ -64,6 +66,15 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         assertThat(resp.status(), is(HttpResponseStatus.UNAUTHORIZED));
         assertThat(resp.content().toString(StandardCharsets.UTF_8), is(expectedBody));
         assertThat(resp.headers().get(HttpHeaderNames.WWW_AUTHENTICATE), is(WWW_AUTHENTICATE_REALM_MESSAGE));
+    }
+
+    @BeforeClass
+    public static void forceEnglishLocale() {
+        // BouncyCastle is parsing date objects with the system locale while creating self-signed SSL certs
+        // This fails for certain locales, e.g. 'ks'.
+        // Until this is fixed, we force the english locale.
+        // See also https://github.com/bcgit/bc-java/issues/405 (different topic, but same root cause)
+        Locale.setDefault(Locale.ENGLISH);
     }
 
     @Test

--- a/server/src/test/java/io/crate/protocols/http/HttpsTransportKeyStoreReloadIntegrationTest.java
+++ b/server/src/test/java/io/crate/protocols/http/HttpsTransportKeyStoreReloadIntegrationTest.java
@@ -40,6 +40,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -60,8 +61,19 @@ public class HttpsTransportKeyStoreReloadIntegrationTest extends SQLHttpIntegrat
         super(true);
     }
 
+    public static void forceEnglishLocale() {
+        // BouncyCastle is parsing date objects with the system locale while creating self-signed SSL certs
+        // This fails for certain locales, e.g. 'ks'.
+        // Until this is fixed, we force the english locale.
+        // See also https://github.com/bcgit/bc-java/issues/405 (different topic, but same root cause)
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+
     @BeforeClass
     public static void beforeTest() throws Exception {
+        forceEnglishLocale();
+
         trustedCert = new SelfSignedCertificate();
 
         keyStoreFile = createTempFile().toFile();

--- a/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
@@ -38,6 +38,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 
@@ -54,8 +55,18 @@ public class SslReqHandlerIntegrationTest extends SQLTransportIntegrationTest {
         super(true);
     }
 
+    public static void forceEnglishLocale() {
+        // BouncyCastle is parsing date objects with the system locale while creating self-signed SSL certs
+        // This fails for certain locales, e.g. 'ks'.
+        // Until this is fixed, we force the english locale.
+        // See also https://github.com/bcgit/bc-java/issues/405 (different topic, but same root cause)
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
     @BeforeClass
     public static void beforeTest() throws Exception {
+        forceEnglishLocale();
+
         trustedCert = new SelfSignedCertificate();
         keyStoreFile = createTempFile().toFile();
 

--- a/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
@@ -36,7 +36,10 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
@@ -44,6 +47,15 @@ import static org.mockito.Mockito.mock;
 public class SslReqHandlerTest extends ESTestCase {
 
     private EmbeddedChannel channel;
+
+    @BeforeClass
+    public static void ensureEnglishLocale() {
+        // BouncyCastle is parsing date objects with the system locale while creating self-signed SSL certs
+        // This fails for certain locales, e.g. 'ks'.
+        // Until this is fixed, we force the english locale.
+        // See also https://github.com/bcgit/bc-java/issues/405 (different topic, but same root cause)
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @After
     public void dispose() {


### PR DESCRIPTION
Due to the usage of JDK 16, we're forced to use the Bouncy Castle library which is used by netty as a fallback impl for generating self-signed certifications.
See https://openjdk.java.net/jeps/396.

But BouncyCastle has an issue when used with random locales as their date/time string parsing isn't fixed to a locale and some locales produce unsupported date/time strings.
See https://github.com/bcgit/bc-java/issues/405.

To workaround this, the locale is forced to `english` at the related tests.

Follow up of https://github.com/crate/crate/commit/d61b7873cb8.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
