### PR TITLE
Optionally use Java VM from "JAVA_BIN" environment variable on *nix systems

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -380,12 +380,23 @@ task createCrateNodeScripts(type: CreateStartScripts) {
         // Unix: Prevent using the system-wide Java installation.
         unixScript.text = insertAfter(unixScript.text, '#!/usr/bin/env sh\n', 'unset JAVA_HOME\n');
 
-        // Unix: Use the bundled Java runtime.
+        // Unix: Use either JAVA_BIN or the bundled Java runtime.
         unixScript.text = unixScript.text.replace('JAVACMD="java"', """
-            if \${darwin}; then
-                JAVACMD="\${APP_HOME}/jdk/Contents/Home/bin/java"
+            # Find Java VM
+            if [ ! -z "\$JAVA_BIN" ]; then
+                JAVACMD="\$JAVA_BIN"
             else
-                JAVACMD="\${APP_HOME}/jdk/bin/java"
+                if \${darwin}; then
+                    JAVACMD="\${APP_HOME}/jdk/Contents/Home/bin/java"
+                else
+                    JAVACMD="\${APP_HOME}/jdk/bin/java"
+                fi
+            fi
+
+            # Sanity checks
+            if [ ! -f "\$JAVACMD" ]; then
+                echo "Java VM not found, please set JAVA_BIN environment variable"
+                exit 1
             fi
         """)
         unixScript.text = unixScript.text.replace('which java', 'which ${JAVACMD}')

--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -89,12 +89,22 @@ elif [ -r "$CRATE_INCLUDE" ]; then
     . "$CRATE_INCLUDE"
 fi
 
-if [ "$(uname -s)" = "Darwin" ]; then
-    JAVA="$CRATE_HOME/jdk/Contents/Home/bin/java"
+# Find Java VM
+if [ ! -z "$JAVA_BIN" ]; then
+    JAVA="$JAVA_BIN"
 else
-    JAVA="$CRATE_HOME/jdk/bin/java"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        JAVA="$CRATE_HOME/jdk/Contents/Home/bin/java"
+    else
+        JAVA="$CRATE_HOME/jdk/bin/java"
+    fi
 fi
 
+# Sanity checks
+if [ ! -f "$JAVA" ]; then
+    echo "Java VM not found, please set JAVA_BIN environment variable"
+    exit 1
+fi
 if [ -z "$CRATE_CLASSPATH" ]; then
     echo "CRATE_CLASSPATH should've been initialized via crate.in.sh" >&2
     exit 1


### PR DESCRIPTION
Hi.

This patch enables the possibility to run CrateDB on other operating systems than the ones it has been built for with respect to the Java VM bundling. Specifically, I am aiming for easy invocation on FreeBSD.

With kind regards,
Andreas.
