### PR TITLE
Automatically generate license report for runtime dependencies

### DIFF
--- a/3RD-PARTY-NOTICES.md
+++ b/3RD-PARTY-NOTICES.md
@@ -1,0 +1,858 @@
+
+#crate
+##Dependency License Report
+_2021-09-08 11:38:06 CEST_
+## Apache License, Version 2.0
+
+**1** **Group:** `com.amazonaws` **Name:** `aws-java-sdk-core` **Version:** `1.11.1021` 
+> - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**2** **Group:** `com.amazonaws` **Name:** `aws-java-sdk-ec2` **Version:** `1.11.1021` 
+> - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**3** **Group:** `com.amazonaws` **Name:** `aws-java-sdk-kms` **Version:** `1.11.1021` 
+> - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**4** **Group:** `com.amazonaws` **Name:** `aws-java-sdk-s3` **Version:** `1.11.1021` 
+> - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**5** **Group:** `com.amazonaws` **Name:** `jmespath-java` **Version:** `1.11.1021` 
+> - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**6** **Group:** `com.carrotsearch` **Name:** `hppc` **Version:** `0.8.2` 
+> - **Manifest Project URL**: [http://www.carrotsearch.com](http://www.carrotsearch.com)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**7** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.11.0` 
+> - **Project URL**: [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [jackson-annotations-2.11.0.jar/META-INF/LICENSE](jackson-annotations-2.11.0.jar/META-INF/LICENSE)
+
+**8** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.11.0` 
+> - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [jackson-core-2.11.0.jar/META-INF/LICENSE](jackson-core-2.11.0.jar/META-INF/LICENSE) 
+    - [jackson-core-2.11.0.jar/META-INF/NOTICE](jackson-core-2.11.0.jar/META-INF/NOTICE)
+
+**9** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.11.0` 
+> - **Project URL**: [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [jackson-databind-2.11.0.jar/META-INF/LICENSE](jackson-databind-2.11.0.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.11.0.jar/META-INF/NOTICE](jackson-databind-2.11.0.jar/META-INF/NOTICE)
+
+**10** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.11.0` 
+> - **Project URL**: [http://github.com/FasterXML/jackson-dataformats-binary](http://github.com/FasterXML/jackson-dataformats-binary)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**11** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-csv` **Version:** `2.11.0` 
+> - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**12** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-smile` **Version:** `2.11.0` 
+> - **Project URL**: [http://github.com/FasterXML/jackson-dataformats-binary](http://github.com/FasterXML/jackson-dataformats-binary)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**13** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-yaml` **Version:** `2.11.0` 
+> - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [jackson-dataformat-yaml-2.11.0.jar/META-INF/LICENSE](jackson-dataformat-yaml-2.11.0.jar/META-INF/LICENSE) 
+    - [jackson-dataformat-yaml-2.11.0.jar/META-INF/NOTICE](jackson-dataformat-yaml-2.11.0.jar/META-INF/NOTICE)
+
+**14** **Group:** `com.google.code.findbugs` **Name:** `jsr305` **Version:** `3.0.1` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**15** **Group:** `com.google.code.gson` **Name:** `gson` **Version:** `2.2.4` 
+> - **POM Project URL**: [http://code.google.com/p/google-gson/](http://code.google.com/p/google-gson/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**16** **Group:** `com.google.errorprone` **Name:** `error_prone_annotations` **Version:** `2.3.4` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**17** **Group:** `com.google.guava` **Name:** `failureaccess` **Version:** `1.0.1` 
+> - **Manifest Project URL**: [https://github.com/google/guava/](https://github.com/google/guava/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**18** **Group:** `com.google.guava` **Name:** `guava` **Version:** `30.0-jre` 
+> - **Manifest Project URL**: [https://github.com/google/guava/](https://github.com/google/guava/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**19** **Group:** `com.google.guava` **Name:** `listenablefuture` **Version:** `9999.0-empty-to-avoid-conflict-with-guava` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**20** **Group:** `com.google.j2objc` **Name:** `j2objc-annotations` **Version:** `1.3` 
+> - **POM Project URL**: [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**21** **Group:** `com.google.protobuf` **Name:** `protobuf-java` **Version:** `2.5.0` 
+> - **Project URL**: [http://code.google.com/p/protobuf](http://code.google.com/p/protobuf)
+> - **Manifest License**: The 2-Clause BSD License (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: The 2-Clause BSD License - [https://opensource.org/licenses/BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause)
+
+**22** **Group:** `com.microsoft.azure` **Name:** `azure-storage` **Version:** `8.6.6` 
+> - **POM Project URL**: [https://github.com/Azure/azure-storage-java](https://github.com/Azure/azure-storage-java)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**23** **Group:** `com.nimbusds` **Name:** `nimbus-jose-jwt` **Version:** `3.9` 
+> - **Manifest Project URL**: [http://connect2id.com](http://connect2id.com)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [https://bitbucket.org/connect2id/nimbus-jose-jwt](https://bitbucket.org/connect2id/nimbus-jose-jwt)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**24** **Group:** `com.squareup.okhttp` **Name:** `okhttp` **Version:** `2.4.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**25** **Group:** `com.squareup.okio` **Name:** `okio` **Version:** `1.4.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**26** **Group:** `com.tdunning` **Name:** `t-digest` **Version:** `3.2` 
+> - **POM Project URL**: [https://github.com/tdunning/t-digest](https://github.com/tdunning/t-digest)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**27** **Group:** `commons-cli` **Name:** `commons-cli` **Version:** `1.3.1` 
+> - **Project URL**: [http://commons.apache.org/proper/commons-cli/](http://commons.apache.org/proper/commons-cli/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-cli-1.3.1.jar/META-INF/LICENSE.txt](commons-cli-1.3.1.jar/META-INF/LICENSE.txt) 
+    - [commons-cli-1.3.1.jar/META-INF/NOTICE.txt](commons-cli-1.3.1.jar/META-INF/NOTICE.txt)
+
+**28** **Group:** `commons-codec` **Name:** `commons-codec` **Version:** `1.10` 
+> - **Project URL**: [http://commons.apache.org/proper/commons-codec/](http://commons.apache.org/proper/commons-codec/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-codec-1.10.jar/META-INF/LICENSE.txt](commons-codec-1.10.jar/META-INF/LICENSE.txt) 
+    - [commons-codec-1.10.jar/META-INF/NOTICE.txt](commons-codec-1.10.jar/META-INF/NOTICE.txt)
+
+**29** **Group:** `commons-collections` **Name:** `commons-collections` **Version:** `3.2.2` 
+> - **Project URL**: [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-collections-3.2.2.jar/META-INF/LICENSE.txt](commons-collections-3.2.2.jar/META-INF/LICENSE.txt) 
+    - [commons-collections-3.2.2.jar/META-INF/NOTICE.txt](commons-collections-3.2.2.jar/META-INF/NOTICE.txt)
+
+**30** **Group:** `commons-configuration` **Name:** `commons-configuration` **Version:** `1.6` 
+> - **Manifest Project URL**: [http://commons.apache.org/configuration/](http://commons.apache.org/configuration/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://commons.apache.org/${pom.artifactId.substring(8)}/](http://commons.apache.org/${pom.artifactId.substring(8)}/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-configuration-1.6.jar/META-INF/LICENSE.txt](commons-configuration-1.6.jar/META-INF/LICENSE.txt) 
+    - [commons-configuration-1.6.jar/META-INF/NOTICE.txt](commons-configuration-1.6.jar/META-INF/NOTICE.txt)
+
+**31** **Group:** `commons-daemon` **Name:** `commons-daemon` **Version:** `1.0.13` 
+> - **Project URL**: [http://commons.apache.org/daemon/](http://commons.apache.org/daemon/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-daemon-1.0.13.jar/META-INF/LICENSE.txt](commons-daemon-1.0.13.jar/META-INF/LICENSE.txt) 
+    - [commons-daemon-1.0.13.jar/META-INF/NOTICE.txt](commons-daemon-1.0.13.jar/META-INF/NOTICE.txt)
+
+**32** **Group:** `commons-digester` **Name:** `commons-digester` **Version:** `1.8` 
+> - **POM Project URL**: [http://jakarta.apache.org/commons/digester/](http://jakarta.apache.org/commons/digester/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-digester-1.8.jar/META-INF/LICENSE.txt](commons-digester-1.8.jar/META-INF/LICENSE.txt) 
+    - [commons-digester-1.8.jar/META-INF/NOTICE.txt](commons-digester-1.8.jar/META-INF/NOTICE.txt)
+
+**33** **Group:** `commons-io` **Name:** `commons-io` **Version:** `2.4` 
+> - **Project URL**: [http://commons.apache.org/io/](http://commons.apache.org/io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-io-2.4.jar/META-INF/LICENSE.txt](commons-io-2.4.jar/META-INF/LICENSE.txt) 
+    - [commons-io-2.4.jar/META-INF/NOTICE.txt](commons-io-2.4.jar/META-INF/NOTICE.txt)
+
+**34** **Group:** `commons-lang` **Name:** `commons-lang` **Version:** `2.6` 
+> - **Project URL**: [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-lang-2.6.jar/META-INF/LICENSE.txt](commons-lang-2.6.jar/META-INF/LICENSE.txt) 
+    - [commons-lang-2.6.jar/META-INF/NOTICE.txt](commons-lang-2.6.jar/META-INF/NOTICE.txt)
+
+**35** **Group:** `commons-logging` **Name:** `commons-logging` **Version:** `1.1.3` 
+> - **Project URL**: [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-logging-1.1.3.jar/META-INF/LICENSE.txt](commons-logging-1.1.3.jar/META-INF/LICENSE.txt) 
+    - [commons-logging-1.1.3.jar/META-INF/NOTICE.txt](commons-logging-1.1.3.jar/META-INF/NOTICE.txt)
+
+**36** **Group:** `commons-net` **Name:** `commons-net` **Version:** `3.1` 
+> - **Project URL**: [http://commons.apache.org/net/](http://commons.apache.org/net/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-net-3.1.jar/META-INF/LICENSE.txt](commons-net-3.1.jar/META-INF/LICENSE.txt) 
+    - [commons-net-3.1.jar/META-INF/NOTICE.txt](commons-net-3.1.jar/META-INF/NOTICE.txt)
+
+**37** **Group:** `io.netty` **Name:** `netty-buffer` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**38** **Group:** `io.netty` **Name:** `netty-codec` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**39** **Group:** `io.netty` **Name:** `netty-codec-dns` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**40** **Group:** `io.netty` **Name:** `netty-codec-http` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**41** **Group:** `io.netty` **Name:** `netty-common` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**42** **Group:** `io.netty` **Name:** `netty-handler` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**43** **Group:** `io.netty` **Name:** `netty-resolver` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**44** **Group:** `io.netty` **Name:** `netty-resolver-dns` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**45** **Group:** `io.netty` **Name:** `netty-transport` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**46** **Group:** `io.netty` **Name:** `netty-transport-native-epoll` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**47** **Group:** `io.netty` **Name:** `netty-transport-native-unix-common` **Version:** `4.1.67.Final` 
+> - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**48** **Group:** `io.sgr` **Name:** `s2-geometry-library-java` **Version:** `1.0.0` 
+> - **POM Project URL**: [https://github.com/sgr-io/s2-geometry-library-java](https://github.com/sgr-io/s2-geometry-library-java)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**49** **Group:** `joda-time` **Name:** `joda-time` **Version:** `2.10.1` 
+> - **Project URL**: [https://www.joda.org/joda-time/](https://www.joda.org/joda-time/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [joda-time-2.10.1.jar/META-INF/LICENSE.txt](joda-time-2.10.1.jar/META-INF/LICENSE.txt) 
+    - [joda-time-2.10.1.jar/META-INF/NOTICE.txt](joda-time-2.10.1.jar/META-INF/NOTICE.txt)
+
+**50** **Group:** `net.java.dev.jna` **Name:** `jna` **Version:** `5.6.0` 
+> - **POM Project URL**: [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: LGPL, version 2.1 - [http://www.gnu.org/licenses/licenses.html](http://www.gnu.org/licenses/licenses.html)
+> - **Embedded license files**: [jna-5.6.0.jar/META-INF/LICENSE](jna-5.6.0.jar/META-INF/LICENSE)
+
+**51** **Group:** `net.minidev` **Name:** `json-smart` **Version:** `1.1.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**52** **Group:** `org.apache.avro` **Name:** `avro` **Version:** `1.7.4` 
+> - **POM Project URL**: [http://avro.apache.org](http://avro.apache.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [avro-1.7.4.jar/META-INF/LICENSE](avro-1.7.4.jar/META-INF/LICENSE) 
+    - [avro-1.7.4.jar/META-INF/NOTICE](avro-1.7.4.jar/META-INF/NOTICE)
+
+**53** **Group:** `org.apache.commons` **Name:** `commons-compress` **Version:** `1.4.1` 
+> - **Project URL**: [http://commons.apache.org/compress/](http://commons.apache.org/compress/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-compress-1.4.1.jar/META-INF/LICENSE.txt](commons-compress-1.4.1.jar/META-INF/LICENSE.txt) 
+    - [commons-compress-1.4.1.jar/META-INF/NOTICE.txt](commons-compress-1.4.1.jar/META-INF/NOTICE.txt)
+
+**54** **Group:** `org.apache.commons` **Name:** `commons-lang3` **Version:** `3.5` 
+> - **Project URL**: [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-lang3-3.5.jar/META-INF/LICENSE.txt](commons-lang3-3.5.jar/META-INF/LICENSE.txt) 
+    - [commons-lang3-3.5.jar/META-INF/NOTICE.txt](commons-lang3-3.5.jar/META-INF/NOTICE.txt)
+
+**55** **Group:** `org.apache.commons` **Name:** `commons-math3` **Version:** `3.6.1` 
+> - **Project URL**: [http://commons.apache.org/proper/commons-math/](http://commons.apache.org/proper/commons-math/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [commons-math3-3.6.1.jar/META-INF/LICENSE.txt](commons-math3-3.6.1.jar/META-INF/LICENSE.txt) 
+    - [commons-math3-3.6.1.jar/META-INF/NOTICE.txt](commons-math3-3.6.1.jar/META-INF/NOTICE.txt)
+
+**56** **Group:** `org.apache.curator` **Name:** `curator-client` **Version:** `2.7.1` 
+> - **Manifest Project URL**: [http://www.apache.org/](http://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [curator-client-2.7.1.jar/META-INF/LICENSE](curator-client-2.7.1.jar/META-INF/LICENSE) 
+    - [curator-client-2.7.1.jar/META-INF/NOTICE](curator-client-2.7.1.jar/META-INF/NOTICE)
+
+**57** **Group:** `org.apache.curator` **Name:** `curator-framework` **Version:** `2.7.1` 
+> - **Manifest Project URL**: [http://www.apache.org/](http://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [curator-framework-2.7.1.jar/META-INF/LICENSE](curator-framework-2.7.1.jar/META-INF/LICENSE) 
+    - [curator-framework-2.7.1.jar/META-INF/NOTICE](curator-framework-2.7.1.jar/META-INF/NOTICE)
+
+**58** **Group:** `org.apache.curator` **Name:** `curator-recipes` **Version:** `2.7.1` 
+> - **Manifest Project URL**: [http://www.apache.org/](http://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [curator-recipes-2.7.1.jar/META-INF/LICENSE](curator-recipes-2.7.1.jar/META-INF/LICENSE) 
+    - [curator-recipes-2.7.1.jar/META-INF/NOTICE](curator-recipes-2.7.1.jar/META-INF/NOTICE)
+
+**59** **Group:** `org.apache.directory.api` **Name:** `api-asn1-api` **Version:** `1.0.0-M20` 
+> - **Manifest Project URL**: [http://www.apache.org/](http://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [api-asn1-api-1.0.0-M20.jar/META-INF/LICENSE](api-asn1-api-1.0.0-M20.jar/META-INF/LICENSE) 
+    - [api-asn1-api-1.0.0-M20.jar/META-INF/NOTICE](api-asn1-api-1.0.0-M20.jar/META-INF/NOTICE)
+
+**60** **Group:** `org.apache.directory.api` **Name:** `api-util` **Version:** `1.0.0-M20` 
+> - **Manifest Project URL**: [http://www.apache.org/](http://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [api-util-1.0.0-M20.jar/META-INF/LICENSE](api-util-1.0.0-M20.jar/META-INF/LICENSE) 
+    - [api-util-1.0.0-M20.jar/META-INF/NOTICE](api-util-1.0.0-M20.jar/META-INF/NOTICE)
+
+**61** **Group:** `org.apache.directory.server` **Name:** `apacheds-i18n` **Version:** `2.0.0-M15` 
+> - **Manifest Project URL**: [http://www.apache.org/](http://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apacheds-i18n-2.0.0-M15.jar/META-INF/LICENSE](apacheds-i18n-2.0.0-M15.jar/META-INF/LICENSE) 
+    - [apacheds-i18n-2.0.0-M15.jar/META-INF/NOTICE](apacheds-i18n-2.0.0-M15.jar/META-INF/NOTICE)
+
+**62** **Group:** `org.apache.directory.server` **Name:** `apacheds-kerberos-codec` **Version:** `2.0.0-M15` 
+> - **Manifest Project URL**: [http://www.apache.org/](http://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apacheds-kerberos-codec-2.0.0-M15.jar/META-INF/LICENSE](apacheds-kerberos-codec-2.0.0-M15.jar/META-INF/LICENSE) 
+    - [apacheds-kerberos-codec-2.0.0-M15.jar/META-INF/NOTICE](apacheds-kerberos-codec-2.0.0-M15.jar/META-INF/NOTICE)
+
+**63** **Group:** `org.apache.hadoop` **Name:** `hadoop-annotations` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-annotations-2.8.1.jar/META-INF/LICENSE.txt](hadoop-annotations-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-annotations-2.8.1.jar/META-INF/NOTICE.txt](hadoop-annotations-2.8.1.jar/META-INF/NOTICE.txt)
+
+**64** **Group:** `org.apache.hadoop` **Name:** `hadoop-auth` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-auth-2.8.1.jar/META-INF/LICENSE.txt](hadoop-auth-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-auth-2.8.1.jar/META-INF/NOTICE.txt](hadoop-auth-2.8.1.jar/META-INF/NOTICE.txt)
+
+**65** **Group:** `org.apache.hadoop` **Name:** `hadoop-client` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-client-2.8.1.jar/META-INF/LICENSE.txt](hadoop-client-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-client-2.8.1.jar/META-INF/NOTICE.txt](hadoop-client-2.8.1.jar/META-INF/NOTICE.txt)
+
+**66** **Group:** `org.apache.hadoop` **Name:** `hadoop-common` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-common-2.8.1.jar/META-INF/LICENSE.txt](hadoop-common-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-common-2.8.1.jar/META-INF/NOTICE.txt](hadoop-common-2.8.1.jar/META-INF/NOTICE.txt)
+
+**67** **Group:** `org.apache.hadoop` **Name:** `hadoop-hdfs` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-hdfs-2.8.1.jar/META-INF/LICENSE.txt](hadoop-hdfs-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-hdfs-2.8.1.jar/META-INF/NOTICE.txt](hadoop-hdfs-2.8.1.jar/META-INF/NOTICE.txt)
+
+**68** **Group:** `org.apache.hadoop` **Name:** `hadoop-hdfs-client` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-hdfs-client-2.8.1.jar/META-INF/LICENSE.txt](hadoop-hdfs-client-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-hdfs-client-2.8.1.jar/META-INF/NOTICE.txt](hadoop-hdfs-client-2.8.1.jar/META-INF/NOTICE.txt)
+
+**69** **Group:** `org.apache.hadoop` **Name:** `hadoop-mapreduce-client-app` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-mapreduce-client-app-2.8.1.jar/META-INF/LICENSE.txt](hadoop-mapreduce-client-app-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-mapreduce-client-app-2.8.1.jar/META-INF/NOTICE.txt](hadoop-mapreduce-client-app-2.8.1.jar/META-INF/NOTICE.txt)
+
+**70** **Group:** `org.apache.hadoop` **Name:** `hadoop-mapreduce-client-common` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-mapreduce-client-common-2.8.1.jar/META-INF/LICENSE.txt](hadoop-mapreduce-client-common-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-mapreduce-client-common-2.8.1.jar/META-INF/NOTICE.txt](hadoop-mapreduce-client-common-2.8.1.jar/META-INF/NOTICE.txt)
+
+**71** **Group:** `org.apache.hadoop` **Name:** `hadoop-mapreduce-client-core` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-mapreduce-client-core-2.8.1.jar/META-INF/LICENSE.txt](hadoop-mapreduce-client-core-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-mapreduce-client-core-2.8.1.jar/META-INF/NOTICE.txt](hadoop-mapreduce-client-core-2.8.1.jar/META-INF/NOTICE.txt)
+
+**72** **Group:** `org.apache.hadoop` **Name:** `hadoop-mapreduce-client-jobclient` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-mapreduce-client-jobclient-2.8.1.jar/META-INF/LICENSE.txt](hadoop-mapreduce-client-jobclient-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-mapreduce-client-jobclient-2.8.1.jar/META-INF/NOTICE.txt](hadoop-mapreduce-client-jobclient-2.8.1.jar/META-INF/NOTICE.txt)
+
+**73** **Group:** `org.apache.hadoop` **Name:** `hadoop-mapreduce-client-shuffle` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-mapreduce-client-shuffle-2.8.1.jar/META-INF/LICENSE.txt](hadoop-mapreduce-client-shuffle-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-mapreduce-client-shuffle-2.8.1.jar/META-INF/NOTICE.txt](hadoop-mapreduce-client-shuffle-2.8.1.jar/META-INF/NOTICE.txt)
+
+**74** **Group:** `org.apache.hadoop` **Name:** `hadoop-yarn-api` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-yarn-api-2.8.1.jar/META-INF/LICENSE.txt](hadoop-yarn-api-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-yarn-api-2.8.1.jar/META-INF/NOTICE.txt](hadoop-yarn-api-2.8.1.jar/META-INF/NOTICE.txt)
+
+**75** **Group:** `org.apache.hadoop` **Name:** `hadoop-yarn-client` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-yarn-client-2.8.1.jar/META-INF/LICENSE.txt](hadoop-yarn-client-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-yarn-client-2.8.1.jar/META-INF/NOTICE.txt](hadoop-yarn-client-2.8.1.jar/META-INF/NOTICE.txt)
+
+**76** **Group:** `org.apache.hadoop` **Name:** `hadoop-yarn-common` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-yarn-common-2.8.1.jar/META-INF/LICENSE.txt](hadoop-yarn-common-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-yarn-common-2.8.1.jar/META-INF/NOTICE.txt](hadoop-yarn-common-2.8.1.jar/META-INF/NOTICE.txt)
+
+**77** **Group:** `org.apache.hadoop` **Name:** `hadoop-yarn-server-common` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-yarn-server-common-2.8.1.jar/META-INF/LICENSE.txt](hadoop-yarn-server-common-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-yarn-server-common-2.8.1.jar/META-INF/NOTICE.txt](hadoop-yarn-server-common-2.8.1.jar/META-INF/NOTICE.txt)
+
+**78** **Group:** `org.apache.hadoop` **Name:** `hadoop-yarn-server-nodemanager` **Version:** `2.8.1` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [hadoop-yarn-server-nodemanager-2.8.1.jar/META-INF/LICENSE.txt](hadoop-yarn-server-nodemanager-2.8.1.jar/META-INF/LICENSE.txt) 
+    - [hadoop-yarn-server-nodemanager-2.8.1.jar/META-INF/NOTICE.txt](hadoop-yarn-server-nodemanager-2.8.1.jar/META-INF/NOTICE.txt)
+
+**79** **Group:** `org.apache.htrace` **Name:** `htrace-core4` **Version:** `4.0.1-incubating` 
+> - **POM Project URL**: [http://incubator.apache.org/projects/htrace.html](http://incubator.apache.org/projects/htrace.html)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [htrace-core4-4.0.1-incubating.jar/META-INF/LICENSE](htrace-core4-4.0.1-incubating.jar/META-INF/LICENSE) 
+    - [htrace-core4-4.0.1-incubating.jar/META-INF/NOTICE](htrace-core4-4.0.1-incubating.jar/META-INF/NOTICE)
+
+**80** **Group:** `org.apache.httpcomponents` **Name:** `httpclient` **Version:** `4.5.12` 
+> - **POM Project URL**: [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [httpclient-4.5.12.jar/META-INF/LICENSE](httpclient-4.5.12.jar/META-INF/LICENSE) 
+    - [httpclient-4.5.12.jar/META-INF/NOTICE](httpclient-4.5.12.jar/META-INF/NOTICE)
+
+**81** **Group:** `org.apache.httpcomponents` **Name:** `httpcore` **Version:** `4.4.12` 
+> - **POM Project URL**: [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [httpcore-4.4.12.jar/META-INF/LICENSE](httpcore-4.4.12.jar/META-INF/LICENSE) 
+    - [httpcore-4.4.12.jar/META-INF/NOTICE](httpcore-4.4.12.jar/META-INF/NOTICE)
+
+**82** **Group:** `org.apache.logging.log4j` **Name:** `log4j-api` **Version:** `2.11.1` 
+> - **Manifest Project URL**: [https://www.apache.org/](https://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [log4j-api-2.11.1.jar/META-INF/LICENSE](log4j-api-2.11.1.jar/META-INF/LICENSE) 
+    - [log4j-api-2.11.1.jar/META-INF/NOTICE](log4j-api-2.11.1.jar/META-INF/NOTICE)
+
+**83** **Group:** `org.apache.logging.log4j` **Name:** `log4j-core` **Version:** `2.11.1` 
+> - **Manifest Project URL**: [https://www.apache.org/](https://www.apache.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [log4j-core-2.11.1.jar/META-INF/LICENSE](log4j-core-2.11.1.jar/META-INF/LICENSE) 
+    - [log4j-core-2.11.1.jar/META-INF/NOTICE](log4j-core-2.11.1.jar/META-INF/NOTICE)
+
+**84** **Group:** `org.apache.lucene` **Name:** `lucene-analyzers-common` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-analyzers-common-8.9.0.jar/META-INF/LICENSE.txt](lucene-analyzers-common-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-analyzers-common-8.9.0.jar/META-INF/NOTICE.txt](lucene-analyzers-common-8.9.0.jar/META-INF/NOTICE.txt)
+
+**85** **Group:** `org.apache.lucene` **Name:** `lucene-analyzers-phonetic` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-analyzers-phonetic-8.9.0.jar/META-INF/LICENSE.txt](lucene-analyzers-phonetic-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-analyzers-phonetic-8.9.0.jar/META-INF/NOTICE.txt](lucene-analyzers-phonetic-8.9.0.jar/META-INF/NOTICE.txt)
+
+**86** **Group:** `org.apache.lucene` **Name:** `lucene-backward-codecs` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-backward-codecs-8.9.0.jar/META-INF/LICENSE.txt](lucene-backward-codecs-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-backward-codecs-8.9.0.jar/META-INF/NOTICE.txt](lucene-backward-codecs-8.9.0.jar/META-INF/NOTICE.txt)
+
+**87** **Group:** `org.apache.lucene` **Name:** `lucene-core` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-core-8.9.0.jar/META-INF/LICENSE.txt](lucene-core-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-core-8.9.0.jar/META-INF/NOTICE.txt](lucene-core-8.9.0.jar/META-INF/NOTICE.txt)
+
+**88** **Group:** `org.apache.lucene` **Name:** `lucene-grouping` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-grouping-8.9.0.jar/META-INF/LICENSE.txt](lucene-grouping-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-grouping-8.9.0.jar/META-INF/NOTICE.txt](lucene-grouping-8.9.0.jar/META-INF/NOTICE.txt)
+
+**89** **Group:** `org.apache.lucene` **Name:** `lucene-join` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-join-8.9.0.jar/META-INF/LICENSE.txt](lucene-join-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-join-8.9.0.jar/META-INF/NOTICE.txt](lucene-join-8.9.0.jar/META-INF/NOTICE.txt)
+
+**90** **Group:** `org.apache.lucene` **Name:** `lucene-misc` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-misc-8.9.0.jar/META-INF/LICENSE.txt](lucene-misc-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-misc-8.9.0.jar/META-INF/NOTICE.txt](lucene-misc-8.9.0.jar/META-INF/NOTICE.txt)
+
+**91** **Group:** `org.apache.lucene` **Name:** `lucene-queries` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-queries-8.9.0.jar/META-INF/LICENSE.txt](lucene-queries-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-queries-8.9.0.jar/META-INF/NOTICE.txt](lucene-queries-8.9.0.jar/META-INF/NOTICE.txt)
+
+**92** **Group:** `org.apache.lucene` **Name:** `lucene-sandbox` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-sandbox-8.9.0.jar/META-INF/LICENSE.txt](lucene-sandbox-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-sandbox-8.9.0.jar/META-INF/NOTICE.txt](lucene-sandbox-8.9.0.jar/META-INF/NOTICE.txt)
+
+**93** **Group:** `org.apache.lucene` **Name:** `lucene-spatial-extras` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-spatial-extras-8.9.0.jar/META-INF/LICENSE.txt](lucene-spatial-extras-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-spatial-extras-8.9.0.jar/META-INF/NOTICE.txt](lucene-spatial-extras-8.9.0.jar/META-INF/NOTICE.txt)
+
+**94** **Group:** `org.apache.lucene` **Name:** `lucene-spatial3d` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-spatial3d-8.9.0.jar/META-INF/LICENSE.txt](lucene-spatial3d-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-spatial3d-8.9.0.jar/META-INF/NOTICE.txt](lucene-spatial3d-8.9.0.jar/META-INF/NOTICE.txt)
+
+**95** **Group:** `org.apache.lucene` **Name:** `lucene-suggest` **Version:** `8.9.0` 
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [lucene-suggest-8.9.0.jar/META-INF/LICENSE.txt](lucene-suggest-8.9.0.jar/META-INF/LICENSE.txt) 
+    - [lucene-suggest-8.9.0.jar/META-INF/NOTICE.txt](lucene-suggest-8.9.0.jar/META-INF/NOTICE.txt)
+
+**96** **Group:** `org.apache.xbean` **Name:** `xbean-bundleutils` **Version:** `4.5` 
+> - **Manifest Project URL**: [http://geronimo.apache.org/maven/xbean/4.5/xbean-bundleutils](http://geronimo.apache.org/maven/xbean/4.5/xbean-bundleutils)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [xbean-bundleutils-4.5.jar/META-INF/LICENSE](xbean-bundleutils-4.5.jar/META-INF/LICENSE) 
+    - [xbean-bundleutils-4.5.jar/META-INF/NOTICE](xbean-bundleutils-4.5.jar/META-INF/NOTICE)
+
+**97** **Group:** `org.apache.xbean` **Name:** `xbean-finder` **Version:** `4.5` 
+> - **Manifest Project URL**: [http://geronimo.apache.org/maven/xbean/4.5/xbean-finder](http://geronimo.apache.org/maven/xbean/4.5/xbean-finder)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [xbean-finder-4.5.jar/META-INF/LICENSE](xbean-finder-4.5.jar/META-INF/LICENSE) 
+    - [xbean-finder-4.5.jar/META-INF/NOTICE](xbean-finder-4.5.jar/META-INF/NOTICE)
+
+**98** **Group:** `org.apache.zookeeper` **Name:** `zookeeper` **Version:** `3.4.6` 
+> - **Manifest Project URL**: [http://hadoop.apache.org/zookeeper](http://hadoop.apache.org/zookeeper)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **Embedded license files**: [zookeeper-3.4.6.jar/LICENSE.txt](zookeeper-3.4.6.jar/LICENSE.txt)
+
+**99** **Group:** `org.codehaus.jackson` **Name:** `jackson-core-asl` **Version:** `1.9.13` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://jackson.codehaus.org](http://jackson.codehaus.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [jackson-core-asl-1.9.13.jar/META-INF/LICENSE](jackson-core-asl-1.9.13.jar/META-INF/LICENSE) 
+    - [jackson-core-asl-1.9.13.jar/META-INF/NOTICE](jackson-core-asl-1.9.13.jar/META-INF/NOTICE)
+
+**100** **Group:** `org.codehaus.jackson` **Name:** `jackson-jaxrs` **Version:** `1.9.13` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://jackson.codehaus.org](http://jackson.codehaus.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: GNU Lesser General Public License (LGPL), Version 2.1 - [http://www.fsf.org/licensing/licenses/lgpl.txt](http://www.fsf.org/licensing/licenses/lgpl.txt)
+> - **Embedded license files**: [jackson-jaxrs-1.9.13.jar/META-INF/LICENSE](jackson-jaxrs-1.9.13.jar/META-INF/LICENSE) 
+    - [jackson-jaxrs-1.9.13.jar/META-INF/NOTICE](jackson-jaxrs-1.9.13.jar/META-INF/NOTICE)
+
+**101** **Group:** `org.codehaus.jackson` **Name:** `jackson-mapper-asl` **Version:** `1.9.13` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://jackson.codehaus.org](http://jackson.codehaus.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [jackson-mapper-asl-1.9.13.jar/META-INF/LICENSE](jackson-mapper-asl-1.9.13.jar/META-INF/LICENSE) 
+    - [jackson-mapper-asl-1.9.13.jar/META-INF/NOTICE](jackson-mapper-asl-1.9.13.jar/META-INF/NOTICE)
+
+**102** **Group:** `org.codehaus.jackson` **Name:** `jackson-xc` **Version:** `1.9.13` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://jackson.codehaus.org](http://jackson.codehaus.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: GNU Lesser General Public License (LGPL), Version 2.1 - [http://www.fsf.org/licensing/licenses/lgpl.txt](http://www.fsf.org/licensing/licenses/lgpl.txt)
+> - **Embedded license files**: [jackson-xc-1.9.13.jar/META-INF/LICENSE](jackson-xc-1.9.13.jar/META-INF/LICENSE) 
+    - [jackson-xc-1.9.13.jar/META-INF/NOTICE](jackson-xc-1.9.13.jar/META-INF/NOTICE)
+
+**103** **Group:** `org.fusesource.leveldbjni` **Name:** `leveldbjni-all` **Version:** `1.8` 
+> - **Manifest Project URL**: [http://fusesource.com/](http://fusesource.com/)
+> - **Manifest License**: The 3-Clause BSD License (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+**104** **Group:** `org.locationtech.spatial4j` **Name:** `spatial4j` **Version:** `0.8` 
+> - **Manifest Project URL**: [http://www.locationtech.org/](http://www.locationtech.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [https://projects.eclipse.org/projects/locationtech.spatial4j](https://projects.eclipse.org/projects/locationtech.spatial4j)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**105** **Group:** `org.mortbay.jetty` **Name:** `jetty` **Version:** `6.1.26` 
+> - **Manifest Project URL**: [http://jetty.mortbay.org](http://jetty.mortbay.org)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+**106** **Group:** `org.mortbay.jetty` **Name:** `jetty-util` **Version:** `6.1.26` 
+> - **Manifest Project URL**: [http://jetty.mortbay.org](http://jetty.mortbay.org)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+**107** **Group:** `org.xerial.snappy` **Name:** `snappy-java` **Version:** `1.0.4.1` 
+> - **Manifest Project URL**: [http://www.xerial.org/](http://www.xerial.org/)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://code.google.com/p/snappy-java/](http://code.google.com/p/snappy-java/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [snappy-java-1.0.4.1.jar/META-INF/maven/org.xerial.snappy/snappy-java/LICENSE](snappy-java-1.0.4.1.jar/META-INF/maven/org.xerial.snappy/snappy-java/LICENSE) 
+    - [snappy-java-1.0.4.1.jar/org/xerial/snappy/native/README](snappy-java-1.0.4.1.jar/org/xerial/snappy/native/README)
+
+**108** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `1.26` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://www.snakeyaml.org](http://www.snakeyaml.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**109** **Group:** `software.amazon.ion` **Name:** `ion-java` **Version:** `1.0.2` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [https://github.com/amznlabs/ion-java/](https://github.com/amznlabs/ion-java/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**110** **Group:** `xerces` **Name:** `xercesImpl` **Version:** `2.9.1` 
+> - **POM Project URL**: [http://xerces.apache.org/xerces2-j](http://xerces.apache.org/xerces2-j)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [xercesImpl-2.9.1.jar/META-INF/LICENSE](xercesImpl-2.9.1.jar/META-INF/LICENSE) 
+    - [xercesImpl-2.9.1.jar/META-INF/NOTICE](xercesImpl-2.9.1.jar/META-INF/NOTICE)
+
+**111** **Group:** `xml-apis` **Name:** `xml-apis` **Version:** `1.3.04` 
+> - **POM Project URL**: [http://xml.apache.org/commons/components/external/](http://xml.apache.org/commons/components/external/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [xml-apis-1.3.04.jar/license/LICENSE](xml-apis-1.3.04.jar/license/LICENSE) 
+    - [xml-apis-1.3.04.jar/license/NOTICE](xml-apis-1.3.04.jar/license/NOTICE)
+
+## BSD Zero Clause License
+
+**112** **Group:** `com.thoughtworks.paranamer` **Name:** `paranamer` **Version:** `2.3` 
+> - **POM License**: BSD Zero Clause License - [https://opensource.org/licenses/0BSD](https://opensource.org/licenses/0BSD)
+
+**113** **Group:** `jline` **Name:** `jline` **Version:** `0.9.94` 
+> - **POM Project URL**: [http://jline.sourceforge.net](http://jline.sourceforge.net)
+> - **POM License**: BSD Zero Clause License - [https://opensource.org/licenses/0BSD](https://opensource.org/licenses/0BSD)
+
+## COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+
+**114** **Group:** `javax.activation` **Name:** `activation` **Version:** `1.1` 
+> - **POM Project URL**: [http://java.sun.com/products/javabeans/jaf/index.jsp](http://java.sun.com/products/javabeans/jaf/index.jsp)
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 - [https://oss.oracle.com/licenses/CDDL](https://oss.oracle.com/licenses/CDDL)
+> - **Embedded license files**: [activation-1.1.jar/META-INF/LICENSE.txt](activation-1.1.jar/META-INF/LICENSE.txt)
+
+**115** **Group:** `javax.xml.stream` **Name:** `stax-api` **Version:** `1.0-2` 
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 - [https://oss.oracle.com/licenses/CDDL](https://oss.oracle.com/licenses/CDDL)
+> - **POM License**: GNU General Public Library - [http://www.gnu.org/licenses/gpl.txt](http://www.gnu.org/licenses/gpl.txt)
+
+## COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+
+**116** **Group:** `com.sun.jersey` **Name:** `jersey-core` **Version:** `1.9` 
+> - **Manifest Project URL**: [http://www.oracle.com/](http://www.oracle.com/)
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 - [https://oss.oracle.com/licenses/CDDL-1.1](https://oss.oracle.com/licenses/CDDL-1.1)
+> - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
+
+**117** **Group:** `com.sun.jersey` **Name:** `jersey-server` **Version:** `1.9` 
+> - **Manifest Project URL**: [http://www.oracle.com/](http://www.oracle.com/)
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 - [https://oss.oracle.com/licenses/CDDL-1.1](https://oss.oracle.com/licenses/CDDL-1.1)
+> - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
+
+**118** **Group:** `javax.xml.bind` **Name:** `jaxb-api` **Version:** `2.2.2` 
+> - **POM Project URL**: [https://jaxb.dev.java.net/](https://jaxb.dev.java.net/)
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 - [https://oss.oracle.com/licenses/CDDL-1.1](https://oss.oracle.com/licenses/CDDL-1.1)
+> - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
+> - **Embedded license files**: [jaxb-api-2.2.2.jar/META-INF/LICENSE.txt](jaxb-api-2.2.2.jar/META-INF/LICENSE.txt)
+
+## Creative Commons Legal Code
+
+**119** **Group:** `org.hdrhistogram` **Name:** `HdrHistogram` **Version:** `2.1.9` 
+> - **Manifest License**: Creative Commons Legal Code (Not Packaged)
+> - **POM Project URL**: [http://hdrhistogram.github.io/HdrHistogram/](http://hdrhistogram.github.io/HdrHistogram/)
+> - **POM License**: Creative Commons Legal Code - [https://creativecommons.org/publicdomain/zero/1.0/legalcode](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
+> - **POM License**: PUBLIC DOMAIN - [http://creativecommons.org/publicdomain/zero/1.0/](http://creativecommons.org/publicdomain/zero/1.0/)
+
+## Eclipse Distribution License - v 1.0
+
+**120** **Group:** `org.locationtech.jts` **Name:** `jts-core` **Version:** `1.15.0` 
+> - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
+> - **POM License**: Eclipse Publish License, Version 1.0 - [https://github.com/locationtech/jts/blob/master/LICENSE_EPLv1.txt](https://github.com/locationtech/jts/blob/master/LICENSE_EPLv1.txt)
+
+## Eclipse Public License - v 1.0
+
+**121** **Group:** `org.mortbay.jetty` **Name:** `jetty` **Version:** `6.1.26` 
+> - **Manifest Project URL**: [http://jetty.mortbay.org](http://jetty.mortbay.org)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+**122** **Group:** `org.mortbay.jetty` **Name:** `jetty-util` **Version:** `6.1.26` 
+> - **Manifest Project URL**: [http://jetty.mortbay.org](http://jetty.mortbay.org)
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+## Eclipse Publish License, Version 1.0
+
+**123** **Group:** `org.locationtech.jts` **Name:** `jts-core` **Version:** `1.15.0` 
+> - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
+> - **POM License**: Eclipse Publish License, Version 1.0 - [https://github.com/locationtech/jts/blob/master/LICENSE_EPLv1.txt](https://github.com/locationtech/jts/blob/master/LICENSE_EPLv1.txt)
+
+## Embedded
+
+**124** **Group:** `org.codehaus.jettison` **Name:** `jettison` **Version:** `1.1` 
+> - **Embedded license files**: [jettison-1.1.jar/META-INF/LICENSE](jettison-1.1.jar/META-INF/LICENSE)
+
+## GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception
+
+**125** **Group:** `com.sun.jersey` **Name:** `jersey-core` **Version:** `1.9` 
+> - **Manifest Project URL**: [http://www.oracle.com/](http://www.oracle.com/)
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 - [https://oss.oracle.com/licenses/CDDL-1.1](https://oss.oracle.com/licenses/CDDL-1.1)
+> - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
+
+**126** **Group:** `com.sun.jersey` **Name:** `jersey-server` **Version:** `1.9` 
+> - **Manifest Project URL**: [http://www.oracle.com/](http://www.oracle.com/)
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 - [https://oss.oracle.com/licenses/CDDL-1.1](https://oss.oracle.com/licenses/CDDL-1.1)
+> - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
+
+**127** **Group:** `javax.xml.bind` **Name:** `jaxb-api` **Version:** `2.2.2` 
+> - **POM Project URL**: [https://jaxb.dev.java.net/](https://jaxb.dev.java.net/)
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 - [https://oss.oracle.com/licenses/CDDL-1.1](https://oss.oracle.com/licenses/CDDL-1.1)
+> - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
+> - **Embedded license files**: [jaxb-api-2.2.2.jar/META-INF/LICENSE.txt](jaxb-api-2.2.2.jar/META-INF/LICENSE.txt)
+
+## GNU General Public Library
+
+**128** **Group:** `javax.xml.stream` **Name:** `stax-api` **Version:** `1.0-2` 
+> - **POM License**: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 - [https://oss.oracle.com/licenses/CDDL](https://oss.oracle.com/licenses/CDDL)
+> - **POM License**: GNU General Public Library - [http://www.gnu.org/licenses/gpl.txt](http://www.gnu.org/licenses/gpl.txt)
+
+## GNU Lesser General Public License (LGPL), Version 2.1
+
+**129** **Group:** `org.codehaus.jackson` **Name:** `jackson-jaxrs` **Version:** `1.9.13` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://jackson.codehaus.org](http://jackson.codehaus.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: GNU Lesser General Public License (LGPL), Version 2.1 - [http://www.fsf.org/licensing/licenses/lgpl.txt](http://www.fsf.org/licensing/licenses/lgpl.txt)
+> - **Embedded license files**: [jackson-jaxrs-1.9.13.jar/META-INF/LICENSE](jackson-jaxrs-1.9.13.jar/META-INF/LICENSE) 
+    - [jackson-jaxrs-1.9.13.jar/META-INF/NOTICE](jackson-jaxrs-1.9.13.jar/META-INF/NOTICE)
+
+**130** **Group:** `org.codehaus.jackson` **Name:** `jackson-xc` **Version:** `1.9.13` 
+> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
+> - **POM Project URL**: [http://jackson.codehaus.org](http://jackson.codehaus.org)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: GNU Lesser General Public License (LGPL), Version 2.1 - [http://www.fsf.org/licensing/licenses/lgpl.txt](http://www.fsf.org/licensing/licenses/lgpl.txt)
+> - **Embedded license files**: [jackson-xc-1.9.13.jar/META-INF/LICENSE](jackson-xc-1.9.13.jar/META-INF/LICENSE) 
+    - [jackson-xc-1.9.13.jar/META-INF/NOTICE](jackson-xc-1.9.13.jar/META-INF/NOTICE)
+
+## LGPL, version 2.1
+
+**131** **Group:** `net.java.dev.jna` **Name:** `jna` **Version:** `5.6.0` 
+> - **POM Project URL**: [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: LGPL, version 2.1 - [http://www.gnu.org/licenses/licenses.html](http://www.gnu.org/licenses/licenses.html)
+> - **Embedded license files**: [jna-5.6.0.jar/META-INF/LICENSE](jna-5.6.0.jar/META-INF/LICENSE)
+
+## MIT License
+
+**132** **Group:** `com.microsoft.azure` **Name:** `azure-keyvault-core` **Version:** `1.2.4` 
+> - **POM Project URL**: [https://github.com/Azure/azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+
+**133** **Group:** `net.sf.jopt-simple` **Name:** `jopt-simple` **Version:** `5.0.2` 
+> - **POM Project URL**: [http://pholser.github.io/jopt-simple](http://pholser.github.io/jopt-simple)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+
+**134** **Group:** `org.checkerframework` **Name:** `checker-qual` **Version:** `3.5.0` 
+> - **Manifest License**: MIT License (Not Packaged)
+> - **POM Project URL**: [https://checkerframework.org](https://checkerframework.org)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+> - **Embedded license files**: [checker-qual-3.5.0.jar/META-INF/LICENSE.txt](checker-qual-3.5.0.jar/META-INF/LICENSE.txt)
+
+**135** **Group:** `org.graalvm.js` **Name:** `js` **Version:** `21.2.0` 
+> - **POM Project URL**: [http://www.graalvm.org/](http://www.graalvm.org/)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+> - **POM License**: Universal Permissive License, Version 1.0 - [http://opensource.org/licenses/UPL](http://opensource.org/licenses/UPL)
+
+**136** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `1.6.2` 
+> - **POM Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+
+**137** **Group:** `org.slf4j` **Name:** `slf4j-log4j12` **Version:** `1.7.10` 
+> - **POM Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+
+## PUBLIC DOMAIN
+
+**138** **Group:** `org.hdrhistogram` **Name:** `HdrHistogram` **Version:** `2.1.9` 
+> - **Manifest License**: Creative Commons Legal Code (Not Packaged)
+> - **POM Project URL**: [http://hdrhistogram.github.io/HdrHistogram/](http://hdrhistogram.github.io/HdrHistogram/)
+> - **POM License**: Creative Commons Legal Code - [https://creativecommons.org/publicdomain/zero/1.0/legalcode](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
+> - **POM License**: PUBLIC DOMAIN - [http://creativecommons.org/publicdomain/zero/1.0/](http://creativecommons.org/publicdomain/zero/1.0/)
+
+**139** **Group:** `org.tukaani` **Name:** `xz` **Version:** `1.0` 
+> - **POM Project URL**: [http://tukaani.org/xz/java.html](http://tukaani.org/xz/java.html)
+> - **POM License**: PUBLIC DOMAIN
+
+## The 2-Clause BSD License
+
+**140** **Group:** `com.google.protobuf` **Name:** `protobuf-java` **Version:** `2.5.0` 
+> - **Project URL**: [http://code.google.com/p/protobuf](http://code.google.com/p/protobuf)
+> - **Manifest License**: The 2-Clause BSD License (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: The 2-Clause BSD License - [https://opensource.org/licenses/BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause)
+
+**141** **Group:** `xmlenc` **Name:** `xmlenc` **Version:** `0.52` 
+> - **POM Project URL**: [http://xmlenc.sourceforge.net](http://xmlenc.sourceforge.net)
+> - **POM License**: The 2-Clause BSD License - [https://opensource.org/licenses/BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause)
+
+## The 3-Clause BSD License
+
+**142** **Group:** `org.fusesource.leveldbjni` **Name:** `leveldbjni-all` **Version:** `1.8` 
+> - **Manifest Project URL**: [http://fusesource.com/](http://fusesource.com/)
+> - **Manifest License**: The 3-Clause BSD License (Not Packaged)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+## The BSD License
+
+**143** **Group:** `org.antlr` **Name:** `antlr4-runtime` **Version:** `4.9.2` 
+> - **Manifest Project URL**: [http://www.antlr.org](http://www.antlr.org)
+> - **POM License**: The BSD License - [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+
+## Unicode/ICU License
+
+**144** **Group:** `com.ibm.icu` **Name:** `icu4j` **Version:** `69.1` 
+> - **POM Project URL**: [http://icu-project.org/](http://icu-project.org/)
+> - **POM License**: Unicode/ICU License - [https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE](https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE)
+> - **Embedded license files**: [icu4j-69.1.jar/LICENSE](icu4j-69.1.jar/LICENSE)
+
+## Universal Permissive License, Version 1.0
+
+**145** **Group:** `org.graalvm.js` **Name:** `js` **Version:** `21.2.0` 
+> - **POM Project URL**: [http://www.graalvm.org/](http://www.graalvm.org/)
+> - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+> - **POM License**: Universal Permissive License, Version 1.0 - [http://opensource.org/licenses/UPL](http://opensource.org/licenses/UPL)
+
+**146** **Group:** `org.graalvm.regex` **Name:** `regex` **Version:** `21.2.0` 
+> - **POM Project URL**: [http://www.graalvm.org/](http://www.graalvm.org/)
+> - **POM License**: Universal Permissive License, Version 1.0 - [http://opensource.org/licenses/UPL](http://opensource.org/licenses/UPL)
+
+**147** **Group:** `org.graalvm.sdk` **Name:** `graal-sdk` **Version:** `21.2.0` 
+> - **POM Project URL**: [https://github.com/oracle/graal](https://github.com/oracle/graal)
+> - **POM License**: Universal Permissive License, Version 1.0 - [http://opensource.org/licenses/UPL](http://opensource.org/licenses/UPL)
+
+**148** **Group:** `org.graalvm.truffle` **Name:** `truffle-api` **Version:** `21.2.0` 
+> - **POM Project URL**: [http://openjdk.java.net/projects/graal](http://openjdk.java.net/projects/graal)
+> - **POM License**: Universal Permissive License, Version 1.0 - [http://opensource.org/licenses/UPL](http://opensource.org/licenses/UPL)
+
+## Unknown
+
+**149** **Group:** `asm` **Name:** `asm` **Version:** `3.1` 
+
+**150** **Group:** `javax.servlet` **Name:** `servlet-api` **Version:** `2.5` 
+
+**151** **Group:** `javax.servlet.jsp` **Name:** `jsp-api` **Version:** `2.1` 
+
+**152** **Group:** `log4j` **Name:** `log4j` **Version:** `1.2.7` 
+
+**153** **Group:** `net.jcip` **Name:** `jcip-annotations` **Version:** `1.0` 
+> - **POM Project URL**: [http://jcip.net/](http://jcip.net/)
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.github.jk1.dependency-license-report' version '2.0'
+}
 
 def download(File downloadDir, String url, String name) {
     downloadDir.mkdirs()
@@ -272,6 +275,38 @@ idea {
             }
         }
     }
+}
+
+import com.github.jk1.license.render.InventoryMarkdownReportRenderer;
+import com.github.jk1.license.filter.LicenseBundleNormalizer;
+task generateLicenseNotes() {
+    /*
+    Generate report about the licenses of the dependencies.
+    This task is an improved variant of the vanilla "generateLicenseReport".
+
+    For invoking it, run::
+
+        ./gradlew generateLicenseNotes
+
+    https://github.com/jk1/Gradle-License-Report
+    */
+
+    licenseReport {
+        outputDir = "${project.rootDir}/buildSrc/build/reports/licenses"
+        renderers = [new InventoryMarkdownReportRenderer("3RD-PARTY-NOTICES.md")]
+        filters = [new LicenseBundleNormalizer()]
+        excludeGroups = ["org.openjdk.jmh"]
+    }
+
+    task createReport(type: Copy) {
+
+        dependsOn "generateLicenseReport"
+
+        from "${project.rootDir}/buildSrc/build/reports/licenses/3RD-PARTY-NOTICES.md"
+        into "${project.rootDir}"
+    }
+
+    dependsOn "createReport"
 }
 
 wrapper {


### PR DESCRIPTION
Hi,

this patch adds the ["Gradle License Report" plugin](https://github.com/jk1/Gradle-License-Report) in order to generate the "NOTICE.md" file in the root directory.

Along the lines, it also cleans up the current versions of the "LICENSE" and "NOTICE" files.

With kind regards,
Andreas.
