### PR TITLE
Cross-link uses of the word "expression" in the docs

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -64,6 +64,11 @@ Cluster license
 The ``sys.cluster.license`` :ref:`expression <gloss-expression>` returns
 information about the currently registered license.
 
+.. NOTE::
+
+      Licenses were removed in CrateDB 4.5. Accordingly, these values are
+      deprecated and return `NULL` in CrateDB 4.5 and higher.
+
 ``license``
 -----------
 

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -61,8 +61,8 @@ The result has at most 1 row::
 Cluster license
 ---------------
 
-The ``sys.cluster.license`` expression returns information about the currently
-registered license.
+The ``sys.cluster.license`` :ref:`expression <gloss-expression>` returns
+information about the currently registered license.
 
 ``license``
 -----------
@@ -88,8 +88,8 @@ registered license.
 Cluster settings
 ----------------
 
-The ``sys.cluster.settings`` expression returns information about the currently
-applied cluster settings.
+The ``sys.cluster.settings`` :ref:`expression <gloss-expression>` returns
+information about the currently applied cluster settings.
 
 ::
 

--- a/docs/appendices/glossary.rst
+++ b/docs/appendices/glossary.rst
@@ -72,9 +72,11 @@ E
 
     :ref:`Built-ins: Subquery expressions <sql_subquery_expressions>`
 
-    :ref:`Data definition: Generation expressions <ddl-generated-columns-expressions>`
+    :ref:`Data definition: Generation expressions
+    <ddl-generated-columns-expressions>`
 
-    :ref:`Scalar functions: Conditional functions and expressions <scalar-conditional-functions-expressions>`
+    :ref:`Scalar functions: Conditional functions and expressions
+    <scalar-conditional-functions-expressions>`
 
     :ref:`Aggregation: Aggregation expressions <aggregation-expressions>`
 

--- a/docs/appendices/release-notes/1.0.0.rst
+++ b/docs/appendices/release-notes/1.0.0.rst
@@ -76,9 +76,9 @@ Changes
 - Nested numeric factors do not require brackets any more; e.g. ``SELECT + -
   10`` is now supported.
 
-- Added subscript support for ``cast`` and ``try_cast`` expressions. e.g.:
-  ``select cast(coordinates as array(double))[1] from sys.summits`` is now
-  possible
+- Added subscript support for ``cast`` and ``try_cast`` :ref:`expressions
+  <gloss-expression>`. e.g.: ``SELECT cast(coordinates AS array(double))[1]
+  FROM sys.summits`` is now possible
 
 - Upgraded Elasticsearch to 2.4.2.
 

--- a/docs/appendices/release-notes/1.0.1.rst
+++ b/docs/appendices/release-notes/1.0.1.rst
@@ -70,7 +70,7 @@ Fixes
    type ``S3`` are now parsed correctly.
 
  - CrateDB no longer throws an error when ``ANY`` or ``ALL`` array comparison
-   expressions are used in ``SELECT`` list. e.g.::
+   :ref:`expressions <gloss-expression>` are used in ``SELECT`` list. e.g.::
 
        select 'foo' = any(some_array)
 

--- a/docs/appendices/release-notes/1.0.4.rst
+++ b/docs/appendices/release-notes/1.0.4.rst
@@ -68,6 +68,7 @@ Fixes
  - Index columns based on string arrays are correctly populated with values.
 
  - Fixed evaluation on ``UPDATE`` of generated columns without referenced
-   columns, e.g. generated columns with a ``CURRENT_TIMESTAMP`` expression.
+   columns, e.g. generated columns with a ``CURRENT_TIMESTAMP``
+   :ref:`expression <gloss-expression>`.
 
  - Fixed global aggregations on JOINs with 3 or more tables.

--- a/docs/appendices/release-notes/1.1.3.rst
+++ b/docs/appendices/release-notes/1.1.3.rst
@@ -39,7 +39,8 @@ Fixes
  - Admin UI improvements.
 
  - Improved the accuracy of results if :ref:`arithmetic operators <arithmetic>`
-   ``+,-,*,/`` are used in expressions that contain only float-type values.
+   (``+``, ``-``, ``*``, and ``/``) are used in :ref:`expressions
+   <gloss-expression>` that contain only float-type values.
 
  - Fixed ``COPY FROM`` to be able to copy data into a partitioned table with a
    generated column as both the primary key and a :ref:`partition column

--- a/docs/appendices/release-notes/1.1.4.rst
+++ b/docs/appendices/release-notes/1.1.4.rst
@@ -12,8 +12,8 @@ Released on 2017/06/02.
     before you upgrade to 1.1.4.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
-    number must be :ref:`version_1.1.1` or higher. If you want to upgrade from a
-    version prior to this, the upgrade will introduce all of the breaking
+    number must be :ref:`version_1.1.1` or higher. If you want to upgrade from
+    a version prior to this, the upgrade will introduce all of the breaking
     changes listed for :ref:`version_1.1.0`, and will require a `full restart
     upgrade`_.
 
@@ -82,9 +82,9 @@ Fixes
  - Fix an issued that cause a ``NullPointerException`` when ordering by system
    columns.
 
- - Fixed validation so that ``SELECT DISTINCT`` can be used only if there
-   is no ``GROUP BY`` present or if the set of ``GROUP BY`` expressions is
-   the same as the set ``SELECT`` expressions.
+ - Fixed validation so that ``SELECT DISTINCT`` can be used only if there is no
+   ``GROUP BY`` present or if the set of ``GROUP BY`` :ref:`expressions
+   <gloss-expression>` is the same as the set ``SELECT`` expressions.
 
  - Added validation that ``ORDER BY`` symbols are included in the ``SELECT``
    list when ``DISTINCT`` is used.

--- a/docs/appendices/release-notes/2.0.6.rst
+++ b/docs/appendices/release-notes/2.0.6.rst
@@ -75,8 +75,8 @@ Fixes
    aggregation symbol twice as a select item on a join query.
 
  - Fixed an issue that caused wrong results to be returned for global
-   aggregation on ``JOINS`` when literal expression in ``WHERE`` clause is
-   evaluated to false, e.g.::
+   aggregation on ``JOINS`` when :ref:`literal expression <sql-literal-value>`
+   in ``WHERE`` clause is evaluated to false, e.g.::
 
      SELECT COUNT(*) FROM t1, t2 WHERE 1=2
 

--- a/docs/appendices/release-notes/2.0.7.rst
+++ b/docs/appendices/release-notes/2.0.7.rst
@@ -71,7 +71,7 @@ Fixes
    node thread pools.
 
  - Fixed the error message to be more descriptive when the condition in a
-   ``CASE/WHEN`` expression is not a boolean.
+   ``CASE/WHEN`` :ref:`expression <gloss-expression>` is not a boolean.
 
  - Fixed an issue which caused an exception if ``EXPLAIN`` is used on a
    statement that uses the ``ANY (array_expression)`` :ref:`operator
@@ -93,7 +93,7 @@ Fixes
 
      SELECT DISTINCT upper(name) FROM t
 
- - Fixed a null pointer exception when running ``select port from sys.nodes``
+ - Fixed a null pointer exception when running ``SELECT port FROM sys.nodes``
    while ``psql.enabled: false`` was set.
 
  - Implemented ``NOT NULL`` constraint validation for nested object columns,

--- a/docs/appendices/release-notes/2.1.1.rst
+++ b/docs/appendices/release-notes/2.1.1.rst
@@ -69,8 +69,9 @@ Fixes
 - Fixed an issue that prevented CrateDB from starting when ``path.home`` was
   set via command line argument.
 
-- Fixed an issue causing ``JOINs`` on virtual tables (sub-selects) which
-  contain ``LIMIT`` and/or ``OFFSET`` to return incorrect results.  E.g.::
+- Fixed an issue causing ``JOINs`` on virtual tables (:ref:`subselects
+  <gloss-subquery>`) which contain ``LIMIT`` and/or ``OFFSET`` to return
+  incorrect results. E.g.::
 
       SELECT * FROM
         (SELECT * FROM t1 ORDER BY a LIMIT 5) t1,
@@ -79,7 +80,7 @@ Fixes
       ON t1.a = t2.max
 
 - Fixed an issue causing ``JOINs`` with aggregations on virtual tables
-  (sub-selects) which also contain aggregations to return incorrect results.
+  (subselects) which also contain aggregations to return incorrect results.
   E.g.::
 
       SELECT t1.a, COUNT(*) FROM t1
@@ -88,7 +89,7 @@ Fixes
       GROUP BY t1.id
 
 - Fixed the error message to be more descriptive when the condition in a
-  ``CASE/WHEN`` expression is not a boolean.
+  ``CASE/WHEN`` :ref:`expression <gloss-expression>` is not a boolean.
 
 - Fixed an issue which caused an exception if ``EXPLAIN`` is used on a
   statement that uses the ``ANY (array_expression)`` :ref:`operators

--- a/docs/appendices/release-notes/2.1.6.rst
+++ b/docs/appendices/release-notes/2.1.6.rst
@@ -50,8 +50,8 @@ Fixes
  - Fixed a bug in the detection of correlated subqueries which are currently
    unsupported.
 
- - Fix display of redundant parenthesis around expressions visible in
-   ``SHOW CREATE`` and ``EXPLAIN`` statements.
+ - Fix display of redundant parenthesis around :ref:`expressions
+   <gloss-expression>` visible in ``SHOW CREATE`` and ``EXPLAIN`` statements.
 
  - Updated Crash to ``0.21.5`` which removes a deprecation warning logged in
    CrateDB server on every REST request.

--- a/docs/appendices/release-notes/2.1.7.rst
+++ b/docs/appendices/release-notes/2.1.7.rst
@@ -48,14 +48,15 @@ Fixes
      ON t1.a = t2.b
 
  - Fixed an issue that caused an error when trying to create a table with a
-   generated column expression of type array.
+   :ref:`generated column expression <ddl-generated-columns-expressions>` of
+   type array.
 
  - Fixed an issue that caused the ``account_user``-column to be empty in the
    twitter tutorial plugin of the Admin UI.
 
- - Fixed an issue when using GRANT/REVOKE/DENY statements on a table with a
-   custom schema set. The statements would result in permission changed on the
-   default ``doc`` schema.
+ - Fixed an issue when using ``GRANT``/``REVOKE``/``DENY`` statements on a
+   table with a custom schema set. The statements would result in permission
+   changed on the default ``doc`` schema.
 
  - Fixed an issue with ``INNER`` and ``CROSS JOINS`` on more than 2 tables that
    could result in a ``Iterator is not on a row`` error.

--- a/docs/appendices/release-notes/2.2.5.rst
+++ b/docs/appendices/release-notes/2.2.5.rst
@@ -13,8 +13,9 @@ Released on 2017/12/14.
 
     If you want to perform a `rolling upgrade`_, your current CrateDB version
     number must be :ref:`version_2.2.0`.  If you want to upgrade from a version
-    prior to this, the upgrade will introduce all of the breaking changes listed
-    for :ref:`version_2.2.0`, and will require a `full restart upgrade`_.
+    prior to this, the upgrade will introduce all of the breaking changes
+    listed for :ref:`version_2.2.0`, and will require a `full restart
+    upgrade`_.
 
 .. WARNING::
 
@@ -66,5 +67,5 @@ Fixes
   statements with ``ORDER BY`` and ``LIMIT`` to execute significantly slower
   than before.
 
-- Fixed support for subscript expressions on the ``values`` column of
-  ``information_schema.table_partitions``.
+- Fixed support for :ref:`subscript expressions <sql-subscripts>` on the
+  ``values`` column of ``information_schema.table_partitions``.

--- a/docs/appendices/release-notes/2.3.0.rst
+++ b/docs/appendices/release-notes/2.3.0.rst
@@ -65,14 +65,14 @@ Breaking Changes
 
 - Table ``information_schema.table_constraints`` is now returning
   ``constraint_name`` as type string instead of type array. Constraint type
-  ``PRIMARY_KEY`` has been changed to ``PRIMARY KEY``. Also PRIMARY KEY
+  ``PRIMARY_KEY`` has been changed to ``PRIMARY KEY``. Also ``PRIMARY KEY``
   constraint is not returned when not explicitly defined.
 
-- :ref:Scalar functions <scalar-functions>` are resolved more strictly based on
-  the argument types. This means that built-in functions with the same name as
-  :ref:`user-defined functions <user-defined-functions>` will always "hide" the
-  latter, even if the UDF has a different set of arguments. Using the same name
-  as a built-in function for a user defined function is considered bad
+- :ref:`Scalar functions <scalar-functions>` are resolved more strictly based
+  on the argument types. This means that built-in functions with the same name
+  as :ref:`user-defined functions <user-defined-functions>` will always "hide"
+  the latter, even if the UDF has a different set of arguments. Using the same
+  name as a built-in function for a user defined function is considered bad
   practice.
 
 
@@ -163,8 +163,8 @@ Changes
   conversion is possible through a type precedence list and convertibility
   checks on the data types.
 
-- Functions which accept regular expression flags now throw an error when
-  invalid flags are provided.
+- Functions which accept :ref:`regular expression <gloss-regular-expression>`
+  flags now throw an error when invalid flags are provided.
 
 - Clients using the PostgreSQL wire protocol will now receive an additional
   ``crate_version`` ParameterStatus message when establishing a connection.

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -167,8 +167,8 @@ Changes
 - Add ``max_token_length`` parameter to whitespace tokenizer.
 
 - Added new tokenizers ``simple_pattern`` and ``simple_pattern_split`` which
-  allow to tokenize text for the fulltext index by a regular expression
-  pattern.
+  allow to tokenize text for the fulltext index by a :ref:`regular expression
+  <gloss-regular-expression>` pattern.
 
 - Added support for CSV file inputs in ``COPY FROM`` statements. Input type is
   inferred using the file's extension or can be set using the optional ``WITH``
@@ -261,8 +261,8 @@ Renamed Settings
 ................
 
 - The ``discovery.type`` setting which was previously used to specify whether a
-  cluster should use DNS discovery or the EC2 API, has been
-  removed. Configuring the use of the EC2 API has now been moved to the
+  cluster should use DNS discovery or the EC2 API, has been removed.
+  Configuring the use of the EC2 API has now been moved to the
   ``discovery.zen.hosts_provider`` setting.
 
 - The ``bootstrap.seccomp`` setting, which controls system call filters, has

--- a/docs/appendices/release-notes/3.0.3.rst
+++ b/docs/appendices/release-notes/3.0.3.rst
@@ -79,8 +79,9 @@ Fixes
 - Made table setting ``blocks.read_only_allow_delete`` configurable for
   partitioned tables.
 
-- Improved performance for expressions involving literal type conversions,
-  e.g. ``select count(*) from users group by name having max(bytes) = 4``.
+- Improved performance for :ref:`expressions <gloss-expression>` involving
+  literal type conversions, e.g. ``select count(*) from users group by name
+  having max(bytes) = 4``.
 
 - Fixed an issue which could result in lost entries at the ``sys.jobs_log`` and
   ``sys.operations_log`` tables when the related settings are changed while

--- a/docs/appendices/release-notes/3.1.0.rst
+++ b/docs/appendices/release-notes/3.1.0.rst
@@ -93,10 +93,11 @@ Changes
   are simply ignored.
 
 - Added a new :ref:`scalar function <scalar-functions>` ``ignore3vl`` which
-  eliminates the 3-valued logic of null handling for every logical expression
-  beneath it. If 3-valued logic is not required, the use of this :ref:`function
-  <gloss-function>` in the ``WHERE`` clause beneath a ``NOT`` :ref:`operator
-  <gloss-operator>` can boost the query performance significantly. E.g.::
+  eliminates the 3-valued logic of null handling for every logical
+  :ref:`expression <gloss-expression>` beneath it. If 3-valued logic is not
+  required, the use of this :ref:`function <gloss-function>` in the ``WHERE``
+  clause beneath a ``NOT`` :ref:`operator <gloss-operator>` can boost the query
+  performance significantly. E.g.::
 
       SELECT * FROM t
       WHERE NOT IGNORE3VL(5 = ANY(t.int_array_col))

--- a/docs/appendices/release-notes/3.1.3.rst
+++ b/docs/appendices/release-notes/3.1.3.rst
@@ -71,8 +71,8 @@ Fixes
 - Fixed a memory leak in the ``MQTT`` ingest service.
 
 - Fixed a memory leak that could occur with clients connecting via PostgreSQL
-  protocol and invoking read queries with statements containing expressions
-  that would fail (such as ``1 / 0``).
+  protocol and invoking read queries with statements containing
+  :ref:`expressions <gloss-expression>` that would fail (such as ``1 / 0``).
 
 - Fixed an issue in the PostgreSQL wire protocol that could result in nodes
   crashing with ``OutOfMemoryError`` if clients queried very large tables

--- a/docs/appendices/release-notes/3.2.0.rst
+++ b/docs/appendices/release-notes/3.2.0.rst
@@ -125,7 +125,8 @@ SQL Improvements
   dimension.
 
 - Added support for the :ref:`ARRAY(subquery) <sql_expressions_array_subquery>`
-  expression, which can turn the result from a subquery into an array.
+  :ref:`expression <gloss-expression>`, which can turn the result from a
+  subquery into an array.
 
 - The :ref:`= ANY <sql_dql_any_array>` :ref:`operator <gloss-operator>` now
   also supports operations on object arrays or nested arrays. This enables
@@ -137,8 +138,8 @@ SQL Improvements
 - Added support for :ref:`INITCAP(string) <scalar-initcap>` which capitalizes
   the first letter of every word while turning all others into lowercase.
 
-- Added the scalar expression :ref:`CURRENT_DATABASE <scalar_current_database>`
-  which returns the current database.
+- Added the :ref:`scalar <gloss-scalar>` expression :ref:`CURRENT_DATABASE
+  <scalar_current_database>` which returns the current database.
 
 - :ref:`Functions <gloss-function>` like :ref:`CURRENT_SCHEMA
   <scalar_current_schema>` and :ref:`CURRENT_USER <current_user>` which depend
@@ -146,7 +147,7 @@ SQL Improvements
   <ddl-generated-columns>`.
 
 - Added support for using :ref:`table functions <table-functions>` in the
-  select list of a query.
+  ``SELECT`` list of a query.
 
 - :ref:`geo_shape <geo_shape_data_type>` columns can now be casted to
   ``object`` with ``cast`` in addition to ``try_cast``.

--- a/docs/appendices/release-notes/3.2.8.rst
+++ b/docs/appendices/release-notes/3.2.8.rst
@@ -60,6 +60,7 @@ Fixes
 
 - Fixed an issue that would cause the wrong evaluation of nested sub-queries in
   cases where the inner sub-query returns a multi-value and the outer returns a
-  single value result. For instance, the assignment sub-query expression in the
-  following update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE
-  x IN (SELECT x FROM t3))")`` might have produced an incorrect result.
+  single value result. For instance, the assignment :ref:`subquery
+  <gloss-subquery>` :ref:`expression <gloss-expression>` in the following
+  update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE x IN
+  (SELECT x FROM t3))")`` might have produced an incorrect result.

--- a/docs/appendices/release-notes/3.3.0.rst
+++ b/docs/appendices/release-notes/3.3.0.rst
@@ -105,7 +105,8 @@ SQL Improvements
 
 - Added support for the ``row_number()`` window function.
 
-- Added support for using any expression in the operand of a ``CASE`` clause.
+- Added support for using any :ref:`expression <gloss-expression>` in the
+  operand of a ``CASE`` clause.
 
 - Fix quoting of identifiers that contain leading digits or spaces when
   printing relation or column names.

--- a/docs/appendices/release-notes/3.3.2.rst
+++ b/docs/appendices/release-notes/3.3.2.rst
@@ -61,6 +61,7 @@ Fixes
 
 - Fixed an issue that would cause the wrong evaluation of nested sub-queries in
   cases where the inner sub-query returns a multi-value and the outer returns a
-  single value result. For instance, the assignment sub-query expression in the
-  following update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE
-  x IN (SELECT x FROM t3))")`` might have produced an incorrect result.
+  single value result. For instance, the assignment :ref:`subquery
+  <gloss-subquery>` :ref:`expression <gloss-expression>` in the following
+  update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE x IN
+  (SELECT x FROM t3))")`` might have produced an incorrect result.

--- a/docs/appendices/release-notes/3.3.4.rst
+++ b/docs/appendices/release-notes/3.3.4.rst
@@ -71,9 +71,10 @@ Fixes
   are also changed to receive ``arrays`` as arguments, instead of ``sets``.
 
 - Fixed an issue that caused an error when trying to create a table with a
-  column definition that contains a predefined array data type and generated
-  expression. For instance, a statement like ``CREATE TABLE foo (col
-  ARRAY(TEXT) AS ['bar'])`` would fail.
+  column definition that contains a predefined array data type and
+  :ref:`generated expression <ddl-generated-columns-expressions>`. For
+  instance, a statement like ``CREATE TABLE foo (col ARRAY(TEXT) AS ['bar'])``
+  would fail.
 
 - Fixed a bug that led to failures of group by a single text column queries on
   columns with the cardinality ration lower than ``0.5``.

--- a/docs/appendices/release-notes/3.3.5.rst
+++ b/docs/appendices/release-notes/3.3.5.rst
@@ -57,7 +57,8 @@ Fixes
   version of CrateDB.
 
 - The values provided in ``INSERT`` or ``UPDATE`` statements for object columns
-  which contain generated expressions are now validated. The computed
+  which contain :ref:`generated expressions
+  <ddl-generated-columns-expressions>` are now validated. The computed
   expression must match the provided value. This makes the behavior consistent
   with how top level columns of a table are treated.
 

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -167,8 +167,8 @@ Removed Settings
 - Removed the deprecated ``license.enterprise`` setting. To use CrateDB without
   any enterprise features one should use the community edition instead.
 
-- Removed the experimental `enable_semijoin` session setting. As this defaulted
-  to false, this execution strategy cannot be used anymore.
+- Removed the experimental ``enable_semijoin`` session setting. As this
+  defaulted to false, this execution strategy cannot be used anymore.
 
 - Removed the possibility of configuring the AWS S3 repository client via the
   ``crate.yaml`` configuration file and command line arguments. Please, use the
@@ -427,7 +427,7 @@ Others
 - Added a new ``_docid`` :ref:`system column
   <sql_administration_system_columns>`.
 
-- Added support for subscript expressions on an object column of a
-  sub-relation.  Examples: ``select a['b'] from (select a from t1)`` or
-  ``select a['b'] from my_view`` where ``my_view`` is defined as ``select a
-  from t1``.
+- Added support for :ref:`subscript expressions <sql-subscripts>` on an object
+  column of a sub-relation.  Examples: ``SELECT a['b'] FROM (SELECT a FROM
+  t1)`` or ``SELECT a['b'] FROM my_view`` where ``my_view`` is defined as
+  ``SELECT a FROM t1``.

--- a/docs/appendices/release-notes/4.0.1.rst
+++ b/docs/appendices/release-notes/4.0.1.rst
@@ -56,7 +56,8 @@ Fixes
   columns to be ignored.
 
 - The values provided in ``INSERT`` or ``UPDATE`` statements for object columns
-  which contain generated expressions are now validated. The computed
+  which contain :ref:`generated expressions
+  <ddl-generated-columns-expressions>` are now validated. The computed
   expression must match the provided value. This makes the behavior consistent
   with how top level columns of a table are treated.
 

--- a/docs/appendices/release-notes/4.0.12.rst
+++ b/docs/appendices/release-notes/4.0.12.rst
@@ -79,12 +79,12 @@ Fixes
 - Fixed an issue that caused ``SELECT *`` to include nested columns of type
   ``geo_shape`` instead of only selecting top-level columns.
 
-- Fixed an issue that caused subscript expressions on top of child relations in
-  which an object column is selected to fail.
+- Fixed an issue that caused :ref:`subscript expressions <sql-subscripts>` on
+  top of child relations in which an object column is selected to fail.
 
-- Fixed a `ClassCastException` that occurred when querying certain columns from
-  ``information_schema.tables``, ``sys.jobs_log`` or ``sys.jobs_metrics`` with
-  a client connected via PostgreSQL wire protocol.
+- Fixed a ``ClassCastException`` that occurred when querying certain columns
+  from ``information_schema.tables``, ``sys.jobs_log`` or ``sys.jobs_metrics``
+  with a client connected via PostgreSQL wire protocol.
 
 - Fixed a regression introduced in ``4.0.11`` which caused a
   ``ClassCastException`` when querying ``sys.allocations``.

--- a/docs/appendices/release-notes/4.0.2.rst
+++ b/docs/appendices/release-notes/4.0.2.rst
@@ -50,6 +50,6 @@ Fixes
 - Fixed an issue in the version handling that would prevent rolling upgrades to
   future versions of CrateDB.
 
-- Arithmetic operations now work on expressions of type :ref:`timestamp without
-  time zone <date-time-types>`, to make it consistent with ``timestamp with
-  time zone``.
+- Arithmetic operations now work on :ref:`expressions <gloss-expression>` of
+  type :ref:`timestamp without time zone <date-time-types>`, to make it
+  consistent with ``timestamp with time zone``.

--- a/docs/appendices/release-notes/4.0.6.rst
+++ b/docs/appendices/release-notes/4.0.6.rst
@@ -64,8 +64,9 @@ Fixes
   after the login redirect in the CrateDB Admin UI.
 
 - Fixed an issue that prevented subqueries from being used in select item
-  expressions that also contain a reference accessed via a relation alias.  For
-  example: ``SELECT t.y IN (SELECT x FROM t2) FROM t1 t``
+  :ref:`expressions <gloss-expression>` that also contain a reference accessed
+  via a relation alias.  For example: ``SELECT t.y IN (SELECT x FROM t2) FROM
+  t1 t``
 
 - Fail the storage engine if indexing on a replica shard fails after it was
   successfully done on a primary shard. It prevents replica and primary shards

--- a/docs/appendices/release-notes/4.0.8.rst
+++ b/docs/appendices/release-notes/4.0.8.rst
@@ -63,6 +63,6 @@ Fixes
   indicating that the index is corrupt.
 
 - Fixed an issue resulting in a parsing exception on ``SHOW TABLE`` statements
-  when a default expression is implicitly cast to the related column type and
-  the column type contains a ``SPACE`` character (like e.g. ``double
-  precision``).
+  when a default :ref:`expression <gloss-expression>` is implicitly cast to the
+  related column type and the column type contains a ``SPACE`` character (like
+  e.g. ``double precision``).

--- a/docs/appendices/release-notes/4.1.1.rst
+++ b/docs/appendices/release-notes/4.1.1.rst
@@ -62,12 +62,12 @@ Fixes
   the partition key is an object field of the :ref:`timestamp
   <timestamp_data_type>` data type.
 
-- Fixed an issue that caused subscript expressions on top of child relations in
-  which an object column is selected to fail.
+- Fixed an issue that caused :ref:`subscript expressions <sql-subscripts>` on
+  top of child relations in which an object column is selected to fail.
 
 - Fixed an issue in :ref:`ref-values` that would not allow combining
-  expressions that can be explicitly casted or ``NULL`` literals in the same
-  column.
+  :ref:`expressions <gloss-expression>` that can be explicitly casted or
+  ``NULL`` literals in the same column.
 
 - Fixed a ``ClassCastException`` that occurred when querying certain columns
   from ``information_schema.tables``, ``sys.jobs_log``, or ``sys.jobs_metrics``

--- a/docs/appendices/release-notes/4.1.3.rst
+++ b/docs/appendices/release-notes/4.1.3.rst
@@ -34,9 +34,9 @@ See the :ref:`version_4.1.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue that led to more than one expression in the form
-  ``<literalValue> AS <alias>`` to be interpreted as the same column if all
-  ``<literalValue>`` expressions are equal.
+- Fixed an issue that led to more than one :ref:`expression <gloss-expression>`
+  in the form ``<literalValue> AS <alias>`` to be interpreted as the same
+  column if all ``<literalValue>`` expressions are equal.
 
 - Fixed an issue that led to a ``NullPointerException`` when using ``GROUP BY``
   on a nested :ref:`partition column <gloss-partition-column>`.

--- a/docs/appendices/release-notes/4.1.7.rst
+++ b/docs/appendices/release-notes/4.1.7.rst
@@ -34,8 +34,8 @@ See the :ref:`version_4.1.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue that caused ``ORDER BY`` expressions referencing table
-  functions used in the ``SELECT`` list to fail.
+- Fixed an issue that caused ``ORDER BY`` :ref:`expressions <gloss-expression>`
+  referencing table functions used in the ``SELECT`` list to fail.
 
 - Fixed an issue that prevented an optimization for ``SELECT DISTINCT
   <single_text_column> FROM <table>`` from working if used within a ``INSERT

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -172,8 +172,8 @@ SQL Standard and PostgreSQL compatibility improvements
   alternative to the existing :ref:`object subscript <sql-object-subscript>`
   syntax.
 
-- Added support for using columns of type ``long`` inside subscript expressions
-  (e.g., ``array_expr[column]``).
+- Added support for using columns of type ``long`` inside :ref:`subscript
+  expressions <sql-subscripts>` (e.g., ``array_expr[column]``).
 
 - Made :ref:`generate_series <table-functions-generate-series>` addressable by
   specifying the ``pg_catalog`` schema explicitly. So, for example, both
@@ -252,8 +252,8 @@ New statements and clauses
 - Added the :ref:`DISCARD <discard>` statement.
 
 - Added the :ref:`CHECK <check_constraint>` constraint syntax, which specifies
-  that the values of certain columns must satisfy a boolean expression on
-  insert and update.
+  that the values of certain columns must satisfy a :ref:`boolean expression
+  <sql-literal-value>` on insert and update.
 
 - Introduced new optional ``RETURNING`` clause for :ref:`INSERT <ref-insert>`
   and :ref:`UPDATE <ref-update>` to return specified values from each row

--- a/docs/appendices/release-notes/4.2.1.rst
+++ b/docs/appendices/release-notes/4.2.1.rst
@@ -33,8 +33,8 @@ Fixes
 =====
 
 - Fixed an issue with the :ref:`quote_ident <scalar-quote-ident>` :ref:`scalar
-  function <scalar-functions>` that caused it to quote subscript expressions
-  like ``"col['x']"`` instead of ``"col"['x']``.
+  function <scalar-functions>` that caused it to quote :ref:`subscript
+  expressions <sql-subscripts>` like ``"col['x']"`` instead of ``"col"['x']``.
 
 - Fixed an issue that prevented the use of subscript expressions as conflict
   target in ``ON CONFLICT`` clauses of ``INSERT`` statements.

--- a/docs/appendices/release-notes/4.2.4.rst
+++ b/docs/appendices/release-notes/4.2.4.rst
@@ -48,7 +48,7 @@ Fixes
 
 - Fixed an issue that prevented :ref:`user-defined functions
   <user-defined-functions>` in a custom schema from working if used in a
-  generated column expression.
+  :ref:`generated column expression <ddl-generated-columns-expressions>`.
 
 - Fixed an issue that allowed users to use a :ref:`function <gloss-function>`
   in a generated column that didn't fully match the given arguments, leading to

--- a/docs/appendices/release-notes/4.2.6.rst
+++ b/docs/appendices/release-notes/4.2.6.rst
@@ -36,8 +36,9 @@ Fixes
 =====
 
 - Fixed a regression introduced in 4.2 which prevented ``DELETE FROM ...``
-  statements with the subquery expression in the where clause from complete
-  deletion of the matching partitions in partitioned tables.
+  statements with the :ref:`subquery <gloss-subquery>` :ref:`expression
+  <gloss-expression>` in the where clause from complete deletion of the
+  matching partitions in partitioned tables.
 
 - Fixed an issue that prevented casts from ``DOUBLE PRECISION`` to ``REAL`` for
   the minimal supported ``REAL`` number ``-3.4028235e38``.
@@ -46,9 +47,9 @@ Fixes
   arguments in JavaScript :ref:`user-defined functions
   <user-defined-functions>`.
 
-- Fixed a regression introduced in 4.2 that could cause subscript expressions
-  to fail with a ``Base argument to subscript must be an object, not null`` or
-  ``Can't handle Symbol`` error.
+- Fixed a regression introduced in 4.2 that could cause :ref:`subscript
+  expressions <sql-subscripts>` to fail with a ``Base argument to subscript
+  must be an object, not null`` or ``Can't handle Symbol`` error.
 
 - Fixed an issue causing a node crash due to OOM when running the ``analyze``
   on large tables.

--- a/docs/appendices/release-notes/4.2.7.rst
+++ b/docs/appendices/release-notes/4.2.7.rst
@@ -39,4 +39,5 @@ Fixes
   broke any further operations accessing table meta data.
 
 - Prevent dropping of a UDF if it is still used inside inside any
-  ``generated column`` expressions, throw an error instead.
+  :ref:`generated column expressions <ddl-generated-columns-expressions>`,
+  throw an error instead.

--- a/docs/appendices/release-notes/4.3.0.rst
+++ b/docs/appendices/release-notes/4.3.0.rst
@@ -86,11 +86,11 @@ SQL Standard and PostgreSQL compatibility improvements
 - Added table function :ref:`generate_subscripts
   <table-functions-generate-subscripts>`
 
-- Added the `pg_catalog.pg_roles table <postgres_pg_catalog>`
+- Added the :ref:`pg_catalog.pg_roles table <postgres_pg_catalog>`
 
-- Added full support for quoted subscript expressions like ``"myObj['x']"``.
-  This allows to use tools like PowerBI with tables that contain object
-  columns.
+- Added full support for quoted :ref:`subscript expressions <sql-subscripts>`
+  like ``"myObj['x']"``.  This allows to use tools like PowerBI with tables
+  that contain object columns.
 
 
 Administration

--- a/docs/appendices/release-notes/4.3.2.rst
+++ b/docs/appendices/release-notes/4.3.2.rst
@@ -48,13 +48,14 @@ Fixes
 - Fixed an issue that could lead to stuck ``INSERT INTO .. RETURNING`` queries.
 
 - Fixed a regression introduced in CrateDB >= ``4.3`` which prevents using
-  ``regexp_matches()`` wrapped inside a subscript expression from being used
-  as a ``GROUP BY`` expression.
+  ``regexp_matches()`` wrapped inside a :ref:`subscript expression
+  <sql-subscripts>` from being used as a ``GROUP BY`` expression.
+
   This fixed the broken AdminUI->Montoring tab as it uses such a statement.
 
-- Fixed validation of ``GROUP BY`` expressions if an alias is used. The
-  validation was by passed and resulted in an execution exception instead of
-  an user friendly validation exception.
+- Fixed validation of ``GROUP BY`` :ref:`expressions <gloss-expression>` if an
+  alias is used. The validation was by passed and resulted in an execution
+  exception instead of an user friendly validation exception.
 
 - Fixed an issue that caused ``IS NULL`` and ``IS NOT NULL`` :ref:`operators
   <gloss-operator>` on columns of type ``OBJECT`` with the column policy

--- a/docs/appendices/release-notes/4.3.3.rst
+++ b/docs/appendices/release-notes/4.3.3.rst
@@ -42,8 +42,9 @@ Fixes
   copying data from one table to another using ``INSERT INTO ...`` while the
   source table contains more than 128 columns.
 
-- Fixed an issue resulting in the full generated expression as the column name
-  inside data exported by ``COPY TO`` statements.
+- Fixed an issue resulting in the full :ref:`generated expression
+  <ddl-generated-columns-expressions>` as the column name inside data exported
+  by ``COPY TO`` statements.
 
 - Fixed an issue resulting double-quoted column names inside data exported by
   ``COPY TO`` statements.
@@ -51,8 +52,8 @@ Fixes
 - Fixed a memory leak in the DNS discovery seed provider. The memory leak
   occurred if you configured ``discovery.seed_providers=srv``.
 
-- Fixed a regression introduced in CrateDB ``4.0`` preventing the global setting
-  ``cluster.info.update.interval`` to be changed.
+- Fixed a regression introduced in CrateDB ``4.0`` preventing the global
+  setting ``cluster.info.update.interval`` to be changed.
 
-- Fixed handling of spaces in `$CRATE_HOME`. Users would get a `No such file or
-  directory` error if the path set via `$CRATE_HOME` contained spaces.
+- Fixed handling of spaces in ``$CRATE_HOME``. Users would get a ``No such file
+  or directory`` error if the path set via ``$CRATE_HOME`` contained spaces.

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -95,10 +95,11 @@ Collecting stats
   | *Default:* ``true`` (Include everything)
   | *Runtime:* ``yes``
 
-  An expression to determine if a job should be recorded into ``sys.jobs_log``.
-  The expression must evaluate to a boolean. If it evaluates to ``true`` the
-  statement will show up ``sys.jobs_log`` until it's evicted due to one of the
-  other rules. (expiration or size limit reached).
+  An :ref:expression <gloss-expression>` to determine if a job should be
+  recorded into ``sys.jobs_log``.  The expression must evaluate to a
+  boolean. If it evaluates to ``true`` the statement will show up in
+  ``sys.jobs_log`` until it's evicted due to one of the other
+  rules. (expiration or size limit reached).
 
   The expression may reference all columns contained in ``sys.jobs_log``. A
   common use case is to include only jobs that took a certain amount of time to

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -627,9 +627,10 @@ sharing`_ settings in CrateDB allow for configuring these.
 
   Define allowed origins of a request. ``*`` allows *any* origin (which can be
   a substantial security risk) and by prepending a ``/`` the string will be
-  treated as a regular expression. For example ``/https?:\/\/crate.io/`` will
-  allow requests from ``https://crate.io`` and ``https://crate.io``. This
-  setting disallows any origin by default.
+  treated as a :ref:`regular expression <gloss-regular-expression>`. For
+  example ``/https?:\/\/crate.io/`` will allow requests from
+  ``https://crate.io`` and ``https://crate.io``. This setting disallows any
+  origin by default.
 
 .. _http.cors.max-age:
 

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -58,8 +58,8 @@ Aggregate expressions
 
 An *aggregate expression* represents the application of an :ref:`aggregate
 function <aggregation-functions>` across rows selected by a query. Besides the
-function signature, expressions might contain supplementary clauses and
-keywords.
+function signature, :ref:`expressions <gloss-expression>` might contain
+supplementary clauses and keywords.
 
 The synopsis of an aggregate expression is one of the following::
 

--- a/docs/general/builtins/array-comparisons.rst
+++ b/docs/general/builtins/array-comparisons.rst
@@ -46,7 +46,7 @@ right-hand values).
 
 The operator returns ``NULL`` if:
 
-- The left-hand expression evaluates to ``NULL``
+- The left-hand :ref:`expression <gloss-expression>` evaluates to ``NULL``
 
 - There are no matching right-hand values and at least one right-hand value is
   ``NULL``
@@ -79,7 +79,7 @@ Here's an example::
 
 The ``ANY`` :ref:`operator <gloss-operator>` returns ``true`` if the defined
 comparison is ``true`` for any of the values in the right-hand array
-expression.
+:ref:`expression <gloss-expression>`.
 
 The operator returns ``false`` if the comparison returns ``false`` for all
 right-hand values or there are no right-hand values.
@@ -126,7 +126,8 @@ Here's an example::
 
 
 The ``ALL`` :ref:`operator <gloss-operator>` returns ``true`` if the defined
-comparison is ``true`` for all values in the right-hand array expression.
+comparison is ``true`` for all values in the right-hand :ref:`array expression
+<sql-array-constructor>`.
 
 The operator returns ``false`` if the comparison returns ``false`` for all
 right-hand values.

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -777,8 +777,9 @@ If you don't specify a time zone, ``truncate`` uses UTC time::
 ``extract(field from source)``
 ------------------------------
 
-``extract`` is a special expression that translates to a function which
-retrieves subfields such as day, hour or minute from a timestamp.
+``extract`` is a special :ref:`expression <gloss-expression>` that translates
+to a function which retrieves subfields such as day, hour or minute from a
+timestamp.
 
 The return type depends on the used ``field``.
 
@@ -888,10 +889,10 @@ The following fields are supported:
 ``CURRENT_TIME``
 ----------------
 
-The ``CURRENT_TIME`` expression returns the time in microseconds
-since midnight UTC at the time the SQL statement was handled. Clock
-time is looked up at most once within the scope of a single query, to
-ensure that multiple occurrences of ``CURRENT_TIME`` evaluate to the
+The ``CURRENT_TIME`` :ref:`expression <gloss-expression>` returns the time in
+microseconds since midnight UTC at the time the SQL statement was
+handled. Clock time is looked up at most once within the scope of a single
+query, to ensure that multiple occurrences of ``CURRENT_TIME`` evaluate to the
 same value.
 
 synopsis::
@@ -1004,8 +1005,8 @@ Synopsis
     DATE_FORMAT( [ format_string, [ timezone, ] ] timestamp )
 
 The only mandatory argument is the ``timestamp`` value to format. It can be any
-expression that is safely convertible to timestamp data type with or without
-timezone.
+:ref:`expression <gloss-expression>` that is safely convertible to timestamp
+data type with or without timezone.
 
 Format
 ......
@@ -1186,9 +1187,9 @@ a timezone) or ``interval``.
 Format
 ......
 
-The syntax for the ``format_string`` differs based the type of the expression.
-For ``timestamp`` expressions, the ``format_string`` is a template string
-containing any of the following symbols:
+The syntax for the ``format_string`` differs based the type of the
+:ref:`expression <gloss-expression>`.  For ``timestamp`` expressions, the
+``format_string`` is a template string containing any of the following symbols:
 
 +-------------------------------------------+---------------------------------------------------------------------------+
 | Pattern                                   | Description                                                               |
@@ -1976,7 +1977,8 @@ Returns: ``double precision``
 Regular expression functions
 ============================
 
-The regular expression functions in CrateDB use `Java Regular Expressions`_.
+The :ref:`regular expression <gloss-regular-expression>` functions in CrateDB
+use `Java Regular Expressions`_.
 
 See the API documentation for more details.
 
@@ -2247,8 +2249,8 @@ It can be used to remove elements from array fields.
 ``array(subquery)``
 -------------------
 
-The ``array(subquery)`` expression is an array constructor function which
-operates on the result of the ``subquery``.
+The ``array(subquery)`` :ref:`expression <gloss-expression>` is an array
+constructor function which operates on the result of the ``subquery``.
 
 Returns: ``array``
 
@@ -2392,9 +2394,9 @@ Conditional functions and expressions
 ``CASE WHEN ... THEN ... END``
 ------------------------------
 
-The ``case`` expression is a generic conditional expression similar to if/else
-statements in other programming languages and can be used wherever an
-expression is valid.
+The ``case`` :ref:`expression <gloss-expression>` is a generic conditional
+expression similar to if/else statements in other programming languages and can
+be used wherever an expression is valid.
 
 ::
 
@@ -2483,12 +2485,12 @@ Example:
 -------------------------------------
 
 The ``if`` function is a conditional function comparing to *if* statements of
-most other programming languages. If the given *condition* expression evaluates
-to `true`, the *result* expression is evaluated and it's value is returned. If
-the *condition* evaluates to `false`, the *result* expression is not evaluated
-and the optional given *default* expression is evaluated instead and it's value
-will be returned. If the *default* argument is omitted, NULL will be returned
-instead.
+most other programming languages. If the given *condition* :ref:`expression
+<gloss-expression>` evaluates to ``true``, the *result* expression is evaluated
+and its value is returned. If the *condition* evaluates to ``false``, the
+*result* expression is not evaluated and the optional given *default*
+expression is evaluated instead and its value will be returned. If the
+*default* argument is omitted, ``NULL`` will be returned instead.
 
 .. Hidden: create table if_example
 

--- a/docs/general/builtins/subquery-expressions.rst
+++ b/docs/general/builtins/subquery-expressions.rst
@@ -11,7 +11,7 @@ returns a boolean value (i.e., ``true`` or ``false``) or ``NULL``.
 
 .. SEEALSO::
 
-    :ref:`sql-scalar-subquery`
+    :ref:`SQL: Value expressions <sql-scalar-subquery>`
 
 .. rubric:: Table of contents
 

--- a/docs/general/builtins/table-functions.rst
+++ b/docs/general/builtins/table-functions.rst
@@ -207,7 +207,8 @@ arrays within the same level.
 ``regexp_matches(source, pattern [, flags])``
 =============================================
 
-Uses the regular expression ``pattern`` to match against the ``source`` string.
+Uses the :ref:`regular expression <gloss-regular-expression>` ``pattern`` to
+match against the ``source`` string.
 
 The result rows have one column:
 

--- a/docs/general/builtins/window-functions.rst
+++ b/docs/general/builtins/window-functions.rst
@@ -39,8 +39,9 @@ The synopsis of a window function call is one of the following
    function_name ( * ) [ FILTER ( WHERE condition ) ] over_clause
 
 where ``function_name`` is a name of a :ref:`general-purpose window
-<window-functions-general-purpose>` or :ref:`aggregate <aggregation-functions>`
-function and ``expression`` is a column reference, scalar function or literal.
+<window-functions-general-purpose>` or :ref:`aggregate function
+<aggregation-functions>` and ``expression`` is a column reference, :ref:`scalar
+function <scalar-functions>` or literal.
 
 If ``FILTER`` is specified, then only the rows that met the :ref:`WHERE
 <sql-select-where>` condition are supplied to the window function. Only window
@@ -106,8 +107,9 @@ ROW``. If ``frame_end`` is omitted it defaults to ``CURRENT ROW``.
 
 In ``RANGE`` mode if the ``frame_start`` is ``CURRENT ROW`` the frame starts
 with the current row's first peer (a row that the window's ``ORDER BY``
-expression sorts as equal to the current row), while a ``frame_end`` of
-``CURRENT ROW`` means the frame will end with the current's row last peer row.
+:ref:`expression <gloss-expression>` sorts as equal to the current row), while
+a ``frame_end`` of ``CURRENT ROW`` means the frame will end with the current's
+row last peer row.
 
 In ``ROWS`` mode ``CURRENT_ROW`` means the current row.
 

--- a/docs/general/ddl/analyzers.rst
+++ b/docs/general/ddl/analyzers.rst
@@ -166,7 +166,7 @@ Creates one single token from the field-contents.
 ``type='pattern'``
 
 An analyzer of type pattern that can flexibly separate text into terms via a
-regular expression.
+:ref:`regular expression <gloss-regular-expression>`.
 
 .. rubric:: Parameters
 
@@ -444,7 +444,8 @@ Pattern tokenizer
 
 ``type='pattern'``
 
-The ``pattern`` tokenizer separates text into terms via a regular expression.
+The ``pattern`` tokenizer separates text into terms via a :ref:`regular
+expression <gloss-regular-expression>`.
 
 .. rubric:: Parameters
 
@@ -472,10 +473,11 @@ Simple pattern tokenizer
 
 ``type='simple_pattern'``
 
-Similar to the ``pattern`` tokenizer, this tokenizer uses a regular expression
-to split matching text into terms, however with a limited, more restrictive
-subset of expressions. This is in general faster than the normal ``pattern``
-tokenizer, but does not support splitting on pattern.
+Similar to the ``pattern`` tokenizer, this tokenizer uses a :ref:`regular
+expression <gloss-regular-expression>` to split matching text into terms,
+however with a limited, more restrictive subset of expressions. This is in
+general faster than the normal ``pattern`` tokenizer, but does not support
+splitting on pattern.
 
 .. rubric:: Parameters
 
@@ -490,8 +492,9 @@ Simple pattern split tokenizer
 ``type='simple_patten_split'``
 
 The ``simple_pattern_split`` tokenizer operates with the same restricted subset
-of regular expressions as the ``simple_pattern`` tokenizer, but it splits the
-input on the pattern, rather than the matching pattern.
+of :ref:`regular expressions <gloss-regular-expression>` as the
+``simple_pattern`` tokenizer, but it splits the input on the pattern, rather
+than the matching pattern.
 
 .. rubric:: Parameters
 
@@ -973,7 +976,8 @@ only_on_same_position
 
 ``type='pattern_capture'``
 
-Emits a token for every capture group in the regular expression
+Emits a token for every capture group in the :ref:`regular expression
+<gloss-regular-expression>`.
 
 .. rubric:: Parameters
 
@@ -987,7 +991,8 @@ preserve_original
 
 ``type='pattern_replace'``
 
-Handle string replacements based on a regular expression.
+Handle string replacements based on a :ref:`regular expression
+<gloss-regular-expression>`.
 
 .. rubric:: Parameters
 

--- a/docs/general/ddl/constraints.rst
+++ b/docs/general/ddl/constraints.rst
@@ -85,9 +85,9 @@ Check
 =====
 
 A check constraint allows you to specify that the values in a certain column
-must satisfy a boolean expression. This can be used to ensure data integrity.
-For example, if you have a table to store metrics from sensors and you want to
-ensure that negative values are rejected::
+must satisfy a :ref:`boolean expression <sql-literal-value>`. This can be used
+to ensure data integrity.  For example, if you have a table to store metrics
+from sensors and you want to ensure that negative values are rejected::
 
      cr> create table metrics (
      ...   id TEXT PRIMARY KEY,

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -514,12 +514,11 @@ time zone. It has the following variants:
    "timestamp with time zone AT TIME ZONE zone", "timestamp without time zone", "Convert \
    given time stamp with time zone to the new time zone, with no time zone designation"
 
-In these expressions, the desired time zone is specified as a string
-(e.g., 'Europe/Madrid', '+02:00'). See :ref:`Timezone <date-format-timezone>`.
+In these :ref:`expressions <gloss-expression>`, the desired time zone is
+specified as a string (e.g., 'Europe/Madrid', '+02:00').
 
-The :ref:`scalar function <scalar-functions>` :ref:`TIMEZONE <scalar-timezone>`
-(zone, timestamp) is equivalent to the SQL-conforming construct timestamp ``AT
-TIME ZONE zone``.
+The scalar function :ref:`TIMEZONE <scalar-timezone>` (zone, timestamp) is
+equivalent to the SQL-conforming timestamp construct ``AT TIME ZONE zone``.
 
 .. _time-data-type:
 
@@ -757,7 +756,7 @@ Temporal arithmetic
 -------------------
 
 The following table specifies the declared types of :ref:`arithmetic
-<arithmetic>` expressions that involves temporal :ref:`operands
+expressions <arithmetic>` that involve temporal :ref:`operands
 <gloss-operand>`:
 
 
@@ -1321,8 +1320,9 @@ Array constructor
 -----------------
 
 Arrays can be written using the array constructor ``ARRAY[]`` or short ``[]``.
-The array constructor is an expression that accepts both literals and
-expressions as its parameters. Parameters may contain zero or more elements.
+The array constructor is an :ref:`expression <gloss-expression>` that accepts
+both literals and expressions as its parameters. Parameters may contain zero or
+more elements.
 
 Synopsis::
 
@@ -1430,8 +1430,8 @@ oidvector
 This is a system type used to represent one or more OID values.
 
 It looks similar to an array of integers, but doesn't support any of the
-:ref:`scalar functions <scalar-functions>` or expressions that can be used on
-regular arrays.
+:ref:`scalar functions <scalar-functions>` or :ref:`expressions
+<gloss-expression>` that can be used on regular arrays.
 
 
 .. _type_conversion:
@@ -1445,8 +1445,8 @@ Type conversion
 --------
 
 A type ``cast`` specifies a conversion from one data type to another. It will
-only succeed if the value of the expression is convertible to the desired data
-type, otherwise an error is thrown.
+only succeed if the value of the :ref:`expression <gloss-expression>` is
+convertible to the desired data type, otherwise an error is returned.
 
 CrateDB supports two equivalent syntaxes for type casts:
 
@@ -1628,7 +1628,8 @@ See the table below for a full list of aliases:
 .. NOTE::
 
    The :ref:`PG_TYPEOF <pg_typeof>` system :ref:`function <gloss-function>` can
-   be used to resolve the data type of any expression.
+   be used to resolve the data type of any :ref:`expression
+   <gloss-expression>`.
 
 
 .. _BigDecimal documentation: https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/math/BigDecimal.html

--- a/docs/general/ddl/generated-columns.rst
+++ b/docs/general/ddl/generated-columns.rst
@@ -6,7 +6,7 @@ Generated columns
 
 It is possible to define columns whose value is computed by applying a
 *generation expression* in the context of the current row. The generation
-expression can reference the values of other columns.
+:ref:`expression <gloss-expression>` can reference the values of other columns.
 
 .. rubric:: Table of contents
 

--- a/docs/general/ddl/partitioned-tables.rst
+++ b/docs/general/ddl/partitioned-tables.rst
@@ -44,7 +44,7 @@ values for the configured :ref:`partition columns <gloss-partition-column>` is
 inserted, a new partition is created and the document will be inserted into
 this partition.
 
-A partitioned table can be queried like a regular table. 
+A partitioned table can be queried like a regular table.
 
 Partitioned tables have the following advantages:
 
@@ -268,8 +268,8 @@ not be atomic and could lead to inconsistent state::
     ColumnValidationException[Validation failed for day: Updating a partitioned-by column is not supported]
 
 When using a :ref:`generated column <sql-create-table-generated-columns>` as
-partition column all the columns referenced in its *generation expression*
-cannot be updated either::
+partition column, all the columns referenced in its :ref:`generation expression
+<ddl-generated-columns-expressions>` cannot be updated either::
 
     cr> UPDATE computed_parted_table set created_at='1970-01-01'
     ... WHERE id = 1;

--- a/docs/general/dml.rst
+++ b/docs/general/dml.rst
@@ -391,8 +391,8 @@ Updating nested objects is also supported::
     cr> update locations set inhabitants['name'] = 'Human' where name = 'Bartledan';
     UPDATE OK, 1 row affected (... sec)
 
-It's also possible to reference a column within the expression, for example to
-increment a number like this::
+It's also possible to reference a column within the :ref:`expression
+<gloss-expression>`, for example to increment a number like this::
 
     cr> update locations set position = position + 1 where position < 3;
     UPDATE OK, 6 rows affected (... sec)

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -163,7 +163,7 @@ Comparison operators
 ====================
 
 CrateDB supports a variety of :ref:`comparison operators
-<comparison-operators>` (including basic operators such as ``=``, ``<``, ``>``,
+<comparison-operators-where>` (including basic operators such as ``=``, ``<``, ``>``,
 and so on).
 
 
@@ -172,8 +172,8 @@ and so on).
 Regular expressions
 -------------------
 
-:ref:`Comparison operators <comparison-operators-where>` for matching using
-regular expressions:
+Comparison operators for matching using :ref:`regular expressions
+<gloss-regular-expression>`:
 
 .. list-table::
    :widths: 5 20 15
@@ -348,7 +348,7 @@ escape them using a backslash::
 ``NOT``
 --------
 
-``NOT`` negates a boolean expression::
+``NOT`` negates a :ref:`boolean expression <sql-literal-value>`::
 
     [ NOT ] boolean_expression
 
@@ -385,7 +385,8 @@ Use this predicate to check for ``NULL`` values as SQL's three-valued logic
 does always return ``NULL`` when comparing ``NULL``.
 
 :expr:
-  Expression of one of the supported :ref:`data-types` supported by CrateDB.
+  :ref:`Expression <gloss-expression>` of one of the supported
+  :ref:`data types <data-types>` supported by CrateDB.
 
 ::
 
@@ -429,7 +430,8 @@ Use this predicate to check for non-``NULL`` values as SQL's three-valued logic
 does always return ``NULL`` when comparing ``NULL``.
 
 :expr:
-  Expression of one of the supported :ref:`data-types` supported by CrateDB.
+  :ref:`Expression <gloss-expression>` of one of the supported
+  :ref:`data types <data-types>` supported by CrateDB.
 
 ::
 
@@ -468,8 +470,8 @@ CrateDB supports a variety of :ref:`array comparisons <sql_array_comparisons>`.
 ------
 
 CrateDB supports the :ref:`operator <gloss-operator>` ``IN`` which allows you
-to verify the membership of the left-hand :ref:`operator <gloss-operand>`
-operand in a right-hand set of expressions. Returns ``true`` if any evaluated
+to verify the membership of the left-hand operator operand in a right-hand set
+of :ref:`expressions <gloss-expression>`. Returns ``true`` if any evaluated
 expression value from a right-hand set equals left-hand operand. Returns
 ``false`` otherwise::
 
@@ -850,9 +852,10 @@ There are two limitations to be aware of:
   is a valid).
 
 * Using the standard syntax, you can only address the elements of one array in
-  a single expression. If you do address the elements of an array, the array
-  index must appear before any object property names (see :ref:`the previous
-  admonition <sql_dql_object_arrays>` for more information).
+  a single :ref:`expression <gloss-expression>`. If you do address the elements
+  of an array, the array index must appear before any object property names
+  (see :ref:`the previous admonition <sql_dql_object_arrays>` for more
+  information).
 
 .. TIP::
 

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -384,7 +384,8 @@ infinite recursion of your mind, beware!)::
 |                               |                                               |               |
 |                               | For further information see :ref:`data-types` |               |
 +-------------------------------+-----------------------------------------------+---------------+
-| ``column_default``            | The default expression of the column          | ``TEXT``      |
+| ``column_default``            | The default :ref:`expression                  | ``TEXT``      |
+|                               | <gloss-expression>` of the column             |               |
 +-------------------------------+-----------------------------------------------+---------------+
 | ``character_maximum_length``  | If the data type is a :ref:`character type    | ``INTEGER``   |
 |                               | <character-data-types>` then return the       |               |

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -391,7 +391,8 @@ Accessing arrays
 ................
 
 Fetching arbitrary rectangular slices of an array using
-``lower-bound:upper-bound`` expression in the array subscript is not supported.
+``lower-bound:upper-bound`` :ref:`expression <gloss-expression>` in the array
+subscript is not supported.
 
 .. SEEALSO::
 
@@ -412,8 +413,10 @@ CrateDB and we love to hear feedback.
 Expression evaluation
 ---------------------
 
-Unlike PostgreSQL, expressions are not evaluated if the query results in 0 rows
-either because of the table is empty or by a not matching where clause.
+Unlike PostgreSQL, :ref:`expressions <gloss-expression>` are not evaluated if
+the query results in 0 rows either because of the table is empty or by a not
+matching ``WHERE`` clause.
+
 
 .. _GitHub: https://github.com/crate/crate
 .. _pg_am: https://www.postgresql.org/docs/10/catalog-pg-am.html

--- a/docs/sql/general/constraints.rst
+++ b/docs/sql/general/constraints.rst
@@ -65,7 +65,8 @@ constraint or a table constraint.
 ---------
 
 The ``CHECK`` constraint specifies that the values of certain columns must
-satisfy a boolean expression on insert and update.
+satisfy a :ref:`boolean expression <sql-literal-value>` on ``INSERT`` and
+``UPDATE``.
 
 Syntax::
 

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -174,7 +174,7 @@ Function call
 A :ref:`function <gloss-function>` can be invoked with a *function call* (a
 process better known as *calling the function*). The corresponding syntax is
 the function name optionally followed by zero or more arguments (in the form of
-:ref:`value expressions <sql-value-expressions>`) enclosed by parentheses::
+value expressions) enclosed by parentheses::
 
     function_name[([expression [, expression ... ]])]
 

--- a/docs/sql/statements/alter-table.rst
+++ b/docs/sql/statements/alter-table.rst
@@ -57,11 +57,11 @@ Use the ``BLOB`` keyword in order to alter a blob table (see
 the ``ADD COLUMN`` keyword won't work.
 
 While altering a partitioned table, using ``ONLY`` will apply changes for the
-table **only** and not for any possible existing partitions. So these changes
+table *only* and not for any possible existing partitions. So these changes
 will only be applied to new partitions. The ``ONLY`` keyword cannot be used
 together with a `PARTITION`_ clause.
 
-See the CREATE TABLE :ref:`sql-create-table-with` for a list of available
+See ``CREATE TABLE`` :ref:`sql-create-table-with` for a list of available
 parameters.
 
 :table_ident:
@@ -137,8 +137,8 @@ Arguments
 ``SET/RESET``
 -------------
 
-Can be used to change a table parameter to a different value.
-Using ``RESET`` will reset the parameter to its default value.
+Can be used to change a table parameter to a different value.  Using ``RESET``
+will reset the parameter to its default value.
 
 :parameter:
   The name of the parameter that is set to a new value or its default.
@@ -159,9 +159,9 @@ Can be used to add an additional column to a table. While columns can be added
 at any time, adding a new :ref:`generated column
 <sql-create-table-generated-columns>` is only possible if the table is empty.
 In addition, adding a base column with :ref:`sql-create-table-default-clause`
-is not supported. It is possible to define a CHECK constraint with the
-restriction that only the column being added may be used in the boolean
-expression.
+is not supported. It is possible to define a ``CHECK`` constraint with the
+restriction that only the column being added may be used in the :ref:`boolean
+expression <sql-literal-value>`.
 
 :data_type:
   Data type of the column which should be added.
@@ -175,11 +175,12 @@ expression.
 ``OPEN/CLOSE``
 --------------
 
-Can be used to open or close the table, respectively. Closing a table prevents
-all operations, except ``ALTER TABLE ... OPEN``, to fail. Operations on closed
-partitions will not produce an exception, but will have no effect. Similarly,
-like ``SELECT`` and ``INSERT`` on partitioned will exclude closed partitions and
-continue working.
+Can be used to open or close the table.
+
+Closing a table means that all operations, except ``ALTER TABLE ... OPEN``,
+will fail. Operations that fail will not return an error, but they will have no
+effect. Operations on tables containing closed partitions won't fail, but those
+operations will exclude all closed partitions.
 
 
 .. _sql-alter-table-rename-to:
@@ -223,7 +224,7 @@ where ``reroute_option`` is::
     }
 
 :shard_id:
-  The shard id. Ranges from 0 up to the specified number of :ref:`sys-shards`
+  The shard ID. Ranges from 0 up to the specified number of :ref:`sys-shards`
   shards of a table.
 
 :node:
@@ -245,11 +246,10 @@ where ``reroute_option`` is::
 
 .. _alter-table-reroute-promote-replica:
 
-**PROMOTE REPLICA**
-  Force promote a stale replica shard to a primary.
-  In case a node holding a primary copy of a shard had a failure and the
-  replica shards are out of sync, the system won't promote the replica to
-  primary automatically, as it would result in a silent data loss.
+**PROMOTE REPLICA** Force promote a stale replica shard to a primary.  In case
+  a node holding a primary copy of a shard had a failure and the replica shards
+  are out of sync, the system won't promote the replica to primary
+  automatically, as it would result in a silent data loss.
 
   Ideally the node holding the primary copy of the shard would be brought back
   into the cluster, but if that is not possible due to a permanent system

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -236,9 +236,9 @@ Parameters
   data should be put.
 
 :uri:
-  An expression which evaluates to a URI as defined in `RFC2396`_. The
-  supported schemes are listed above. The last part of the path may also
-  contain ``*`` wildcards to match multiple files.
+  An :ref:`expression <gloss-expression>` which evaluates to a URI as defined
+  in `RFC2396`_. The supported schemes are listed above. The last part of the
+  path may also contain ``*`` wildcards to match multiple files.
 
 
 .. _sql-copy-from-clauses:
@@ -344,7 +344,8 @@ default for *all* URIs.
 ``node_filters``
 ''''''''''''''''
 
-A filter expression to select the nodes to run the *read* operation.
+A filter :ref:`expression <gloss-expression>` to select the nodes to run the
+*read* operation.
 
 It's an object in the form of::
 
@@ -355,8 +356,9 @@ It's an object in the form of::
 
 Only one of the keys is required.
 
-The ``name`` regular expression is applied on the ``name`` of all execution
-nodes, whereas the ``id`` regex is applied on the ``node id``.
+The ``name`` :ref:`regular expression <gloss-regular-expression>` is applied on
+the ``name`` of all execution nodes, whereas the ``id`` regex is applied on the
+``node id``.
 
 If both keys are set, *both* regular expressions have to match for a node to be
 included.

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -63,12 +63,13 @@ Parameters
   The name (optionally schema-qualified) of the table to be exported.
 
 :column:
-  (optional) A list of column expressions that should be exported.
+  (optional) A list of column :ref:`expressions <gloss-expression>` that should
+  be exported.
 
 .. NOTE::
 
-   Declaring columns changes the output to JSON list format, which is
-   currently not supported by the COPY FROM statement.
+   When declaring columns, this changes the output to JSON list format, which
+   is currently not supported by the ``COPY FROM`` statement.
 
 
 .. _sql-copy-to-clauses:
@@ -154,8 +155,9 @@ The ``TO`` clause allows you to specify an output location.
 :output_uri:
   The output URI.
 
-The output URI can be any expression that evaluates to a string. The string
-must be a valid URI that uses the ``file://`` or ``s3://`` URI scheme.
+The output URI can be any :ref:`expression <gloss-expression>` that evaluates
+to a string. The string must be a valid URI that uses the ``file://`` or
+``s3://`` URI scheme.
 
 For example:
 
@@ -182,8 +184,8 @@ You may have to configure a new `Docker volume`_ to accomplish this.
 Microsoft Windows
 .................
 
-If you are using *Microsoft Windows*, you must include the drive letter in
-the file URI.
+If you are using *Microsoft Windows*, you must include the drive letter in the
+file URI.
 
 For example, the above file URI should instead be written as
 ``file:///C://tmp/import_data/quotes.json``.
@@ -197,8 +199,8 @@ Amazon Web Services
 ...................
 
 A ``secretkey`` provided by *Amazon Web Services* (AWS) can contain characters
-such as '/', '+' or '='. Such characters must be URI encoded. The same encoding
-as in :ref:`sql-copy-from-s3` applies.
+such as ``/``, ``+`` or ``=``. Such characters must be URI encoded. The same
+encoding as in :ref:`sql-copy-from-s3` applies.
 
 Additionally, versions prior to 0.51.x use HTTP for connections to S3. Since
 0.51.x these connections are using the HTTPS protocol. Please make sure you
@@ -244,15 +246,14 @@ Optional parameter to override default output behavior.
 Possible values for the ``format`` settings are:
 
 :json_object:
-  Each row in the result set is serialized as JSON object and written to
-  an output file where one line contains one object. This is the default
-  behavior if no columns are defined. Use this format to import with
+  Each row in the result set is serialized as JSON object and written to an
+  output file where one line contains one object. This is the default behavior
+  if no columns are defined. Use this format to import with
   :ref:`sql-copy-from`.
 
 :json_array:
-  Each row in the result set is serialized as JSON array, storing one
-  array per line in an output file. This is the default behavior if
-  columns are defined.
+  Each row in the result set is serialized as JSON array, storing one array per
+  line in an output file. This is the default behavior if columns are defined.
 
 
 .. _Amazon S3: https://aws.amazon.com/s3/

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -125,8 +125,8 @@ The optional default clause defines the default value of the column. The value
 is inserted when the column is a target of a ``INSERT`` statement that doesn't
 contain an explicit value for it.
 
-The default clause expression is variable-free, it means that subqueries and
-cross-references to other columns are not allowed.
+The default clause :ref:`expression <gloss-expression>` is variable-free, it
+means that subqueries and cross-references to other columns are not allowed.
 
 
 .. _sql-create-table-generated-columns:
@@ -204,11 +204,12 @@ Parameters
   object specifiers.
 
 :generation_expression:
-  An expression (usually a :ref:`function call <sql-function-call>`) that is
-  applied in the context of the current row. As such it can reference other
-  base columns of the table. Referencing other generated columns (including
-  itself) is not supported. The generation expression is evaluated each time a
-  row is inserted or the referenced base columns are updated.
+  An :ref:`expression <ddl-generated-columns-expressions>` (usually a
+  :ref:`function call <sql-function-call>`) that is applied in the context of
+  the current row. As such it can reference other base columns of the
+  table. Referencing other generated columns (including itself) is not
+  supported. The generation expression is evaluated each time a row is inserted
+  or the referenced base columns are updated.
 
 
 .. _sql-create-table-if-not-exists:

--- a/docs/sql/statements/delete.rst
+++ b/docs/sql/statements/delete.rst
@@ -35,10 +35,10 @@ Parameters
 
 :table_alias:
   A substitute name for the target table. When an alias is provided, it
-  completely hides the actual name of the table. For example, given
-  ``DELETE FROM foo AS f``, the remainder of the ``DELETE`` statement must
-  refer to this table as ``f`` not ``foo``.
+  completely hides the actual name of the table. For example, given ``DELETE
+  FROM foo AS f``, the remainder of the ``DELETE`` statement must refer to this
+  table as ``f`` not ``foo``.
 
 :condition:
-  An expression that returns a value of type boolean. Only rows for
-  which this expression returns true will be deleted.
+  An expression that returns a value of type boolean. Only rows for which this
+  expression returns ``true`` will be deleted.

--- a/docs/sql/statements/explain.rst
+++ b/docs/sql/statements/explain.rst
@@ -43,10 +43,10 @@ execution if the statement being explained involves queries which are executed
 using Lucene.
 
 The output includes verbose low level information per queried shard. Since SQL
-query expressions do not always have a direct 1:1 mapping to Lucene queries the
-output may be more complex but in most cases it should still be possible to
-identify the most expensive parts of a query expression.
-Some familiarity with Lucene helps in interpreting the output.
+query :ref:`expressions <gloss-expression>` do not always have a direct 1:1
+mapping to Lucene queries, the output may be more complex but in most cases it
+should still be possible to identify the most expensive parts of a query
+expression.  Some familiarity with Lucene helps in interpreting the output.
 
 A short excerpt of a query breakdown looks like this::
 

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -46,8 +46,8 @@ the explicit or implicit column list left-to-right.
 Each column not present in the explicit or implicit column list will not be
 filled.
 
-If the expression for any column is not of the correct data type, automatic
-type conversion will be attempted.
+If the :ref:`expression <gloss-expression>` for any column is not of the
+correct data type, automatic type conversion will be attempted.
 
 The optional ``RETURNING`` clause causes ``INSERT`` to compute and return
 values based from each row actually inserted (or updated, if an ``ON
@@ -138,7 +138,8 @@ Parameters
     The name of a column or field in the table pointed to by *table_ident*.
 
 :expression:
-    An expression or value to assign to the corresponding column.
+    An :ref:`expression <gloss-expression>` or value to assign to the
+    corresponding column.
 
 :query:
     A query (``SELECT`` statement) that supplies the rows to be inserted.

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -55,16 +55,16 @@ as follows:
 - If the :ref:`GROUP BY <sql-select-group-by>` clause is specified, the output
   is combined into groups of rows that match on one or more values.
 
-- The actual output rows are computed using the ``SELECT`` output expressions
-  for each selected row or row group.
+- The actual output rows are computed using the ``SELECT`` output
+  :ref:`expressions <gloss-expression>` for each selected row or row group.
 
 - If the :ref:`ORDER BY <sql-select-order-by>` clause is specified, the
   returned rows are sorted in the specified order. If ``ORDER BY`` is not
   given, the rows are returned in whatever order the system finds fastest to
   produce.
 
-- If :ref:`DISTINCT <sql-select-list>` is specified, one unique row is
-  kept. All other duplicate rows are removed from the result set.
+- If :ref:`DISTINCT <sql-select-list>` is specified, one unique row is kept.
+  All other duplicate rows are removed from the result set.
 
 - If the :ref:`LIMIT <sql-select-limit>` or :ref:`OFFSET <sql-select-offset>`
   clause is specified, the ``SELECT`` statement only returns a subset of the
@@ -82,9 +82,9 @@ Parameters
 The ``SELECT`` List
 -------------------
 
-The ``SELECT`` list specifies expressions that form the output rows of the
-``SELECT`` statement. The expressions can (and usually do) refer to columns
-computed in the ``FROM`` clause.
+The ``SELECT`` list specifies :ref:`expressions <gloss-expression>` that form
+the output rows of the ``SELECT`` statement. The expressions can (and usually
+do) refer to columns computed in the ``FROM`` clause.
 
 ::
 
@@ -198,8 +198,8 @@ relations together.
   ``INNER``.
 
 :join_condition:
-  An expression which specifies which rows in a join are considered a
-  match.
+  An :ref:`expression <gloss-expression>` which specifies which rows in a join
+  are considered a match.
 
   The ``join_condition`` is not applicable for joins of type ``CROSS`` and must
   have a returning value of type ``boolean``.
@@ -267,8 +267,8 @@ returned::
     WHERE condition
 
 :condition:
-  A where condition is any expression that evaluates to a result of type
-  boolean.
+  A ``WHERE`` condition is any :ref:`expression <gloss-expression>` that
+  evaluates to a result of type boolean.
 
   Any row that does not satisfy this condition will be eliminated from the
   output. A row satisfies the condition if it returns true when the actual row
@@ -312,9 +312,9 @@ The optional ``HAVING`` clause defines the condition to be met for values
 within a resulting row of a ``GROUP BY`` clause.
 
 :condition:
-  A ``HAVING`` condition is any expression that evaluates to a result of type
-  boolean. Every row for which the condition is not satisfied will be
-  eliminated from the output.
+  A ``HAVING`` condition is any :ref:`expression <sql-literal-value>` that
+  evaluates to a result of type boolean. Every row for which the condition is
+  not satisfied will be eliminated from the output.
 
 .. NOTE::
 
@@ -379,7 +379,8 @@ specified expression(s).
 
 :expression:
   Can be the name or ordinal number of an output column, or it can be an
-  arbitrary expression formed from input-column values.
+  arbitrary :ref:`expression <gloss-expression>` formed from input-column
+  values.
 
 The optional keyword ``ASC`` (ascending) or ``DESC`` (descending) after any
 expression allows to define the direction in which values are sorted. The

--- a/docs/sql/statements/update.rst
+++ b/docs/sql/statements/update.rst
@@ -25,15 +25,15 @@ Synopsis
 Description
 ===========
 
-UPDATE changes the values of the specified columns in all rows that satisfy
+``UPDATE`` changes the values of the specified columns in all rows that satisfy
 the condition. Only the columns to be modified need be mentioned in the SET
 clause; columns not explicitly modified retain their previous values.
 
-The optional RETURNING clause for UPDATE causes the query to return the
-specified values from each row that was updated. Any expression using the
-table's columns can be computed. The new (post-update) values of the table's
-columns are used. The syntax of the RETURNING list is identical to that of
-the output list of SELECT.
+The optional ``RETURNING`` clause for ``UPDATE`` causes the query to return the
+specified values from each row that was updated. Any :ref:`expression
+<gloss-expression>` using the table's columns can be computed. The new
+(post-update) values of the table's columns are used. The syntax of the
+``RETURNING`` list is identical to that of the output list of ``SELECT``.
 
 Parameters
 ==========
@@ -49,21 +49,21 @@ Parameters
     ``UPDATE`` statement must refer to this table as ``f`` not ``foo``.
 
 :column_ident:
-    The name of a column in the table identified by *table_ident*. Subfields
+    The name of a column in the table identified by ``table_ident``. Subfields
     can also be defined by using the subscript notation with square
     brackets.
 
 :expression:
-    An expression to assign to the column.
+    An :ref:`expression <gloss-expression>` to assign to the column.
 
 :condition:
     An expression that returns a value of type boolean. Only rows for
     which this expression returns true will be updated.
 
 :output_expression:
-    An expression to be computed and returned by the UPDATE command after each
-    row is updated. The expression can use any column names of the table or
-    ``*`` to return all columns. :ref:`System columns
+    An expression to be computed and returned by the ``UPDATE`` command after
+    each row is updated. The expression can use any column names of the table
+    or ``*`` to return all columns. :ref:`System columns
     <sql_administration_system_columns>` can also be returned.
 
 :output_name:

--- a/docs/sql/statements/values.rst
+++ b/docs/sql/statements/values.rst
@@ -40,5 +40,5 @@ An example::
 It is commonly used in :ref:`ref-insert` to provide values to insert into a
 table.
 
-All expressions within the same column must have the same type or its types
-can be implicitly converted.
+All :ref:`expressions <gloss-expression>` within the same column must have the
+same type or its types can be implicitly converted.


### PR DESCRIPTION
This commit follows up on the addition of "expression" terms added to the
glossary. Links to the existing docs for expression related terms have been
added where possible. For all other eligible uses of the word "expression",
links to the glossary have been added.

Eligible uses are limited to the first mention of the term per section in a
document

Some RST fixes and improvements accompany these changes where they were spotted
near to existing changes being made.

--

this is based off of `nomi/gloss-03`, but once that is merged, I will rebase it onto `master`
