### PR TITLE
Ensure existing _meta information in mapping is preserved on ALTER TABLE

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -63,6 +63,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused ``ALTER TABLE ADD COLUMN`` statements to remove
+  constraints like analyzers or ``NOT NULL`` from existing columns in the same
+  table.
+
 - Allow executing ``CREATE TABEL .. AS`` as a regular user with ``DDL``
   permission on the target schema, and ``DQL`` permission on the source
   relations.

--- a/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
+++ b/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
@@ -139,10 +139,6 @@ public class MetadataToASTNodeResolver {
             this.tableInfo = tableInfo;
         }
 
-        private Table<Expression> extractTable() {
-            return new Table<>(QualifiedName.of(tableInfo.ident().fqn()), false);
-        }
-
         private List<TableElement<Expression>> extractTableElements() {
             List<TableElement<Expression>> elements = new ArrayList<>();
             // column definitions
@@ -338,7 +334,7 @@ public class MetadataToASTNodeResolver {
 
 
         private CreateTable<Expression> extractCreateTable() {
-            Table<Expression> table = extractTable();
+            Table<Expression> table = new Table<>(QualifiedName.of(tableInfo.ident().fqn()), false);
             List<TableElement<Expression>> tableElements = extractTableElements();
             Optional<PartitionedBy<Expression>> partitionedBy = createPartitionedBy();
             Optional<ClusteredBy<Expression>> clusteredBy = createClusteredBy();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -240,7 +240,6 @@ public class MetadataMappingService {
 
         public ClusterState applyRequest(ClusterState currentState, PutMappingClusterStateUpdateRequest request,
                                           Map<Index, MapperService> indexMapperServices) throws IOException {
-
             CompressedXContent mappingUpdateSource = new CompressedXContent(request.source());
             final Metadata metadata = currentState.metadata();
             final List<IndexMetadata> updateList = new ArrayList<>();

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -21,6 +21,20 @@
 
 package io.crate.analyze;
 
+import static io.crate.testing.TestingHelpers.mapToSortedString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
 import io.crate.common.collections.Maps;
 import io.crate.data.Row;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
@@ -34,20 +48,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static io.crate.testing.TestingHelpers.mapToSortedString;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 
 public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -527,5 +527,33 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
         BoundAddColumn addColumn = analyze("alter table tbl add column browser text");
         Map<String, Object> mapping = (Map<String, Object>) addColumn.mapping().get("properties");
         assertThat(mapping, Matchers.hasEntry(is("num"), is(Map.of("index", false, "type", "long"))));
+    }
+
+    @Test
+    public void test_adding_a_column_with_constraint_adds_existing_constraints_in_mapping() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("CREATE TABLE tbl (author text CHECK (author != ''))")
+            .build();
+        BoundAddColumn addColumn = analyze("ALTER TABLE tbl ADD COLUMN dummy text CHECK (dummy != '')");
+        Map<String, Object> mapping = (Map<String, Object>) addColumn.mapping();
+        Map<String, Object> meta = (Map<String, Object>) mapping.get("_meta");
+        Map<String, Object> checks = (Map<String, Object>) meta.get("check_constraints");
+
+        // not asserting concrete keys because check names contain random suffixes
+        assertThat(checks.size(), is(2));
+    }
+
+    @Test
+    public void test_adding_not_null_column_only_contains_new_column_names_in_constraints() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("CREATE TABLE tbl (author text NOT NULL)")
+            .build();
+        BoundAddColumn addColumn = analyze("ALTER TABLE tbl ADD COLUMN dummy text NOT NULL");
+        Map<String, Object> mapping = (Map<String, Object>) addColumn.mapping();
+        Map<String, Object> meta = (Map<String, Object>) mapping.get("_meta");
+        Collection<String> notNull = (Collection<String>)
+            ((Map<String, Object>) meta.get("constraints")).get("not_null");
+
+        assertThat(notNull, Matchers.containsInAnyOrder("dummy"));
     }
 }


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/11216

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)