### PR TITLE
Fix flaky testPipelineConfiguration

### DIFF
--- a/server/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
+++ b/server/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
@@ -61,6 +61,11 @@ public class CrateHttpsTransportTest extends ESTestCase {
     private static String defaultKeyStoreType = KeyStore.getDefaultType();
 
     @BeforeClass
+    public static void disableProcessorCheck() {
+        System.setProperty("es.set.netty.runtime.available.processors", "false");
+    }
+
+    @BeforeClass
     public static void beforeTests() throws IOException {
         trustStoreFile = getAbsoluteFilePathFromClassPath("truststore.jks");
         keyStoreFile = getAbsoluteFilePathFromClassPath("keystore.jks");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Failed sometimes:

    java.lang.IllegalStateException: availableProcessors is already set to [32], rejecting [32]
    	at __randomizedtesting.SeedInfo.seed([C7D7B92910D2EA4B:9BA1905F600FB093]:0)
    	at io.netty.util.NettyRuntime$AvailableProcessorsHolder.setAvailableProcessors(NettyRuntime.java:51)
    	at io.netty.util.NettyRuntime.setAvailableProcessors(NettyRuntime.java:87)
    	at org.elasticsearch.transport.netty4.Netty4Utils.setAvailableProcessors(Netty4Utils.java:72)
    	at org.elasticsearch.http.netty4.Netty4HttpServerTransport.<init>(Netty4HttpServerTransport.java:245)
    	at io.crate.protocols.http.CrateHttpsTransportTest.testPipelineConfiguration(CrateHttpsTransportTest.java:110)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)