### PR TITLE
bp: Relax translog assertion in testRestoreLocalHistoryFromTranslog

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -4607,7 +4607,6 @@ public class InternalEngineTests extends EngineTestCase {
             final EngineConfig engineConfig;
             final SeqNoStats prevSeqNoStats;
             final List<DocIdSeqNoAndSource> prevDocs;
-            final int totalTranslogOps;
             try (InternalEngine engine = createEngine(store, createTempDir(), globalCheckpoint::get)) {
                 engineConfig = engine.config();
                 for (final long seqNo : seqNos) {
@@ -4626,16 +4625,19 @@ public class InternalEngineTests extends EngineTestCase {
                 engine.syncTranslog();
                 prevSeqNoStats = engine.getSeqNoStats(globalCheckpoint.get());
                 prevDocs = getDocIds(engine, true);
-                totalTranslogOps = engine.getTranslog().totalOperations();
             }
             try (InternalEngine engine = new InternalEngine(engineConfig)) {
+                final Translog.TranslogGeneration currrentTranslogGeneration = new Translog.TranslogGeneration(
+                    engine.getTranslog().getTranslogUUID(), engine.getTranslog().currentFileGeneration());
                 engine.recoverFromTranslog(translogHandler, globalCheckpoint.get());
                 engine.restoreLocalHistoryFromTranslog(translogHandler);
                 assertThat(getDocIds(engine, true), equalTo(prevDocs));
                 SeqNoStats seqNoStats = engine.getSeqNoStats(globalCheckpoint.get());
                 assertThat(seqNoStats.getLocalCheckpoint(), equalTo(prevSeqNoStats.getLocalCheckpoint()));
                 assertThat(seqNoStats.getMaxSeqNo(), equalTo(prevSeqNoStats.getMaxSeqNo()));
-                assertThat(engine.getTranslog().totalOperations(), equalTo(totalTranslogOps));
+                try (Translog.Snapshot snapshot = engine.getTranslog().newSnapshotFromGen(currrentTranslogGeneration, Long.MAX_VALUE)) {
+                    assertThat("restore from local translog must not add operations to translog", snapshot, SnapshotMatchers.size(0));
+                }
             }
             assertConsistentHistoryBetweenTranslogAndLuceneIndex(engine, createMapperService("test"));
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/elastic/elasticsearch/commit/f0b7c01a8956cbbe81874b41f338ae05f37bbfb0

Fixes a flakyness we had

    java.lang.AssertionError:
    Expected: <283>
         but: was <282>
    	at __randomizedtesting.SeedInfo.seed([84683FEB084C62A:8DAC98B0BBFC5B2B]:0)
    	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
    	at org.junit.Assert.assertThat(Assert.java:956)
    	at org.junit.Assert.assertThat(Assert.java:923)
    	at org.elasticsearch.index.engine.InternalEngineTests.testRestoreLocalHistoryFromTranslog(InternalEngineTests.java:4638)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)