### PR TITLE
Avoid NPE if a channel is closed

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
+++ b/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
@@ -85,7 +85,10 @@ public class DelayableWriteChannel implements Channel {
     @Override
     public ChannelFuture close() {
         ChannelFuture close = delegate.close();
-        delay.releaseAll();
+        DelayedWrites localDelay = delay;  // 1 volatile read
+        if (localDelay != null) {
+            localDelay.releaseAll();
+        }
         return close;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

As far as I can tell this didn't really cause a real issue. Closing the
channel is one of the last actions when a client disconnects.

It resulted in the `exceptionCaught` handler being fired and logging an
error.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)