### PR TITLE
bp: Do not force refresh when write indexing buffer

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -524,7 +524,7 @@ should be crossed out as well.
 - [ ] d1deeaeb74c Allow proxy mode server name to be configured (#50774)
 - [ ] d9528406bf3 Use default profile for remote connections (#50828)
 - [ ] a0513217dba Move metadata storage to Lucene (#50907)
-- [ ] 0510af87868 Do not force refresh when write indexing buffer (#50769)
+- [x] 0510af87868 Do not force refresh when write indexing buffer (#50769)
 - [x] 40801af8840 Import replicated closed dangling indices (#50649)
 - [x] fdd413370ef Deleted docs disregarded for if_seq_no check (#50526)
 - [x] 4c1f1b2acab Declare remaining parsers `final` (#50571)

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1680,9 +1680,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public void writeIndexingBuffer() throws EngineException {
-        // we obtain a read lock here, since we don't want a flush to happen while we are writing
-        // since it flushes the index as well (though, in terms of concurrency, we are allowed to do it)
-        refresh("write indexing buffer", SearcherScope.INTERNAL, true);
+        refresh("write indexing buffer", SearcherScope.INTERNAL, false);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices;
+
+import io.crate.integrationtests.SQLTransportIntegrationTest;
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.codec.CodecService;
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.engine.InternalEngine;
+import org.elasticsearch.plugins.EnginePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.is;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class IndexingMemoryControllerIT extends SQLTransportIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+            // small indexing buffer so that we can trigger refresh after buffering 100 deletes
+            .put("indices.memory.index_buffer_size", "1kb").build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        var classes = new HashSet<>(super.nodePlugins());
+        classes.add(TestEnginePlugin.class);
+        return classes;
+    }
+
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    public static class TestEnginePlugin extends Plugin implements EnginePlugin {
+
+        EngineConfig engineConfigWithLargerIndexingMemory(EngineConfig config) {
+            // We need to set a larger buffer for the IndexWriter; otherwise, it will flush before the IndexingMemoryController.
+            Settings settings = Settings.builder().put(config.getIndexSettings().getSettings())
+                .put("indices.memory.index_buffer_size", "10mb").build();
+            IndexSettings indexSettings = new IndexSettings(config.getIndexSettings().getIndexMetadata(), settings);
+            return new EngineConfig(config.getShardId(), config.getAllocationId(), config.getThreadPool(),
+                                    indexSettings, config.getStore(), config.getMergePolicy(), config.getAnalyzer(),
+                                    new CodecService(null, LogManager.getLogger(IndexingMemoryControllerIT.class)),
+                                    config.getEventListener(), config.getQueryCache(),
+                                    config.getQueryCachingPolicy(), config.getTranslogConfig(), config.getFlushMergesAfter(),
+                                    config.getExternalRefreshListener(), config.getInternalRefreshListener(),
+                                    config.getCircuitBreakerService(), config.getGlobalCheckpointSupplier(), config.retentionLeasesSupplier(),
+                                    config.getPrimaryTermSupplier(), config.getTombstoneDocSupplier());
+        }
+
+        @Override
+        public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
+            return Optional.of(config -> new InternalEngine(engineConfigWithLargerIndexingMemory(config)));
+        }
+    }
+
+    public void testDeletesAloneCanTriggerRefresh() throws Exception {
+        // Disable refresh interval to make sure it won't be executed while the test is running
+        execute("create table doc.test(x int) clustered into 1 shards with(number_of_replicas=0, refresh_interval='-1')");
+
+        for (int i = 0; i < 100; i++) {
+            execute("insert into doc.test(x) values(?)", new Object[]{i});
+        }
+        // Force merge so we know all merges are done before we start deleting:
+        execute("optimize table doc.test");
+
+        for (int i = 0; i < 100; i++) {
+            execute("delete from doc.test where x = ?", new Object[]{i});
+        }
+
+        // need to assert busily as IndexingMemoryController refreshes in background
+        assertBusy(() -> {
+            execute("select count(*) from doc.test");
+            assertThat(response.rows()[0][0], is(0L));
+        });
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -1,0 +1,460 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices;
+
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.codec.CodecService;
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.InternalEngine;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.elasticsearch.common.util.concurrent.EsExecutors.PROCESSORS_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+public class IndexingMemoryControllerTests extends IndexShardTestCase {
+
+    @Override
+    public Settings threadPoolSettings() {
+        // This test was failing on github actions because the processor size was so small that the
+        // refresh threadpool ended up with only 1 thread. That was too small for this test to run correctly.
+        // Therefore lets set the number of processor to 4 to make sure the size of the refresh threadpool is at least 2.
+        return Settings.builder().put(PROCESSORS_SETTING.getKey(), 4).build();
+    }
+
+    static class MockController extends IndexingMemoryController {
+
+        // Size of each shard's indexing buffer
+        final Map<IndexShard, Long> indexBufferRAMBytesUsed = new HashMap<>();
+
+        // How many bytes this shard is currently moving to disk
+        final Map<IndexShard, Long> writingBytes = new HashMap<>();
+
+        // Shards that are currently throttled
+        final Set<IndexShard> throttled = new HashSet<>();
+
+        MockController(Settings settings) {
+            super(Settings.builder()
+                      .put("indices.memory.interval", "200h") // disable it
+                      .put(settings)
+                      .build(), null, null);
+        }
+
+        public void deleteShard(IndexShard shard) {
+            indexBufferRAMBytesUsed.remove(shard);
+            writingBytes.remove(shard);
+        }
+
+        @Override
+        public List<IndexShard> availableShards() {
+            return new ArrayList<>(indexBufferRAMBytesUsed.keySet());
+        }
+
+        @Override
+        protected long getIndexBufferRAMBytesUsed(IndexShard shard) {
+            return indexBufferRAMBytesUsed.get(shard) + writingBytes.get(shard);
+        }
+
+        @Override
+        protected long getShardWritingBytes(IndexShard shard) {
+            Long bytes = writingBytes.get(shard);
+            if (bytes == null) {
+                return 0;
+            } else {
+                return bytes;
+            }
+        }
+
+        @Override
+        protected void checkIdle(IndexShard shard, long inactiveTimeNS) {
+        }
+
+        @Override
+        public void writeIndexingBufferAsync(IndexShard shard) {
+            long bytes = indexBufferRAMBytesUsed.put(shard, 0L);
+            writingBytes.put(shard, writingBytes.get(shard) + bytes);
+            indexBufferRAMBytesUsed.put(shard, 0L);
+        }
+
+        @Override
+        public void activateThrottling(IndexShard shard) {
+            assertTrue(throttled.add(shard));
+        }
+
+        @Override
+        public void deactivateThrottling(IndexShard shard) {
+            assertTrue(throttled.remove(shard));
+        }
+
+        public void doneWriting(IndexShard shard) {
+            writingBytes.put(shard, 0L);
+        }
+
+        public void assertBuffer(IndexShard shard, int expectedMB) {
+            Long actual = indexBufferRAMBytesUsed.get(shard);
+            if (actual == null) {
+                actual = 0L;
+            }
+            assertEquals(expectedMB * 1024 * 1024, actual.longValue());
+        }
+
+        public void assertThrottled(IndexShard shard) {
+            assertTrue(throttled.contains(shard));
+        }
+
+        public void assertNotThrottled(IndexShard shard) {
+            assertFalse(throttled.contains(shard));
+        }
+
+        public void assertWriting(IndexShard shard, int expectedMB) {
+            Long actual = writingBytes.get(shard);
+            if (actual == null) {
+                actual = 0L;
+            }
+            assertEquals(expectedMB * 1024 * 1024, actual.longValue());
+        }
+
+        public void simulateIndexing(IndexShard shard) {
+            Long bytes = indexBufferRAMBytesUsed.get(shard);
+            if (bytes == null) {
+                bytes = 0L;
+                // First time we are seeing this shard:
+                writingBytes.put(shard, 0L);
+            }
+            // Each doc we index takes up a megabyte!
+            bytes += 1024*1024;
+            indexBufferRAMBytesUsed.put(shard, bytes);
+            forceCheck();
+        }
+
+        @Override
+        protected Cancellable scheduleTask(ThreadPool threadPool) {
+            return null;
+        }
+    }
+
+    public void testShardAdditionAndRemoval() throws IOException {
+
+        MockController controller = new MockController(Settings.builder()
+                                                           .put("indices.memory.index_buffer_size", "4mb").build());
+        IndexShard shard0 = newStartedShard();
+        controller.simulateIndexing(shard0);
+        controller.assertBuffer(shard0, 1);
+
+        // add another shard
+        IndexShard shard1 = newStartedShard();
+        controller.simulateIndexing(shard1);
+        controller.assertBuffer(shard0, 1);
+        controller.assertBuffer(shard1, 1);
+
+        // remove first shard
+        controller.deleteShard(shard0);
+        controller.forceCheck();
+        controller.assertBuffer(shard1, 1);
+
+        // remove second shard
+        controller.deleteShard(shard1);
+        controller.forceCheck();
+
+        // add a new one
+        IndexShard shard2 = newStartedShard();
+        controller.simulateIndexing(shard2);
+        controller.assertBuffer(shard2, 1);
+        closeShards(shard0, shard1, shard2);
+    }
+
+    public void testActiveInactive() throws IOException {
+
+        MockController controller = new MockController(Settings.builder()
+                                                           .put("indices.memory.index_buffer_size", "5mb")
+                                                           .build());
+
+        IndexShard shard0 = newStartedShard();
+        controller.simulateIndexing(shard0);
+        IndexShard shard1 = newStartedShard();
+        controller.simulateIndexing(shard1);
+
+        controller.assertBuffer(shard0, 1);
+        controller.assertBuffer(shard1, 1);
+
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard1);
+
+        controller.assertBuffer(shard0, 2);
+        controller.assertBuffer(shard1, 2);
+
+        // index into one shard only, crosses the 5mb limit, so shard1 is refreshed
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard0);
+        controller.assertBuffer(shard0, 0);
+        controller.assertBuffer(shard1, 2);
+
+        controller.simulateIndexing(shard1);
+        controller.simulateIndexing(shard1);
+        controller.assertBuffer(shard1, 4);
+        controller.simulateIndexing(shard1);
+        controller.simulateIndexing(shard1);
+        // shard1 crossed 5 mb and is now cleared:
+        controller.assertBuffer(shard1, 0);
+        closeShards(shard0, shard1);
+    }
+
+    public void testMinBufferSizes() {
+        MockController controller = new MockController(Settings.builder()
+                                                           .put("indices.memory.index_buffer_size", "0.001%")
+                                                           .put("indices.memory.min_index_buffer_size", "6mb").build());
+
+        assertThat(controller.indexingBufferSize(), equalTo(new ByteSizeValue(6, ByteSizeUnit.MB)));
+    }
+
+    public void testNegativeMinIndexBufferSize() {
+        Exception e = expectThrows(IllegalArgumentException.class,
+                                   () -> new MockController(Settings.builder()
+                                                                .put("indices.memory.min_index_buffer_size", "-6mb").build()));
+        assertEquals("failed to parse setting [indices.memory.min_index_buffer_size] with value [-6mb] as a size in bytes", e.getMessage());
+
+    }
+
+    public void testNegativeInterval() {
+        Exception e = expectThrows(IllegalArgumentException.class,
+                                   () -> new MockController(Settings.builder()
+                                                                .put("indices.memory.interval", "-42s").build()));
+        assertEquals("failed to parse value [-42s] for setting [indices.memory.interval], must be >= [0ms]", e.getMessage());
+
+    }
+
+    public void testNegativeShardInactiveTime() {
+        Exception e = expectThrows(IllegalArgumentException.class,
+                                   () -> new MockController(Settings.builder()
+                                                                .put("indices.memory.shard_inactive_time", "-42s").build()));
+        assertEquals("failed to parse value [-42s] for setting [indices.memory.shard_inactive_time], must be >= [0ms]", e.getMessage());
+
+    }
+
+    public void testNegativeMaxIndexBufferSize() {
+        Exception e = expectThrows(IllegalArgumentException.class,
+                                   () -> new MockController(Settings.builder()
+                                                                .put("indices.memory.max_index_buffer_size", "-6mb").build()));
+        assertEquals("failed to parse setting [indices.memory.max_index_buffer_size] with value [-6mb] as a size in bytes", e.getMessage());
+
+    }
+
+    public void testMaxBufferSizes() {
+        MockController controller = new MockController(Settings.builder()
+                                                           .put("indices.memory.index_buffer_size", "90%")
+                                                           .put("indices.memory.max_index_buffer_size", "6mb").build());
+
+        assertThat(controller.indexingBufferSize(), equalTo(new ByteSizeValue(6, ByteSizeUnit.MB)));
+    }
+
+    public void testThrottling() throws Exception {
+
+        MockController controller = new MockController(Settings.builder()
+                                                           .put("indices.memory.index_buffer_size", "4mb").build());
+        IndexShard shard0 = newStartedShard();
+        IndexShard shard1 = newStartedShard();
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard0);
+        controller.assertBuffer(shard0, 3);
+        controller.simulateIndexing(shard1);
+        controller.simulateIndexing(shard1);
+
+        // We are now using 5 MB, so we should be writing shard0 since it's using the most heap:
+        controller.assertWriting(shard0, 3);
+        controller.assertWriting(shard1, 0);
+        controller.assertBuffer(shard0, 0);
+        controller.assertBuffer(shard1, 2);
+
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard1);
+        controller.simulateIndexing(shard1);
+
+        // Now we are still writing 3 MB (shard0), and using 5 MB index buffers, so we should now 1) be writing shard1,
+        // and 2) be throttling shard1:
+        controller.assertWriting(shard0, 3);
+        controller.assertWriting(shard1, 4);
+        controller.assertBuffer(shard0, 1);
+        controller.assertBuffer(shard1, 0);
+
+        controller.assertNotThrottled(shard0);
+        controller.assertThrottled(shard1);
+
+        logger.info("--> Indexing more data");
+
+        // More indexing to shard0
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard0);
+        controller.simulateIndexing(shard0);
+
+        // Now we are using 5 MB again, so shard0 should also be writing and now also be throttled:
+        controller.assertWriting(shard0, 8);
+        controller.assertWriting(shard1, 4);
+        controller.assertBuffer(shard0, 0);
+        controller.assertBuffer(shard1, 0);
+
+        controller.assertThrottled(shard0);
+        controller.assertThrottled(shard1);
+
+        // Both shards finally finish writing, and throttling should stop:
+        controller.doneWriting(shard0);
+        controller.doneWriting(shard1);
+        controller.forceCheck();
+        controller.assertNotThrottled(shard0);
+        controller.assertNotThrottled(shard1);
+        closeShards(shard0, shard1);
+    }
+
+    public void testTranslogRecoveryWorksWithIMC() throws IOException {
+        IndexShard shard = newStartedShard(true);
+        for (int i = 0; i < 100; i++) {
+            indexDoc(shard, Integer.toString(i), "{}", XContentType.JSON, null);
+        }
+        shard.close("simon says", false);
+        AtomicReference<IndexShard> shardRef = new AtomicReference<>();
+        Settings settings = Settings.builder().put("indices.memory.index_buffer_size", "50kb").build();
+        Iterable<IndexShard> iterable = () -> (shardRef.get() == null) ? Collections.emptyIterator()
+            : Collections.singleton(shardRef.get()).iterator();
+        AtomicInteger flushes = new AtomicInteger();
+        IndexingMemoryController imc = new IndexingMemoryController(settings, threadPool, iterable) {
+            @Override
+            protected void writeIndexingBufferAsync(IndexShard shard) {
+                assertEquals(shard, shardRef.get());
+                flushes.incrementAndGet();
+                shard.writeIndexingBuffer();
+            }
+        };
+        shard = reinitShard(shard, imc);
+        shardRef.set(shard);
+        assertEquals(0, imc.availableShards().size());
+        DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
+        shard.markAsRecovering("store", new RecoveryState(shard.routingEntry(), localNode, null));
+
+        assertEquals(1, imc.availableShards().size());
+        assertTrue(recoverFromStore(shard));
+        assertThat("we should have flushed in IMC at least once", flushes.get(), greaterThanOrEqualTo(1));
+        closeShards(shard);
+    }
+
+    EngineConfig configWithRefreshListener(EngineConfig config, ReferenceManager.RefreshListener listener) {
+        final List<ReferenceManager.RefreshListener> internalRefreshListener = new ArrayList<>(config.getInternalRefreshListener());;
+        internalRefreshListener.add(listener);
+        return new EngineConfig(config.getShardId(), config.getAllocationId(), config.getThreadPool(),
+                                config.getIndexSettings(), config.getStore(), config.getMergePolicy(), config.getAnalyzer(),
+                                new CodecService(null, logger), config.getEventListener(), config.getQueryCache(),
+                                config.getQueryCachingPolicy(), config.getTranslogConfig(), config.getFlushMergesAfter(),
+                                config.getExternalRefreshListener(), internalRefreshListener,
+                                config.getCircuitBreakerService(), config.getGlobalCheckpointSupplier(), config.retentionLeasesSupplier(),
+                                config.getPrimaryTermSupplier(), config.getTombstoneDocSupplier());
+    }
+
+    ThreadPoolStats.Stats getRefreshThreadPoolStats() {
+        final ThreadPoolStats stats = threadPool.stats();
+        for (ThreadPoolStats.Stats s : stats) {
+            if (s.getName().equals(ThreadPool.Names.REFRESH)) {
+                return s;
+            }
+        }
+        throw new AssertionError("refresh thread pool stats not found [" + stats + "]");
+    }
+
+    public void testSkipRefreshIfShardIsRefreshingAlready() throws Exception {
+        SetOnce<CountDownLatch> refreshLatch = new SetOnce<>();
+        ReferenceManager.RefreshListener refreshListener = new ReferenceManager.RefreshListener() {
+            @Override
+            public void beforeRefresh() {
+                if (refreshLatch.get() != null) {
+                    try {
+                        refreshLatch.get().await();
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                }
+            }
+
+            @Override
+            public void afterRefresh(boolean didRefresh) {
+
+            }
+        };
+        IndexShard shard = newStartedShard(randomBoolean(), Settings.EMPTY,
+                                           config -> new InternalEngine(configWithRefreshListener(config, refreshListener)));
+        refreshLatch.set(new CountDownLatch(1)); // block refresh
+        final IndexingMemoryController controller = new IndexingMemoryController(
+            Settings.builder().put("indices.memory.interval", "200h") // disable it
+                .put("indices.memory.index_buffer_size", "1024b")
+                .build(),
+            threadPool,
+            Collections.singleton(shard)) {
+            @Override
+            protected long getIndexBufferRAMBytesUsed(IndexShard shard) {
+                return randomLongBetween(1025, 10 * 1024 * 1024);
+            }
+
+            @Override
+            protected long getShardWritingBytes(IndexShard shard) {
+                return 0L;
+            }
+        };
+        int iterations = randomIntBetween(10, 100);
+        ThreadPoolStats.Stats beforeStats = getRefreshThreadPoolStats();
+        for (int i = 0; i < iterations; i++) {
+            controller.forceCheck();
+        }
+
+        assertBusy(() -> {
+            ThreadPoolStats.Stats stats = getRefreshThreadPoolStats();
+            assertThat(stats.getCompleted(), equalTo(beforeStats.getCompleted() + iterations - 1));
+        });
+
+        refreshLatch.get().countDown(); // allow refresh
+        assertBusy(() -> {
+            ThreadPoolStats.Stats stats = getRefreshThreadPoolStats();
+            assertThat(stats.getCompleted(), equalTo(beforeStats.getCompleted() + iterations));
+        });
+        closeShards(shard);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
