### PR TITLE
Remove materialize from Buckets

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/Buckets.java
+++ b/libs/dex/src/main/java/io/crate/data/Buckets.java
@@ -50,13 +50,4 @@ public class Buckets {
             }
         };
     }
-
-    public static Object[][] materialize(Bucket bucket) {
-        Object[][] res = new Object[bucket.size()][];
-        int i = 0;
-        for (Row row : bucket) {
-            res[i++] = row.materialize();
-        }
-        return res;
-    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The method was only used in tests


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)