### PR TITLE
Cross-link uses of the word "expression" in the docs

### DIFF
--- a/docs/appendices/release-notes/1.0.4.rst
+++ b/docs/appendices/release-notes/1.0.4.rst
@@ -67,8 +67,8 @@ Fixes
 
  - Index columns based on string arrays are correctly populated with values.
 
- - Fixed evaluation on ``UPDATE`` of generated columns without referenced
-   columns, e.g. generated columns with a ``CURRENT_TIMESTAMP``
-   :ref:`expression <gloss-expression>`.
+ - Fixed :ref:`evaluation <gloss-evaluation>` on ``UPDATE`` of generated
+   columns without referenced columns, e.g., generated columns with a
+   ``CURRENT_TIMESTAMP`` :ref:`expression <gloss-expression>`.
 
  - Fixed global aggregations on JOINs with 3 or more tables.

--- a/docs/appendices/release-notes/1.1.5.rst
+++ b/docs/appendices/release-notes/1.1.5.rst
@@ -38,9 +38,9 @@ Changelog
 Fixes
 -----
 
- - Fixed an issue that leads to an exception if the statement evaluates on
-   arrays that are provided in an :ref:`aggregation function
-   <aggregation-functions>`.
+ - Fixed an issue that leads to an exception if the statement :ref:`evaluates
+   <gloss-evaluation>` on arrays that are provided in an :ref:`aggregation
+   function <aggregation-functions>`.
 
  - Fixed a performance regression that could cause ``JOIN`` queries to execute
    slower than they used to.

--- a/docs/appendices/release-notes/2.0.6.rst
+++ b/docs/appendices/release-notes/2.0.6.rst
@@ -76,7 +76,7 @@ Fixes
 
  - Fixed an issue that caused wrong results to be returned for global
    aggregation on ``JOINS`` when :ref:`literal expression <sql-literal-value>`
-   in ``WHERE`` clause is evaluated to false, e.g.::
+   in ``WHERE`` clause is :ref:`evaluated <gloss-evaluation>` to false, e.g.::
 
      SELECT COUNT(*) FROM t1, t2 WHERE 1=2
 

--- a/docs/appendices/release-notes/2.2.6.rst
+++ b/docs/appendices/release-notes/2.2.6.rst
@@ -51,10 +51,10 @@ Fixes
   tables to not work correctly. This only occurred if a ``query`` instead of
   the ``VALUES`` clause was used.
 
-- Fixed the evaluation of JavaScript :ref:`user-defined functions
-  <user-defined-functions>` that caused CrateDB to crash because of an
-  unhandled assertion when providing the UDF with EcmaScript 6 arrow function
-  syntax (``var f = (x) => x;``).
+- Fixed the :ref:`evaluation <gloss-evaluation>` of JavaScript
+  :ref:`user-defined functions <user-defined-functions>` that caused CrateDB to
+  crash because of an unhandled assertion when providing the UDF with
+  EcmaScript 6 arrow function syntax (``var f = (x) => x;``).
 
 - Fixed an issue where batch operations executed using the PosgreSQL wire
   protocol returned 0 as row count, even though the actual row count was

--- a/docs/appendices/release-notes/3.2.0.rst
+++ b/docs/appendices/release-notes/3.2.0.rst
@@ -85,10 +85,10 @@ Breaking Changes
 
 - The ``*`` of ``SELECT *`` statements in the query clause of :ref:`view
   definitions <ddl-views>` is no longer expanded at view creation time but lazy
-  whenever a view is evaluated. That means columns added to a table after the
-  views initial creation will show up in queries on the view. It is generally
-  recommended to avoid using ``*`` in views but always specify columns
-  explicitly.
+  whenever a view is :ref:`evaluated <gloss-evaluation>`. That means columns
+  added to a table after the views initial creation will show up in queries on
+  the view. It is generally recommended to avoid using ``*`` in views but
+  always specify columns explicitly.
 
 
 Changes

--- a/docs/appendices/release-notes/3.2.8.rst
+++ b/docs/appendices/release-notes/3.2.8.rst
@@ -58,9 +58,10 @@ Fixes
   prohibited. So the query can be written as follows: ``INSERT INTO target
   (SELECT * FROM source LIMIT 10)``.
 
-- Fixed an issue that would cause the wrong evaluation of nested
-  :ref:`subqueries <gloss-subquery>` in cases where the inner subquery returns
-  a multi-value and the outer returns a single value result. For instance, the
-  assignment subquery :ref:`expression <gloss-expression>` in the following
-  update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE x IN
-  (SELECT x FROM t3))")`` might have produced an incorrect result.
+- Fixed an issue that would cause the wrong :ref:`evaluation
+  <gloss-evaluation>` of nested :ref:`subqueries <gloss-subquery>` in cases
+  where the inner subquery returns a multi-value and the outer returns a single
+  value result. For instance, the assignment subquery :ref:`expression
+  <gloss-expression>` in the following update statement ``UPDATE t1 SET x =
+  (SELECT COUNT(*) FROM t2 WHERE x IN (SELECT x FROM t3))")`` might have
+  produced an incorrect result.

--- a/docs/appendices/release-notes/3.3.2.rst
+++ b/docs/appendices/release-notes/3.3.2.rst
@@ -59,9 +59,10 @@ Fixes
   prohibited. So the query can be written as follows: ``INSERT INTO target
   (SELECT * FROM source LIMIT 10)``.
 
-- Fixed an issue that would cause the wrong evaluation of nested
-  :ref:`subqueries <gloss-subquery>` in cases where the inner subquery returns
-  a multi-value and the outer returns a single value result. For instance, the
-  assignment subquery :ref:`expression <gloss-expression>` in the following
-  update statement ``UPDATE t1 SET x = (SELECT COUNT(*) FROM t2 WHERE x IN
-  (SELECT x FROM t3))")`` might have produced an incorrect result.
+- Fixed an issue that would cause the wrong :ref:`evaluation
+  <gloss-evaluation>` of nested :ref:`subqueries <gloss-subquery>` in cases
+  where the inner subquery returns a multi-value and the outer returns a single
+  value result. For instance, the assignment subquery :ref:`expression
+  <gloss-expression>` in the following update statement ``UPDATE t1 SET x =
+  (SELECT COUNT(*) FROM t2 WHERE x IN (SELECT x FROM t3))")`` might have
+  produced an incorrect result.

--- a/docs/appendices/release-notes/3.3.4.rst
+++ b/docs/appendices/release-notes/3.3.4.rst
@@ -63,8 +63,8 @@ Fixes
   statements`` if the client relied on the behavior that closing prepared
   statements should implicitly close related portals.
 
-- Fixed a bug that led to ``is null`` predicates against ``ignored`` objects
-  fields to always evaluate to true.
+- Fixed a bug that led to ``is null`` predicates against ``ignored`` object
+  fields to always :ref:`evaluate <gloss-evaluation>` to true.
 
 - Fixed ``collect_set`` to return an ``array`` type in order to be able to
   return the results over ``JDBC``. ``collection_count`` and ``collection_avg``

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -315,8 +315,9 @@ SQL Standard and PostgreSQL compatibility improvements
 - Added the :ref:`pg_get_userbyid` :ref:`scalar function <scalar-functions>` to
   enhance PostgreSQL compatibility.
 
-- Enabled scalar function evaluation when used :ref:`in the query FROM clause
-  in place of a relation<table-functions-scalar>`.
+- Enabled scalar function :ref:`evaluation <gloss-evaluation>` when used
+  :ref:`in the query FROM clause in place of a
+  relation<table-functions-scalar>`.
 
 - Show the session setting description in the output of the ``SHOW ALL``
   statement.
@@ -394,9 +395,9 @@ Performance and resiliency improvements
      <resiliency_replicas_fall_out_of_sync>`
 
 - Predicates like ``abs(x) = 1`` which require a :ref:`scalar function
-  <scalar-functions>` evaluation and cannot operate on table indices directly
-  are now candidates for the query cache. This can result in order of magnitude
-  performance increases on subsequent queries.
+  <scalar-functions>` :ref:`evaluation <gloss-evaluation>` and cannot operate
+  on table indices directly are now candidates for the query cache. This can
+  result in order of magnitude performance increases on subsequent queries.
 
 - Routing awareness attributes are now also taken into consideration for
   primary key lookups. (Queries like ``SELECT * FROM t WHERE pk = 1``)

--- a/docs/appendices/release-notes/4.0.7.rst
+++ b/docs/appendices/release-notes/4.0.7.rst
@@ -54,9 +54,9 @@ Fixes
   now no longer cause a ``NullPointerException`` but instead advice users to
   use ``RESET GLOBAL`` to reset settings to their default value.
 
-- Fixed evaluation of generated columns when they are based on columns with
-  default constraints and no user given values. Default contraints where not
-  taken into account before.
+- Fixed :ref:`evaluation <gloss-evaluation>` of generated columns when they are
+  based on columns with default constraints and no user given values. Default
+  contraints where not taken into account before.
 
 - Fixed an issue when using ``try_cast('invalid-ts' as timestamp)`` which
   resulted in a parsing exception instead of an expected ``NULL`` value.

--- a/docs/appendices/release-notes/4.1.0.rst
+++ b/docs/appendices/release-notes/4.1.0.rst
@@ -176,9 +176,9 @@ Functions and operators
 - Added support for CIDR notation comparisons through special purpose
   :ref:`operator <gloss-operator>` ``<<`` associated with type IP.
 
-  Statements like ``192.168.0.0 << 192.168.0.1/24`` evaluate as true, meaning
-  ``SELECT ip FROM ips_table WHERE ip << 192.168.0.1/24`` returns matching
-  :ref:`ip <ip-type>` addresses.
+  Statements like ``192.168.0.0 << 192.168.0.1/24`` :ref:`evaluate
+  <gloss-evaluation>` as true, meaning ``SELECT ip FROM ips_table WHERE ip <<
+  192.168.0.1/24`` returns matching :ref:`IP addresses <ip-type>`.
 
 
 New statements and clauses

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -96,9 +96,9 @@ Collecting stats
   | *Runtime:* ``yes``
 
   An :ref:expression <gloss-expression>` to determine if a job should be
-  recorded into ``sys.jobs_log``.  The expression must evaluate to a
-  boolean. If it evaluates to ``true`` the statement will show up in
-  ``sys.jobs_log`` until it's evicted due to one of the other
+  recorded into ``sys.jobs_log``.  The expression must :ref:`evaluate
+  <gloss-evaluation>` to a boolean. If it evaluates to ``true`` the statement
+  will show up in ``sys.jobs_log`` until it's evicted due to one of the other
   rules. (expiration or size limit reached).
 
   The expression may reference all columns contained in ``sys.jobs_log``. A

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -70,8 +70,9 @@ Supported session settings
   | *Modifiable:* ``yes``
 
   An :ref:`experimental <experimental-warning>` setting which enables CrateDB
-  to consider whether a Join operation should be evaluated using the
-  ``HashJoin`` implementation instead of the ``Nested-Loops`` implementation.
+  to consider whether a ``JOIN`` :ref:`operation <gloss-operator>` should be
+  :ref:`evaluated <gloss-evaluation>` using the ``HashJoin`` implementation
+  instead of the ``Nested-Loops`` implementation.
 
   .. NOTE::
 

--- a/docs/general/builtins/array-comparisons.rst
+++ b/docs/general/builtins/array-comparisons.rst
@@ -46,7 +46,8 @@ right-hand values).
 
 The operator returns ``NULL`` if:
 
-- The left-hand :ref:`expression <gloss-expression>` evaluates to ``NULL``
+- The left-hand :ref:`expression <gloss-expression>` :ref:`evaluates
+  <gloss-evaluation>` to ``NULL``
 
 - There are no matching right-hand values and at least one right-hand value is
   ``NULL``
@@ -86,7 +87,7 @@ right-hand values or there are no right-hand values.
 
 The operator returns ``NULL`` if:
 
-- The left-hand expression evaluates to ``NULL``
+- The left-hand expression :ref:`evaluates <gloss-evaluation>` to ``NULL``
 
 - There are no matching right-hand values and at least one right-hand value is
   ``NULL``
@@ -134,7 +135,7 @@ right-hand values.
 
 The operator returns ``NULL`` if:
 
-- The left-hand expression evaluates to ``NULL``
+- The left-hand expression :ref:`evaluates <gloss-evaluation>` to ``NULL``
 
 - No comparison returns ``false`` and at least one right-hand value is ``NULL``
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -892,8 +892,8 @@ The following fields are supported:
 The ``CURRENT_TIME`` :ref:`expression <gloss-expression>` returns the time in
 microseconds since midnight UTC at the time the SQL statement was
 handled. Clock time is looked up at most once within the scope of a single
-query, to ensure that multiple occurrences of ``CURRENT_TIME`` evaluate to the
-same value.
+query, to ensure that multiple occurrences of ``CURRENT_TIME`` :ref:`evaluate
+<gloss-evaluation>` to the same value.
 
 synopsis::
 
@@ -2486,11 +2486,12 @@ Example:
 
 The ``if`` function is a conditional function comparing to *if* statements of
 most other programming languages. If the given *condition* :ref:`expression
-<gloss-expression>` evaluates to ``true``, the *result* expression is evaluated
-and its value is returned. If the *condition* evaluates to ``false``, the
-*result* expression is not evaluated and the optional given *default*
-expression is evaluated instead and its value will be returned. If the
-*default* argument is omitted, ``NULL`` will be returned instead.
+<gloss-expression>` :ref:`evaluates <gloss-evaluation>` to ``true``, the
+*result* expression is evaluated and its value is returned. If the *condition*
+evaluates to ``false``, the *result* expression is not evaluated and the
+optional given *default* expression is evaluated instead and its value will be
+returned. If the *default* argument is omitted, ``NULL`` will be returned
+instead.
 
 .. Hidden: create table if_example
 
@@ -2524,7 +2525,7 @@ expression is evaluated instead and its value will be returned. If the
 
 The ``coalesce`` function takes one or more arguments of the same type and
 returns the first non-null value of these. The result will be NULL only if all
-the arguments evaluate to NULL.
+the arguments :ref:`evaluate <gloss-evaluation>` to NULL.
 
 Returns: same type as arguments
 
@@ -2545,7 +2546,8 @@ Returns: same type as arguments
 
 The ``greatest`` function takes one or more arguments of the same type and will
 return the largest value of these. NULL values in the arguments list are
-ignored. The result will be NULL only if all the arguments evaluate to NULL.
+ignored. The result will be NULL only if all the arguments :ref:`evaluate
+<gloss-evaluation>` to NULL.
 
 Returns: same type as arguments
 
@@ -2564,7 +2566,8 @@ Returns: same type as arguments
 
 The ``least`` function takes one or more arguments of the same type and will
 return the smallest value of these. NULL values in the arguments list are
-ignored. The result will be NULL only if all the arguments evaluate to NULL.
+ignored. The result will be NULL only if all the arguments :ref:`evaluate
+<gloss-evaluation>` to NULL.
 
 Returns: same type as arguments
 
@@ -3063,8 +3066,8 @@ Special functions
 
 The ``ignore3vl`` function operates on a boolean argument and eliminates the
 `3-valued logic`_ on the whole tree of :ref:`operators <gloss-operator>`
-beneath it. More specifically, ``FALSE`` is evaluated to ``FALSE``, ``TRUE`` to
-``TRUE`` and ``NULL`` to ``FALSE``.
+beneath it. More specifically, ``FALSE`` is :ref:`evaluated <gloss-evaluation>`
+to ``FALSE``, ``TRUE`` to ``TRUE`` and ``NULL`` to ``FALSE``.
 
 Returns: ``boolean``
 

--- a/docs/general/builtins/subquery-expressions.rst
+++ b/docs/general/builtins/subquery-expressions.rst
@@ -53,7 +53,7 @@ subquery returns no rows).
 
 The operator returns ``NULL`` if:
 
-- The left-hand expression evaluates to ``NULL``
+- The left-hand expression :ref:`evaluates <gloss-evaluation>` to ``NULL``
 
 - There are no matching right-hand values and at least one right-hand value is
   ``NULL``
@@ -103,7 +103,7 @@ result rows of the subquery or if the subquery returns no rows.
 
 The operator returns ``NULL`` if:
 
-- The left-hand expression evaluates to ``NULL``
+- The left-hand expression :ref:`evaluates <gloss-evaluation>` to ``NULL``
 
 - There are no matching right-hand values and at least one right-hand value is
   ``NULL``
@@ -150,6 +150,6 @@ result rows of the subquery.
 
 The operator returns ``NULL`` if:
 
-- The left-hand expression evaluates to ``NULL``
+- The left-hand expression :ref:`evaluates <gloss-evaluation>` to ``NULL``
 
 - No comparison returns ``false`` and at least one right-hand value is ``NULL``

--- a/docs/general/builtins/table-functions.rst
+++ b/docs/general/builtins/table-functions.rst
@@ -10,11 +10,13 @@ Table functions are :ref:`functions <gloss-function>` that produce a set of
 rows. They can either be used in place of a relation in the ``FROM`` clause, or
 within the select list of a query.
 
-If used within the select list, the table functions will be evaluated per row
-of the relations in the ``FROM`` clause, generating one or more rows which are
-appended to the result set.  If multiple table functions with different amounts
-of rows are used, ``null`` values will be returned for the functions that are
-exhausted. An example::
+If used within the select list, the table functions will be :ref:`evaluated
+<gloss-evaluation>` per row of the relations in the ``FROM`` clause, generating
+one or more rows which are appended to the result set.  If multiple table
+functions with different amounts of rows are used, ``NULL`` values will be
+returned for the functions that are exhausted.
+
+For example::
 
 
     cr> select unnest([1, 2, 3]), unnest([1, 2]);
@@ -33,7 +35,10 @@ exhausted. An example::
     Table functions in the select list are executed after aggregations. So
     aggregations can be used as arguments to table functions, but the other way
     around is not allowed, unless sub queries are utilized.
-    (SELECT aggregate_func(col) FROM (SELECT table_func(...) as col) ...)
+
+    For example::
+
+        (SELECT aggregate_func(col) FROM (SELECT table_func(...) AS col) ...)
 
 .. rubric:: Table of contents
 
@@ -81,7 +86,7 @@ no column.
 unnest takes any number of array parameters and produces a table where each
 provided array argument results in a column.
 
-The columns are named ``colN`` where N is a number starting at 1.
+The columns are named ``colN`` where ``N`` is a number starting at 1.
 
 ::
 
@@ -150,13 +155,13 @@ The return value always matches the ``start`` / ``stop`` types.
 
 Generate the subscripts for the specified dimension ``dim`` of the given
 ``array``. Zero rows are returned for arrays that do not have the requested
-dimension, or for NULL arrays (but valid subscripts are returned for NULL
-array elements).
+dimension, or for ``NULL`` arrays (but valid subscripts are returned for
+``NULL`` array elements).
 
 If ``reverse`` is ``true`` the subscripts will be returned in reverse order.
 
 This example takes a one dimensional array of four elements, where elements
-at positions 1 and 3 are NULL:
+at positions 1 and 3 are ``NULL``:
 
 ::
 
@@ -187,8 +192,8 @@ This example returns the reversed list of subscripts for the same array:
     SELECT 4 rows in set (... sec)
 
 This example works on an array of three dimensions. Each of the elements within
-a given level must be either NULL, or an array of the same size as the other
-arrays within the same level.
+a given level must be either ``NULL``, or an array of the same size as the
+other arrays within the same level.
 
 ::
 

--- a/docs/general/builtins/window-functions.rst
+++ b/docs/general/builtins/window-functions.rst
@@ -430,7 +430,8 @@ Example::
 ``first_value(arg)``
 --------------------
 
-Returns the argument value evaluated at the first row within the window.
+Returns the argument value :ref:`evaluated <gloss-evaluation>` at the first row
+within the window.
 
 Its return type is the type of its argument.
 
@@ -456,7 +457,8 @@ Example::
 ``last_value(arg)``
 -------------------
 
-Returns the argument value evaluated at the last row within the window.
+Returns the argument value :ref:`evaluated <gloss-evaluation>` at the last row
+within the window.
 
 Its return type is the type of its argument.
 
@@ -482,8 +484,9 @@ Example::
 ``nth_value(arg, number)``
 --------------------------
 
-Returns the argument value evaluated at row that is the nth row within the
-window. Null is returned if the nth row doesn't exist in the window.
+Returns the argument value :ref:`evaluated <gloss-evaluation>` at row that is
+the nth row within the window. ``NULL`` is returned if the nth row doesn't
+exist in the window.
 
 Its return type is the type of its first argument.
 
@@ -519,10 +522,10 @@ Synopsis
 
    lag(argument any [, offset integer [, default any]])
 
-Returns the argument value evaluated at the row that precedes the current row
-by the offset within the partition. If there is no such row, the return value
-is ``default``. If ``offset`` or ``default`` arguments are missing, they
-default to ``1`` and ``null``, respectively.
+Returns the argument value :ref:`evaluated <gloss-evaluation>` at the row that
+precedes the current row by the offset within the partition. If there is no
+such row, the return value is ``default``. If ``offset`` or ``default``
+arguments are missing, they default to ``1`` and ``null``, respectively.
 
 Both ``offset`` and ``default`` are evaluated with respect to the current row.
 
@@ -573,12 +576,12 @@ Synopsis
    lead(argument any [, offset integer [, default any]])
 
 The ``lead`` function is the counterpart of the :ref:`lag window function
-<window-functions-lag>` as it allows the evaluation of the argument at rows
-that follow the current row. ``lead`` returns the argument value evaluated at
-the row that follows the current row by the offset within the partition. If
-there is no such row, the return value is ``default``.  If ``offset`` or
-``default`` arguments are missing, they default to ``1`` and ``null``,
-respectively.
+<window-functions-lag>` as it allows the :ref:`evaluation <gloss-evaluation>`
+of the argument at rows that follow the current row. ``lead`` returns the
+argument value evaluated at the row that follows the current row by the offset
+within the partition. If there is no such row, the return value is ``default``.
+If ``offset`` or ``default`` arguments are missing, they default to ``1`` or
+``null``, respectively.
 
 Both ``offset`` and ``default`` are evaluated with respect to the current row.
 

--- a/docs/general/ddl/generated-columns.rst
+++ b/docs/general/ddl/generated-columns.rst
@@ -1,3 +1,5 @@
+.. highlight:: psql
+
 .. _ddl-generated-columns:
 
 =================
@@ -39,7 +41,8 @@ Generated columns are read-only. Their values are computed as needed for every
 
 For example::
 
-    cr> INSERT INTO computed (dividend, divisor) VALUES (1.7, 1.5), (0.0, 10.0);
+    cr> INSERT INTO computed (dividend, divisor)
+    ... VALUES (1.7, 1.5), (0.0, 10.0);
     INSERT OK, 2 rows affected (... sec)
 
 .. Hidden: Refresh::
@@ -60,10 +63,10 @@ The generated column is now filled with the computed value::
     +----------+---------+--------------------+
     SELECT 2 rows in set (... sec)
 
-The generation expression is evaluated in the context of the current row. This
-means that you can compute a generated value from the values of base columns in
-the same row. However, it is not possible to reference other generated columns
-from within a generation expression.
+The generation expression is :ref:`evaluated <gloss-evaluation>` in the context
+of the current row. This means that you can compute a generated value from the
+values of base columns in the same row. However, it is not possible to
+reference other generated columns from within a generation expression.
 
 .. NOTE::
 
@@ -73,7 +76,8 @@ from within a generation expression.
 If values are supplied for generated columns, these values are validated
 against the result of applying the generation expression::
 
-    cr> INSERT INTO computed (dividend, divisor, quotient) VALUES (100.0, 2.0, 12.0);
+    cr> INSERT INTO computed (dividend, divisor, quotient)
+    ... VALUES (100.0, 2.0, 12.0);
     SQLParseException[Given value 12.0 for generated column quotient does not match calculation (dividend / divisor) = 50.0]
 
 .. WARNING::
@@ -94,7 +98,7 @@ inserted, and subsequently updated every time the row is updated::
     cr> CREATE TABLE computed_non_deterministic (
     ...   id LONG,
     ...   last_modified TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS CURRENT_TIMESTAMP
-    ... )
+    ... );
     CREATE OK, 1 row affected (... sec)
 
 

--- a/docs/general/ddl/partitioned-tables.rst
+++ b/docs/general/ddl/partitioned-tables.rst
@@ -64,7 +64,8 @@ Partitioned tables have the following advantages:
 - Deleting data from a partitioned table is cheap if full partitions are
   dropped. Full partitions are dropped with ``DELETE`` statements where the
   optimizer can infer from the ``WHERE`` clause and partition columns that all
-  records of a partition match without having to evaluate against the records.
+  records of a partition match without having to :ref:`evaluate
+  <gloss-evaluation>` against the records.
 
 
 Partitioned tables have the following disadvantages:
@@ -364,8 +365,8 @@ For example, the following query will only operate on the partition for
     +----------+
     SELECT 1 row in set (... sec)
 
-Any combination of conditions that can be evaluated to a partition before
-actually executing the query is supported::
+Any combination of conditions that can be :ref:`evaluated <gloss-evaluation>`
+to a partition before actually executing the query is supported::
 
     cr> SELECT id, title FROM parted_table
     ... WHERE date_trunc('year', day) > '1970-01-01'

--- a/docs/general/dql/joins.rst
+++ b/docs/general/dql/joins.rst
@@ -26,10 +26,10 @@ Cross joins
 
 Referencing two tables results in a ``CROSS JOIN``.
 
-The result is computed by creating every possible combination (`Cartesian
-Product`_) of their rows (``t1 * t2 * t3 * tn``) and then applying the given
-query operation on it (``WHERE`` clause, ``SELECT`` list, ``ORDER BY`` clause,
-...)::
+The result is computed by creating every possible combination (i.e., a
+`cartesian product`_) of their rows (``t1 * t2 * t3 * tn``) and then applying
+the given query operation on it (e.g., ``WHERE`` clause, ``SELECT`` list,
+``ORDER BY`` clause, and so on)::
 
     cr> select articles.name as article, colors.name as color, price
     ... from articles cross join colors
@@ -105,10 +105,11 @@ Outer joins
 Left outer joins
 ................
 
-Left outer join returns tuples for all matching records of the *left* and
-*right* relation like :ref:`inner joins <inner-joins>`. Additionally it returns
-*tuples* for all other records from *left* that don't match any record on the
-*right* by using null values for the columns of the *right* relation::
+Left outer join returns tuples for all matching records of the left-hand and
+right-hand relation like :ref:`inner joins <inner-joins>`. Additionally it
+returns tuples for all other records from left-hand that don't match any record
+on the right-hand by using ``NULL`` values for the columns of the right-hand
+relation::
 
     cr> select e.name || ' ' || e.surname as employee, coalesce(d.name, '') as manager_of_department
     ... from employees e left join departments d
@@ -142,10 +143,11 @@ Left outer join returns tuples for all matching records of the *left* and
 Right outer joins
 .................
 
-Right outer join returns tuples for all matching records of the *right* and
-*left* relation like :ref:`inner joins <inner-joins>`. Additionally it returns
-tuples for all other records from *right* that don't match any record on the
-*left* by using null values for the columns of the *left* relation::
+Right outer join returns tuples for all matching records of the right-hand and
+left-hand relation like :ref:`inner joins <inner-joins>`. Additionally it
+returns tuples for all other records from right-hand that don't match any
+record on the left-hand by using ``NULL`` values for the columns of the
+left-hand relation::
 
     cr> select e.name || ' ' || e.surname as employee, d.name as manager_of_department
     ... from employees e right join departments d
@@ -167,13 +169,13 @@ tuples for all other records from *right* that don't match any record on the
 Full outer joins
 ................
 
-Full outer join returns tuples for all matching records of the *left* and
-*right* relation like :ref:`inner joins <inner-joins>`. Additionally it returns
-tuples for all other records from *left* that don't match any record on the
-*right* by using null values for the columns of the *right*
-relation. Additionally it returns tuples for all other records from *right*
-that don't match any record on the *left* by using null values for the columns
-of the *left* relation::
+Full outer join returns tuples for all matching records of the left-hand and
+right-hand relation like :ref:`inner joins <inner-joins>`. Additionally it
+returns tuples for all other records from left-hand that don't match any record
+on the right-hand by using ``NULL`` values for the columns of the right-hand
+relation. Additionally it returns tuples for all other records from right-hand
+that don't match any record on the left-hand by using ``NULL`` values for the
+columns of the left-hand relation::
 
     cr> select e.name || ' ' || e.surname as employee, coalesce(d.name, '') as manager_of_department
     ... from employees e full join departments d
@@ -235,10 +237,11 @@ Available join algorithms
 Nested loop join algorithm
 ..........................
 
-The nested loop algorithm evaluates the join conditions on every record of the
-left table with every record of the right table in a distributed manner (for
-each shard of the used tables). The right table is scanned once for every row
-in the left table.
+The nested loop algorithm :ref:`evaluates <gloss-evaluation>` the join
+conditions on every record of the left-hand table with every record of the
+right-hand table in a distributed manner (for each shard of the used
+tables). The right-hand table is scanned once for every row in the left-hand
+table.
 
 This is the default algorithm used for all types of joins.
 
@@ -246,11 +249,11 @@ This is the default algorithm used for all types of joins.
 Block hash join algorithm
 .........................
 
-The performance of `Equi-Joins`_ is substantially improved by using the `Hash
-Join`_ algorithm. At first one relation is scanned and loaded into a hash table
-using the attributes of the join conditions as hash keys. Once the hash table
-is build, the second relation is scanned and the join condition values of every
-row are hashed and matched against the hash table.
+The performance of `equi-joins`_ is substantially improved by using the `hash
+join`_ algorithm. At first, one relation is scanned and loaded into a hash
+table using the attributes of the join conditions as hash keys. Once the hash
+table is built, the second relation is scanned and the join condition values of
+every row are hashed and matched against the hash table.
 
 In order to built a hash table even if the first relation wouldn't fit into the
 available memory, only a certain block size of a relation is loaded at
@@ -267,7 +270,7 @@ the join condition satisfies the following rules:
   - Every argument of a ``EQUAL`` operator can only references fields from one
     relation
 
-The `Hash Join`_ algorithm is faster but has a bigger memory footprint. As such
+The `hash join`_ algorithm is faster but has a bigger memory footprint. As such
 it can explicitly be disabled on demand when memory is scarce using the session
 setting :ref:`enable_hashjoin <conf-session-enable-hashjoin>`::
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -378,8 +378,9 @@ null        null
 ``IS NULL``
 -----------
 
-Returns ``TRUE`` if ``expr`` evaluates to ``NULL``. Given a column reference it
-returns ``TRUE`` if the field contains ``NULL`` or is missing.
+Returns ``TRUE`` if ``expr`` :ref:`evaluates <gloss-evaluation>` to
+``NULL``. Given a column reference, it returns ``TRUE`` if the field contains
+``NULL`` or is missing.
 
 Use this predicate to check for ``NULL`` values as SQL's three-valued logic
 does always return ``NULL`` when comparing ``NULL``.
@@ -423,8 +424,9 @@ does always return ``NULL`` when comparing ``NULL``.
 ``IS NOT NULL``
 ---------------
 
-Returns ``TRUE`` if ``expr`` does not evaluate to ``NULL``. Additionally, for
-column references it returns ``FALSE`` if the column does not exist.
+Returns ``TRUE`` if ``expr`` does not :ref:`evaluate <gloss-evaluation>` to
+``NULL``. Additionally, for column references it returns ``FALSE`` if the
+column does not exist.
 
 Use this predicate to check for non-``NULL`` values as SQL's three-valued logic
 does always return ``NULL`` when comparing ``NULL``.
@@ -471,9 +473,9 @@ CrateDB supports a variety of :ref:`array comparisons <sql_array_comparisons>`.
 
 CrateDB supports the :ref:`operator <gloss-operator>` ``IN`` which allows you
 to verify the membership of the left-hand operator operand in a right-hand set
-of :ref:`expressions <gloss-expression>`. Returns ``true`` if any evaluated
-expression value from a right-hand set equals left-hand operand. Returns
-``false`` otherwise::
+of :ref:`expressions <gloss-expression>`. Returns ``true`` if any
+:ref:`evaluated <gloss-evaluation>` expression value from a right-hand set
+equals left-hand operand. Returns ``false`` otherwise::
 
     cr> select name, kind from locations
     ... where (kind in ('Star System', 'Planet'))  order by name asc;

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -413,9 +413,9 @@ CrateDB and we love to hear feedback.
 Expression evaluation
 ---------------------
 
-Unlike PostgreSQL, :ref:`expressions <gloss-expression>` are not evaluated if
-the query results in 0 rows either because of the table is empty or by a not
-matching ``WHERE`` clause.
+Unlike PostgreSQL, :ref:`expressions <gloss-expression>` are not
+:ref:`evaluated <gloss-evaluation>` if the query results in 0 rows either
+because of the table is empty or by not matching the ``WHERE`` clause.
 
 
 .. _GitHub: https://github.com/crate/crate

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -7,7 +7,8 @@ Value expressions
 =================
 
 A value :ref:`expression <gloss-expression>` is a combination of one or more
-values, operators, and functions that *evaluates* to a single value.
+values, :ref:`operators <gloss-operator>`, and functions that :ref:`evaluate
+<gloss-evaluation>` to a single value.
 
 .. rubric:: Table of contents
 

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -236,9 +236,10 @@ Parameters
   data should be put.
 
 :uri:
-  An :ref:`expression <gloss-expression>` which evaluates to a URI as defined
-  in `RFC2396`_. The supported schemes are listed above. The last part of the
-  path may also contain ``*`` wildcards to match multiple files.
+  An :ref:`expression <gloss-expression>` which :ref:`evaluates
+  <gloss-evaluation>` to a URI as defined in `RFC2396`_. The supported schemes
+  are listed above. The last part of the path may also contain ``*`` wildcards
+  to match multiple files.
 
 
 .. _sql-copy-from-clauses:

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -155,9 +155,9 @@ The ``TO`` clause allows you to specify an output location.
 :output_uri:
   The output URI.
 
-The output URI can be any :ref:`expression <gloss-expression>` that evaluates
-to a string. The string must be a valid URI that uses the ``file://`` or
-``s3://`` URI scheme.
+The output URI can be any :ref:`expression <gloss-expression>` that
+:ref:`evaluates <gloss-evaluation>` to a string. The string must be a valid URI
+that uses the ``file://`` or ``s3://`` URI scheme.
 
 For example:
 

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -206,10 +206,10 @@ Parameters
 :generation_expression:
   An :ref:`expression <ddl-generated-columns-expressions>` (usually a
   :ref:`function call <sql-function-call>`) that is applied in the context of
-  the current row. As such it can reference other base columns of the
-  table. Referencing other generated columns (including itself) is not
-  supported. The generation expression is evaluated each time a row is inserted
-  or the referenced base columns are updated.
+  the current row. As such, it can reference other base columns of the table.
+  Referencing other generated columns (including itself) is not supported. The
+  generation expression is :ref:`evaluated <gloss-evaluation>` each time a row
+  is inserted or the referenced base columns are updated.
 
 
 .. _sql-create-table-if-not-exists:

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -246,8 +246,9 @@ an alias:
     ( select_stmt ) [ AS ] alias
 
 The :ref:`subselect <gloss-subquery>` behaves like a temporary table that is
-evaluated at runtime. The clauses of the surrounding ``SELECT`` statements are
-applied on the result of the inner ``SELECT`` statement.
+:ref:`evaluated <gloss-evaluation>` at runtime. The clauses of the surrounding
+``SELECT`` statements are applied on the result of the inner ``SELECT``
+statement.
 
 :select_stmt:
   A ``SELECT`` statement.
@@ -268,7 +269,7 @@ returned::
 
 :condition:
   A ``WHERE`` condition is any :ref:`expression <gloss-expression>` that
-  evaluates to a result of type boolean.
+  :ref:`evaluates <gloss-evaluation>` to a result of type boolean.
 
   Any row that does not satisfy this condition will be eliminated from the
   output. A row satisfies the condition if it returns true when the actual row
@@ -313,8 +314,8 @@ within a resulting row of a ``GROUP BY`` clause.
 
 :condition:
   A ``HAVING`` condition is any :ref:`expression <sql-literal-value>` that
-  evaluates to a result of type boolean. Every row for which the condition is
-  not satisfied will be eliminated from the output.
+  :ref:`evaluates <gloss-evaluation>` to a result of type boolean. Every row
+  for which the condition is not satisfied will be eliminated from the output.
 
 .. NOTE::
 


### PR DESCRIPTION
This commit follows up on the addition of the "subquery" term added to the
glossary. For eligible uses of the word and related words, links to the
glossary have been added.

Eligible uses are limited to the first mention of the term per section in a
document

Some RST fixes and improvements accompany these changes where they were spotted
near to existing changes being made.

---

this is based off of `nomi/gloss-05`, but once that is merged, I will rebase it onto `master`