### PR TITLE
accept start transaction statements

### DIFF
--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -82,8 +82,8 @@ OBJECT``. With CrateDB, Binary Data is instead stored in separate BLOB Tables
 (see :ref:`blob_support`) which can be sharded and replicated.
 
 
-Transactions (``BEGIN``, ``COMMIT``, and ``ROLLBACK``)
-------------------------------------------------------
+Transactions (``BEGIN``, ``START``, ``COMMIT``, and ``ROLLBACK``)
+-----------------------------------------------------------------
 
 CrateDB is focused on providing analytical capabilities over supporting
 traditional transactional use cases, and thus it does not provide transaction

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -72,6 +72,10 @@ Changes
 - Users can now read tables within the ``pg_catalog`` schema without explicit
   ``DQL`` permission. They will only see records the user has privileges on.
 
+- CrateDB now accepts the ``START TRANSACTION`` statement for :ref:`PostgreSQL
+  wire protocol <postgres_wire_protocol>` compatibility. However, CrateDB does
+  not support transactions and will silently ignore this statement.
+
 Fixes
 =====
 

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -251,13 +251,13 @@ is implemented::
     +-----------------------+
     SHOW 1 row in set (... sec)
 
-BEGIN/COMMIT statements
------------------------
+BEGIN/START/COMMIT statements
+-----------------------------
 
-For compatibility with clients that use the Postgres wire protocol, such as the
-Golang lib/pq and pgx drivers, the full PostgreSQL syntax of the
-:ref:`BEGIN <ref-begin>` and :ref:`COMMIT <ref-commit>` statements is
-implemented, for example::
+For compatibility with clients that use the PostgresSQL wire protocol (e.g.,
+the Golang lib/pq and pgx drivers), CrateDB will accept the :ref:`BEGIN
+<ref-begin>`, :ref:`COMMIT <ref-commit>`, and :ref:`START TRASNACTION
+<sql-start-transaction>` statements. For example::
 
     cr> BEGIN TRANSACTION ISOLATION LEVEL READ UNCOMMITTED,
     ...                   READ ONLY,
@@ -267,8 +267,8 @@ implemented, for example::
     cr> COMMIT
     COMMIT OK, 0 rows affected  (... sec)
 
-Since CrateDB does not support transactions, both the ``COMMIT`` and ``BEGIN``
-statement and any of its parameters are ignored.
+CrateDB will silently ignore the ``COMMIT``, ``BEGIN``, and ``START`` TRANSACTION
+statements and all respective parameters.
 
 Client compatibility
 ====================

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -14,6 +14,7 @@ SQL Statements
     alter-user
     analyze
     begin
+    start-transaction
     commit
     copy-from
     copy-to

--- a/docs/sql/statements/start-transaction.rst
+++ b/docs/sql/statements/start-transaction.rst
@@ -1,0 +1,47 @@
+.. highlight:: psql
+
+.. _sql-start-transaction:
+
+=====================
+``START TRANSACTION``
+=====================
+
+CrateDB accepts the ``START TRANSACTION`` statement for compatibility with the
+:ref:`PostgreSQL wire protocol <postgres_wire_protocol>`. However, CrateDB does
+not support transactions and will silently ignore this statement.
+.. SEEALSO::
+
+    :ref:`Appendix: SQL compatibility <crate_standard_sql>`
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+Synopsis
+========
+
+::
+
+   START TRANSACTION [ transaction_mode [ , ...] ]
+
+Where ``transaction_mode`` is one of::
+
+   ISOLATION LEVEL isolation_level | (READ WRITE | READ ONLY) | [NOT] DEFERRABLE
+
+Where ``isolation_level`` is one of::
+
+   { SERIALIZABLE | REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED }
+
+
+Description
+===========
+
+CrateDB will silently ignore the ``START TRANSACTION`` statement.
+
+Parameters
+==========
+
+:transaction_mode:
+  This parameter has no effect.

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -33,6 +33,7 @@ singleExpression
 statement
     : query                                                                          #default
     | BEGIN (WORK | TRANSACTION)? (transactionMode (',' transactionMode)*)?          #begin
+    | START TRANSACTION (transactionMode (',' transactionMode)*)?                    #startTransaction
     | COMMIT                                                                         #commit
     | EXPLAIN (ANALYZE)? statement                                                   #explain
     | OPTIMIZE TABLE tableWithPartitions withProperties?                             #optimize
@@ -675,7 +676,7 @@ nonReserved
     | PARTITIONS | PLAIN | PRECEDING | RANGE | REFRESH | ROW | ROWS | SCHEMAS | SECOND | SESSION
     | SHARDS | SHOW | STORAGE | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME | ZONE | WITHOUT
     | TIMESTAMP | TO | TOKENIZER | TOKEN_FILTERS | TYPE | VALUES | VIEW | YEAR
-    | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN | COMMIT
+    | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN | START | COMMIT
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | PREPARE
     | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL | CLUSTER | RETRY | FAILED | FILTER
@@ -831,6 +832,7 @@ LOCAL : 'LOCAL';
 LICENSE : 'LICENSE';
 
 BEGIN: 'BEGIN';
+START: 'START';
 COMMIT: 'COMMIT';
 WORK: 'WORK';
 TRANSACTION: 'TRANSACTION';

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -238,6 +238,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
+    public Node visitStartTransaction(SqlBaseParser.StartTransactionContext context) {
+        return new BeginStatement();
+    }
+
+    @Override
     public Node visitAnalyze(SqlBaseParser.AnalyzeContext ctx) {
         return new AnalyzeStatement();
     }

--- a/server/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
@@ -42,7 +42,7 @@ public class PgGetKeywordsFunctionTest extends AbstractTableFunctionsTest {
             rows.add(new RowN(it.next().materialize()));
         }
         rows.sort(Comparator.comparing(x -> ((String) x.get(0))));
-        assertThat(rows.size(), is(245));
+        assertThat(rows.size(), is(246));
         Row row = rows.get(0);
 
         assertThat(row.get(0), is("add"));

--- a/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
@@ -25,8 +25,11 @@ package io.crate.integrationtests;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
 import org.junit.Test;
+import org.postgresql.util.PSQLException;
 
 import java.sql.PreparedStatement;
+
+import static io.crate.testing.Asserts.assertThrows;
 
 @UseJdbc(value = 1)
 public class PostgresCompatIntegrationTest extends SQLIntegrationTestCase {
@@ -34,6 +37,14 @@ public class PostgresCompatIntegrationTest extends SQLIntegrationTestCase {
     @Test
     public void testBeginStatement() {
         execute("BEGIN");
+        assertNoErrorResponse(response);
+    }
+
+    @Test
+    public void testStartTransactionStatement() {
+        assertThrows(() -> execute("START"), PSQLException.class, "ERROR: line 1:6: missing 'TRANSACTION'");
+
+        execute("START TRANSACTION");
         assertNoErrorResponse(response);
     }
 
@@ -64,8 +75,34 @@ public class PostgresCompatIntegrationTest extends SQLIntegrationTestCase {
     }
 
     @Test
+    public void testStartTransactionStatementWithTransactionMode() {
+        String[] statements = new String[]{
+            "START TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+            "START TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+            "START TRANSACTION ISOLATION LEVEL READ COMMITTED",
+            "START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED",
+            "START TRANSACTION READ WRITE",
+            "START TRANSACTION READ ONLY",
+            "START TRANSACTION DEFERRABLE",
+            "START TRANSACTION NOT DEFERRABLE"
+        };
+        for (String statement : statements) {
+            execute(statement);
+            assertNoErrorResponse(response);
+        }
+    }
+
+    @Test
     public void testBeginStatementWithMultipleTransactionModes() {
         execute("BEGIN ISOLATION LEVEL SERIALIZABLE, " +
+                "      READ WRITE, " +
+                "      DEFERRABLE");
+        assertNoErrorResponse(response);
+    }
+
+    @Test
+    public void testStartTransactionStatementWithMultipleTransactionModes() {
+        execute("START TRANSACTION ISOLATION LEVEL SERIALIZABLE, " +
                 "      READ WRITE, " +
                 "      DEFERRABLE");
         assertNoErrorResponse(response);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

accepting ``START TRANSACTION`` statements for Postgres compatibility, but as CrateDB does not support transactions, this command has no effect.

**originally:**
```SQL
cr> START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
SQLParseException[line 1:1: mismatched input 'START' expecting {'SELECT', 'DEALLOCATE', 'CREATE', 'ALTER', 'KILL', 'BEGIN', 'COMMIT', 'ANALYZE', 'DISCARD', 'EXPLAIN', 'SHOW', 'OPTIMIZE', 'REFRESH', 'RESTORE', 'DROP', 'INSERT', 'VALUES', 'DELETE', 'UPDATE', 'SET', 'RESET', 'COPY', 'GRANT', 'DENY', 'REVOKE', START}]
```

closes #11214 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
