### PR TITLE
block default accesses to sys related entries from pg_catalog (fixes 11282)

### DIFF
--- a/server/src/main/java/io/crate/metadata/FunctionName.java
+++ b/server/src/main/java/io/crate/metadata/FunctionName.java
@@ -27,6 +27,8 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import io.crate.metadata.information.InformationSchemaInfo;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -96,6 +98,6 @@ public final class FunctionName implements Writeable {
     }
 
     public boolean isBuiltin() {
-        return schema == null || Schemas.isSystemSchema(schema);
+        return schema == null || InformationSchemaInfo.NAME.equals(schema) || PgCatalogSchemaInfo.NAME.equals(schema);
     }
 }

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -408,10 +408,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return true;
     }
 
-    public static boolean isSystemSchema(@Nullable String schemaName) {
-        return !isDefaultOrCustomSchema(schemaName) && !BlobSchemaInfo.NAME.equals(schemaName);
-    }
-
     public boolean tableExists(RelationName relationName) {
         SchemaInfo schemaInfo = schemas.get(relationName.schema());
         if (schemaInfo == null) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

fix for #11282 
> To make things consistent we should probably later on (separately) also make some changes to how the information_schema tables are handled. For example information_schema.tables should probably return the information_schema and pg_catalog tables as well for a user who doesn't have explicit permissions on those tables.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
