### PR TITLE
Remove jcenter repository

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,6 @@
 import java.nio.file.Paths
 import org.apache.tools.ant.filters.ReplaceTokens;
 
-buildscript {
-    repositories {
-        jcenter()
-    }
-}
-
 apply plugin: 'distribution'
 apply from: "$rootDir/gradle/javaModule.gradle"
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'org.apache.commons:commons-compress:1.19'
+    implementation 'org.apache.commons:commons-compress:1.20'
     testImplementation "junit:junit:4.12"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.27.0"
 }

--- a/docs/admin/discovery.rst
+++ b/docs/admin/discovery.rst
@@ -83,10 +83,6 @@ You can download the libraries using a simple ``build.gradle`` file:
 
     apply plugin: "java"
 
-    repositories {
-      jcenter()
-    }
-
     dependencies {
         compile('com.microsoft.azure:azure-mgmt-utility:0.9.3') {
             exclude group: 'stax', module: 'stax-api'

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -33,7 +33,6 @@ jdks {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven { url "https://jitpack.io" }
 }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

> The RepositoryHandler.jcenter() method has been deprecated. This is
> scheduled to be removed in Gradle 8.0. JFrog announced JCenter's
> shutdown in February 2021. Use mavenCentral() instead

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)