### PR TITLE
Remove AssertingLeafReader classpath order requirement

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -123,11 +123,7 @@ artifacts {
 
 test {
     outputs.dir("$projectDir/data")
-
     jacoco.excludes = ["*Test*"]
-
-    // make sure sources are first on classpath because we do override some class(es) (currently: lucene's AssertingLeafReader)
-    classpath = sourceSets.main.output + sourceSets.test.output + configurations.testCompile
 }
 
 clean.dependsOn('cleanTest')

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -22,10 +22,10 @@
 
 package io.crate.execution.engine.collect.collectors;
 
-import io.crate.expression.reference.doc.lucene.CollectorContext;
-import io.crate.expression.reference.doc.lucene.LongColumnReference;
-import org.elasticsearch.test.ESTestCase;
-import io.crate.testing.BatchIteratorTester;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -38,15 +38,16 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LongColumnReference;
+import io.crate.testing.BatchIteratorTester;
 
-public class LuceneBatchIteratorTest extends ESTestCase {
+public class LuceneBatchIteratorTest {
 
     private List<LongColumnReference> columnRefs;
     private IndexSearcher indexSearcher;
     private ArrayList<Object[]> expectedResult;
+
 
     @Before
     public void prepareSearcher() throws Exception {

--- a/server/src/test/java/org/apache/lucene/index/PatchedAssertingLeafReader.java
+++ b/server/src/test/java/org/apache/lucene/index/PatchedAssertingLeafReader.java
@@ -34,7 +34,7 @@ import org.apache.lucene.util.automaton.CompiledAutomaton;
  * A {@link FilterLeafReader} that can be used to apply
  * additional checks for tests.
  */
-public class AssertingLeafReader extends FilterLeafReader {
+public class PatchedAssertingLeafReader extends FilterLeafReader {
 
     private static void assertThread(String object, Thread creationThread) {
         // CRATE PATCH: pause/resume logic in crate can cause thread switches
@@ -46,7 +46,7 @@ public class AssertingLeafReader extends FilterLeafReader {
          */
     }
 
-    public AssertingLeafReader(LeafReader in) {
+    public PatchedAssertingLeafReader(LeafReader in) {
         super(in);
         // check some basic reader sanity
         assert in.maxDoc() >= 0;

--- a/server/src/test/java/org/elasticsearch/index/MockEngineFactoryPlugin.java
+++ b/server/src/test/java/org/elasticsearch/index/MockEngineFactoryPlugin.java
@@ -18,18 +18,17 @@
  */
 package org.elasticsearch.index;
 
-import org.apache.lucene.index.AssertingDirectoryReader;
-import org.apache.lucene.index.FilterDirectoryReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.plugins.EnginePlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.engine.AssertingDirectoryReader;
 import org.elasticsearch.test.engine.MockEngineFactory;
 import org.elasticsearch.test.engine.MockEngineSupport;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * A plugin to use {@link MockEngineFactory}.
@@ -45,10 +44,6 @@ public class MockEngineFactoryPlugin extends Plugin implements EnginePlugin {
 
     @Override
     public Optional<EngineFactory> getEngineFactory(final IndexSettings indexSettings) {
-        return Optional.of(new MockEngineFactory(getReaderWrapperClass()));
-    }
-
-    protected Class<? extends FilterDirectoryReader> getReaderWrapperClass() {
-        return AssertingDirectoryReader.class;
+        return Optional.of(new MockEngineFactory(AssertingDirectoryReader.class));
     }
 }

--- a/server/src/test/java/org/elasticsearch/test/engine/AssertingDirectoryReader.java
+++ b/server/src/test/java/org/elasticsearch/test/engine/AssertingDirectoryReader.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package org.elasticsearch.test.engine;
+
+import java.io.IOException;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PatchedAssertingLeafReader;
+
+/**
+ * AssertingDirectoryReader
+ */
+public final class AssertingDirectoryReader extends FilterDirectoryReader {
+
+  static class AssertingSubReaderWrapper extends SubReaderWrapper {
+    @Override
+    public LeafReader wrap(LeafReader reader) {
+      return new PatchedAssertingLeafReader(reader);
+    }
+  }
+
+  public AssertingDirectoryReader(DirectoryReader in) throws IOException {
+    super(in, new AssertingSubReaderWrapper());
+  }
+
+  @Override
+  protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+    return new AssertingDirectoryReader(in);
+  }
+
+  @Override
+  public CacheHelper getReaderCacheHelper() {
+    return in.getReaderCacheHelper();
+  }
+}
+


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Instead of implicitly overriding the `AssertingLeafReader` by putting
our custom variant first in the classpath this changes the test setup to
load our version.

The build configuration is already complex enough, don't need to
complicate it further with hacks.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)