### PR TITLE
Avoid creating unused tables in AlterTableAddColumnAnalyzerTest

### DIFF
--- a/server/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/test/java/io/crate/testing/SQLExecutor.java
@@ -352,7 +352,10 @@ public class SQLExecutor {
          * Note that these tables are not part of the clusterState and rely on a stubbed getRouting
          * Using {@link #addTable(String)} is preferred for this reason.
          * </p>
+         *
+         * @deprecated Please only add the tables used by a test scenario
          */
+        @Deprecated
         public Builder enableDefaultTables() throws IOException {
             // we should try to reduce the number of tables here eventually...
             addTable(USER_TABLE_DEFINITION);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds more boilerplate to the test cases but has some advantages:

- The schema of a table is visible right next to the test scenario,
  making it easier to reason about the scenario.

- Setup is cheaper because it doesn't create unused tables

- Makes it easier to write and use a table definition that is suited for
  the test, as you don't have to make a trade-off between adding yet
  another table to the long list of tables or figure out a neat way to
  modify the schema of a pre-defined table without affecting the tests
  already using the schema.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)