### PR TITLE
Rename test base classes to clarify they're not tests

### DIFF
--- a/app/src/test/java/io/crate/node/UnsafeBootstrapAndDetachCommandIT.java
+++ b/app/src/test/java/io/crate/node/UnsafeBootstrapAndDetachCommandIT.java
@@ -22,7 +22,7 @@
 
 package io.crate.node;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.testing.UseJdbc;
 import joptsimple.OptionSet;
 import org.elasticsearch.ElasticsearchException;
@@ -49,7 +49,7 @@ import java.util.Locale;
 import static org.hamcrest.Matchers.containsString;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numClientNodes = 0, numDataNodes = 0, autoManageMasterNodes = false)
-public class UnsafeBootstrapAndDetachCommandIT extends SQLTransportIntegrationTest {
+public class UnsafeBootstrapAndDetachCommandIT extends SQLIntegrationTestCase {
 
     private MockTerminal executeCommand(ElasticsearchNodeCommand command,
                                         Environment environment,

--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -42,7 +42,7 @@ import java.util.List;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.is;
 
-public class HyperLogLogDistinctAggregationTest extends AggregationTest {
+public class HyperLogLogDistinctAggregationTest extends AggregationTestCase {
 
     @Before
     public void prepareFunctions() throws Exception {

--- a/extensions/functions/src/test/java/io/crate/window/NthValueFunctionIntegrationTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/NthValueFunctionIntegrationTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.window;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.plugins.Plugin;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ import java.util.Collection;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-public class NthValueFunctionIntegrationTest extends SQLTransportIntegrationTest {
+public class NthValueFunctionIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/extensions/functions/src/test/java/io/crate/window/RankFunctionsIntegrationTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/RankFunctionsIntegrationTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.window;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.plugins.Plugin;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ import java.util.Collection;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-public class RankFunctionsIntegrationTest extends SQLTransportIntegrationTest {
+public class RankFunctionsIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/extensions/functions/src/test/java/io/crate/window/WindowFunctionsITest.java
+++ b/extensions/functions/src/test/java/io/crate/window/WindowFunctionsITest.java
@@ -28,9 +28,9 @@ import java.util.Collection;
 import org.elasticsearch.plugins.Plugin;
 import org.junit.Test;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 
-public class WindowFunctionsITest extends SQLTransportIntegrationTest {
+public class WindowFunctionsITest extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/extensions/lang-js/src/test/java/io/crate/operation/language/JavaScriptUDFIntegrationTest.java
+++ b/extensions/lang-js/src/test/java/io/crate/operation/language/JavaScriptUDFIntegrationTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.operation.language;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.module.JavaScriptLanguageModule;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -40,7 +40,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
-public class JavaScriptUDFIntegrationTest extends SQLTransportIntegrationTest {
+public class JavaScriptUDFIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -23,7 +23,7 @@
 package io.crate.operation.language;
 
 import io.crate.analyze.FunctionArgumentDefinition;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionService;
@@ -55,7 +55,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 
-public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTest {
+public class JavascriptUserDefinedFunctionTest extends ScalarTestCase {
 
     private static final String JS = JavaScriptLanguage.NAME;
 

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/CommonAnalyzerITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/CommonAnalyzerITest.java
@@ -28,10 +28,10 @@ import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.junit.Test;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.testing.TestingHelpers;
 
-public class CommonAnalyzerITest extends SQLTransportIntegrationTest {
+public class CommonAnalyzerITest extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
@@ -35,11 +35,11 @@ import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.junit.Test;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.integrationtests.Setup;
 import io.crate.testing.TestingHelpers;
 
-public class FulltextITest extends SQLTransportIntegrationTest{
+public class FulltextITest extends SQLIntegrationTestCase{
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -57,7 +57,7 @@ import org.junit.Test;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.testing.SQLResponse;
 
-public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
+public class FulltextAnalyzerResolverTest extends SQLIntegrationTestCase {
 
     private static FulltextAnalyzerResolver fulltextAnalyzerResolver;
 

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
@@ -23,7 +23,7 @@
 package org.elasticsearch.repositories.azure;
 
 import com.sun.net.httpserver.HttpServer;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.plugins.Plugin;
 import org.junit.After;
@@ -41,7 +41,7 @@ import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.is;
 
-public class AzureSnapshotIntegrationTest extends SQLTransportIntegrationTest {
+public class AzureSnapshotIntegrationTest extends SQLIntegrationTestCase {
 
     private static final String CONTAINER_NAME = "crate_snapshots";
 

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryIntegrationTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryIntegrationTest.java
@@ -22,7 +22,7 @@
 
 package org.elasticsearch.repositories.s3;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.plugins.Plugin;
 import org.junit.Test;
 
@@ -35,7 +35,7 @@ import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.startsWith;
 
-public class S3RepositoryIntegrationTest extends SQLTransportIntegrationTest {
+public class S3RepositoryIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/plugins/es-repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryITest.java
+++ b/plugins/es-repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryITest.java
@@ -19,9 +19,9 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 
-public class URLRepositoryITest extends SQLTransportIntegrationTest {
+public class URLRepositoryITest extends SQLIntegrationTestCase {
 
     @ClassRule
     public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();

--- a/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.auth;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.testing.UseJdbc;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @UseJdbc(value = 1)
-public class AuthenticationIntegrationTest extends SQLTransportIntegrationTest {
+public class AuthenticationIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected boolean addMockHttpTransport() {

--- a/server/src/test/java/io/crate/auth/AuthenticationWithSSLIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationWithSSLIntegrationTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.auth;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.protocols.ssl.SslSettings;
 import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
@@ -55,7 +55,7 @@ import static org.hamcrest.Matchers.is;
  * support is disabled. In this test we have SSL support.
  */
 @UseJdbc(value = 1)
-public class AuthenticationWithSSLIntegrationTest extends SQLTransportIntegrationTest {
+public class AuthenticationWithSSLIntegrationTest extends SQLIntegrationTestCase {
 
     private static File trustStoreFile;
     private static File keyStoreFile;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -24,7 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -34,7 +34,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
-public class ArbitraryAggregationTest extends AggregationTest {
+public class ArbitraryAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -32,7 +32,7 @@ import org.junit.Test;
 import java.util.List;
 
 
-public class ArrayAggTest extends AggregationTest {
+public class ArrayAggTest extends AggregationTestCase {
 
     @Test
     public void test_array_agg_adds_all_items_to_array() throws Exception {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -25,7 +25,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -34,7 +34,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 
-public class AverageAggregationTest extends AggregationTest {
+public class AverageAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -27,7 +27,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -41,7 +41,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-public class CollectSetAggregationTest extends AggregationTest {
+public class CollectSetAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -24,7 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import io.crate.common.MutableLong;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SearchPath;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -37,7 +37,7 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.CoreMatchers.is;
 
 
-public class CountAggregationTest extends AggregationTest {
+public class CountAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -25,7 +25,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-public class GeometricMeanAggregationtest extends AggregationTest {
+public class GeometricMeanAggregationtest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
@@ -21,10 +21,10 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import org.junit.Test;
 
-public class KahanSummationForDoubleTest extends AggregationTest {
+public class KahanSummationForDoubleTest extends AggregationTestCase {
 
     @Test
     public void shouldSumTwoValues() {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
@@ -21,10 +21,10 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import org.junit.Test;
 
-public class KahanSummationForFloatTest extends AggregationTest {
+public class KahanSummationForFloatTest extends AggregationTestCase {
 
     @Test
     public void shouldSumTwoValues() {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -22,7 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 
-public class MaximumAggregationTest extends AggregationTest {
+public class MaximumAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -22,7 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 
-public class MinimumAggregationTest extends AggregationTest {
+public class MinimumAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -25,7 +25,7 @@ import io.crate.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class PercentileAggregationTest extends AggregationTest {
+public class PercentileAggregationTest extends AggregationTestCase {
 
     private Object execSingleFractionPercentile(DataType<?> argumentType, Object[][] rows) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -25,7 +25,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-public class StdDevAggregationTest extends AggregationTest {
+public class StdDevAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -23,14 +23,14 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import io.crate.expression.symbol.Literal;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import org.elasticsearch.Version;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-public class StringAggTest extends AggregationTest {
+public class StringAggTest extends AggregationTestCase {
 
     @Test
     public void testAllValuesAreNull() throws Exception {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -26,7 +26,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -38,7 +38,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 
-public class SumAggregationTest extends AggregationTest {
+public class SumAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType,
                                       DataType<?> returnType,

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -24,7 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
-import io.crate.operation.aggregation.AggregationTest;
+import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -33,7 +33,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 
-public class VarianceAggregationTest extends AggregationTest {
+public class VarianceAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -38,7 +38,7 @@ import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
@@ -80,7 +80,7 @@ import static org.mockito.Mockito.mock;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
 @UseRandomizedSchema(random = false)
-public class DocLevelCollectTest extends SQLTransportIntegrationTest {
+public class DocLevelCollectTest extends SQLIntegrationTestCase {
 
     private static final String TEST_TABLE_NAME = "test_table";
     private static final Reference testDocLevelReference = new Reference(

--- a/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -32,7 +32,7 @@ import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
@@ -74,7 +74,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
-public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
+public class HandlerSideLevelCollectTest extends SQLIntegrationTestCase {
 
     private MapSideDataCollectOperation operation;
     private Functions functions;

--- a/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
@@ -23,7 +23,7 @@
 package io.crate.execution.engine.collect;
 
 import io.crate.execution.engine.collect.sources.ShardCollectSource;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -37,7 +37,7 @@ import java.util.stream.StreamSupport;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 1, supportsDedicatedMasters = false)
-public class ShardCollectorProviderTest extends SQLTransportIntegrationTest {
+public class ShardCollectorProviderTest extends SQLIntegrationTestCase {
 
     public void assertNumberOfShardEntriesInShardCollectSource(int numberOfShards) throws Exception {
         final Field shards = ShardCollectSource.class.getDeclaredField("shards");

--- a/server/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
@@ -25,7 +25,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -47,7 +47,7 @@ import com.carrotsearch.hppc.IntIndexedContainer;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class InternalCountOperationTest extends SQLTransportIntegrationTest {
+public class InternalCountOperationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testCount() throws Exception {

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.expression.reference.StaticTableReferenceResolver;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, supportsDedicatedMasters = false)
-public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
+public class SystemCollectSourceTest extends SQLIntegrationTestCase {
 
     @Test
     public void testOrderBySymbolsDoNotAppearTwiceInRows() throws Exception {

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -36,7 +36,7 @@ import io.crate.execution.engine.pipeline.TableSettingsResolver;
 import io.crate.execution.jobs.NodeLimits;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
@@ -67,7 +67,7 @@ import static io.crate.testing.TestingHelpers.isRow;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
-public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
+public class IndexWriterProjectorTest extends SQLIntegrationTestCase {
 
     private static final ColumnIdent ID_IDENT = new ColumnIdent("id");
 

--- a/server/src/test/java/io/crate/executor/transport/DependencyCarrierDDLTest.java
+++ b/server/src/test/java/io/crate/executor/transport/DependencyCarrierDDLTest.java
@@ -26,7 +26,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
-public class DependencyCarrierDDLTest extends SQLTransportIntegrationTest {
+public class DependencyCarrierDDLTest extends SQLIntegrationTestCase {
 
     private DependencyCarrier executor;
 

--- a/server/src/test/java/io/crate/expression/operator/AllOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/AllOperatorTest.java
@@ -22,10 +22,10 @@
 
 package io.crate.expression.operator;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
-public class AllOperatorTest extends AbstractScalarFunctionsTest {
+public class AllOperatorTest extends ScalarTestCase {
 
     @Test
     public void test_value_eq_all_array_is_false_if_no_item_matches() {

--- a/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
@@ -1,6 +1,6 @@
 package io.crate.expression.operator;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Symbol;
 import org.junit.Test;
 
@@ -11,7 +11,7 @@ import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.isSQL;
 import static org.hamcrest.Matchers.contains;
 
-public class AndOperatorTest extends AbstractScalarFunctionsTest {
+public class AndOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeBooleanTrueAndNonLiteral() throws Exception {

--- a/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.expression.operator;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
-public class CIDROperatorTest extends AbstractScalarFunctionsTest {
+public class CIDROperatorTest extends ScalarTestCase {
 
     @Test
     public void test_ipv4_operands_in_wrong_order() {

--- a/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
@@ -1,13 +1,13 @@
 package io.crate.expression.operator;
 
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class CmpOperatorTest extends AbstractScalarFunctionsTest {
+public class CmpOperatorTest extends ScalarTestCase {
 
     @Test
     public void testLte() {

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -1,13 +1,13 @@
 package io.crate.expression.operator;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class EqOperatorTest extends AbstractScalarFunctionsTest {
+public class EqOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbol() {

--- a/server/src/test/java/io/crate/expression/operator/InOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/InOperatorTest.java
@@ -22,14 +22,14 @@ package io.crate.expression.operator;
 
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.operator.any.AnyOperator;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class InOperatorTest extends AbstractScalarFunctionsTest {
+public class InOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbolSetLiteralIntegerIncluded() {

--- a/server/src/test/java/io/crate/expression/operator/LikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/LikeOperatorTest.java
@@ -21,13 +21,13 @@
 package io.crate.expression.operator;
 
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.expression.operator.LikeOperators.DEFAULT_ESCAPE;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class LikeOperatorTest extends AbstractScalarFunctionsTest {
+public class LikeOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbolEqual() {

--- a/server/src/test/java/io/crate/expression/operator/OrOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/OrOperatorTest.java
@@ -1,11 +1,11 @@
 package io.crate.expression.operator;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class OrOperatorTest extends AbstractScalarFunctionsTest {
+public class OrOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalize() throws Exception {

--- a/server/src/test/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperatorTest.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.operator;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-public class RegexpMatchCaseInsensitiveOperatorTest extends AbstractScalarFunctionsTest {
+public class RegexpMatchCaseInsensitiveOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalize() throws Exception {

--- a/server/src/test/java/io/crate/expression/operator/RegexpMatchOperatortest.java
+++ b/server/src/test/java/io/crate/expression/operator/RegexpMatchOperatortest.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.operator;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-public class RegexpMatchOperatortest extends AbstractScalarFunctionsTest {
+public class RegexpMatchOperatortest extends ScalarTestCase {
 
     @Test
     public void testNormalize() throws Exception {

--- a/server/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
@@ -21,12 +21,12 @@
 
 package io.crate.expression.operator.any;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
+public class AnyEqOperatorTest extends ScalarTestCase {
 
     @Test
     public void testEvaluate() throws Exception {

--- a/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
@@ -21,12 +21,12 @@
 
 package io.crate.expression.operator.any;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class AnyLikeOperatorTest extends AbstractScalarFunctionsTest  {
+public class AnyLikeOperatorTest extends ScalarTestCase  {
 
     @Test
     public void testNormalizeSingleSymbolEqual() {

--- a/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
@@ -21,12 +21,12 @@
 
 package io.crate.expression.operator.any;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class AnyNotLikeOperatorTest extends AbstractScalarFunctionsTest {
+public class AnyNotLikeOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSingleSymbolEqual() {

--- a/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.predicate;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class IsNullPredicateTest extends AbstractScalarFunctionsTest {
+public class IsNullPredicateTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbolFalse() throws Exception {

--- a/server/src/test/java/io/crate/expression/predicate/NotPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/NotPredicateTest.java
@@ -23,13 +23,13 @@ package io.crate.expression.predicate;
 
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class NotPredicateTest extends AbstractScalarFunctionsTest {
+public class NotPredicateTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbolNull() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
+public class ArrayCatFunctionTest extends ScalarTestCase {
 
     private static final ArrayType<Integer> INTEGER_ARRAY_TYPE = new ArrayType<>(DataTypes.INTEGER);
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -37,7 +37,7 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
+public class ArrayDifferenceFunctionTest extends ScalarTestCase {
 
     private static final ArrayType<Integer> INTEGER_ARRAY_TYPE = new ArrayType<>(DataTypes.INTEGER);
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
-public class ArrayLowerFunctionTest extends AbstractScalarFunctionsTest {
+public class ArrayLowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSecondArgumentIsNull() {

--- a/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
-public class ArrayToStringFunctionTest extends AbstractScalarFunctionsTest {
+public class ArrayToStringFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -37,7 +37,7 @@ import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
 
-public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
+public class ArrayUniqueFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeWithValueSymbols() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
-public class ArrayUpperFunctionTest extends AbstractScalarFunctionsTest {
+public class ArrayUpperFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSecondArgumentIsNull() {

--- a/server/src/test/java/io/crate/expression/scalar/AsciiFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AsciiFunctionTest.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
-public class AsciiFunctionTest extends AbstractScalarFunctionsTest {
+public class AsciiFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_ascii_returns_code_of_first_character() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/CollectionAvgFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/CollectionAvgFunctionTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class CollectionAvgFunctionTest extends AbstractScalarFunctionsTest {
+public class CollectionAvgFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluate() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/CollectionCountFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/CollectionCountFunctionTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class CollectionCountFunctionTest extends AbstractScalarFunctionsTest {
+public class CollectionCountFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluate() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
+public class ConcatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testOneArgument() {

--- a/server/src/test/java/io/crate/expression/scalar/CurrentDatabaseFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/CurrentDatabaseFunctionTest.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
-public class CurrentDatabaseFunctionTest extends AbstractScalarFunctionsTest {
+public class CurrentDatabaseFunctionTest extends ScalarTestCase {
 
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/CurrentDateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/CurrentDateFunctionTest.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 
 
-public class CurrentDateFunctionTest extends AbstractScalarFunctionsTest {
+public class CurrentDateFunctionTest extends ScalarTestCase {
 
     private static final long CURRENT_TIMESTAMP = 1422294644581L;
 

--- a/server/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
+public class DateFormatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeDefault() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.not;
 
-public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
+public class DateTruncFunctionTest extends ScalarTestCase {
 
     // timestamp for Do Feb 25 12:38:01.123 UTC 1999
     private static final Literal TIMESTAMP = Literal.of(DataTypes.TIMESTAMPZ, 919946281123L);

--- a/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
@@ -25,7 +25,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
-public class ExtractFunctionsTest extends AbstractScalarFunctionsTest {
+public class ExtractFunctionsTest extends ScalarTestCase {
 
     private static final String D_2014_02_15___21_33_23 = "2014-02-15T21:33:23";
 

--- a/server/src/test/java/io/crate/expression/scalar/FormatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/FormatFunctionTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class FormatFunctionTest extends AbstractScalarFunctionsTest {
+public class FormatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbol() {

--- a/server/src/test/java/io/crate/expression/scalar/GenRandomTextUUIDFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/GenRandomTextUUIDFunctionTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import io.crate.testing.MoreMatchers;
 
-public class GenRandomTextUUIDFunctionTest extends AbstractScalarFunctionsTest {
+public class GenRandomTextUUIDFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_gen_random_text_uuid_returns_a_uuid() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/HashFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HashFunctionsTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class HashFunctionsTest extends AbstractScalarFunctionsTest {
+public class HashFunctionsTest extends ScalarTestCase {
 
     @Test
     public void testEvaluate() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/LengthFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/LengthFunctionTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 
-public class LengthFunctionTest extends AbstractScalarFunctionsTest {
+public class LengthFunctionTest extends ScalarTestCase {
 
     @Test
     public void testOctetLengthEvaluateOnString() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/PiFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/PiFunctionTest.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
-public class PiFunctionTest extends AbstractScalarFunctionsTest{
+public class PiFunctionTest extends ScalarTestCase{
 
     @Test
     public void test_pi_returns_pi() {

--- a/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
@@ -33,7 +33,7 @@ import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class StringToArrayFunctionTest extends AbstractScalarFunctionsTest {
+public class StringToArrayFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -33,7 +33,7 @@ import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
+public class SubscriptFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_long_can_be_used_as_array_index() {

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class SubscriptObjectFunctionTest extends AbstractScalarFunctionsTest {
+public class SubscriptObjectFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluate() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/SubstrFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubstrFunctionTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.core.Is.is;
 
-public class SubstrFunctionTest extends AbstractScalarFunctionsTest {
+public class SubstrFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbol() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
@@ -25,7 +25,7 @@ package io.crate.expression.scalar;
 import io.crate.exceptions.ConversionException;
 import org.junit.Test;
 
-public class TypeInferenceTest extends AbstractScalarFunctionsTest {
+public class TypeInferenceTest extends ScalarTestCase {
 
     @Test
     public void testComparison() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -22,14 +22,14 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class AbsFunctionTest extends AbstractScalarFunctionsTest {
+public class AbsFunctionTest extends ScalarTestCase {
 
     @Test
     public void testAbs() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AddFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AddFunctionTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SearchPath;
 import io.crate.types.DataTypes;
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class AddFunctionTest extends AbstractScalarFunctionsTest {
+public class AddFunctionTest extends ScalarTestCase {
 
     @Test
     public void testTimestampTypeValidation() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ArithmeticOverflowTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ArithmeticOverflowTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
-public class ArithmeticOverflowTest extends AbstractScalarFunctionsTest {
+public class ArithmeticOverflowTest extends ScalarTestCase {
 
     @Test
     public void test_integer_overflow() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
@@ -23,7 +23,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -32,7 +32,7 @@ import java.util.List;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class ArrayFunctionTest extends AbstractScalarFunctionsTest {
+public class ArrayFunctionTest extends ScalarTestCase {
 
     @Test
     public void testTypeValidation() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class CeilFunctionTest extends AbstractScalarFunctionsTest {
+public class CeilFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateOnDouble() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class ExpFunctionTest extends AbstractScalarFunctionsTest {
+public class ExpFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_exp_scalar() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class FloorFunctionTest extends AbstractScalarFunctionsTest {
+public class FloorFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateOnDouble() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
@@ -23,13 +23,13 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class Ignore3vlFunctionTest extends AbstractScalarFunctionsTest {
+public class Ignore3vlFunctionTest extends ScalarTestCase {
 
     @Test
     public void testIgnore3vlFunction() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.hamcrest.Matchers;
 import org.joda.time.Period;
 import org.junit.Test;
 
-public class IntervalFunctionTest extends AbstractScalarFunctionsTest {
+public class IntervalFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_interval_to_interval() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
@@ -22,14 +22,14 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class LogFunctionTest extends AbstractScalarFunctionsTest {
+public class LogFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeValueSymbol() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
@@ -22,14 +22,14 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class MapFunctionTest extends AbstractScalarFunctionsTest {
+public class MapFunctionTest extends ScalarTestCase {
 
     @Test
     public void testMapWithWrongNumOfArguments() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ModulusFunctionTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class ModulusFunctionTest extends AbstractScalarFunctionsTest {
+public class ModulusFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_modulus_scalar() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ import static io.crate.testing.SymbolMatchers.isFunction;
 import static org.hamcrest.Matchers.nullValue;
 
 
-public class NegateFunctionsTest extends AbstractScalarFunctionsTest {
+public class NegateFunctionsTest extends ScalarTestCase {
 
     @Test
     public void testNegateReference() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/NumericArithmeticTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/NumericArithmeticTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import java.math.BigDecimal;
 
-public class NumericArithmeticTest extends AbstractScalarFunctionsTest {
+public class NumericArithmeticTest extends ScalarTestCase {
 
     @Test
     public void test_numeric_add() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
@@ -22,10 +22,10 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
-public class PowerFunctionTest extends AbstractScalarFunctionsTest {
+public class PowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testPowerWithIntegers() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctionsTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class RadiansDegreesFunctionsTest extends AbstractScalarFunctionsTest {
+public class RadiansDegreesFunctionsTest extends ScalarTestCase {
 
     @Test
     public void test_radians_scalar() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
@@ -22,7 +22,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.data.Input;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Function;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.sameInstance;
 
 
-public class RandomFunctionTest extends AbstractScalarFunctionsTest {
+public class RandomFunctionTest extends ScalarTestCase {
 
     private RandomFunction random;
     private TransactionContext txnCtx = TransactionContext.of(DUMMY_SESSION_INFO);

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -22,13 +22,13 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 
 
-public class RoundFunctionTest extends AbstractScalarFunctionsTest {
+public class RoundFunctionTest extends ScalarTestCase {
 
     @Test
     public void testRound() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
@@ -22,13 +22,13 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 
 
-public class SquareRootFunctionTest extends AbstractScalarFunctionsTest {
+public class SquareRootFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSqrt() {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctionsTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -32,7 +32,7 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 
-public class TrigonometricFunctionsTest extends AbstractScalarFunctionsTest {
+public class TrigonometricFunctionsTest extends ScalarTestCase {
 
     @Test
     public void testEvaluate() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TruncFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TruncFunctionTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -31,7 +31,7 @@ import java.util.List;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class TruncFunctionTest extends AbstractScalarFunctionsTest {
+public class TruncFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeOnDouble() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -23,7 +23,7 @@
 package io.crate.expression.scalar.cast;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.Style;
@@ -55,7 +55,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 // cast is just a wrapper around  DataType.value(val) which is why here are just a few tests
-public class CastFunctionTest extends AbstractScalarFunctionsTest {
+public class CastFunctionTest extends ScalarTestCase {
 
     private static String timezone;
 

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -23,11 +23,11 @@
 package io.crate.expression.scalar.conditional;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
-public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
+public class ConditionalFunctionTest extends ScalarTestCase {
 
     @Test
     public void testCoalesce() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionPostgresCompatabilityTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionPostgresCompatabilityTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.expression.scalar.formatting;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 
-public class ToCharFunctionPostgresCompatabilityTest extends AbstractScalarFunctionsTest {
+public class ToCharFunctionPostgresCompatabilityTest extends ScalarTestCase {
 
     @Test
     public void testPostgresHourOfDayCompatibilityTimestamp() {

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
@@ -22,14 +22,14 @@
 
 package io.crate.expression.scalar.formatting;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.hamcrest.core.IsSame;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.not;
 
 
-public class ToCharFunctionTest extends AbstractScalarFunctionsTest {
+public class ToCharFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateTimestamp() {

--- a/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.scalar.geo;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class CoordinateFunctionTest extends AbstractScalarFunctionsTest {
+public class CoordinateFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateWithGeoPointLiterals() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -22,7 +22,7 @@
 package io.crate.expression.scalar.geo;
 
 import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -32,7 +32,7 @@ import org.locationtech.spatial4j.shape.impl.PointImpl;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.nullValue;
 
-public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
+public class DistanceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testResolveWithTooManyArguments() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
@@ -22,13 +22,13 @@
 package io.crate.expression.scalar.geo;
 
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class GeoHashFunctionTest extends AbstractScalarFunctionsTest {
+public class GeoHashFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateWithGeoPointLiterals() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/geo/IntersectsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/IntersectsFunctionTest.java
@@ -25,7 +25,7 @@ package io.crate.expression.scalar.geo;
 import io.crate.expression.symbol.Literal;
 import io.crate.exceptions.ConversionException;
 import io.crate.geo.GeoJSONUtils;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -35,7 +35,7 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.TestingHelpers.jsonMap;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 
-public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
+public class IntersectsFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeFromStringLiterals() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.scalar.geo;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -31,7 +31,7 @@ import java.util.Map;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class WithinFunctionTest extends AbstractScalarFunctionsTest {
+public class WithinFunctionTest extends ScalarTestCase {
 
     private static final String FNAME = WithinFunction.NAME;
 

--- a/server/src/test/java/io/crate/expression/scalar/postgres/CurrentSettingFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/CurrentSettingFunctionTest.java
@@ -22,14 +22,14 @@
 
 package io.crate.expression.scalar.postgres;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class CurrentSettingFunctionTest extends AbstractScalarFunctionsTest {
+public class CurrentSettingFunctionTest extends ScalarTestCase {
 
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.postgres;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class PgBackendPidFunctionTest extends AbstractScalarFunctionsTest {
+public class PgBackendPidFunctionTest extends ScalarTestCase {
 
     @Test
     public void testPgBackendPid() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgGetExprFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgGetExprFunctionTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.postgres;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class PgGetExprFunctionTest extends AbstractScalarFunctionsTest {
+public class PgGetExprFunctionTest extends ScalarTestCase {
 
     @Test
     public void testPgGetExpr() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunctionTest.java
@@ -23,12 +23,12 @@
 package io.crate.expression.scalar.postgres;
 
 import io.crate.user.User;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class PgGetUserByIdFunctionTest extends AbstractScalarFunctionsTest {
+public class PgGetUserByIdFunctionTest extends ScalarTestCase {
 
     @Test
     public void testPgGetUserById() {

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgPostmasterStartTimeTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgPostmasterStartTimeTest.java
@@ -25,10 +25,10 @@ package io.crate.expression.scalar.postgres;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.metadata.SystemClock;
 
-public class PgPostmasterStartTimeTest extends AbstractScalarFunctionsTest {
+public class PgPostmasterStartTimeTest extends ScalarTestCase {
 
     @Test
     public void test_pg_postmaster_start_time_returns_timestamp() {

--- a/server/src/test/java/io/crate/expression/scalar/postgres/VersionFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/VersionFunctionTest.java
@@ -22,13 +22,13 @@
 
 package io.crate.expression.scalar.postgres;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.elasticsearch.Version;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.startsWith;
 
-public class VersionFunctionTest extends AbstractScalarFunctionsTest {
+public class VersionFunctionTest extends ScalarTestCase {
 
     @Test
     public void testVersion() {

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -22,14 +22,14 @@
 package io.crate.expression.scalar.regex;
 
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class RegexpReplaceFunctionTest extends AbstractScalarFunctionsTest {
+public class RegexpReplaceFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_replace_no_match() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
@@ -24,9 +24,9 @@ package io.crate.expression.scalar.string;
 
 import org.junit.Test;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 
-public class ChrFunctionTest extends AbstractScalarFunctionsTest {
+public class ChrFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_null_value_returns_null() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
-public class EncodeDecodeFunctionTest extends AbstractScalarFunctionsTest {
+public class EncodeDecodeFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidBytea() {

--- a/server/src/test/java/io/crate/expression/scalar/string/InitCapFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/InitCapFunctionTest.java
@@ -1,13 +1,13 @@
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class InitCapFunctionTest extends AbstractScalarFunctionsTest {
+public class InitCapFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeCapInitFuncForAllLowerCase() {

--- a/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
@@ -32,7 +32,7 @@ import java.util.List;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class QuoteIdentFunctionTest extends AbstractScalarFunctionsTest {
+public class QuoteIdentFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {

--- a/server/src/test/java/io/crate/expression/scalar/string/ReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/ReplaceFunctionTest.java
@@ -22,15 +22,15 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class ReplaceFunctionTest extends AbstractScalarFunctionsTest {
-    
+public class ReplaceFunctionTest extends ScalarTestCase {
+
     @Test
     public void testNormalizeReplaceFunc() throws Exception {
         assertNormalize("replace('Crate', 'C', 'D')", isLiteral("Drate"));

--- a/server/src/test/java/io/crate/expression/scalar/string/StringCaseFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringCaseFunctionTest.java
@@ -23,13 +23,13 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class StringCaseFunctionTest extends AbstractScalarFunctionsTest {
+public class StringCaseFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeLowerFunc() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/string/StringLeftRightFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringLeftRightFunctionTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
-public class StringLeftRightFunctionTest extends AbstractScalarFunctionsTest {
+public class StringLeftRightFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateLeftFunc() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/string/StringPaddingFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringPaddingFunctionTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
-public class StringPaddingFunctionTest extends AbstractScalarFunctionsTest {
+public class StringPaddingFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_lpad_parameter_len_too_big() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/string/StringRepeatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringRepeatFunctionTest.java
@@ -22,10 +22,10 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
-public class StringRepeatFunctionTest extends AbstractScalarFunctionsTest {
+public class StringRepeatFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_repeat_zero_times_returns_empty_string() {

--- a/server/src/test/java/io/crate/expression/scalar/string/StringSplitPartFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringSplitPartFunctionTest.java
@@ -22,10 +22,10 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
-public class StringSplitPartFunctionTest extends AbstractScalarFunctionsTest {
+public class StringSplitPartFunctionTest extends ScalarTestCase {
 
     @Test
     public void split_part_mid() {

--- a/server/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/TranslateFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Literal;
@@ -30,7 +30,7 @@ import io.crate.types.DataTypes;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
-public class TranslateFunctionTest extends AbstractScalarFunctionsTest {
+public class TranslateFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeTranslateFunc() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/string/TrimFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/TrimFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.string;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.hamcrest.core.IsSame;
@@ -31,7 +31,7 @@ import org.junit.Test;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.not;
 
-public class TrimFunctionTest extends AbstractScalarFunctionsTest {
+public class TrimFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeTrim() {

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -22,14 +22,14 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.testing.SqlExpressions;
 import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
+public class CurrentSchemaFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeCurrentSchemaDefaultSchema() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import org.junit.Test;
 
@@ -31,7 +31,7 @@ import java.util.List;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
-public class CurrentSchemasFunctionTest extends AbstractScalarFunctionsTest {
+public class CurrentSchemasFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeWithDefaultSchemas() {

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/FormatTypeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/FormatTypeFunctionTest.java
@@ -2,9 +2,9 @@ package io.crate.expression.scalar.systeminformation;
 
 import org.junit.Test;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 
-public class FormatTypeFunctionTest extends AbstractScalarFunctionsTest {
+public class FormatTypeFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_format_type_null_oid_returns_null() throws Exception {

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunctionTest.java
@@ -22,10 +22,10 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import org.junit.Test;
 
-public class ObjDescriptionFunctionTest extends AbstractScalarFunctionsTest {
+public class ObjDescriptionFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_obj_description_always_returns_null() {

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.OidHash;
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class PgFunctionIsVisibleFunctionTest extends AbstractScalarFunctionsTest {
+public class PgFunctionIsVisibleFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_null_oid_results_in_null() {

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.OidHash;
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class PgGetFunctionResultFunctionTest extends AbstractScalarFunctionsTest {
+public class PgGetFunctionResultFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_null_oid_results_in_null() {

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
-public class PgTypeofFunctionTest extends AbstractScalarFunctionsTest {
+public class PgTypeofFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_sample_case_with_qualified_function_name() {

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimeFunctionTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.expression.scalar.timestamp;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SystemClock;
 import io.crate.types.TimeTZ;
@@ -35,7 +35,7 @@ import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.Matchers.instanceOf;
 
-public class CurrentTimeFunctionTest extends AbstractScalarFunctionsTest {
+public class CurrentTimeFunctionTest extends ScalarTestCase {
 
     private static final long CURRENT_TIME_MILLIS = (10 * 3600 + 57 * 60 + 12) * 1000L; // 10:57:12 UTC
 

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunctionTest.java
@@ -1,7 +1,7 @@
 package io.crate.expression.scalar.timestamp;
 
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.metadata.SystemClock;
 import org.junit.After;
 import org.junit.Before;
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
 
-public class CurrentTimestampFunctionTest extends AbstractScalarFunctionsTest {
+public class CurrentTimestampFunctionTest extends ScalarTestCase {
 
     private static final long EXPECTED_TIMESTAMP = 1422294644581L;
 

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/NowFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/NowFunctionTest.java
@@ -22,13 +22,13 @@
 
 package io.crate.expression.scalar.timestamp;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.metadata.SystemClock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class NowFunctionTest extends AbstractScalarFunctionsTest {
+public class NowFunctionTest extends ScalarTestCase {
 
     private static final long EXPECTED_TIMESTAMP = 1422294644581L;
 

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
@@ -22,12 +22,12 @@
 
 package io.crate.expression.scalar.timestamp;
 
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
-public class TimezoneFunctionTest extends AbstractScalarFunctionsTest {
+public class TimezoneFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateInvalidZoneIsNull() {

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -29,7 +29,7 @@ import io.crate.testing.TestingHelpers;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.CoreMatchers.is;
 
-public class AggregateExpressionIntegrationTest extends SQLTransportIntegrationTest {
+public class AggregateExpressionIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void test_sum_int() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.core.Is.is;
 // ensure that only data nodes are picked for rerouting
 @ESIntegTestCase.ClusterScope(supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
 @UseRandomizedSchema(random = false)
-public class AlterTableRerouteIntegrationTest extends SQLTransportIntegrationTest {
+public class AlterTableRerouteIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testAlterTableRerouteMoveShard() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/AnalyzeITest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnalyzeITest.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 
-public class AnalyzeITest extends SQLTransportIntegrationTest{
+public class AnalyzeITest extends SQLIntegrationTestCase{
 
     @Test
     public void test_analyze_statement_refreshes_table_stats_and_stats_are_visible_in_pg_class_and_pg_stats() {

--- a/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-public class AnyIntegrationTest extends SQLTransportIntegrationTest {
+public class AnyIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testAnyOnArrayLiteralDeleteUpdateSelect() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
-public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
+public class ArithmeticIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testMathFunctionNullArguments() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/ArrayMapperITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ArrayMapperITest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class ArrayMapperITest extends SQLTransportIntegrationTest {
+public class ArrayMapperITest extends SQLIntegrationTestCase {
 
     @Test
     public void testInsertGetArray() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/ArraySubQueryIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ArraySubQueryIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-public class ArraySubQueryIntegrationTest extends SQLTransportIntegrationTest {
+public class ArraySubQueryIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -31,7 +31,7 @@ import org.junit.Before;
 
 import java.util.Objects;
 
-public abstract class BaseUsersIntegrationTest extends SQLTransportIntegrationTest {
+public abstract class BaseUsersIntegrationTest extends SQLIntegrationTestCase {
 
     private Session superUserSession;
     private Session normalUserSession;

--- a/server/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 1)
-public class BulkInsertOnClientNodeTest extends SQLTransportIntegrationTest {
+public class BulkInsertOnClientNodeTest extends SQLIntegrationTestCase {
 
     public BulkInsertOnClientNodeTest() {
         super(new SQLTransportExecutor(

--- a/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class CastIntegrationTest extends SQLTransportIntegrationTest {
+public class CastIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testTryCastValidLiteralCasting() {

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, supportsDedicatedMasters = false, numClientNodes = 0)
-public class CircuitBreakerIntegrationTest extends SQLTransportIntegrationTest {
+public class CircuitBreakerIntegrationTest extends SQLIntegrationTestCase {
 
     @After
     public void resetBreakerLimit() {

--- a/server/src/test/java/io/crate/integrationtests/ClientNodeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ClientNodeIntegrationTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 2, supportsDedicatedMasters = false)
-public class ClientNodeIntegrationTest extends SQLTransportIntegrationTest {
+public class ClientNodeIntegrationTest extends SQLIntegrationTestCase {
 
     public ClientNodeIntegrationTest() {
         super(new SQLTransportExecutor(

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
+public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
 
     private String copyFilePath = Paths.get(getClass().getResource("/essetup/data/copy").toURI()).toUri().toString();
 

--- a/server/src/test/java/io/crate/integrationtests/ConcurrencyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ConcurrencyIntegrationTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class ConcurrencyIntegrationTest extends SQLTransportIntegrationTest {
+public class ConcurrencyIntegrationTest extends SQLIntegrationTestCase {
 
     private ExecutorService executor;
 

--- a/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.core.Is.is;
 
 import org.junit.Test;
 
-public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
+public class CountStarIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testCountWithPartitionFilter() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import java.util.Locale;
 
-public class CrateSettingsIntegrationTest extends SQLTransportIntegrationTest {
+public class CrateSettingsIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testAllSettingsAreSelectable() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 
-public class CreateTableAsIntegrationTest extends SQLTransportIntegrationTest {
+public class CreateTableAsIntegrationTest extends SQLIntegrationTestCase {
 
     /*
      * Testing re-creation of ColumnDefinitions is covered by SymbolToColumnDefinitionConverterTest

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CreateTableIntegrationTest extends SQLTransportIntegrationTest {
+public class CreateTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testCreateTableIfNotExistsConcurrently() throws Throwable {

--- a/server/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-public class CustomSchemaIntegrationTest extends SQLTransportIntegrationTest {
+public class CustomSchemaIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     @UseRandomizedSchema(random = false)

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -63,7 +63,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
 @ESIntegTestCase.ClusterScope()
 @UseRandomizedSchema(random = false)
-public class DDLIntegrationTest extends SQLTransportIntegrationTest {
+public class DDLIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testCreateTable() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class DanglingIndicesIntegrationTest extends SQLTransportIntegrationTest {
+public class DanglingIndicesIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testDanglingIndicesAreFilteredOutFromDBCatalog() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/DefaultSchemaIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DefaultSchemaIntegrationTest.java
@@ -31,7 +31,7 @@ import java.nio.file.Paths;
 
 import static org.hamcrest.core.Is.is;
 
-public class DefaultSchemaIntegrationTest extends SQLTransportIntegrationTest {
+public class DefaultSchemaIntegrationTest extends SQLIntegrationTestCase {
 
 
     @Rule

--- a/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
-public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
+public class DeleteIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-public class DiskUsagesITest extends SQLTransportIntegrationTest {
+public class DiskUsagesITest extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/server/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.core.Is.is;
  * the contract of having the same value of the routing field on only one shard. So in Crate the behaviour is
  * different and is asserted via tests in this class.
  */
-public class EmptyStringRoutingIntegrationTest extends SQLTransportIntegrationTest {
+public class EmptyStringRoutingIntegrationTest extends SQLIntegrationTestCase {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/server/src/test/java/io/crate/integrationtests/ExplainAnalyzeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ExplainAnalyzeIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class ExplainAnalyzeIntegrationTest extends SQLTransportIntegrationTest {
+public class ExplainAnalyzeIntegrationTest extends SQLIntegrationTestCase {
 
     @Before
     public void initTestData() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 
-public class FulltextIntegrationTest extends SQLTransportIntegrationTest  {
+public class FulltextIntegrationTest extends SQLIntegrationTestCase  {
 
     @Test
     public void testSelectMatch() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsITest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-public class GCDanglingArtifactsITest extends SQLTransportIntegrationTest {
+public class GCDanglingArtifactsITest extends SQLIntegrationTestCase {
 
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 
-public class GeoShapeIntegrationTest extends SQLTransportIntegrationTest {
+public class GeoShapeIntegrationTest extends SQLIntegrationTestCase {
 
     private static final Map<String, Object> GEO_SHAPE1 = Map.of(
         "coordinates", new double[][]{

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -31,7 +31,7 @@ import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.is;
 
-public class GroupByAggregateBreakerTest extends SQLTransportIntegrationTest {
+public class GroupByAggregateBreakerTest extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-public class GroupByAggregateTest extends SQLTransportIntegrationTest {
+public class GroupByAggregateTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class InformationSchemaQueryTest extends SQLTransportIntegrationTest {
+public class InformationSchemaQueryTest extends SQLIntegrationTestCase {
 
     @Test
     public void testDoNotIgnoreClosedTables() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class InformationSchemaTest extends SQLTransportIntegrationTest {
+public class InformationSchemaTest extends SQLIntegrationTestCase {
 
     @After
     public void dropLeftoverViews() {

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
+public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
@@ -39,7 +39,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.containsString;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1, supportsDedicatedMasters = false)
-public class JobIntegrationTest extends SQLTransportIntegrationTest {
+public class JobIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/server/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.core.Is.is;
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
 @UseRandomizedSchema(random = false) // Avoid set session stmt to interfere with tests
 @UseHashJoins(1) // Avoid set session stmt to interfere with tests
-public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
+public class JobLogIntegrationTest extends SQLIntegrationTestCase {
 
     @After
     public void resetSettings() {

--- a/server/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 import static org.hamcrest.core.Is.is;
 
-public class JoinGroupByIntegrationTests extends SQLTransportIntegrationTest {
+public class JoinGroupByIntegrationTests extends SQLIntegrationTestCase {
 
     @Before
     public void initTestData() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -57,7 +57,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class JoinIntegrationTest extends SQLTransportIntegrationTest {
+public class JoinIntegrationTest extends SQLIntegrationTestCase {
 
     @After
     public void resetStatsAndBreakerSettings() {

--- a/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class KillIntegrationTest extends SQLTransportIntegrationTest {
+public class KillIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 @Seed("54904E791E52DEFD")
-public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTest {
+public class LuceneQueryBuilderIntegrationTest extends SQLIntegrationTestCase {
 
     private static final int NUMBER_OF_BOOLEAN_CLAUSES = 10_000;
 

--- a/server/src/test/java/io/crate/integrationtests/MetricsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetricsITest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
-public class MetricsITest extends SQLTransportIntegrationTest {
+public class MetricsITest extends SQLIntegrationTestCase {
 
     @Before
     public void clearStats() {

--- a/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
-public class NodeStatsTest extends SQLTransportIntegrationTest {
+public class NodeStatsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSysNodesMem() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-public class ObjectColumnTest extends SQLTransportIntegrationTest {
+public class ObjectColumnTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
@@ -36,7 +36,7 @@ import static io.netty.handler.codec.rtsp.RtspResponseStatuses.BAD_REQUEST;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
-public class OpenCloseTableIntegrationTest extends SQLTransportIntegrationTest {
+public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Before
     public void prepareClosedTable() {

--- a/server/src/test/java/io/crate/integrationtests/OrderByITest.java
+++ b/server/src/test/java/io/crate/integrationtests/OrderByITest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-public class OrderByITest extends SQLTransportIntegrationTest {
+public class OrderByITest extends SQLIntegrationTestCase {
 
     @Test
     public void testOrderByIpType() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
-public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
+public class OuterJoinIntegrationTest extends SQLIntegrationTestCase {
 
     @Before
     public void setupTestData() {

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -60,7 +60,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLette
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class PartitionedTableConcurrentIntegrationTest extends SQLTransportIntegrationTest {
+public class PartitionedTableConcurrentIntegrationTest extends SQLIntegrationTestCase {
 
     private final TimeValue ACCEPTABLE_RELOCATION_TIME = new TimeValue(10, TimeUnit.SECONDS);
 

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -83,7 +83,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 2)
-public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest {
+public class PartitionedTableIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
     private String copyFilePath = Paths.get(getClass().getResource("/essetup/data/copy").toURI()).toUri().toString();

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
-public class PgCatalogITest extends SQLTransportIntegrationTest {
+public class PgCatalogITest extends SQLIntegrationTestCase {
 
     @Before
     public void createRelations() {

--- a/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import java.sql.PreparedStatement;
 
 @UseJdbc(value = 1)
-public class PostgresCompatIntegrationTest extends SQLTransportIntegrationTest {
+public class PostgresCompatIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testBeginStatement() {

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -79,7 +79,7 @@ import io.crate.types.DataTypes;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-public class PostgresITest extends SQLTransportIntegrationTest {
+public class PostgresITest extends SQLIntegrationTestCase {
 
     private static final String NO_IPV6 = "CRATE_TESTS_NO_IPV6";
     private static final String RO = "node_s0";

--- a/server/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.core.Is.is;
 @UseJdbc(1)
 @UseRandomizedSchema(random = false) // Avoid set session stmt to interfere with tests
 @UseHashJoins(1) // Avoid set session stmt to interfere with tests
-public class PostgresJobsLogsITest extends SQLTransportIntegrationTest {
+public class PostgresJobsLogsITest extends SQLIntegrationTestCase {
 
     Properties properties = new Properties();
 

--- a/server/src/test/java/io/crate/integrationtests/PromoteStaleReplicaITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PromoteStaleReplicaITest.java
@@ -34,7 +34,7 @@ import static org.elasticsearch.env.Environment.PATH_DATA_SETTING;
 import static org.hamcrest.CoreMatchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
-public class PromoteStaleReplicaITest extends SQLTransportIntegrationTest {
+public class PromoteStaleReplicaITest extends SQLIntegrationTestCase {
 
     @Test
     public void test_stale_replica_can_manually_be_promoted() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
@@ -32,7 +32,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
+public class QueryThenFetchIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testCrateSearchServiceSupportsOrderByOnFunctionWithBooleanReturnType() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1)
 @UseRandomizedSchema(random = false)
-public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
+public class ReadOnlyNodeIntegrationTest extends SQLIntegrationTestCase {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/server/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -30,7 +30,7 @@ import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
-public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
+public class RegexpIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/RelationAliasITest.java
+++ b/server/src/test/java/io/crate/integrationtests/RelationAliasITest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
-public class RelationAliasITest extends SQLTransportIntegrationTest {
+public class RelationAliasITest extends SQLIntegrationTestCase {
 
     @Test
     public void testRelationAliasWithColumnAliases() {

--- a/server/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest {
+public class RemoteCollectorIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testUpdateWithExpressionAndRelocatedShard() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 
-public class RenameTableIntegrationTest extends SQLTransportIntegrationTest {
+public class RenameTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testRenameTable() {

--- a/server/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
@@ -36,7 +36,7 @@ import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static org.hamcrest.Matchers.is;
 
-public class RepositoryIntegrationTest extends SQLTransportIntegrationTest {
+public class RepositoryIntegrationTest extends SQLIntegrationTestCase {
 
     @ClassRule
     public static TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();

--- a/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
@@ -30,7 +30,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
-public class ResizeShardsITest extends SQLTransportIntegrationTest {
+public class ResizeShardsITest extends SQLIntegrationTestCase {
 
     private String getADataNodeName(ClusterState state) {
         assertThat(state.nodes().getDataNodes().isEmpty(), is(false));

--- a/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -44,7 +44,7 @@ import java.util.Locale;
 
 import static org.hamcrest.Matchers.is;
 
-public abstract class SQLHttpIntegrationTest extends SQLTransportIntegrationTest {
+public abstract class SQLHttpIntegrationTest extends SQLIntegrationTestCase {
 
     private HttpPost httpPost;
     private InetSocketAddress address;

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -46,7 +46,7 @@ import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
+public class SQLTypeMappingTest extends SQLIntegrationTestCase {
 
     private void setUpSimple() throws IOException {
         setUpSimple(2);

--- a/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 
 @UseJdbc(0) // data types needed
-public class ScalarIntegrationTest extends SQLTransportIntegrationTest {
+public class ScalarIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testExtractFunctionReturnTypes() {

--- a/server/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
-public class SelectOrderByIntegrationTest extends SQLTransportIntegrationTest {
+public class SelectOrderByIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectOrderByNullSortingASC() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SeqNoBasedOCCIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SeqNoBasedOCCIntegrationTest.java
@@ -25,7 +25,7 @@ package io.crate.integrationtests;
 import org.junit.Test;
 
 
-public class SeqNoBasedOCCIntegrationTest extends SQLTransportIntegrationTest {
+public class SeqNoBasedOCCIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testDeleteWhereSeqNoAndTermThatMatch() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/ShardLimitsIT.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardLimitsIT.java
@@ -33,7 +33,7 @@ import io.crate.testing.SQLErrorMatcher;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 @ClusterScope(numDataNodes = 2, supportsDedicatedMasters = false, numClientNodes = 0)
-public class ShardLimitsIT extends SQLTransportIntegrationTest {
+public class ShardLimitsIT extends SQLIntegrationTestCase {
 
     @After
     public void reset_settings() {

--- a/server/src/test/java/io/crate/integrationtests/ShardStatsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardStatsTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class ShardStatsTest extends SQLTransportIntegrationTest {
+public class ShardStatsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectZeroLimit() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/ShardingUpsertIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardingUpsertIntegrationTest.java
@@ -31,7 +31,7 @@ import java.nio.file.Paths;
 
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class ShardingUpsertIntegrationTest extends SQLTransportIntegrationTest {
+public class ShardingUpsertIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
 @UseRandomizedSchema(random = false)
-public class ShowIntegrationTest extends SQLTransportIntegrationTest {
+public class ShowIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testShowCrateSystemTable() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -72,7 +72,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest {
+public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
 
     private static final String REPOSITORY_NAME = "my_repo";
     private static final String SNAPSHOT_NAME = "my_snapshot";

--- a/server/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
@@ -23,7 +23,7 @@ package io.crate.integrationtests;
 
 import org.junit.Test;
 
-public class SqlAlchemyIntegrationTest extends SQLTransportIntegrationTest {
+public class SqlAlchemyIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSqlAlchemyGeneratedCountWithStar() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -30,7 +30,7 @@ import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.core.Is.is;
 
-public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTest {
+public class StaticInformationSchemaQueryTest extends SQLIntegrationTestCase {
 
     @Before
     public void tableCreation() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static org.apache.lucene.index.IndexWriter.MAX_TERM_LENGTH;
 import static org.hamcrest.Matchers.is;
 
-public class StorageOptionsITest extends SQLTransportIntegrationTest {
+public class StorageOptionsITest extends SQLIntegrationTestCase {
 
     @Test
     public void testInsertStringGreaterThanDocValuesLimit() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SubSelectGroupByIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectGroupByIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-public class SubSelectGroupByIntegrationTest extends SQLTransportIntegrationTest {
+public class SubSelectGroupByIntegrationTest extends SQLIntegrationTestCase {
 
     @Before
     public void initTestData() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
+public class SubSelectIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
@@ -33,7 +33,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-public class SwapTableITest extends SQLTransportIntegrationTest {
+public class SwapTableITest extends SQLIntegrationTestCase {
 
     @Test
     public void testSwapTwoTablesWithDropSource() {

--- a/server/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(
     numDataNodes = 0, numClientNodes = 0, supportsDedicatedMasters = false)
-public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
+public class SysCheckerIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testChecksPresenceAndSeverityLevels() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVE
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope
-public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
+public class SysClusterSettingsTest extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/server/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -33,7 +33,7 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
 
-public class SysClusterTest extends SQLTransportIntegrationTest {
+public class SysClusterTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSysCluster() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
@@ -31,7 +31,7 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class SysHealthITest extends SQLTransportIntegrationTest {
+public class SysHealthITest extends SQLIntegrationTestCase {
 
     @Test
     public void testTablesHealth() throws IOException {

--- a/server/src/test/java/io/crate/integrationtests/SysJobsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysJobsTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SysJobsTest extends SQLTransportIntegrationTest {
+public class SysJobsTest extends SQLIntegrationTestCase {
 
     @After
     public void resetStatsEnabled() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
+public class SysNodeCheckerIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testChecksPresenceAndSeverityLevels() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SysNodeResiliencyIntegrationTest extends SQLTransportIntegrationTest {
+public class SysNodeResiliencyIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, supportsDedicatedMasters = false)
-public class SysNodesITest extends SQLTransportIntegrationTest {
+public class SysNodesITest extends SQLIntegrationTestCase {
 
     @Override
     protected boolean addMockHttpTransport() {

--- a/server/src/test/java/io/crate/integrationtests/SysOperationsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysOperationsTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
-public class SysOperationsTest extends SQLTransportIntegrationTest {
+public class SysOperationsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testDistinctSysOperations() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SysRepositoriesServiceTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysRepositoriesServiceTest.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope()
 @UseJdbc(0) // missing column types
-public class SysRepositoriesServiceTest extends SQLTransportIntegrationTest {
+public class SysRepositoriesServiceTest extends SQLIntegrationTestCase {
 
     @ClassRule
     public static TemporaryFolder TEMP_FOLDER = new TemporaryFolder();

--- a/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SysSegmentsTableInfoTest extends SQLTransportIntegrationTest {
+public class SysSegmentsTableInfoTest extends SQLIntegrationTestCase {
 
     @Test
     public void test_retrieve_segment_information() {

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -60,7 +60,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
-public class SysShardsTest extends SQLTransportIntegrationTest {
+public class SysShardsTest extends SQLIntegrationTestCase {
 
     @Before
     public void initTestData() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -55,7 +55,7 @@ import io.crate.types.TimestampType;
 
 @ESIntegTestCase.ClusterScope()
 @UseJdbc(0) // missing column types
-public class SysSnapshotsTest extends SQLTransportIntegrationTest {
+public class SysSnapshotsTest extends SQLIntegrationTestCase {
 
     @ClassRule
     public static TemporaryFolder TEMP_FOLDER = new TemporaryFolder();

--- a/server/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
@@ -38,7 +38,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
+public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
 
     @ClassRule
     public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();

--- a/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -33,7 +33,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
-public class TableFunctionITest extends SQLTransportIntegrationTest {
+public class TableFunctionITest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectFromUnnest() {

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -37,7 +37,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-public class TableSettingsTest extends SQLTransportIntegrationTest {
+public class TableSettingsTest extends SQLIntegrationTestCase {
 
     @Before
     public void prepare() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.is;
 
 
 @ESIntegTestCase.ClusterScope(supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
-public class TableStatsServiceIntegrationTest extends SQLTransportIntegrationTest {
+public class TableStatsServiceIntegrationTest extends SQLIntegrationTestCase {
 
     @Before
     public void setRefreshInterval() {

--- a/server/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
@@ -35,7 +35,7 @@ import java.nio.file.Path;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
-public class TablesNeedUpgradeSysCheckTest extends SQLTransportIntegrationTest {
+public class TablesNeedUpgradeSysCheckTest extends SQLIntegrationTestCase {
 
     private void startUpNodeWithDataDir(String dataPath) throws Exception {
         Path indexDir = createTempDir();

--- a/server/src/test/java/io/crate/integrationtests/TasksServiceIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TasksServiceIntegrationTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.core.Is.is;
 
-public class TasksServiceIntegrationTest extends SQLTransportIntegrationTest {
+public class TasksServiceIntegrationTest extends SQLIntegrationTestCase {
 
     Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
@@ -39,7 +39,7 @@ import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, maxNumDataNodes = 2)
-public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegrationTest {
+public class ThreadPoolsExhaustedIntegrationTest extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -70,7 +70,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
-public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegrationTest {
+public class TransportSQLActionClassLifecycleTest extends SQLIntegrationTestCase {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
-public class TransportSQLActionSingleNodeTest extends SQLTransportIntegrationTest {
+public class TransportSQLActionSingleNodeTest extends SQLIntegrationTestCase {
 
     @Test
     public void testUnassignedShards() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -73,7 +73,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class TransportSQLActionTest extends SQLTransportIntegrationTest {
+public class TransportSQLActionTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class UnassignedShardsTest extends SQLTransportIntegrationTest {
+public class UnassignedShardsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testUnassignedReplicasAreVisibleAsUnassignedInSysShards() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 1)
-public class UnionIntegrationTest extends SQLTransportIntegrationTest {
+public class UnionIntegrationTest extends SQLIntegrationTestCase {
 
     @Before
     public void beforeTest() {

--- a/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -45,7 +45,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERR
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 
-public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
+public class UpdateIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -68,7 +68,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.containsString;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
-public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegrationTest {
+public class UserDefinedFunctionsIntegrationTest extends SQLIntegrationTestCase {
 
     public static class DummyFunction<InputType> extends Scalar<String, InputType>  {
 

--- a/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
-public class VersionHandlingIntegrationTest extends SQLTransportIntegrationTest {
+public class VersionHandlingIntegrationTest extends SQLIntegrationTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -47,7 +47,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-public class ViewsITest extends SQLTransportIntegrationTest {
+public class ViewsITest extends SQLIntegrationTestCase {
 
     @After
     public void dropViews() {

--- a/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.core.Is.is;
 
-public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
+public class WherePKIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testWherePkColInWithLimit() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-public class WindowFunctionsIntegrationTest extends SQLTransportIntegrationTest {
+public class WindowFunctionsIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testAvgOnEmptyOver() {

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
@@ -22,7 +22,7 @@
 
 package io.crate.integrationtests.disruption.discovery;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-public abstract class AbstractDisruptionTestCase extends SQLTransportIntegrationTest {
+public abstract class AbstractDisruptionTestCase extends SQLIntegrationTestCase {
 
     static final TimeValue DISRUPTION_HEALING_OVERHEAD = TimeValue.timeValueSeconds(40);
 

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
@@ -23,7 +23,7 @@
 package io.crate.integrationtests.disruption.discovery;
 
 import io.crate.exceptions.DuplicateKeyException;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.CorruptIndexException;
 import org.elasticsearch.ElasticsearchException;
@@ -78,7 +78,7 @@ import static org.hamcrest.Matchers.not;
  */
 @TestLogging("_root:DEBUG,org.elasticsearch.cluster.service:TRACE")
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-@SQLTransportIntegrationTest.Slow
+@SQLIntegrationTestCase.Slow
 public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiscoveryDisruptionIT.java
@@ -22,7 +22,7 @@
 
 package io.crate.integrationtests.disruption.discovery;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.JoinHelper;
 import org.elasticsearch.cluster.coordination.PublicationTransportHandler;
@@ -52,7 +52,7 @@ import static io.crate.metadata.IndexParts.toIndexName;
  */
 @TestLogging("_root:DEBUG,org.elasticsearch.cluster.service:TRACE")
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-@SQLTransportIntegrationTest.Slow
+@SQLIntegrationTestCase.Slow
 public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
 
     /**

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiskDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiskDisruptionIT.java
@@ -20,7 +20,7 @@ package io.crate.integrationtests.disruption.discovery;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.common.unit.TimeValue;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.testing.UseRandomizedSchema;
 
 import org.apache.lucene.mockfile.FilterFileSystemProvider;
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-@SQLTransportIntegrationTest.Slow
+@SQLIntegrationTestCase.Slow
 public class DiskDisruptionIT extends AbstractDisruptionTestCase {
 
     private static DisruptTranslogFileSystemProvider disruptTranslogFileSystemProvider;

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
@@ -22,7 +22,7 @@
 
 package io.crate.integrationtests.disruption.discovery;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.cluster.ClusterState;
@@ -57,7 +57,7 @@ import static org.hamcrest.Matchers.not;
  * Tests relating to the loss of the master.
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-@SQLTransportIntegrationTest.Slow
+@SQLIntegrationTestCase.Slow
 public class MasterDisruptionIT extends AbstractDisruptionTestCase {
 
     /**

--- a/server/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
@@ -22,7 +22,7 @@
 
 package io.crate.integrationtests.disruption.routing;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.metadata.IndexParts;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -61,8 +61,8 @@ import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.not;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-@SQLTransportIntegrationTest.Slow
-public class PrimaryAllocationIT extends SQLTransportIntegrationTest {
+@SQLIntegrationTestCase.Slow
+public class PrimaryAllocationIT extends SQLIntegrationTestCase {
 
     private String schema;
     private String indexName;

--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/SequenceConsistencyIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/SequenceConsistencyIT.java
@@ -22,7 +22,7 @@
 
 package io.crate.integrationtests.disruption.seqno;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.integrationtests.disruption.discovery.AbstractDisruptionTestCase;
 import io.crate.metadata.IndexParts;
 import org.elasticsearch.ElasticsearchTimeoutException;
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
-@SQLTransportIntegrationTest.Slow
+@SQLIntegrationTestCase.Slow
 public class SequenceConsistencyIT extends AbstractDisruptionTestCase {
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/SimpleVersioningIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/SimpleVersioningIT.java
@@ -18,13 +18,13 @@
  */
 package io.crate.integrationtests.disruption.seqno;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.junit.Test;
 
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class SimpleVersioningIT extends SQLTransportIntegrationTest {
+public class SimpleVersioningIT extends SQLIntegrationTestCase {
 
     @Test
     public void test_compare_and_set() {

--- a/server/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasITest.java
@@ -25,7 +25,7 @@ import com.carrotsearch.hppc.IntIndexedContainer;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
 import io.crate.expression.symbol.Symbol;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.CheckConstraint;
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-public class SchemasITest extends SQLTransportIntegrationTest {
+public class SchemasITest extends SQLIntegrationTestCase {
 
     private Schemas schemas;
     private RoutingProvider routingProvider = new RoutingProvider(Randomness.get().nextInt(), Collections.emptyList());

--- a/server/src/test/java/io/crate/metadata/sys/SysAllocationsTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysAllocationsTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.sys;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 import io.crate.types.ArrayType;
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.startsWith;
 
 @UseJdbc(0)
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class SysAllocationsTest extends SQLTransportIntegrationTest {
+public class SysAllocationsTest extends SQLIntegrationTestCase {
 
     @Before
     public void initTestData() throws Exception {

--- a/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerIntegrationTest.java
@@ -22,7 +22,7 @@
 
 package io.crate.protocols.postgres;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.protocols.ssl.SslSettings;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 @UseJdbc(value = 1)
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
-public class SslReqHandlerIntegrationTest extends SQLTransportIntegrationTest {
+public class SslReqHandlerIntegrationTest extends SQLIntegrationTestCase {
 
     private final static char[] EMPTY_PASS = new char[]{};
 

--- a/server/src/test/java/io/crate/user/scalar/UserFunctionTest.java
+++ b/server/src/test/java/io/crate/user/scalar/UserFunctionTest.java
@@ -23,7 +23,7 @@
 package io.crate.user.scalar;
 
 import io.crate.user.User;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Symbol;
 import io.crate.testing.SqlExpressions;
 import org.junit.Before;
@@ -32,7 +32,7 @@ import org.junit.Test;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
 
-public class UserFunctionTest extends AbstractScalarFunctionsTest {
+public class UserFunctionTest extends ScalarTestCase {
 
     private static final User TEST_USER = User.of("testUser");
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -21,7 +21,7 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 
-public class TransportCreatePartitionsActionTest extends SQLTransportIntegrationTest {
+public class TransportCreatePartitionsActionTest extends SQLIntegrationTestCase {
 
     TransportCreatePartitionsAction action;
 

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.cluster;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -36,7 +36,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-public class ClusterHealthIT extends SQLTransportIntegrationTest {
+public class ClusterHealthIT extends SQLIntegrationTestCase {
 
     @Test
     public void testSimpleLocalHealth() {

--- a/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -45,10 +45,10 @@ import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.junit.Test;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 
 @ClusterScope(scope= Scope.TEST, numDataNodes=0)
-public class FilteringAllocationIT extends SQLTransportIntegrationTest {
+public class FilteringAllocationIT extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -21,7 +21,7 @@ package org.elasticsearch.gateway;
 
 import io.crate.action.sql.SQLOperations;
 import io.crate.common.unit.TimeValue;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.testing.SQLTransportExecutor;
 import org.apache.logging.log4j.LogManager;
@@ -75,7 +75,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
-public class GatewayIndexStateIT extends SQLTransportIntegrationTest {
+public class GatewayIndexStateIT extends SQLIntegrationTestCase {
 
     private final Logger logger = LogManager.getLogger(GatewayIndexStateIT.class);
 

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -52,11 +52,11 @@ import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import io.crate.types.DataTypes;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-public class ReplicaShardAllocatorIT extends SQLTransportIntegrationTest {
+public class ReplicaShardAllocatorIT extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index;
 
 import io.crate.common.unit.TimeValue;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, supportsDedicatedMasters = false)
-public class IndexServiceTests extends SQLTransportIntegrationTest {
+public class IndexServiceTests extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/server/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.seqno;
 
 import io.crate.common.unit.TimeValue;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
-public class GlobalCheckpointSyncIT extends SQLTransportIntegrationTest {
+public class GlobalCheckpointSyncIT extends SQLIntegrationTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncIT.java
@@ -34,9 +34,9 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.junit.Test;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 
-public class RetentionLeaseBackgroundSyncIT extends SQLTransportIntegrationTest {
+public class RetentionLeaseBackgroundSyncIT extends SQLIntegrationTestCase {
 
     @Test
     public void testBackgroundRetentionLeaseSync() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -60,9 +60,9 @@ import org.junit.Test;
 
 import io.crate.common.collections.Lists2;
 import io.crate.common.unit.TimeValue;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 
-public class RetentionLeaseIT extends SQLTransportIntegrationTest  {
+public class RetentionLeaseIT extends SQLIntegrationTestCase  {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogHistoryTest.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogHistoryTest.java
@@ -22,13 +22,13 @@
 
 package org.elasticsearch.index.translog;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-public class TranslogHistoryTest extends SQLTransportIntegrationTest {
+public class TranslogHistoryTest extends SQLIntegrationTestCase {
 
     public void test_translog_is_trimmed_with_soft_deletes_enabled() throws Exception {
         execute("create table doc.test(x int) clustered into 1 shards with(number_of_replicas=1, \"soft_deletes.enabled\"='true')");
@@ -38,7 +38,7 @@ public class TranslogHistoryTest extends SQLTransportIntegrationTest {
         for(int i = 0; i < numDocs; i++) {
             execute("insert into doc.test(x) values(?)", new Object[]{i});
         }
-        
+
         execute("refresh table doc.test");
         execute("optimize table doc.test");
 

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.indices;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
@@ -37,7 +37,7 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-public class IndexingMemoryControllerIT extends SQLTransportIntegrationTest {
+public class IndexingMemoryControllerIT extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.indices.recovery;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -32,7 +32,7 @@ import static org.elasticsearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLIN
 import static org.hamcrest.Matchers.is;
 
 @ClusterScope(numDataNodes = 0, scope = ESIntegTestCase.Scope.TEST)
-public class DanglingIndicesIT extends SQLTransportIntegrationTest {
+public class DanglingIndicesIT extends SQLIntegrationTestCase {
 
     private Settings buildSettings(boolean importDanglingIndices) {
         return Settings.builder()

--- a/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.indices.state;
 
 import io.crate.execution.ddl.tables.TransportCloseTable;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class CloseIndexIT extends SQLTransportIntegrationTest {
+public class CloseIndexIT extends SQLIntegrationTestCase {
 
     @Override
     public Settings indexSettings() {

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
@@ -22,7 +22,7 @@
 
 package org.elasticsearch.repositories.blobstore;
 
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.SQLIntegrationTestCase;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
@@ -60,7 +60,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-public class BlobStoreRepositoryTest extends SQLTransportIntegrationTest {
+public class BlobStoreRepositoryTest extends SQLIntegrationTestCase {
 
     private static final String REPOSITORY_NAME = "my_repo";
 

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -61,7 +61,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
-public abstract class AbstractScalarFunctionsTest extends CrateDummyClusterServiceUnitTest {
+public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
 
     protected SqlExpressions sqlExpressions;
     protected Map<RelationName, AnalyzedRelation> tableSources;

--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
@@ -146,9 +146,9 @@ import io.crate.user.UserLookup;
 @UseJdbc
 @UseHashJoins
 @UseRandomizedSchema
-public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
+public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
 
-    private static final Logger LOGGER = LogManager.getLogger(SQLTransportIntegrationTest.class);
+    private static final Logger LOGGER = LogManager.getLogger(SQLIntegrationTestCase.class);
     private static final int ORIGINAL_PAGE_SIZE = Paging.PAGE_SIZE;
 
     protected static SessionSettings DUMMY_SESSION_INFO = new SessionSettings(
@@ -198,11 +198,11 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
 
     protected SQLResponse response;
 
-    public SQLTransportIntegrationTest() {
+    public SQLIntegrationTestCase() {
         this(false);
     }
 
-    public SQLTransportIntegrationTest(boolean useSSL) {
+    public SQLIntegrationTestCase(boolean useSSL) {
         this(new SQLTransportExecutor(
             new SQLTransportExecutor.ClientProvider() {
                 @Override
@@ -251,7 +251,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         Paging.PAGE_SIZE = ORIGINAL_PAGE_SIZE;
     }
 
-    public SQLTransportIntegrationTest(SQLTransportExecutor sqlExecutor) {
+    public SQLIntegrationTestCase(SQLTransportExecutor sqlExecutor) {
         this.sqlExecutor = sqlExecutor;
     }
 

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -134,7 +134,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public abstract class AggregationTest extends ESTestCase {
+public abstract class AggregationTestCase extends ESTestCase {
 
     protected static final RamAccounting RAM_ACCOUNTING = RamAccounting.NO_ACCOUNTING;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- `AbstractScalarFunctionsTest` → `ScalarTestCase`
- `SQLTransportIntegrationTest` → `SQLIntegrationTestCase`
- `AggregationTest` → `AggregationTestCase`


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)