### PR TITLE
Add support for reading cgroup stats from v2 cgroup hierarchy

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,8 @@ None
 Changes
 =======
 
+- Added support for reading ``cgroup`` information in the ``cgroup v2`` format.
+
 - Improved the internal throttling mechanism used for ``INSERT FROM QUERY`` and
   ``COPY FROM`` operations. This should lead to these queries utilizing more
   resources if the cluster can spare them.

--- a/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -192,7 +192,6 @@ public class NodeStatsTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @AwaitsFix(bugUrl = "https://github.com/crate/crate/issues/11197")
     public void testSysNodesCgroup() throws Exception {
         if (Constants.LINUX && !"true".equals(System.getenv("SHIPPABLE"))) { // cgroups are only available on Linux
             SQLResponse response = execute("select" +
@@ -209,11 +208,11 @@ public class NodeStatsTest extends SQLTransportIntegrationTest {
             assertThat(response.rows()[0][0], notNullValue());
             assertThat((long) response.rows()[0][1], greaterThanOrEqualTo(0L));
             assertThat(response.rows()[0][2], notNullValue());
-            assertThat((long) response.rows()[0][3], greaterThanOrEqualTo(0L));
+            assertThat((long) response.rows()[0][3], anyOf(equalTo(-1L), greaterThanOrEqualTo(0L)));
             assertThat((long) response.rows()[0][4], anyOf(equalTo(-1L), greaterThanOrEqualTo(0L)));
-            assertThat((long) response.rows()[0][5], greaterThanOrEqualTo(0L));
-            assertThat((long) response.rows()[0][6], greaterThanOrEqualTo(0L));
-            assertThat((long) response.rows()[0][7], greaterThanOrEqualTo(0L));
+            assertThat((long) response.rows()[0][5], anyOf(equalTo(-1L), greaterThanOrEqualTo(0L)));
+            assertThat((long) response.rows()[0][6], anyOf(equalTo(-1L), greaterThanOrEqualTo(0L)));
+            assertThat((long) response.rows()[0][7], anyOf(equalTo(-1L), greaterThanOrEqualTo(0L)));
         } else {
             // for all other OS cgroup fields should return `null`
             response = execute("select os['cgroup']," +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html

Closes https://github.com/crate/crate/issues/11197

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)