### PR TITLE
Add closed column to sys.shards table 

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -993,6 +993,9 @@ Table schema
         * INITIALIZING
         * UNASSIGNED
       - ``TEXT``
+    * - ``closed``
+      - The state of the table associated with the shard.
+      - ``BOOLEAN``
     * - ``table_name``
       - The name of the table this shard belongs to
       - ``TEXT``

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,9 @@ None
 Changes
 =======
 
+- Added a ``closed`` column to :ref:`sys-shards <sys-shards>` exposing
+  the state of the table associated with the shard.
+
 - Added :ref:`array_to_string <scalar-array-to-string>` scalar function
   that concatenates array elements into a single string using a separator and
   an optional null-string.

--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -174,6 +174,10 @@ public class ShardRowContext {
         }
     }
 
+    public boolean isClosed() {
+        return indexShard.mapperService() == null;
+    }
+
     @Nullable
     public String minLuceneVersion() {
         long numDocs;

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -81,6 +81,7 @@ public class SysShardsTableInfo {
         static final ColumnIdent RELOCATING_NODE = new ColumnIdent("relocating_node");
         public static final ColumnIdent SIZE = new ColumnIdent("size");
         static final ColumnIdent STATE = new ColumnIdent("state");
+        static final ColumnIdent CLOSED = new ColumnIdent("closed");
         static final ColumnIdent ROUTING_STATE = new ColumnIdent("routing_state");
         static final ColumnIdent ORPHAN_PARTITION = new ColumnIdent("orphan_partition");
 
@@ -107,6 +108,7 @@ public class SysShardsTableInfo {
             entry(Columns.RELOCATING_NODE, () -> constant(null)),
             entry(Columns.SIZE, () -> constant(0L)),
             entry(Columns.STATE, () -> forFunction(UnassignedShard::state)),
+            entry(Columns.CLOSED, () -> constant(null)),
             entry(Columns.ROUTING_STATE, () -> forFunction(UnassignedShard::state)),
             entry(Columns.ORPHAN_PARTITION, () -> forFunction(UnassignedShard::orphanedPartition)),
             entry(Columns.RECOVERY, NestedNullObjectExpression::new),
@@ -131,6 +133,7 @@ public class SysShardsTableInfo {
             .add("relocating_node", STRING, r -> r.indexShard().routingEntry().relocatingNodeId())
             .add("size", LONG, ShardRowContext::size)
             .add("state", STRING, r -> r.indexShard().state().toString())
+            .add("closed", BOOLEAN, ShardRowContext::isClosed)
             .add("routing_state", STRING,r -> r.indexShard().routingEntry().state().toString())
             .add("orphan_partition", BOOLEAN, ShardRowContext::isOrphanedPartition)
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -530,7 +530,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(846, response.rowCount());
+        assertEquals(847, response.rowCount());
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -278,10 +278,11 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
                 "and tables.table_schema = columns.table_schema " +
                 "and tables.table_name = columns.table_name " +
                 "order by columns.column_name " +
-                "limit 4");
-        assertThat(response.rowCount(), is(4L));
+                "limit 5");
+        assertThat(response.rowCount(), is(5L));
         assertThat(printedTable(response.rows()),
             is("strict| blob_path\n" +
+               "strict| closed\n" +
                "strict| id\n" +
                "strict| min_lucene_version\n" +
                "strict| node\n"));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `closed`column shows if the table associated with the the shard is open or closed. 

Note:
When a shard gets closed, it changes its state to `CLOSED` and then gets restarted without the expensive resources such as mapperservice etc. and is back as a `STARTED` shard.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
