### PR TITLE
Split UserLookup and UserManager

### DIFF
--- a/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
@@ -22,9 +22,9 @@
 
 package io.crate.planner.statement;
 
+import static io.crate.data.SentinelRow.SENTINEL;
+
 import io.crate.analyze.AnalyzedSetSessionAuthorizationStatement;
-import io.crate.user.User;
-import io.crate.user.UserManager;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -32,18 +32,18 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
-
-import static io.crate.data.SentinelRow.SENTINEL;
+import io.crate.user.User;
+import io.crate.user.UserLookup;
 
 public class SetSessionAuthorizationPlan implements Plan {
 
     private final AnalyzedSetSessionAuthorizationStatement setSessionAuthorization;
-    private final UserManager userManager;
+    private final UserLookup userLookup;
 
     public SetSessionAuthorizationPlan(AnalyzedSetSessionAuthorizationStatement setSessionAuthorization,
-                                       UserManager userManager) {
+                                       UserLookup userLookup) {
         this.setSessionAuthorization = setSessionAuthorization;
-        this.userManager = userManager;
+        this.userLookup = userLookup;
     }
 
     @Override
@@ -61,7 +61,7 @@ public class SetSessionAuthorizationPlan implements Plan {
         String userName = setSessionAuthorization.user();
         User user;
         if (userName != null) {
-            user = userManager.findUser(userName);
+            user = userLookup.findUser(userName);
             if (user == null) {
                 throw new IllegalArgumentException("User '" + userName + "' does not exist.");
             }

--- a/server/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/server/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 
 import io.crate.action.sql.SQLOperations;
+import io.crate.user.UserLookup;
 import io.crate.user.UserManager;
 import io.crate.plugin.PipelineRegistry;
 import io.crate.protocols.ssl.SslContextProvider;
@@ -40,6 +41,7 @@ public class RestSQLAction {
     public RestSQLAction(Settings settings,
                          SQLOperations sqlOperations,
                          PipelineRegistry pipelineRegistry,
+                         UserLookup userLookup,
                          Provider<UserManager> userManagerProvider,
                          CircuitBreakerService breakerService,
                          SslContextProvider sslContextProvider) {
@@ -51,7 +53,7 @@ public class RestSQLAction {
                 settings,
                 sqlOperations,
                 breakerService::getBreaker,
-                userManager,
+                userLookup,
                 userManager::getAccessControl,
                 corsConfig
             )

--- a/server/src/main/java/io/crate/user/UserLookup.java
+++ b/server/src/main/java/io/crate/user/UserLookup.java
@@ -22,6 +22,8 @@
 
 package io.crate.user;
 
+import java.util.Collections;
+
 import javax.annotation.Nullable;
 
 public interface UserLookup {
@@ -31,4 +33,8 @@ public interface UserLookup {
      */
     @Nullable
     User findUser(String userName);
+
+    default Iterable<User> users() {
+        return Collections.emptyList();
+    }
 }

--- a/server/src/main/java/io/crate/user/UserLookupService.java
+++ b/server/src/main/java/io/crate/user/UserLookupService.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.user;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+
+import io.crate.user.metadata.UsersMetadata;
+import io.crate.user.metadata.UsersPrivilegesMetadata;
+
+public class UserLookupService implements UserLookup, ClusterStateListener {
+
+    private volatile Set<User> users = Set.of(User.CRATE_USER);
+
+    @Inject
+    public UserLookupService(ClusterService clusterService) {
+        clusterService.addListener(this);
+    }
+
+    @Override
+    public Iterable<User> users() {
+        return users;
+    }
+
+    @Nullable
+    public User findUser(String userName) {
+        for (User user : users()) {
+            if (userName.equals(user.name())) {
+                return user;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        Metadata prevMetadata = event.previousState().metadata();
+        Metadata newMetadata = event.state().metadata();
+
+        UsersMetadata prevUsers = prevMetadata.custom(UsersMetadata.TYPE);
+        UsersMetadata newUsers = newMetadata.custom(UsersMetadata.TYPE);
+
+        UsersPrivilegesMetadata prevUsersPrivileges = prevMetadata.custom(UsersPrivilegesMetadata.TYPE);
+        UsersPrivilegesMetadata newUsersPrivileges = newMetadata.custom(UsersPrivilegesMetadata.TYPE);
+
+        if (prevUsers != newUsers || prevUsersPrivileges != newUsersPrivileges) {
+            users = getUsers(newUsers, newUsersPrivileges);
+        }
+    }
+
+
+    static Set<User> getUsers(@Nullable UsersMetadata metadata,
+                              @Nullable UsersPrivilegesMetadata privilegesMetadata) {
+        HashSet<User> users = new HashSet<User>();
+        users.add(User.CRATE_USER);
+        if (metadata != null) {
+            for (Map.Entry<String, SecureHash> user: metadata.users().entrySet()) {
+                String userName = user.getKey();
+                SecureHash password = user.getValue();
+                Set<Privilege> privileges = null;
+                if (privilegesMetadata != null) {
+                    privileges = privilegesMetadata.getUserPrivileges(userName);
+                    if (privileges == null) {
+                        // create empty set
+                        privilegesMetadata.createPrivileges(userName, Set.of());
+                    }
+                }
+                users.add(User.of(userName, privileges, password));
+            }
+        }
+        return Collections.unmodifiableSet(users);
+    }
+}

--- a/server/src/main/java/io/crate/user/UserManagementModule.java
+++ b/server/src/main/java/io/crate/user/UserManagementModule.java
@@ -24,14 +24,6 @@ package io.crate.user;
 
 import org.elasticsearch.common.inject.AbstractModule;
 
-import io.crate.user.UserLookup;
-import io.crate.user.UserManager;
-import io.crate.user.TransportAlterUserAction;
-import io.crate.user.TransportCreateUserAction;
-import io.crate.user.TransportDropUserAction;
-import io.crate.user.TransportPrivilegesAction;
-import io.crate.user.UserManagerService;
-
 public class UserManagementModule extends AbstractModule {
 
     @Override
@@ -41,6 +33,6 @@ public class UserManagementModule extends AbstractModule {
         bind(TransportAlterUserAction.class).asEagerSingleton();
         bind(TransportPrivilegesAction.class).asEagerSingleton();
         bind(UserManager.class).to(UserManagerService.class).asEagerSingleton();
-        bind(UserLookup.class).to(UserManagerService.class).asEagerSingleton();
+        bind(UserLookup.class).to(UserLookupService.class).asEagerSingleton();
     }
 }

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.user.Privilege;
 import io.crate.user.User;
+import io.crate.user.UserLookupService;
 import io.crate.user.UserManager;
 import io.crate.user.UserManagerService;
 import io.crate.exceptions.UnauthorizedException;
@@ -97,8 +98,8 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                 return true;
             }
         };
-        userManager = new UserManagerService(null, null,
-            null, null, mock(SysTableRegistry.class), clusterService, new DDLClusterStateService()) {
+        UserLookupService userLookupService = new UserLookupService(clusterService) {
+
             @Nullable
             @Override
             public User findUser(String userName) {
@@ -108,6 +109,15 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                 return super.findUser(userName);
             }
         };
+        userManager = new UserManagerService(
+            null,
+            null,
+            null,
+            null,
+            mock(SysTableRegistry.class),
+            clusterService,
+            userLookupService,
+            new DDLClusterStateService());
 
         e = SQLExecutor.builder(clusterService)
             .addBlobTable("create blob table blobs")

--- a/server/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -22,14 +22,15 @@
 
 package io.crate.integrationtests;
 
-import io.crate.action.sql.SQLOperations;
-import io.crate.action.sql.Session;
-import io.crate.user.User;
-import io.crate.user.UserManager;
-import io.crate.testing.SQLResponse;
+import java.util.Objects;
+
 import org.junit.Before;
 
-import java.util.Objects;
+import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
+import io.crate.testing.SQLResponse;
+import io.crate.user.User;
+import io.crate.user.UserLookup;
 
 public abstract class BaseUsersIntegrationTest extends SQLIntegrationTestCase {
 
@@ -70,8 +71,8 @@ public abstract class BaseUsersIntegrationTest extends SQLIntegrationTestCase {
 
     public SQLResponse executeAs(String stmt, String userName) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class);
-        UserManager userManager = internalCluster().getInstance(UserManager.class);
-        User user = Objects.requireNonNull(userManager.findUser(userName), "User " + userName + " must exist");
+        UserLookup userLookup = internalCluster().getInstance(UserLookup.class);
+        User user = Objects.requireNonNull(userLookup.findUser(userName), "User " + userName + " must exist");
         Session session = sqlOperations.createSession(null, user);
         return execute(stmt, null, session);
     }

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
@@ -27,6 +27,7 @@ import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.netty.EventLoopGroups;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.user.StubUserManager;
+import io.crate.user.User;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.common.network.NetworkService;
@@ -159,7 +160,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             mock(SQLOperations.class),
             userManager,
             networkService,
-            new AlwaysOKAuthentication(userManager),
+            new AlwaysOKAuthentication(userName -> User.CRATE_USER),
             new EventLoopGroups(),
             mock(SslContextProvider.class));
         try {

--- a/server/src/test/java/io/crate/user/UserLookupServiceTest.java
+++ b/server/src/test/java/io/crate/user/UserLookupServiceTest.java
@@ -22,33 +22,34 @@
 
 package io.crate.user;
 
-import io.crate.user.metadata.UserDefinitions;
-import io.crate.user.metadata.UsersMetadata;
-import io.crate.user.metadata.UsersPrivilegesMetadata;
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import org.junit.Test;
-
-import java.util.Set;
-
 import static io.crate.user.User.CRATE_USER;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-public class UserManagerServiceTest extends CrateDummyClusterServiceUnitTest {
+import java.util.Set;
+
+import org.junit.Test;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.user.metadata.UserDefinitions;
+import io.crate.user.metadata.UsersMetadata;
+import io.crate.user.metadata.UsersPrivilegesMetadata;
+
+public class UserLookupServiceTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNullAndEmptyMetadata() {
         // the users list will always contain a crate user
-        Set<User> users = UserManagerService.getUsers(null, null);
+        Set<User> users = UserLookupService.getUsers(null, null);
         assertThat(users, contains(CRATE_USER));
 
-        users = UserManagerService.getUsers(new UsersMetadata(), new UsersPrivilegesMetadata());
+        users = UserLookupService.getUsers(new UsersMetadata(), new UsersPrivilegesMetadata());
         assertThat(users, contains(CRATE_USER));
     }
 
     @Test
     public void testNewUser() {
-        Set<User> users = UserManagerService.getUsers(new UsersMetadata(UserDefinitions.SINGLE_USER_ONLY), new UsersPrivilegesMetadata());
+        Set<User> users = UserLookupService.getUsers(new UsersMetadata(UserDefinitions.SINGLE_USER_ONLY), new UsersPrivilegesMetadata());
         assertThat(users, containsInAnyOrder(User.of("Arthur"), CRATE_USER));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will allow us to instantiate the `HostBasedAuthentication` class before the
injector has been fully configured. This will be necessary to make
`Authentication` available within the `Netty4Transport` to have
HBA/SSL/transport integration.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)