### PR TITLE
Update getting-started URLs within reference documentation

### DIFF
--- a/docs/cli-tools.rst
+++ b/docs/cli-tools.rst
@@ -48,7 +48,7 @@ The ``crate`` executable runs the CrateDB daemon.
 .. SEEALSO::
 
     This section is a low-level command reference. For help installing CrateDB
-    for the first time, check out `Getting Started With CrateDB`_.
+    for the first time, check out the `CrateDB installation tutorial`_.
     Alternatively, consult the `deployment guide`_ for help running CrateDB in
     production.
 
@@ -213,7 +213,7 @@ Options
 
 .. _deployment guide: https://crate.io/docs/crate/howtos/en/latest/deployment/index.html
 .. _Detach a node from its cluster: https://crate.io/docs/crate/howtos/en/latest/best-practices/crate-node.html#detach-a-node-from-its-cluster
-.. _Getting Started With CrateDB: https://crate.io/docs/crate/getting-started/en/latest/install/index.html
+.. _CrateDB installation tutorial: https://crate.io/docs/crate/tutorials/en/latest/install.html
 .. _graceful stop: https://crate.io/docs/crate/howtos/en/latest/admin/rolling-upgrade.html#step-2-graceful-stop
 .. _PATH: https://kb.iu.edu/d/acar
 .. _Perform an unsafe cluster bootstrap: https://crate.io/docs/crate/howtos/en/latest/best-practices/crate-node.html#perform-an-unsafe-cluster-bootstrap

--- a/docs/config/environment.rst
+++ b/docs/config/environment.rst
@@ -48,7 +48,7 @@ Application variables
 
   If you are installing manually, in most cases, this should be set to the
   directory from which you would normally execute ``bin/crate``, i.e. the root
-  directory of the `expanded tarball`_.
+  directory of the `basic installation`_.
 
 .. _conf-env-java:
 
@@ -108,7 +108,7 @@ General
 
   Default values are as follows:
 
-  - For `basic installations`_, the process working directory
+  - For a `basic installation`_, the process working directory
 
   - If you have installed `a CrateDB Linux package`_, ``/var/lib/crate``
 
@@ -147,11 +147,9 @@ logging of the JVM.
    The :ref:`logging configuration <conf-logging-gc>` documentation has
    the complete list of garbage collection logging environment variables.
 
-.. _basic installations: https://crate.io/docs/crate/getting-started/en/latest/install-run/basic.html
-.. _a CrateDB Linux package: https://crate.io/docs/crate/getting-started/en/latest/install-run/special/linux.html
-.. _CrateDB on Docker: https://crate.io/docs/crate/getting-started/en/latest/install-run/special/docker.html
-.. _Java options: https://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html#CBBIJCHG
+.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-unix-windows
+.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/install.html#linux
+.. _CrateDB on Docker: https://crate.io/docs/crate/tutorials/en/latest/install.html#docker
 .. _environment variables: https://en.wikipedia.org/wiki/Environment_variable
-.. _expanded tarball: https://crate.io/docs/crate/getting-started/en/latest/install-run/basic.html
 .. _Concurrent Mark Sweep: https://docs.oracle.com/javase/10/gctuning/concurrent-mark-sweep-cms-collector.htm
-.. _G1: https://docs.oracle.com/javase/10/gctuning/garbage-first-garbage-collector.htm
+.. _G1: https://docs.oracle.com/en/java/javase/16/gctuning/garbage-first-g1-garbage-collector1.html

--- a/docs/config/logging.rst
+++ b/docs/config/logging.rst
@@ -160,14 +160,14 @@ garbage collection logging.
 ``CRATE_GC_LOG_DIR``: *path to logs directory* (default: varies)
   The log file directory.
 
-  For `basic installations`_, the ``logs`` directory in the
+  For a `basic installation`_, the ``logs`` directory in the
   :ref:`CRATE_HOME <conf-env-crate-home>` directory is default.
 
   If you have installed `a CrateDB Linux package`_, the default directory is
   ``/var/log/crate`` instead.
 
-.. _basic installations: https://crate.io/docs/crate/getting-started/en/latest/install-run/basic.html
-.. _a CrateDB Linux package: https://crate.io/docs/crate/getting-started/en/latest/install-run/special/linux.html
+.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-unix-windows
+.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/install.html#linux
 
 .. _conf-logging-gc-log-size:
 

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -15,8 +15,8 @@ client implementation perspective.
    `Client Libraries`_ — Officially supported clients and community supported
    clients
 
-.. _Connecting to CrateDB: https://crate.io/docs/crate/getting-started/en/latest/connect/index.html
-.. _Client Libraries: https://crate.io/docs/crate/getting-started/en/latest/clients/index.html
+.. _Connecting to CrateDB: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
+.. _Client Libraries: https://crate.io/docs/crate/clients-tools/en/latest/
 
 .. rubric:: Table of contents
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The getting-started urls are all redirecting to https://crate.io/docs/crate/reference/en/4.5/index.html but should link to the tutorial section.

IMO within the docs we should use the correct URLs. I will create a separate issue to look into the redirect URLs from old `getting-started` to new `tutorials section.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
