### PR TITLE
Implement array_min and array_max scalar functions.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -61,6 +61,10 @@ Changes
   that concatenates array elements into a single string using a separator and
   an optional null-string.
 
+- Added :ref:`array_min <scalar-array-min>` and :ref:`array_max
+  <scalar-array-max>` scalar functions returning the minimal and maximal
+  element in array respectively.
+
 - Added support for reading ``cgroup`` information in the ``cgroup v2`` format.
 
 - Improved the internal throttling mechanism used for ``INSERT FROM QUERY`` and

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2446,6 +2446,46 @@ null_string
 If the ``null_string`` argument is omitted or NULL, none of the substrings of
 the input will be replaced by NULL.
 
+.. _scalar-array-min:
+
+``array_min(array)``
+--------------------
+
+The ``array_min`` function returns the smallest element in ``array``. If
+``array`` is ``NULL`` or an empty array, the function returns ``NULL``. This
+function supports arrays of any of the :ref:`primitive types
+<sql_ddl_datatypes_primitives>`.
+
+::
+
+    cr> SELECT array_min([3, 2, 1]) AS min;
+    +-----+
+    | min |
+    +-----+
+    |   1 |
+    +-----+
+    SELECT 1 row in set (... sec)
+
+.. _scalar-array-max:
+
+``array_max(array)``
+--------------------
+
+The ``array_max`` function returns the largest element in ``array``. If
+``array`` is ``NULL`` or an empty array, the function returns ``NULL``. This
+function supports arrays of any of the :ref:`primitive types
+<sql_ddl_datatypes_primitives>`.
+
+::
+
+    cr> SELECT array_max([1,2,3]) AS max;
+    +-----+
+    | max |
+    +-----+
+    |   3 |
+    +-----+
+    SELECT 1 row in set (... sec)
+
 .. _scalar-conditional-functions-expressions:
 
 Conditional functions and expressions

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+
+import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
+
+public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
+
+    public static final String NAME = "array_max";
+
+    private final DataType dataType;
+
+    public static void register(ScalarFunctionModule module) {
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
+                DataTypes.NUMERIC.getTypeSignature()
+            ),
+            ArrayMaxFunction::new
+        );
+
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    new ArrayType(supportedType).getTypeSignature(),
+                    supportedType.getTypeSignature()
+                ),
+                ArrayMaxFunction::new
+            );
+        }
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    private ArrayMaxFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        this.dataType = signature.getReturnType().createType();
+        ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), signature.getName().name());
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public T evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
+        List<T> values = (List) args[0].value();
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+
+        // Taking first element in order not to initialize max
+        // with type dependant TYPE.MIN_VALUE.
+        T max = values.get(0);
+
+        for (int i = 1; i < values.size(); i++) {
+            T item = values.get(i);
+            if (item != null) {
+                //max can be null on the first iteration.
+                if (max == null) {
+                    max = item;
+                } else if (dataType.compare(item, max) > 0) {
+                    max = item;
+                }
+            }
+        }
+        return max;
+    }
+}
+

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+
+import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
+
+public class ArrayMinFunction<T> extends Scalar<T, List<T>> {
+
+    public static final String NAME = "array_min";
+
+    private final DataType dataType;
+
+    public static void register(ScalarFunctionModule module) {
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
+                DataTypes.NUMERIC.getTypeSignature()
+            ),
+            ArrayMinFunction::new
+        );
+
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    new ArrayType(supportedType).getTypeSignature(),
+                    supportedType.getTypeSignature()
+                ),
+                ArrayMinFunction::new
+            );
+        }
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    private ArrayMinFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        this.dataType = signature.getReturnType().createType();
+        ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), signature.getName().name());
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public T evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
+        List<T> values = (List) args[0].value();
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+
+        // Taking first element in order not to initialize min
+        // with type dependant TYPE.MAX_VALUE.
+        T min = values.get(0);
+
+        for (int i = 1; i < values.size(); i++) {
+            T item = values.get(i);
+            if (item != null) {
+                //min can be null on the first iteration.
+                if (min == null) {
+                    min = item;
+                } else if (dataType.compare(item, min) < 0) {
+                    min = item;
+                }
+            }
+        }
+        return min;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -173,6 +173,8 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         ArrayLowerFunction.register(this);
         StringToArrayFunction.register(this);
         ArrayToStringFunction.register(this);
+        ArrayMinFunction.register(this);
+        ArrayMaxFunction.register(this);
 
         CoalesceFunction.register(this);
         GreatestFunction.register(this);

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
@@ -1,0 +1,68 @@
+package io.crate.expression.scalar;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static io.crate.testing.Asserts.assertThrows;
+
+public class ArrayMaxFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_array_returns_max_element() {
+        List<DataType> typesToTest = new ArrayList(DataTypes.PRIMITIVE_TYPES);
+        typesToTest.add(DataTypes.NUMERIC);
+
+        for(DataType type: typesToTest) {
+            var valuesToTest = TestingHelpers.getRandomsOfType(2, 10, type);
+
+            var expected = valuesToTest.stream()
+                .filter(o -> o != null)
+                .max((o1, o2) -> type.compare(o1, o2))
+                .get();
+
+            String expression = String.format(Locale.ENGLISH, "array_max(?::%s[])", type.getName());
+            assertEvaluate(expression, expected, Literal.of(valuesToTest, new ArrayType<>(type)));
+        }
+    }
+
+    @Test
+    public void test_array_first_element_null_returns_max() {
+        assertEvaluate("array_max([null, 1])", 1);
+    }
+
+    @Test
+    public void test_all_elements_nulls_results_in_null() {
+        assertEvaluate("array_max(cast([null, null] as array(integer)))", null);
+    }
+
+    @Test
+    public void test_null_array_results_in_null() {
+        assertEvaluate("array_max(null::int[])", null);
+    }
+
+    @Test
+    public void test_null_array_given_directly_results_in_null() {
+       assertEvaluate("array_max(null)", null);
+    }
+
+    @Test
+    public void test_empty_array_results_in_null() {
+        assertEvaluate("array_max(cast([] as array(integer)))", null);
+    }
+
+    @Test
+    public void test_empty_array_given_directly_throws_exception() {
+        assertThrows(() -> assertEvaluate("array_max([])", null),
+            UnsupportedOperationException.class,
+            "Unknown function: array_max([]), no overload found for matching argument types: (undefined_array).");
+    }
+
+}

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
@@ -1,0 +1,67 @@
+package io.crate.expression.scalar;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static io.crate.testing.Asserts.assertThrows;
+
+public class ArrayMinFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_array_returns_min_element() {
+        List<DataType> typesToTest = new ArrayList(DataTypes.PRIMITIVE_TYPES);
+        typesToTest.add(DataTypes.NUMERIC);
+
+        for(DataType type: typesToTest) {
+            var valuesToTest = TestingHelpers.getRandomsOfType(2, 10, type);
+
+            var expected = valuesToTest.stream()
+                .filter(o -> o != null)
+                .min((o1, o2) -> type.compare(o1, o2))
+                .get();
+
+            String expression = String.format(Locale.ENGLISH, "array_min(?::%s[])", type.getName());
+            assertEvaluate(expression, expected, Literal.of(valuesToTest, new ArrayType<>(type)));
+        }
+    }
+
+    @Test
+    public void test_array_first_element_null_returns_min() {
+        assertEvaluate("array_min([null, 1])", 1);
+    }
+
+    @Test
+    public void test_all_elements_nulls_results_in_null() {
+        assertEvaluate("array_min(cast([null, null] as array(integer)))", null);
+    }
+
+    @Test
+    public void test_null_array_results_in_null() {
+        assertEvaluate("array_min(null::int[])", null);
+    }
+
+    @Test
+    public void test_null_array_given_directly_results_in_null() {
+        assertEvaluate("array_min(null)", null);
+    }
+
+    @Test
+    public void test_empty_array_results_in_null() {
+        assertEvaluate("array_min(cast([] as array(integer)))", null);
+    }
+
+    @Test
+    public void test_empty_array_given_directly_throws_exception() {
+        assertThrows(() -> assertEvaluate("array_min([])", null),
+            UnsupportedOperationException.class,
+            "Unknown function: array_min([]), no overload found for matching argument types: (undefined_array).");
+    }
+}

--- a/server/src/testFixtures/java/io/crate/expression/symbol/ParameterBinder.java
+++ b/server/src/testFixtures/java/io/crate/expression/symbol/ParameterBinder.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.symbol;
+
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ParameterBinder extends FunctionCopyVisitor<Function<? super ParameterSymbol, ? extends Symbol>> {
+
+    private static final ParameterBinder BINDER = new ParameterBinder();
+
+    private ParameterBinder() {
+        super();
+    }
+
+    /**
+     * Applies {@code mapper} on all {@link ParameterSymbol} instances within {@code tree}
+     */
+    public static Symbol bindParameters(Symbol tree, Function<? super ParameterSymbol, ? extends Symbol> mapper) {
+        return tree.accept(BINDER, mapper);
+    }
+
+    @Override
+    public Symbol visitParameterSymbol(ParameterSymbol parameter, Function<? super ParameterSymbol, ? extends Symbol> mapper) {
+        return requireNonNull(mapper.apply(parameter), "mapper function used in ParameterBinder must not return null values");
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -40,6 +40,7 @@ import io.crate.types.IntegerType;
 import io.crate.types.IntervalType;
 import io.crate.types.IpType;
 import io.crate.types.LongType;
+import io.crate.types.NumericType;
 import io.crate.types.ObjectType;
 import io.crate.types.Regclass;
 import io.crate.types.RegclassType;
@@ -50,6 +51,7 @@ import org.joda.time.Period;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -146,9 +148,15 @@ public class DataTypeTesting {
                     map.put("x", innerValueGenerator.get());
                     return (T) map;
                 };
+
             case IntervalType.ID:
                 return () -> {
                     return (T) new Period().withSeconds(RandomNumbers.randomIntBetween(random, 0, Integer.MAX_VALUE));
+                };
+
+            case NumericType.ID:
+                return () -> {
+                    return (T) new BigDecimal(random.nextDouble());
                 };
 
         }

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -21,6 +21,7 @@
 
 package io.crate.testing;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.where.DocKeys;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Sorted;
@@ -63,6 +64,7 @@ import java.io.PrintStream;
 import java.lang.reflect.Array;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -435,5 +437,21 @@ public class TestingHelpers {
                 hasEntry(
                     is(Version.Property.UPGRADED.toString()),
                     versionUpgraded == null ? nullValue() : is(versionUpgraded.externalNumber()))));
+    }
+
+    public static <T> List<T> getRandomsOfType(int minLength, int maxLength, DataType<T> dataType) {
+        var values = new ArrayList<T>();
+
+        boolean addNull = RandomizedTest.randomBoolean();
+        int length  = RandomizedTest.randomIntBetween(minLength, maxLength);
+        if (addNull) {
+            length = length - 1;
+            values.add(null);
+        }
+        var generator = DataTypeTesting.getDataGenerator(dataType);
+        for (int i = 0; i < length; i++) {
+            values.add(dataType.sanitizeValue(generator.get()));
+        }
+        return values;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
