### PR TITLE
any user can access pg_catalog by default

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,9 @@ Changes
 
 - Included the shard information for closed tables in ``sys.shards`` table.
 
+- Users can now read tables within the ``pg_catalog`` schema without explicit
+  ``DQL`` permission. They will only see records the user has privileges on.
+
 Fixes
 =====
 

--- a/server/src/main/java/io/crate/metadata/FunctionName.java
+++ b/server/src/main/java/io/crate/metadata/FunctionName.java
@@ -94,4 +94,8 @@ public final class FunctionName implements Writeable {
         }
         return schema + "." + name;
     }
+
+    public boolean isBuiltin() {
+        return schema == null || Schemas.isSystemSchema(schema);
+    }
 }

--- a/server/src/main/java/io/crate/metadata/RelationName.java
+++ b/server/src/main/java/io/crate/metadata/RelationName.java
@@ -154,7 +154,7 @@ public final class RelationName implements Writeable {
         if (!isValidRelationOrSchemaName(name)) {
             throw new InvalidRelationName(this);
         }
-        if (Schemas.READ_ONLY_SCHEMAS.contains(schema)) {
+        if (Schemas.READ_ONLY_SYSTEM_SCHEMAS.contains(schema)) {
             throw new IllegalArgumentException("Cannot create relation in read-only schema: " + schema);
         }
     }

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -77,7 +77,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
 
     private static final Logger LOGGER = LogManager.getLogger(Schemas.class);
 
-    public static final Collection<String> READ_ONLY_SCHEMAS = Set.of(
+    public static final Collection<String> READ_ONLY_SYSTEM_SCHEMAS = Set.of(
         SysSchemaInfo.NAME,
         InformationSchemaInfo.NAME,
         PgCatalogSchemaInfo.NAME
@@ -401,10 +401,15 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         if (schemaName.equalsIgnoreCase(InformationSchemaInfo.NAME)
             || schemaName.equalsIgnoreCase(SysSchemaInfo.NAME)
             || schemaName.equalsIgnoreCase(BlobSchemaInfo.NAME)
+            || schemaName.equalsIgnoreCase(PgCatalogSchemaInfo.NAME)
             ) {
             return false;
         }
         return true;
+    }
+
+    public static boolean isSystemSchema(@Nullable String schemaName) {
+        return !isDefaultOrCustomSchema(schemaName) && !BlobSchemaInfo.NAME.equals(schemaName);
     }
 
     public boolean tableExists(RelationName relationName) {

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -173,7 +173,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void testCreateTableInSystemSchemasIsProhibited() {
-        for (String schema : Schemas.READ_ONLY_SCHEMAS) {
+        for (String schema : Schemas.READ_ONLY_SYSTEM_SCHEMAS) {
             try {
                 analyze(String.format("CREATE TABLE %s.%s (ordinal INTEGER, name STRING)", schema, "my_table"));
                 fail("create table in read-only schema must fail");

--- a/server/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
@@ -111,7 +111,7 @@ public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCreatingAViewInReadOnlySchemaIsProhibited() {
-        for (String schema : Schemas.READ_ONLY_SCHEMAS) {
+        for (String schema : Schemas.READ_ONLY_SYSTEM_SCHEMAS) {
             try {
                 e.analyze(String.format(Locale.ENGLISH, "create view %s.v1 as select 1", schema));
                 fail("creating a view in read-only schema must fail");

--- a/server/src/test/java/io/crate/user/PrivilegesTest.java
+++ b/server/src/test/java/io/crate/user/PrivilegesTest.java
@@ -58,4 +58,12 @@ public class PrivilegesTest extends ESTestCase {
         Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.table", user);
         Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.views", user);
     }
+
+    @Test
+    public void testUserWithNoPrivilegesCanAccessPgCatalogSchema() throws Exception {
+        //ensureUserHasPrivilege will not throw an exception if the schema is `pg_catalog`
+        Privileges.ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "pg_catalog", user);
+        Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_am", user);
+        Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_database", user);
+    }
 }

--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -835,7 +835,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         Random random = RandomizedContext.current().getRandom();
         while (true) {
             String schemaName = RandomStrings.randomAsciiLettersOfLengthBetween(random, 1, 20).toLowerCase();
-            if (!Schemas.READ_ONLY_SCHEMAS.contains(schemaName) &&
+            if (!Schemas.READ_ONLY_SYSTEM_SCHEMAS.contains(schemaName) &&
                 !Identifiers.isKeyWord(schemaName) &&
                 !containsExtendedAsciiChars(schemaName)) {
                 return schemaName;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will allow the user can access generic system data from pg_catalog schema and only the data that the user has the privileges for. ex) From a fresh cluster, super user can see 71 rows from pg_class table. A new user should be able to see them as well without any privileges granted.

**1) allow all users to access pg_catalog to handle below observations.**

original behaviours on different clients:

**crash**
```SQL
cr> show search_path;
SchemaUnknownException[Schema 'pg_catalog' unknown]
cr> select current_schemas(true);
+-----------------------+
| current_schemas       |
+-----------------------+
| ["pg_catalog", "doc"] |
+-----------------------+
SELECT 1 row in set (0.081 sec)
```

**pgcli** (cannot log on since it tries to access pg_catalog.pg_settings while logging in)
```SQL
pgcli postgresql://nuser2@localhost:5432/
Schema 'pg_catalog' unknown
```

**2) protect any rows that users do not have permissions for.**


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
