### PR TITLE
Add closed table to sys shards

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,8 @@ Changes
   ``COPY FROM`` operations. This should lead to these queries utilizing more
   resources if the cluster can spare them.
 
+- Included the shard information for closed tables in ``sys.shards`` table.
+
 Fixes
 =====
 

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -61,7 +61,6 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.Operation;
 
 public class LuceneShardCollectorProvider extends ShardCollectorProvider {
 
@@ -110,7 +109,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             fieldTypeLookup = mapperService::fullName;
         }
         var relationName = RelationName.fromIndexName(indexShard.shardId().getIndexName());
-        this.table = schemas.getTableInfo(relationName, Operation.READ);
+        this.table = schemas.getTableInfo(relationName);
         this.docInputFactory = new DocInputFactory(
             nodeCtx,
             new LuceneReferenceResolver(

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -225,7 +225,7 @@ public class SysShardsTableInfo {
      * Any shards that are not yet assigned to a node will have a NEGATIVE shard id (see {@link UnassignedShard}
      */
     public static Routing getRouting(ClusterState clusterState, RoutingProvider routingProvider, SessionContext sessionContext) {
-        String[] concreteIndices = Arrays.stream(clusterState.metadata().getConcreteAllOpenIndices())
+        String[] concreteIndices = Arrays.stream(clusterState.metadata().getConcreteAllIndices())
             .filter(index -> !IndexParts.isDangling(index))
             .toArray(String[]::new);
         User user = sessionContext != null ? sessionContext.sessionUser() : null;

--- a/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
@@ -64,6 +64,16 @@ public class ShardCollectorProviderTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testClosedIndicesHaveNoShardEntriesAfterSelectFromSysShards() throws Exception {
+        execute("create table t(i int) with (number_of_replicas='0-all')");
+        ensureGreen();
+        execute("alter table t close");
+        execute("select * from sys.shards where table_name = 't'");
+        waitUntilShardOperationsFinished();
+        assertNoShardEntriesLeftInShardCollectSource();
+    }
+
+    @Test
     public void testDeletedIndicesHaveNoShardEntries() throws Exception {
         execute("create table tt(i int) with (number_of_replicas='0-all')");
         ensureGreen();

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
@@ -45,9 +45,6 @@ public class InformationSchemaQueryTest extends SQLTransportIntegrationTest {
         assertEquals(2L, response.rowCount());
         execute("select * from information_schema.columns where table_name = 't3'");
         assertEquals(2, response.rowCount());
-
-        execute("select * from sys.shards");
-        assertEquals(5L, response.rowCount()); // t3 isn't included, as it is closed.
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

this will include shard information in sys.shards for closed tables.
this closes  #11069 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
