### PR TITLE
Add caution block to blob documentation

### DIFF
--- a/docs/general/blobs.rst
+++ b/docs/general/blobs.rst
@@ -10,6 +10,15 @@ CrateDB includes support to store `binary large objects`_. By utilizing
 CrateDB's cluster features the files can be replicated and sharded just like
 regular data.
 
+.. CAUTION::
+
+    We are considering to deprecate the support of blobs soon and potentially
+    removing it with CrateDB 5.0.
+
+    We would love to hear your feedback if you currently use blobs or are
+    considering to use it. Please `contact us`_ or add your comment to the
+    relevant `Github issue`_.
+
 .. rubric:: Table of contents
 
 .. contents::
@@ -205,3 +214,5 @@ If the blob doesn't exist a 404 Not Found error is returned::
     DROP OK, 1 row affected (... sec)
 
 .. _binary large objects: https://en.wikipedia.org/wiki/Binary_large_object
+.. _contact us: https://crate.io/contact/
+.. _Github issue: https://github.com/crate/crate/issues/11108


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Make readers of the documentation aware that we are considering to deprecate support for blobs

While browsing the documentation today I came about the blobs docs and thought that a `Caution` block on this page could be a considerate information for future readers. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
