### PR TITLE
Don't wrap ssl settings into CrateSetting

### DIFF
--- a/server/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/server/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -126,14 +126,14 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
         settings.add(AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting());
 
         // Settings for SSL
-        settings.add(SslConfigSettings.SSL_HTTP_ENABLED.setting());
-        settings.add(SslConfigSettings.SSL_PSQL_ENABLED.setting());
-        settings.add(SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.setting());
-        settings.add(SslConfigSettings.SSL_TRUSTSTORE_PASSWORD.setting());
-        settings.add(SslConfigSettings.SSL_KEYSTORE_FILEPATH.setting());
-        settings.add(SslConfigSettings.SSL_KEYSTORE_PASSWORD.setting());
-        settings.add(SslConfigSettings.SSL_KEYSTORE_KEY_PASSWORD.setting());
-        settings.add(SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL.setting());
+        settings.add(SslConfigSettings.SSL_HTTP_ENABLED);
+        settings.add(SslConfigSettings.SSL_PSQL_ENABLED);
+        settings.add(SslConfigSettings.SSL_TRUSTSTORE_FILEPATH);
+        settings.add(SslConfigSettings.SSL_TRUSTSTORE_PASSWORD);
+        settings.add(SslConfigSettings.SSL_KEYSTORE_FILEPATH);
+        settings.add(SslConfigSettings.SSL_KEYSTORE_PASSWORD);
+        settings.add(SslConfigSettings.SSL_KEYSTORE_KEY_PASSWORD);
+        settings.add(SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL);
 
         // also add CrateSettings
         for (CrateSetting<?> crateSetting : CrateSettings.CRATE_CLUSTER_SETTINGS) {

--- a/server/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
+++ b/server/src/main/java/io/crate/protocols/ssl/SslConfigSettings.java
@@ -22,20 +22,15 @@
 
 package io.crate.protocols.ssl;
 
-import io.crate.settings.CrateSetting;
-import io.crate.types.DataTypes;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+
 import io.crate.common.unit.TimeValue;
 
 /**
  * Settings for configuring Postgres SSL. Only applicable to the ssl-impl module.
  */
 public final class SslConfigSettings {
-
-    private static final Logger LOGGER = LogManager.getLogger(SslConfigSettings.class);
 
     private SslConfigSettings() {
     }
@@ -51,45 +46,54 @@ public final class SslConfigSettings {
 
     static final String SSL_RESOURCE_POLL_INTERVAL_NAME = "ssl.resource_poll_interval";
 
-    public static final CrateSetting<Boolean> SSL_HTTP_ENABLED = CrateSetting.of(
-        Setting.boolSetting(SSL_HTTP_ENABLED_SETTING_NAME, false, Setting.Property.NodeScope),
-        DataTypes.BOOLEAN);
-    public static final CrateSetting<Boolean> SSL_PSQL_ENABLED = CrateSetting.of(
-        Setting.boolSetting(SSL_PSQL_ENABLED_SETTING_NAME, false, Setting.Property.NodeScope),
-        DataTypes.BOOLEAN);
+    public static final Setting<Boolean> SSL_HTTP_ENABLED = Setting.boolSetting(
+        SSL_HTTP_ENABLED_SETTING_NAME,
+        false,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<Boolean> SSL_PSQL_ENABLED = Setting.boolSetting(
+        SSL_PSQL_ENABLED_SETTING_NAME,
+        false,
+        Setting.Property.NodeScope
+    );
 
-    public static final CrateSetting<String> SSL_TRUSTSTORE_FILEPATH = CrateSetting.of(
-        Setting.simpleString(SSL_TRUSTSTORE_FILEPATH_SETTING_NAME, Setting.Property.NodeScope),
-        DataTypes.STRING);
+    public static final Setting<String> SSL_TRUSTSTORE_FILEPATH = Setting.simpleString(
+        SSL_TRUSTSTORE_FILEPATH_SETTING_NAME,
+        Setting.Property.NodeScope
+    );
 
-    public static final CrateSetting<String> SSL_TRUSTSTORE_PASSWORD = CrateSetting.of(
-        Setting.simpleString(SSL_TRUSTSTORE_PASSWORD_SETTING_NAME, Setting.Property.NodeScope),
-        DataTypes.STRING);
+    public static final Setting<String> SSL_TRUSTSTORE_PASSWORD = Setting.simpleString(
+        SSL_TRUSTSTORE_PASSWORD_SETTING_NAME,
+        Setting.Property.NodeScope
+    );
 
-    public static final CrateSetting<String> SSL_KEYSTORE_FILEPATH = CrateSetting.of(
-        Setting.simpleString(SSL_KEYSTORE_FILEPATH_SETTING_NAME, Setting.Property.NodeScope),
-        DataTypes.STRING);
+    public static final Setting<String> SSL_KEYSTORE_FILEPATH = Setting.simpleString(
+        SSL_KEYSTORE_FILEPATH_SETTING_NAME,
+        Setting.Property.NodeScope
+    );
 
-    public static final CrateSetting<String> SSL_KEYSTORE_PASSWORD = CrateSetting.of(
-        Setting.simpleString(SSL_KEYSTORE_PASSWORD_SETTING_NAME, "", Setting.Property.NodeScope),
-        DataTypes.STRING);
+    public static final Setting<String> SSL_KEYSTORE_PASSWORD = Setting.simpleString(
+        SSL_KEYSTORE_PASSWORD_SETTING_NAME,
+        "",
+        Setting.Property.NodeScope
+    );
 
-    public static final CrateSetting<String> SSL_KEYSTORE_KEY_PASSWORD = CrateSetting.of(
-        Setting.simpleString(SSL_KEYSTORE_KEY_PASSWORD_SETTING_NAME, Setting.Property.NodeScope),
-        DataTypes.STRING);
+    public static final Setting<String> SSL_KEYSTORE_KEY_PASSWORD = Setting.simpleString(
+        SSL_KEYSTORE_KEY_PASSWORD_SETTING_NAME,
+        Setting.Property.NodeScope
+    );
 
-    public static final CrateSetting<TimeValue> SSL_RESOURCE_POLL_INTERVAL = CrateSetting.of(
-        Setting.positiveTimeSetting(
-            SSL_RESOURCE_POLL_INTERVAL_NAME,
-            TimeValue.timeValueMinutes(5),
-            Setting.Property.NodeScope),
-        DataTypes.STRING);
+    public static final Setting<TimeValue> SSL_RESOURCE_POLL_INTERVAL = Setting.positiveTimeSetting(
+        SSL_RESOURCE_POLL_INTERVAL_NAME,
+        TimeValue.timeValueMinutes(5),
+        Setting.Property.NodeScope
+    );
 
     public static boolean isHttpsEnabled(Settings settings) {
-        return SSL_HTTP_ENABLED.setting().get(settings);
+        return SSL_HTTP_ENABLED.get(settings);
     }
 
     public static boolean isPSQLSslEnabled(Settings settings) {
-        return SSL_PSQL_ENABLED.setting().get(settings);
+        return SSL_PSQL_ENABLED.get(settings);
     }
 }

--- a/server/src/main/java/io/crate/protocols/ssl/SslConfiguration.java
+++ b/server/src/main/java/io/crate/protocols/ssl/SslConfiguration.java
@@ -163,12 +163,12 @@ public final class SslConfiguration {
     }
 
     public static SslContext buildSslContext(Settings settings) {
-        var keystorePath = SslConfigSettings.SSL_KEYSTORE_FILEPATH.setting().get(settings);
-        var keystorePass = SslConfigSettings.SSL_KEYSTORE_PASSWORD.setting().get(settings).toCharArray();
-        var keystoreKeyPass = SslConfigSettings.SSL_KEYSTORE_KEY_PASSWORD.setting().get(settings).toCharArray();
+        var keystorePath = SslConfigSettings.SSL_KEYSTORE_FILEPATH.get(settings);
+        var keystorePass = SslConfigSettings.SSL_KEYSTORE_PASSWORD.get(settings).toCharArray();
+        var keystoreKeyPass = SslConfigSettings.SSL_KEYSTORE_KEY_PASSWORD.get(settings).toCharArray();
 
-        var trustStorePath = SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.setting().get(settings);
-        var trustStorePass = SslConfigSettings.SSL_TRUSTSTORE_PASSWORD.setting().get(settings).toCharArray();
+        var trustStorePath = SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.get(settings);
+        var trustStorePass = SslConfigSettings.SSL_TRUSTSTORE_PASSWORD.get(settings).toCharArray();
 
         try {
             var keyStore = loadKeyStore(keystorePath, keystorePass);

--- a/server/src/main/java/io/crate/protocols/ssl/SslContextProviderService.java
+++ b/server/src/main/java/io/crate/protocols/ssl/SslContextProviderService.java
@@ -69,7 +69,7 @@ public class SslContextProviderService extends AbstractLifecycleComponent {
         if (filesToWatch.isEmpty()) {
             return;
         }
-        TimeValue pollIntervalSetting = SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL.setting().get(settings);
+        TimeValue pollIntervalSetting = SslConfigSettings.SSL_RESOURCE_POLL_INTERVAL.get(settings);
         watchRoutine = threadPool.scheduleWithFixedDelay(
             () -> pollForChanges(filesToWatch),
             pollIntervalSetting,
@@ -79,11 +79,11 @@ public class SslContextProviderService extends AbstractLifecycleComponent {
 
     List<FingerPrint> createFilesToWatch() {
         ArrayList<FingerPrint> filesToWatch = new ArrayList<>();
-        var keystorePath = SslConfigSettings.SSL_KEYSTORE_FILEPATH.setting().get(settings);
+        var keystorePath = SslConfigSettings.SSL_KEYSTORE_FILEPATH.get(settings);
         if (!keystorePath.isEmpty()) {
             filesToWatch.add(FingerPrint.create(Paths.get(keystorePath)));
         }
-        var trustStorePath = SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.setting().get(settings);
+        var trustStorePath = SslConfigSettings.SSL_TRUSTSTORE_FILEPATH.get(settings);
         if (!trustStorePath.isEmpty()) {
             filesToWatch.add(FingerPrint.create(Paths.get(trustStorePath)));
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

All we did with the `CrateSetting` instances is access `setting` to get
the underlying `Setting` out of it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)