### PR TITLE
Three improvements for the glossary

### DIFF
--- a/docs/appendices/glossary.rst
+++ b/docs/appendices/glossary.rst
@@ -23,6 +23,14 @@ Terms
 
 .. _gloss-b:
 
+B
+-
+
+.. _gloss-binary-operator:
+
+**Binary operator**
+    See :ref:`operation <gloss-operation>`.
+
 
 .. _gloss-c:
 
@@ -32,7 +40,7 @@ C
 .. _gloss-clustered-by-column:
 
 **CLUSTERED BY column**
-    Better known as a :ref:`routing column <gloss-routing-column>`.
+    See :ref:`routing column <gloss-routing-column>`.
 
 
 .. _gloss-d:
@@ -40,9 +48,38 @@ C
 
 .. _gloss-e:
 
+E
+-
+
+.. _gloss-evaluation:
+
+**Evaluation**
+    See :ref:`expression <gloss-expression>`.
+
+.. _gloss-expression:
+
+**Expression**
+    Any valid SQL that produces a value (e.g., :ref:`column references
+    <sql-column-reference>`, :ref:`comparison operators
+    <comparison-operators>`, and :ref:`functions <gloss-function>`) through a
+    process known as *evaluation*.
+
+    Contrary to a :ref:`statement <gloss-statement>`.
+
+.. SEEALSO::
+
+    :ref:`SQL: Value expressions <sql-value-expressions>`
+
+    :ref:`Built-ins: Subquery expressions <sql_subquery_expressions>`
+
+    :ref:`Data definition: Generation expressions <ddl-generated-columns-expressions>`
+
+    :ref:`Scalar functions: Conditional functions and expressions <scalar-conditional-functions-expressions>`
+
+    :ref:`Aggregation: Aggregation expressions <aggregation-expressions>`
+
 
 .. _gloss-f:
-
 
 F
 -
@@ -165,9 +202,10 @@ O
 **Operator**
     A reserved keyword (e.g., :ref:`IN <sql_in_array_comparison>`) or sequence
     of symbols (e.g., :ref:`>= <comparison-operators-basic>`) that can be used
-    in an SQL statement to manipulate one or more expressions and return a
-    result (e.g., ``true`` or ``false``). This process is known as an
-    *operation* and the expressions can be called *operands* or *arguments*.
+    in an SQL statement to manipulate one or more :ref:`expressions
+    <gloss-expression>` and return a result (e.g., ``true`` or ``false``). This
+    process is known as an *operation* and the expressions can be called
+    *operands* or *arguments*.
 
     An operator that takes one operand is known as a *unary operator* and an
     operator that takes two is known as a *binary operator*.
@@ -179,9 +217,6 @@ O
         :ref:`comparison-operators`
 
         :ref:`sql_array_comparisons`
-
-        :ref:`sql_subquery_expressions`
-
 
 
 .. _gloss-p:
@@ -195,8 +230,7 @@ P
     A column used to :ref:`partition a table <partitioned-tables>`. Specified
     by the :ref:`PARTITIONED BY clause <sql-create-table-partitioned-by>`.
 
-    Also known as a :ref:`PARTITIONED BY column <gloss-partitioned-by-column>`
-    or :ref:`partitioned column <gloss-partitioned-column>`.
+    Also known as a *PARTITIONED BY column* or *partitioned column*.
 
     A table may be partitioned by one or more columns:
 
@@ -208,7 +242,7 @@ P
 
     .. SEEALSO::
 
-        :ref:`partitioned-tables`
+        :ref:`Data definition: Partitioned tables <partitioned-tables>`
 
         :ref:`Generated columns: Partitioning
         <ddl-generated-columns-partitioning>`
@@ -235,12 +269,12 @@ P
 .. _gloss-partitioned-by-column:
 
 **PARTITIONED BY column**
-    Better known as a :ref:`partition column <gloss-partition-column>`.
+    See :ref:`partition column <gloss-partition-column>`.
 
 .. _gloss-partitioned-column:
 
 **Partitioned column**
-    Better known as a :ref:`partition column <gloss-partition-column>`.
+    See :ref:`partition column <gloss-partition-column>`.
 
 
 .. _gloss-q:
@@ -251,13 +285,31 @@ P
 R
 -
 
+.. _gloss-regular-expression:
+
+**Regular expression**
+    An :ref:`expression <gloss-expression>` used to search for patterns in a
+    :ref:`string <data-type-varchar>`.
+
+    .. SEEALSO::
+
+        `Wikipedia: Regular expression`_
+
+        :ref:`Data definition: Fulltext analyzers <sql-analyzer>`
+
+        :ref:`Querying: Regular expressions <sql_dql_regexp>`
+
+        :ref:`Scalar functions: Regular expressions <scalar-regexp>`
+
+        :ref:`Table functions: regexp_matches <table-functions-regexp-matches>`
+
 .. _gloss-routing-column:
 
 **Routing column**
     Values in this column are used to compute a hash which is then used to
     route the corresponding row to a specific shard.
 
-    Also known as the :ref:`CLUSTERED BY column <gloss-clustered-by-column>`.
+    Also known as the *CLUSTERED BY column*.
 
     All rows that have the same routing column row value are stored in the same
     shard.
@@ -303,9 +355,8 @@ S
 
     .. NOTE::
 
-        Shard allocation is sometimes referred to as :ref:`shard routing
-        <gloss-shard-routing>`, which is not to be confused with :ref:`row
-        routing <gloss-routing-column>`.
+        Shard allocation is sometimes referred to as *shard routing*, which is
+        not to be confused with :ref:`row routing <gloss-routing-column>`.
 
     .. SEEALSO::
 
@@ -344,8 +395,39 @@ S
 .. _gloss-shard-routing:
 
 **Shard routing**
-    Properly known as :ref:`shard allocation <gloss-shard-allocation>`.
+    See :ref:`shard allocation <gloss-shard-allocation>`.
 
+.. _gloss-statement:
+
+**Statement**
+    Any valid SQL that serves as a database instruction (e.g., :ref:`CREATE
+    TABLE <sql-create-table>`, :ref:`INSERT <ref-insert>`, and :ref:`SELECT
+    <sql-select>`) instead of producing a value.
+
+    Contrary to an :ref:`expression <gloss-expression>`.
+
+    .. SEEALSO::
+
+        :ref:`ddl`
+
+        :ref:`dml`
+
+        :ref:`dql`
+
+        :ref:`sql-statements`
+
+.. _gloss-subquery:
+
+**Subquery**
+    A :ref:`SELECT <sql-select>` statement used as a relation in the :ref:`FROM
+    <sql-select-from>` clause of a parent ``SELECT`` statement.
+
+    Also known as a *subselect*.
+
+.. _gloss-subselect:
+
+**Subselect**
+    See :ref:`subquery <gloss-subquery>`.
 
 .. _gloss-t:
 
@@ -355,13 +437,31 @@ S
 U
 -
 
+.. _gloss-unary-operator:
+
+**Unary operator**
+    See :ref:`operation <gloss-operation>`.
+
 .. _gloss-uncorrelated-subquery:
 
 **Uncorrelated subquery**
-    A subquery that does not reference any relations in a parent statement.
+    A :ref:`scalar subquery <sql-scalar-subquery>` that does not reference any
+    relations (e.g., tables) in the parent :ref:`SELECT <sql-select>`
+    statement.
 
+    .. SEEALSO::
+
+        :ref:`Built-ins: Subquery expressions <sql_subquery_expressions>`
 
 .. _gloss-v:
+
+V
+-
+
+.. _gloss-value-expression:
+
+**Value expression**
+    See :ref:`expression <gloss-expression>`.
 
 
 .. _gloss-w:
@@ -374,3 +474,6 @@ U
 
 
 .. _gloss-z:
+
+
+.. _Wikipedia\: Regular expression: https://en.wikipedia.org/wiki/Regular_expression

--- a/docs/appendices/release-notes/2.1.1.rst
+++ b/docs/appendices/release-notes/2.1.1.rst
@@ -56,8 +56,8 @@ Changes
 - Enabled ``mapping.total_fields.limit`` setting for tables in order to be able
   to increase maximum number of columns higher than the default of ``1000``.
 
-- :ref:Table functions <table-functions>` now support value expressions as
-  arguments.
+- :ref:`Table functions <table-functions>` now support :ref:`value expressions
+  <sql-value-expressions>` as arguments.
 
 Fixes
 -----

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1983,7 +1983,7 @@ See the API documentation for more details.
 .. NOTE::
 
    Be aware that, in contrast to the functions, the :ref:`regular expression
-   operator <sql_ddl_regexp>` uses `Lucene Regular Expressions`_.
+   operator <sql_dql_regexp>` uses `Lucene Regular Expressions`_.
 
 .. _Lucene Regular Expressions: https://lucene.apache.org/core/4_9_0/core/org/apache/lucene/util/automaton/RegExp.html
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2384,6 +2384,7 @@ null_string
 If the ``null_string`` argument is omitted or NULL, none of the substrings of
 the input will be replaced by NULL.
 
+.. _scalar-conditional-functions-expressions:
 
 Conditional functions and expressions
 =====================================

--- a/docs/general/builtins/subquery-expressions.rst
+++ b/docs/general/builtins/subquery-expressions.rst
@@ -11,7 +11,7 @@ returns a boolean value (i.e., ``true`` or ``false``) or ``NULL``.
 
 .. SEEALSO::
 
-    :ref:`sql_array_comparisons`
+    :ref:`sql-scalar-subquery`
 
 .. rubric:: Table of contents
 

--- a/docs/general/ddl/index.rst
+++ b/docs/general/ddl/index.rst
@@ -1,5 +1,6 @@
 .. highlight:: psql
-.. _sql_ddl:
+
+.. _ddl:
 
 ===============
 Data definition

--- a/docs/general/ddl/index.rst
+++ b/docs/general/ddl/index.rst
@@ -6,6 +6,16 @@
 Data definition
 ===============
 
+This section provides an overview of how to create tables and perform other
+data-definition related operations with CrateDB.
+
+.. SEEALSO::
+
+    :ref:`General use: Data manipulation <dml>`
+
+    :ref:`General use: Querying <dql>`
+
+
 .. rubric:: Table of contents
 
 .. toctree::

--- a/docs/general/dml.rst
+++ b/docs/general/dml.rst
@@ -6,6 +6,15 @@
 Data manipulation
 =================
 
+This section provides an overview of how to manipulate data (e.g., inserting
+rows) with CrateDB.
+
+.. SEEALSO::
+
+    :ref:`General use: Data definition <ddl>`
+
+    :ref:`General use: Querying <dql>`
+
 .. rubric:: Table of contents
 
 .. contents::

--- a/docs/general/dql/index.rst
+++ b/docs/general/dql/index.rst
@@ -1,12 +1,13 @@
 .. highlight:: psql
-.. _sql_dql:
+
+.. _dql:
 
 ========
 Querying
 ========
 
-This section provides an overview on how to query documents using SQL.  See
-:ref:`sql_ddl` for information about `Table creation` and other Data Definition
+This section provides an overview on how to query documents using SQL. See
+:ref:`ddl` for information about `Table creation` and other Data Definition
 statements.
 
 .. rubric:: Table of contents

--- a/docs/general/dql/index.rst
+++ b/docs/general/dql/index.rst
@@ -6,9 +6,13 @@
 Querying
 ========
 
-This section provides an overview on how to query documents using SQL. See
-:ref:`ddl` for information about `Table creation` and other Data Definition
-statements.
+This section provides an overview of how to query CrateDB.
+
+.. SEEALSO::
+
+    :ref:`General use: Data definition <ddl>`
+
+    :ref:`General use: Data manipulation <dml>`
 
 .. rubric:: Table of contents
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -167,12 +167,13 @@ CrateDB supports a variety of :ref:`comparison operators
 and so on).
 
 
-.. _sql_ddl_regexp:
+.. _sql_dql_regexp:
 
 Regular expressions
 -------------------
 
-:ref:`Operators <gloss-operator>` for matching using regular expressions:
+:ref:`Comparison operators <comparison-operators-where>` for matching using
+regular expressions:
 
 .. list-table::
    :widths: 5 20 15

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -360,7 +360,14 @@ Type casts
 ----------
 
 CrateDB accepts the :ref:`type_conversion` syntax for conversion of one data
-type to another (see `Value Expressions`_).
+type to another.
+
+.. SEEALSO::
+
+    `PostgreSQL value expressions`_
+
+    :ref:`CrateDB value expressions <sql-value-expressions>`
+
 
 Arrays
 ------
@@ -433,4 +440,4 @@ either because of the table is empty or by a not matching where clause.
 .. _PostgreSQL JDBC Query docs: https://jdbc.postgresql.org/documentation/head/query.html
 .. _PostgreSQL simple query: https://www.postgresql.org/docs/current/static/protocol-flow.html#id-1.10.5.7.4
 .. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/current/static/protocol.html
-.. _Value Expressions: https://www.postgresql.org/docs/current/static/sql-expressions.html
+.. _PostgreSQL value expressions: https://www.postgresql.org/docs/current/static/sql-expressions.html

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -79,16 +79,17 @@ Parameter references can either be unnumbered or numbered:
 Operator invocation
 ===================
 
-An :ref:`operator <gloss-operator>` can be invoked as a value expression in two
-ways:
+An :ref:`operator <gloss-operator>` can be invoked as a value expression in one
+of two way: *binary* or *unary*.
 
-- Binary: ``expression operator expression``
+The syntax of a binary operator::
 
-- Unary: ``operator expression``
+    expression operator expression
 
-.. SEEALSO::
+The syntax of a unary operator::
 
-    :ref:`comparison-operators`
+    operator expression
+
 
 .. _sql-subscripts:
 

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -6,9 +6,8 @@
 Value expressions
 =================
 
-Value expressions are expressions which return a single value.
-
-They can be used in many contexts of many statements.
+A value :ref:`expression <gloss-expression>` is a combination of one or more
+values, operators, and functions that *evaluates* to a single value.
 
 .. rubric:: Table of contents
 
@@ -260,8 +259,9 @@ Example::
 Scalar subquery
 ===============
 
-A :ref:`scalar <gloss-scalar>` subquery is a subquery that returns a single
-value (i.e., one row with one column).
+A scalar subquery (also known as a :ref:`subquery expression
+<sql_subquery_expressions>`) is a subquery that returns a single value (i.e.,
+one row with one column).
 
 If zero rows are returned, it will be treated as null value. In the case that
 more than one row (or more than one column) is returned, CrateDB will treat it

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -80,7 +80,7 @@ Operator invocation
 ===================
 
 An :ref:`operator <gloss-operator>` can be invoked as a value expression in one
-of two way: *binary* or *unary*.
+of two ways: *binary* or *unary*.
 
 The syntax of a binary operator::
 

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -1,3 +1,5 @@
+.. _sql-statements:
+
 ==============
 SQL Statements
 ==============

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -29,7 +29,8 @@ Synopsis
 Description
 ===========
 
-``INSERT`` creates one or more rows specified by value expressions.
+``INSERT`` creates one or more rows specified by :ref:`value expressions
+<sql-value-expressions>`.
 
 The target column names can be listed in any order. If the target column names
 are omitted, they default to all columns of the table or up to N columns if

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -34,7 +34,7 @@ Synopsis
 
 where ``relation`` is::
 
-    relation_reference | joined_relation | table_function | sub_select
+    relation_reference | joined_relation | table_function | subselect
 
 
 .. _sql-select-description:
@@ -235,17 +235,17 @@ rows and has columns.
 
 .. _sql-select-sub-select:
 
-Sub-select
+Subselect
 ''''''''''
 
-A ``sub_select`` is another ``SELECT`` statement surrounded by parentheses with
+A ``subselect`` is another ``SELECT`` statement surrounded by parentheses with
 an alias:
 
 ::
 
     ( select_stmt ) [ AS ] alias
 
-The sub-select behaves like a temporary table that is evaluated at runtime. The
+The subselect behaves like a temporary table that is evaluated at runtime. The
 clauses of the surrounding ``SELECT`` statements are applied on the result of
 the inner ``SELECT`` statement.
 
@@ -253,7 +253,7 @@ the inner ``SELECT`` statement.
   A ``SELECT`` statement.
 
 :alias:
-  An :ref:`alias <sql_reference_relation_alias>` for the sub-select.
+  An :ref:`alias <sql_reference_relation_alias>` for the subselect.
 
 
 .. _sql-select-where:


### PR DESCRIPTION
three improvements for the glossary:

- Add more terms to the glossary
- Improve the documentation of binary and unary operators
- Improve cross-references for "value expression" term

see commit messages for details

this is based off of `nomi/gloss-20210302-02`, but once that branch is merged, I will rebase onto `master`
