### PR TITLE
Fix NPE in array_to_string

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
@@ -82,11 +82,14 @@ class ArrayToStringFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public String evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>[] args) {
+    @SafeVarargs
+    public final String evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>... args) {
         @SuppressWarnings("unchecked")
         List<Object> values = (List<Object>) args[0].value();
+        if (values == null) {
+            return null;
+        }
         String separator = (String) args[1].value();
-
         if (separator == null) {
             return null;
         }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
@@ -42,6 +42,11 @@ public class ArrayToStringFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
+    public void test_null_array_results_in_null() {
+        assertEvaluate("array_to_string(null::text[], ',')", null);
+    }
+
+    @Test
     public void testEmptyArray() {
         assertEvaluate("array_to_string(cast([] as array(integer)), '')", "");
         assertEvaluate("array_to_string(cast([] as array(integer)), ',')", "");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The array argument could be null.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)