### PR TITLE
Remove `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-*.rst @crate/tech-writing
-docs/ @crate/tech-writing
-docs/appendices/release-notes/unreleased.rst
-devs/docs/es-backports.rst


### PR DESCRIPTION
The `@crate/tech-writing` team no longer exists.
