### PR TITLE
Make candidates in function signature matching lazier

### DIFF
--- a/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
+++ b/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
@@ -488,24 +488,8 @@ public class SignatureBinder {
         private SolverReturnStatus current = SolverReturnStatus.UNCHANGED_SATISFIED;
 
         public void add(SolverReturnStatus newStatus) {
-            switch (newStatus) {
-                case UNCHANGED_SATISFIED:
-                    break;
-                case UNCHANGED_NOT_SATISFIED:
-                    if (current == SolverReturnStatus.UNCHANGED_SATISFIED) {
-                        current = SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
-                    }
-                    break;
-                case CHANGED:
-                    if (current == SolverReturnStatus.UNCHANGED_SATISFIED ||
-                        current == SolverReturnStatus.UNCHANGED_NOT_SATISFIED) {
-                        current = SolverReturnStatus.CHANGED;
-                    }
-                    break;
-                case UNSOLVABLE:
-                default:
-                    current = SolverReturnStatus.UNSOLVABLE;
-                    break;
+            if (newStatus.ordinal() > current.ordinal()) {
+                current = newStatus;
             }
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)