### PR TITLE
Remove reference to CMS GC

### DIFF
--- a/docs/config/environment.rst
+++ b/docs/config/environment.rst
@@ -118,38 +118,8 @@ General
 
       Make sure there is enough disk space available for heap dumps.
 
-.. _garbage-collection:
-
-Garbage collection
-------------------
-
-Collector
-~~~~~~~~~
-
-CrateDB uses the `G1`_ garbage collector by default.
-
-Before CrateDB 4.1 it defaulted to use the `Concurrent Mark Sweep` garbage
-collector. If you'd like to continue using CMS, you can switch setting the
-following :ref:`CRATE_JAVA_OPTS <conf-env-java-opts>`::
-
-
-  export CRATE_JAVA_OPTS="-XX:-UseG1GC -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseConcMarkSweepGC"
-
-
-Logging
-~~~~~~~
-
-CrateDB logs JVM garbage collection times using the built-in garbage collection
-logging of the JVM.
-
-.. SEEALSO::
-
-   The :ref:`logging configuration <conf-logging-gc>` documentation has
-   the complete list of garbage collection logging environment variables.
 
 .. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-unix-windows
 .. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/install.html#linux
 .. _CrateDB on Docker: https://crate.io/docs/crate/tutorials/en/latest/install.html#docker
 .. _environment variables: https://en.wikipedia.org/wiki/Environment_variable
-.. _Concurrent Mark Sweep: https://docs.oracle.com/javase/10/gctuning/concurrent-mark-sweep-cms-collector.htm
-.. _G1: https://docs.oracle.com/en/java/javase/16/gctuning/garbage-first-g1-garbage-collector1.html

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/GcNames.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/GcNames.java
@@ -35,7 +35,7 @@ public class GcNames {
         if ("Survivor Space".equals(poolName) || "PS Survivor Space".equals(poolName) || "Par Survivor Space".equals(poolName) || "G1 Survivor Space".equals(poolName)) {
             return SURVIVOR;
         }
-        if ("Tenured Gen".equals(poolName) || "PS Old Gen".equals(poolName) || "CMS Old Gen".equals(poolName) || "G1 Old Gen".equals(poolName)) {
+        if ("Tenured Gen".equals(poolName) || "PS Old Gen".equals(poolName) || "G1 Old Gen".equals(poolName)) {
             return OLD;
         }
         return defaultName;
@@ -45,7 +45,7 @@ public class GcNames {
         if ("Copy".equals(gcName) || "PS Scavenge".equals(gcName) || "ParNew".equals(gcName) || "G1 Young Generation".equals(gcName)) {
             return YOUNG;
         }
-        if ("MarkSweepCompact".equals(gcName) || "PS MarkSweep".equals(gcName) || "ConcurrentMarkSweep".equals(gcName) || "G1 Old Generation".equals(gcName)) {
+        if ("MarkSweepCompact".equals(gcName) || "PS MarkSweep".equals(gcName) || "G1 Old Generation".equals(gcName)) {
             return OLD;
         }
         return defaultName;


### PR DESCRIPTION
CMS was removed with JDK 14 https://openjdk.java.net/jeps/363

## Summary of the changes / Why this improves CrateDB

As noted in https://github.com/crate/crate/pull/11212#pullrequestreview-629984161 CMS is no longer part of current JDK.

This PR removes documentation on how to enable it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
