### PR TITLE
gradle/server: Replace deprecated `compile` dependency declarations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,8 @@ dependencies {
         exclude group: 'org.apache.xbean', module: 'xbean-asm-util'
     }
 
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+
     // include the extensions module in classpath to be able to use it with Crate launched from within intellij
     runtime project(':extensions:functions')
     runtime project(':extensions:lang-js')

--- a/app/src/main/java/io/crate/plugin/PluginLoader.java
+++ b/app/src/main/java/io/crate/plugin/PluginLoader.java
@@ -22,8 +22,9 @@
 
 package io.crate.plugin;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.crate.Plugin;
+import io.crate.common.annotations.VisibleForTesting;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.xbean.finder.ResourceFinder;

--- a/app/src/main/java/io/crate/plugin/PluginLoaderPlugin.java
+++ b/app/src/main/java/io/crate/plugin/PluginLoaderPlugin.java
@@ -22,7 +22,7 @@
 
 package io.crate.plugin;
 
-import com.google.common.annotations.VisibleForTesting;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -10,19 +10,23 @@ archivesBaseName = 'crate-benchmarks'
 test.enabled = false
 
 dependencies {
-    compile project(':server')
-    compile project(path: ':server', configuration: 'testOutput')
-    compile project(path: ':libs:dex', configuration: 'testOutput')
-    compile project(path: ':extensions:functions', configuration: 'testOutput')
+    implementation project(':server')
+    implementation project(path: ':server', configuration: 'testOutput')
+    implementation project(path: ':libs:dex', configuration: 'testOutput')
+    implementation project(path: ':extensions:functions', configuration: 'testOutput')
     implementation project(':libs:sql-parser')
 
-    compile 'org.openjdk.jmh:jmh-core:1.25'
+    implementation "joda-time:joda-time:${versions.jodatime}"
+    implementation "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
+    implementation "com.google.guava:guava:${versions.guava}"
+
+    implementation 'org.openjdk.jmh:jmh-core:1.25'
     implementation 'org.openjdk.jmh:jmh-generator-annprocess:1.25'
     annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.25'
 
     // Dependencies of JMH
-    runtime 'net.sf.jopt-simple:jopt-simple:4.6'
-    runtime 'org.apache.commons:commons-math3:3.2'
+    runtimeOnly 'net.sf.jopt-simple:jopt-simple:4.6'
+    runtimeOnly 'org.apache.commons:commons-math3:3.2'
 }
 
 compileTestJava {

--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.collect.collectors;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RamAccounting;
 import io.crate.breaker.RowAccountingWithEstimators;
@@ -52,6 +51,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.shard.ShardId;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -120,7 +120,8 @@ public class OrderedLuceneBatchIteratorBenchmark {
         BatchIterator<Row> it = OrderedLuceneBatchIteratorFactory.newInstance(
             Collections.singletonList(createOrderedCollector(indexSearcher, columnName)),
             OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
-            ROW_ACCOUNTING, MoreExecutors.directExecutor(),
+            ROW_ACCOUNTING,
+            EsExecutors.directExecutor(),
             () -> 1,
             false
         );

--- a/extensions/functions/build.gradle
+++ b/extensions/functions/build.gradle
@@ -11,6 +11,8 @@ configurations {
 
 dependencies {
     implementation project(':server')
+    implementation "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
 
     testImplementation project(path: ':server', configuration: 'testOutput')
     testImplementation project(path: ':libs:dex', configuration: 'testOutput')

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -23,9 +23,9 @@
 package io.crate.operation.aggregation;
 
 import com.carrotsearch.hppc.BitMixer;
-import com.google.common.annotations.VisibleForTesting;
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;

--- a/extensions/jmx-monitoring/build.gradle
+++ b/extensions/jmx-monitoring/build.gradle
@@ -7,6 +7,8 @@ description = 'CrateDB JMX monitoring plugin'
 dependencies {
     implementation project(':libs:dex')
     implementation project(':server')
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
+    implementation "com.google.guava:guava:${versions.guava}"
 
     testImplementation project(path: ':server', configuration: 'testOutput')
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"

--- a/extensions/lang-js/build.gradle
+++ b/extensions/lang-js/build.gradle
@@ -22,9 +22,11 @@ jar.dependsOn('writePropertiesFile')
 dependencies {
     implementation project(':server')
 
+    implementation "com.google.code.findbugs:jsr305:${versions.jsr305}"
     implementation "org.graalvm.js:js:${versions.graalvm}"
     implementation "org.graalvm.sdk:graal-sdk:${versions.graalvm}"
     implementation "org.graalvm.truffle:truffle-api:${versions.graalvm}"
+    implementation "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
 
     testImplementation project(path: ':server', configuration: 'testOutput')
     testImplementation project(path: ':libs:dex', configuration: 'testOutput')

--- a/plugins/es-analysis-common/build.gradle
+++ b/plugins/es-analysis-common/build.gradle
@@ -24,6 +24,7 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 
 dependencies {
     implementation project(':server')
+    implementation "org.apache.lucene:lucene-analyzers-common:${versions.lucene}"
 
     testImplementation project(path: ':server', configuration: 'testOutput')
     testImplementation project(path: ':libs:dex', configuration: 'testOutput')

--- a/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -45,8 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Joiner;
-
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.common.settings.Settings;
@@ -310,7 +308,7 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
     public void testBuiltInAnalyzers() throws Exception {
         List<String> analyzers = new ArrayList<>(fulltextAnalyzerResolver.getBuiltInAnalyzers());
         Collections.sort(analyzers);
-        assertThat(Joiner.on(", ").join(analyzers),
+        assertThat(String.join(", ", analyzers),
             is("arabic, armenian, basque, bengali, brazilian, bulgarian, catalan, chinese, cjk, " +
                "czech, danish, default, dutch, english, fingerprint, finnish, french, " +
                "galician, german, greek, hindi, hungarian, indonesian, irish, " +
@@ -346,7 +344,7 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
     public void testBuiltInTokenFilters() throws Exception {
         List<String> tokenFilters = new ArrayList<>(fulltextAnalyzerResolver.getBuiltInTokenFilters());
         Collections.sort(tokenFilters);
-        assertThat(Joiner.on(", ").join(tokenFilters),
+        assertThat(String.join(", ", tokenFilters),
             is("apostrophe, arabic_normalization, arabic_stem, asciifolding, bengali_normalization, brazilian_stem, " +
                "cjk_bigram, cjk_width, classic, common_grams, czech_stem, decimal_digit, delimited_payload, " +
                "delimited_payload_filter, dictionary_decompounder, dutch_stem, " +
@@ -365,7 +363,7 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
     public void testBuiltInCharFilters() throws Exception {
         List<String> charFilters = new ArrayList<>(fulltextAnalyzerResolver.getBuiltInCharFilters());
         Collections.sort(charFilters);
-        assertThat(Joiner.on(", ").join(charFilters),
+        assertThat(String.join(", ", charFilters),
             is("html_strip, mapping, pattern_replace"));
     }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'java-library'
 apply from: "$rootDir/gradle/javaModule.gradle"
 
 archivesBaseName = 'crate-server'
@@ -8,77 +9,77 @@ configurations {
 }
 
 dependencies {
-    compile project(':libs:dex')
-    compile project(':libs:es-x-content')
-    compile project(':libs:pgwire')
-    compile project(':libs:shared')
-    compile project(':libs:cli')
-    compile project(':libs:sql-parser')
-    compile project(':libs:guice')
+    api project(':libs:dex')
+    api project(':libs:es-x-content')
+    api project(':libs:shared')
+    api project(':libs:cli')
+    api project(':libs:guice')
+    api project(':libs:sql-parser')
+    implementation project(':libs:pgwire')
 
     compileOnly project(':libs:es-plugin-classloader')
-    testRuntime project(':libs:es-plugin-classloader')
 
-    compile "io.netty:netty-buffer:${versions.netty4}"
-    compile "io.netty:netty-codec-http:${versions.netty4}"
-    compile "io.netty:netty-codec:${versions.netty4}"
-    compile "io.netty:netty-common:${versions.netty4}"
-    compile "io.netty:netty-handler:${versions.netty4}"
-    compile "io.netty:netty-resolver:${versions.netty4}"
-    compile "io.netty:netty-transport-native-epoll:${versions.netty4}:linux-x86_64"
-    compile "io.netty:netty-transport:${versions.netty4}"
+    api "org.apache.logging.log4j:log4j-api:${versions.log4j2}"
+    api "org.apache.logging.log4j:log4j-core:${versions.log4j2}"
 
-    compile "org.apache.lucene:lucene-core:${versions.lucene}"
-    compile "org.apache.lucene:lucene-analyzers-common:${versions.lucene}"
-    compile "org.apache.lucene:lucene-backward-codecs:${versions.lucene}"
-    compile "org.apache.lucene:lucene-grouping:${versions.lucene}"
-    compile "org.apache.lucene:lucene-join:${versions.lucene}"
-    compile "org.apache.lucene:lucene-misc:${versions.lucene}"
-    compile "org.apache.lucene:lucene-queries:${versions.lucene}"
-    compile "org.apache.lucene:lucene-sandbox:${versions.lucene}"
-    compile "org.apache.lucene:lucene-spatial-extras:${versions.lucene}"
-    compile "org.apache.lucene:lucene-spatial3d:${versions.lucene}"
-    compile "org.apache.lucene:lucene-suggest:${versions.lucene}"
+    api "io.netty:netty-buffer:${versions.netty4}"
+    api "io.netty:netty-codec-http:${versions.netty4}"
+    implementation "io.netty:netty-codec:${versions.netty4}"
+    implementation "io.netty:netty-common:${versions.netty4}"
+    implementation "io.netty:netty-handler:${versions.netty4}"
+    implementation "io.netty:netty-resolver:${versions.netty4}"
+    implementation "io.netty:netty-transport-native-epoll:${versions.netty4}:linux-x86_64"
+    implementation "io.netty:netty-transport:${versions.netty4}"
+
+    api "org.apache.lucene:lucene-core:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-analyzers-common:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-backward-codecs:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-grouping:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-join:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-misc:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-queries:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-sandbox:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-spatial-extras:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-spatial3d:${versions.lucene}"
+    implementation "org.apache.lucene:lucene-suggest:${versions.lucene}"
     // lucene spatial
-    compile "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
-    compile "org.locationtech.jts:jts-core:${versions.jts}"
+    implementation "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
+    implementation "org.locationtech.jts:jts-core:${versions.jts}"
 
-    compile "org.apache.logging.log4j:log4j-api:${versions.log4j2}"
-    compile "org.apache.logging.log4j:log4j-core:${versions.log4j2}"
+    implementation "net.java.dev.jna:jna:${versions.jna}"
 
-    compile "net.java.dev.jna:jna:${versions.jna}"
+    implementation "com.tdunning:t-digest:3.2"
+    implementation "org.hdrhistogram:HdrHistogram:2.1.9"
+    implementation "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
 
-    compile "com.tdunning:t-digest:3.2"
-    compile "org.hdrhistogram:HdrHistogram:2.1.9"
-    compile "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
-
-    compile "com.google.guava:guava:${versions.guava}"
-    compile "com.amazonaws:aws-java-sdk-s3:${versions.aws}"
-    compile "org.apache.commons:commons-math3:${versions.commonsmath}"
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:${versions.jackson}"
-    compile "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+    implementation "com.google.guava:guava:${versions.guava}"
+    implementation "com.amazonaws:aws-java-sdk-s3:${versions.aws}"
+    implementation "org.apache.commons:commons-math3:${versions.commonsmath}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
     // Needed by aws-java-sdk-s3 in Java 9
-    compile "javax.xml.bind:jaxb-api:${versions.jaxb_api}"
+    runtimeOnly "javax.xml.bind:jaxb-api:${versions.jaxb_api}"
 
-    testCompile project(path: ':libs:dex', configuration: 'testOutput')
+    testRuntimeOnly project(':libs:es-plugin-classloader')
+    testImplementation project(path: ':libs:dex', configuration: 'testOutput')
 
-    testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-    testCompile "org.apache.lucene:lucene-codecs:${versions.lucene}"
-    testCompile "org.apache.lucene:lucene-test-framework:${versions.lucene}"
-    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
-    testCompile "org.mockito:mockito-core:${versions.mockito}"
-    testCompile "org.postgresql:postgresql:${versions.jdbc}"
-    testCompile 'com.pholser:junit-quickcheck-core:0.9'
-    testCompile 'com.pholser:junit-quickcheck-generators:0.9'
-    testCompile 'org.skyscreamer:jsonassert:1.3.0'
-    testCompile "junit:junit:${versions.junit}"
-    testCompile "org.junit.jupiter:junit-jupiter:${versions.junit5}"
-    testCompile ("org.junit.vintage:junit-vintage-engine") {
+    testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+    testRuntimeOnly "org.apache.lucene:lucene-codecs:${versions.lucene}"
+    testImplementation "org.apache.lucene:lucene-test-framework:${versions.lucene}"
+    testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.postgresql:postgresql:${versions.jdbc}"
+    testImplementation 'com.pholser:junit-quickcheck-core:0.9'
+    testImplementation 'com.pholser:junit-quickcheck-generators:0.9'
+    testImplementation 'org.skyscreamer:jsonassert:1.3.0'
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation "org.junit.jupiter:junit-jupiter:${versions.junit5}"
+    testRuntimeOnly ("org.junit.vintage:junit-vintage-engine") {
         because 'allows JUnit 3 and JUnit 4 tests to run'
     }
 
     // Required to use SelfSignedCertificate from netty
-    testCompile "org.bouncycastle:bcpkix-jdk15on:1.68"
+    testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:1.68"
 }
 
 //noinspection GroovyAssignabilityCheck


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`compile` and `runtime` are deprecated and should be replaced with `implementation` and `runtimeOnly`.
This only touches `server` - most other modules are already changed, except for `app` which will be a bit more work.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)