### PR TITLE
Set tableOid in RowDescription only if all result columns have positions

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,4 +59,7 @@ None
 Fixes
 =====
 
-None
+- Changed the ``RowDescription`` message that is sent to PostgreSQL clients to
+  avoid that the JDBC client triggers queries against ``pg_catalog`` schema
+  tables each time information from the ``MetaData`` of a ``ResultSet`` is
+  accessed.

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -367,6 +367,10 @@ public class Messages {
         channel.write(buffer);
     }
 
+    private static boolean isRefWithPosition(Symbol symbol) {
+        return symbol instanceof Reference && ((Reference) symbol).position() != null;
+    }
+
     /**
      * RowDescription (B)
      * <p>
@@ -391,7 +395,10 @@ public class Messages {
         buffer.writeInt(0); // will be set at the end
         buffer.writeShort(columns.size());
 
-        int tableOid = relation == null ? 0 : OidHash.relationOid(relation);
+        int tableOid = 0;
+        if (relation != null && columns.stream().allMatch(Messages::isRefWithPosition)) {
+            tableOid = OidHash.relationOid(relation);
+        }
         int idx = 0;
         for (Symbol column : columns) {
             byte[] nameBytes = Symbols.pathFromSymbol(column).sqlFqn().getBytes(StandardCharsets.UTF_8);

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -22,45 +22,6 @@
 
 package io.crate.integrationtests;
 
-import io.crate.action.sql.SQLOperations;
-import io.crate.execution.engine.collect.stats.JobsLogService;
-import io.crate.protocols.postgres.PostgresNetty;
-import io.crate.testing.DataTypeTesting;
-import io.crate.testing.UseJdbc;
-import io.crate.types.DataTypes;
-
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.postgresql.PGProperty;
-import org.postgresql.geometric.PGpoint;
-import org.postgresql.jdbc.PreferQueryMode;
-import org.postgresql.util.PGobject;
-import org.postgresql.util.PSQLException;
-import org.postgresql.util.PSQLState;
-
-import java.sql.Array;
-import java.sql.BatchUpdateException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.StringJoiner;
-import java.util.UUID;
-
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.protocols.postgres.PostgresNetty.PSQL_PORT_SETTING;
@@ -73,6 +34,49 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
+
+import java.sql.Array;
+import java.sql.BatchUpdateException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringJoiner;
+import java.util.UUID;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.postgresql.PGProperty;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.util.PGobject;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import io.crate.action.sql.SQLOperations;
+import io.crate.execution.engine.collect.stats.JobsLogService;
+import io.crate.execution.engine.collect.stats.JobsLogs;
+import io.crate.protocols.postgres.PostgresNetty;
+import io.crate.testing.DataTypeTesting;
+import io.crate.testing.UseJdbc;
+import io.crate.types.DataTypes;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
 public class PostgresITest extends SQLTransportIntegrationTest {
@@ -939,6 +943,43 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void test_metadata_calls_do_not_query_pg_catalog_tables_repeatedly() throws Exception {
+        var properties = new Properties();
+        properties.put("user", "crate");
+        properties.put("password", "");
+        try (var conn = DriverManager.getConnection(url(RW), properties)) {
+            var stmt = conn.createStatement();
+            stmt.execute("create table uservisits (\"adRevenue\" float, \"cCode\" text, \"duration\" float)");
+
+            conn.setAutoCommit(false);
+            stmt = conn.createStatement();
+            stmt.setFetchSize(101);
+            ResultSet result = stmt.executeQuery(
+                    "select avg(\"adRevenue\") from uservisits group by \"cCode\", \"duration\" limit 100");
+
+            long numQueries = getNumQueriesFromJobsLogs();
+            ResultSetMetaData metaData = result.getMetaData();
+            for (int i = 0; i < 50; i++) {
+                // These calls must not invoke extra queries
+                metaData.isAutoIncrement(1);
+            }
+            assertThat(getNumQueriesFromJobsLogs(), is(numQueries));
+            result.close();
+        }
+    }
+
+    private long getNumQueriesFromJobsLogs() {
+        long result = 0;
+        Iterable<JobsLogs> jobLogs = internalCluster().getInstances(JobsLogs.class);
+        for (JobsLogs jobsLogs : jobLogs) {
+            for (var metrics : jobsLogs.metrics()) {
+                result += metrics.totalCount();
+            }
+        }
+        return result;
     }
 
     private void assertSelectNameFromSysClusterWorks(Connection conn) throws SQLException {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

With 4.4.0 we started sending the table-oid and attnum information in
the RowDescription.
Unfortunately, sending the table-oid causes the JDBC to re-request field
meta data each time a metadata property is accessed because the caching
layer built into pgjdbc is skipped if the query that uses the table-oid
and attnum leads to an empty result.

Closes https://github.com/crate/crate/issues/11156


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)