### PR TITLE
Copyedit new node-to-node encryption docs

### DIFF
--- a/docs/admin/auth/hba.rst
+++ b/docs/admin/auth/hba.rst
@@ -1,7 +1,7 @@
 .. _admin_hba:
 
 ===============================
-Host Based Authentication (HBA)
+Host-Based Authentication (HBA)
 ===============================
 
 This section explains how to configure CrateDB client connection and
@@ -27,6 +27,9 @@ authentication.
 
 .. contents::
    :local:
+
+
+.. _admin_hba_cratedb:
 
 Authentication against CrateDB
 ==============================
@@ -143,6 +146,9 @@ superuser) can authenticate to CrateDB from any IP address using the
 
    For general help managing users, see :ref:`administration_user_management`.
 
+
+.. _admin_hba_user:
+
 Authenticating as a superuser
 =============================
 
@@ -160,6 +166,9 @@ the the ``auth.host_based`` setting, like this:
         config:
           0:
             user: crate
+
+
+.. _admin_hba_admin_ui:
 
 Authenticating to Admin UI
 ==========================
@@ -193,15 +202,16 @@ For more information, consult the :ref:`privileges section
     DROP OK, 1 row affected (... sec)
 
 
+.. _admin_hba_node:
 
-Node to Node communication
+Node-to-node communication
 ==========================
 
-The :ref:`Host Based Authentication <admin_hba>` mechanism can also be used to
-control node to node communication. This is useful if you're building a multi
-zone setup where the communication with the nodes in another zone should happen
-via SSL and the communication with the nodes in the same zone should happen
-without SSL.
+You can use the :ref:`Host-Based Authentication <admin_hba>` mechanism for
+node-to-node communication.
+
+For example, if you wanted to configure a `multi-zone cluster`_, you could do
+this:
 
 .. code-block:: yaml
 
@@ -211,14 +221,25 @@ without SSL.
         config:
           0:
             address: 192.168.0.0/24
-            method: trust
             protocol: transport
+            method: trust
           1:
-            method: cert
             protocol: transport
             ssl: on
+            method: cert
+
+Here, communication between nodes in the same zone (i.e., matching the
+``192.168.0.0/24`` netmask) can happen without SSL. In contrast, communication
+between nodes in different zones (i.e., any non-matching network address) must
+happen via :ref:`SSL <admin_ssl>`.
+
+This example would require that you set :ref:`ssl.transport.mode
+<ssl.transport.mode>` to ``dual``.
+
+.. NOTE::
+
+    CrateDB only supports the :ref:`trust <auth_trust>` and :ref:`cert
+    <auth_cert>` authentication methods for node-to-node communication.
 
 
-Node to node communication only supports the ``trust`` and ``cert``
-authorization methods. Any other authorization methods that are available for
-user client connections are not available.
+.. _multi-zone cluster: https://crate.io/docs/crate/howtos/en/latest/clustering/multi-zone-setup.html

--- a/docs/admin/ssl.rst
+++ b/docs/admin/ssl.rst
@@ -4,27 +4,37 @@
 Secured communications (SSL/TLS)
 ================================
 
-CrateDB allows to encrypt the communication between multiple CrateDB nodes, or
-to encrypt the communication between a HTTTP or PostgreSQL client and a CrateDB
-node.
+You can encrypt the internal communication between CrateDB nodes and the
+external communication with HTTP and PostgreSQL clients. When you configure
+encryption, CrateDB secures connections using *Transport Layer Security* (TLS).
 
-If enabled, connections are secured using Transport Layer Security (TLS).
+You can enable SSL on a per-protocol basis:
 
-SSL can be enabled on a per protocol basis:
+.. rst-class:: open
 
-- If enabled for HTTP, all connections will require HTTPS.
+- If you enable SSL for :ref:`HTTP <sql_http_endpoint>`, all connections will
+  require HTTPS.
 
-- If enabled for PostgreSQL, clients can negotiate on a per connection basis if
-  the connection should be secured. You can enforce SSL usage via the
-  :ref:`Host Based Authentication feature <admin_hba>`.
+- By default, if you enable SSL for the :ref:`PostgreSQL wire protocol
+  <postgres_wire_protocol>`, clients can negotiate on a per-connection basis
+  whether to use SSL. However, you can enforce SSL via :ref:`Host-Based
+  Authentication <admin_hba>`.
 
-- If enabled for the transport protocol, a node can either only accept SSL
-  connections, or it can operate in a ``DUAL`` mode, in which it accepts both
-  SSL and non-SSL connections. The latter mode can be useful in multi-zone
-  setups where a part of the cluster communicates via SSL, while another part
-  doesn't. More fine granular control is possible via the :ref:`Host Based
-  Authentication <admin_hba>` feature.
+- If you enable SSL for the CrateDB transport protocol (used for intra-node
+  communication), nodes can operate in two modes:
 
+  1. Only accept SSL connections (:ref:`ssl.transport.mode
+     <ssl.transport.mode>` set to ``on``)
+
+  2. Accept SSL and non-SSL connections (:ref:`ssl.transport.mode
+     <ssl.transport.mode>` set to ``dual``)
+
+.. TIP::
+
+   You can use ``dual`` SSL mode and :ref:`Host-Based Authentication
+   <admin_hba_node>` to configure a multi-zone cluster that allows
+   non-encrypted traffic between nodes in the same zone but enforces encryption
+   for nodes communicating between zones.
 
 .. rubric:: Table of contents
 

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -552,13 +552,25 @@ Layer Security (TLS).
   Set this to true to enable secure communication between the CrateDB node
   and the client through SSL via the PostgreSQL wire protocol.
 
+.. _ssl.transport.mode:
 
 **ssl.transport.mode**
   | *Default:* ``off``
   | *Runtime:* ``no``
 
-  Set to ``dual`` or ``on`` to enable secure communication between two or more
-  CrateDB nodes.
+  For communication between nodes, choose:
+
+  ``off``
+    SSL cannot be used
+  ``off``
+    SSL must be used
+  ``dual``
+    SSL may be used
+
+  .. SEEALSO::
+
+      :ref:`Host-Based Authentication: Node-to-node communication
+      <admin_hba_node>`
 
 .. _ssl.keystore_filepath:
 


### PR DESCRIPTION
Specifically:

- Minor edits affecting multiple files:

  - Rephrasing to use the active voice (e.g., "you can do x" vs "x can be done")
  - Use of hyphens (e.g., "multi-zone" vs "multi zone")

- Add labels to `hba.rst` so other pages can link directly to the "Node-to-node communication" section

- Rework the "Node-to-node communication" section:

  - Introduce the example with a short, easy-to-scan sentence
  - Add a link to the multi-zone how-to guide
  - Explain the example in detail in a subsequent para
  - Specify that `ssl.transport.mode` must be set to `dual`
  - Move the note about trust methods to a `NOTE` admonition

- Rework the `ssl.rst` intro:

  - Switch to active voice (as above)
  - Use an "open" style RST list (i.e., paragraph spacing is used when styled) per https://github.com/crate/crate-docs/blob/main/style/rst.rst#open
  - Rework mention of `dual` (see below for rationale)
  - Split modes into a sublist for better clarity
  - Expand and move multi-zone node to a `NOTE` block for better visibility

  I found it confusing that only the second mode was given a name (`dual`). After reading the description of the setting, I considered saying that the first mode is called `on`.

  Taken together, "off", "dual", and "on" seem okay to me. However, in isolation, I think there is a disparity between "on" and "dual" because "on" is normally paired with "off" and "dual" is normally paired with "single".

  To get around this, I reworked it so that `ssl.rst` frames the choice (after enabling SSL) as one of two (unnamed) modes. But, so as not to lose the information about one of them being tied to the `duel`, I added explicit parentheses referencing the three-value `ssl.transport.mode` setting.

- Modify `node.rst`:

  - Add a label for `ssl.transport.mode` so that we can link to this setting
  - Expanded the description for clarity
  - Added a `SEEALSO` admonition linking to the "Node-to-node communication" section so that readers can see how `dual` behavior can be configured (it is not obvious by itself what `dual` would be used for)
