### PR TITLE
Ensure varchar(n) type can match signatures with text

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would cause columns of type ``varchar`` with a length
+  limited to be incorrectly casted to another type if used as argument in a
+  function that has several type overloads.
+
 - Fixed an issue that caused ``ALTER TABLE ADD COLUMN`` statements to remove
   constraints like analyzers or ``NOT NULL`` from existing columns in the same
   table.

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -65,10 +65,12 @@ import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.SymbolMatchers;
 import io.crate.testing.T3;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.StringType;
 import io.crate.types.TimeTZ;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -519,6 +521,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         assertThat(collectSet.arguments().size(), is(1));
         assertThat(collectSet.arguments().get(0), isReference("load['1']"));
+    }
+
+    @Test
+    public void test_count_distinct_on_length_limited_varchar_preserves_varchar_type() throws Exception {
+        var executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (name varchar(10))")
+            .build();
+
+        Symbol symbol = executor.asSymbol("count(distinct name)");
+        assertThat(symbol, SymbolMatchers.isFunction("collection_count", List.of(new ArrayType<>(DataTypes.STRING))));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11296


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)