### PR TITLE
Fix self-sign certificate generation at the ClientCertAuthTest

### DIFF
--- a/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
+++ b/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
@@ -28,11 +28,13 @@ import org.elasticsearch.test.ESTestCase;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.elasticsearch.common.network.InetAddresses;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
 import java.util.Date;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -44,6 +46,15 @@ public class ClientCertAuthTest extends ESTestCase {
     // "example.com" is the CN used in SelfSignedCertificate
     private User exampleUser = User.of("example.com");
     private SSLSession sslSession;
+
+    @BeforeClass
+    public static void ensureEnglishLocale() {
+        // BouncyCastle is parsing date objects with the system locale while creating self-signed SSL certs
+        // This fails for certain locales, e.g. 'ks'.
+        // Until this is fixed, we force the english locale.
+        // See also https://github.com/bcgit/bc-java/issues/405 (different topic, but same root cause)
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Before
     public void setUpSsl() throws Exception {


### PR DESCRIPTION
Follow up of https://github.com/crate/crate/commit/20c41e8259e

Missed that usage :(

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
