### PR TITLE
Improve note about the Java version within the sandbox setup

### DIFF
--- a/devs/docs/basics.rst
+++ b/devs/docs/basics.rst
@@ -13,7 +13,7 @@ to build documentation and run tests require Python_.
 
 To set up a minimal development environment, you will need:
 
-- Java_ (>= 11)
+- Java_ 15
 - Python_ (>= 3.7)
 
 Then, clone the repository and navigate into its directory::


### PR DESCRIPTION
Hi there,

currently, compiling and invoking CrateDB through Gradle by using `./gradlew clean app:run` does not work on either Java 11 nor Java 16 (see #11102 and https://github.com/crate/crate/issues/11229#issuecomment-819397180). So, it might be a good idea to reflect that within the documentation until the situation changes.

With kind regards,
Andreas.

