### PR TITLE
Implement array_sum scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,9 @@ Changes
   <scalar-array-max>` scalar functions returning the minimal and maximal
   element in array respectively.
 
+- Added the :ref:`array_sum <scalar-array-sum>` scalar function
+  that returns the sum of all elements in an array.
+
 - Added support for reading ``cgroup`` information in the ``cgroup v2`` format.
 
 - Improved the internal throttling mechanism used for ``INSERT FROM QUERY`` and

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2486,6 +2486,49 @@ function supports arrays of any of the :ref:`primitive types
     +-----+
     SELECT 1 row in set (... sec)
 
+.. _scalar-array-sum:
+
+``array_sum(array)``
+--------------------
+
+Returns the sum of array elements that are not ``NULL``.
+Depending on the argument type a suitable return type is chosen. For ``real``
+and ``double precison`` argument types the return type is equal to the argument
+type. For ``char``, ``smallint``, ``integer`` and ``bigint`` the return type
+changes to ``bigint``. If the range of ``bigint`` values (-2^64 to 2^64-1) gets
+exceeded an ``ArithmeticException`` will be raised.
+
+::
+
+    cr> SELECT array_sum([1,2,3]) AS sum;
+    +-----+
+    | sum |
+    +-----+
+    |   6 |
+    +-----+
+    SELECT 1 row in set (... sec)
+
+The sum on the bigint array will result in an overflow in the following query:
+
+::
+
+    cr> SELECT array_sum([9223372036854775807,9223372036854775807]) as sum;
+    ArithmeticException[long overflow]
+
+To address the overflow of the sum of the given array elements,
+we cast the array to the numeric data type:
+
+::
+
+    cr>  SELECT array_sum([9223372036854775807,9223372036854775807] :: numeric[])
+    ... as sum;
+    +----------------------+
+    |                  sum |
+    +----------------------+
+    | 18446744073709551614 |
+    +----------------------+
+    SELECT 1 row in set (... sec)
+
 .. _scalar-conditional-functions-expressions:
 
 Conditional functions and expressions

--- a/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.data.Input;
+import io.crate.execution.engine.aggregation.impl.KahanSummationForDouble;
+import io.crate.execution.engine.aggregation.impl.KahanSummationForFloat;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.function.Function;
+
+import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
+
+public class ArraySumFunction<T extends Number, R extends Number> extends Scalar<R, List<T>> {
+
+    public static final String NAME = "array_sum";
+
+    private final DataType<R> returnType;
+    private final Function summationFunction;
+
+    private final Function<List<BigDecimal>, BigDecimal> numericFunction = list -> {
+        BigDecimal sum = BigDecimal.ZERO;
+        boolean hasNotNull = false;
+        for (int i = 0; i < list.size(); i++) {
+            var item = list.get(i);
+            if (item != null) {
+                hasNotNull = true;
+                sum = sum.add(item);
+            }
+        }
+        return hasNotNull ? sum : null;
+    };
+
+    private final Function<List<Float>, Float> floatFunction = list -> {
+        var kahanSummationForFloat = new KahanSummationForFloat();
+        float sum = 0;
+        boolean hasNotNull = false;
+        for (int i = 0; i < list.size(); i++) {
+            var item = list.get(i);
+            if (item != null) {
+                hasNotNull = true;
+                sum = kahanSummationForFloat.sum(sum, item);
+            }
+        }
+        return hasNotNull ? sum : null;
+    };
+
+    private final Function<List<Double>, Double> doubleFunction = list -> {
+        var kahanSummationForDouble = new KahanSummationForDouble();
+        double sum = 0;
+        boolean hasNotNull = false;
+        for (int i = 0; i < list.size(); i++) {
+            var item = list.get(i);
+            if (item != null) {
+                hasNotNull = true;
+                sum = kahanSummationForDouble.sum(sum, item);
+            }
+        }
+        return hasNotNull ? sum : null;
+    };
+
+
+    private final Function<List<Number>, Long> longFunction = list -> {
+        Long sum = 0L;
+        boolean hasNotNull = false;
+        for (int i = 0; i < list.size(); i++) {
+            var item = list.get(i);
+            if (item != null) {
+                hasNotNull = true;
+                sum = Math.addExact(sum, item.longValue());
+            }
+        }
+        return hasNotNull ? sum : null;
+    };
+
+    public static void register(ScalarFunctionModule module) {
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
+                DataTypes.NUMERIC.getTypeSignature()
+            ),
+            ArraySumFunction::new
+        );
+
+        for (var supportedType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            DataType inputDependantOutputType = DataTypes.LONG;
+            if (supportedType == DataTypes.FLOAT || supportedType == DataTypes.DOUBLE) {
+                inputDependantOutputType = supportedType;
+            }
+
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    new ArrayType(supportedType).getTypeSignature(),
+                    inputDependantOutputType.getTypeSignature()
+                ),
+                ArraySumFunction::new
+            );
+        }
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    private ArraySumFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        returnType = (DataType<R>) signature.getReturnType().createType();
+
+        if (returnType == DataTypes.FLOAT) {
+            summationFunction = floatFunction;
+        } else if (returnType == DataTypes.DOUBLE) {
+            summationFunction = doubleFunction;
+        } else if (returnType == DataTypes.NUMERIC) {
+            summationFunction = numericFunction;
+        } else {
+            summationFunction = longFunction;
+        }
+
+        ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), signature.getName().name());
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public R evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
+        List<T> values = (List) args[0].value();
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        return returnType.implicitCast(summationFunction.apply(values));
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -175,6 +175,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         ArrayToStringFunction.register(this);
         ArrayMinFunction.register(this);
         ArrayMaxFunction.register(this);
+        ArraySumFunction.register(this);
 
         CoalesceFunction.register(this);
         GreatestFunction.register(this);

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
@@ -23,10 +23,10 @@ public class ArrayMaxFunctionTest extends ScalarTestCase {
         for(DataType type: typesToTest) {
             var valuesToTest = TestingHelpers.getRandomsOfType(2, 10, type);
 
-            var expected = valuesToTest.stream()
+            var optional = valuesToTest.stream()
                 .filter(o -> o != null)
-                .max((o1, o2) -> type.compare(o1, o2))
-                .get();
+                .max((o1, o2) -> type.compare(o1, o2));
+            var expected = optional.orElse(null);
 
             String expression = String.format(Locale.ENGLISH, "array_max(?::%s[])", type.getName());
             assertEvaluate(expression, expected, Literal.of(valuesToTest, new ArrayType<>(type)));

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
@@ -23,10 +23,10 @@ public class ArrayMinFunctionTest extends ScalarTestCase {
         for(DataType type: typesToTest) {
             var valuesToTest = TestingHelpers.getRandomsOfType(2, 10, type);
 
-            var expected = valuesToTest.stream()
+            var optional = valuesToTest.stream()
                 .filter(o -> o != null)
-                .min((o1, o2) -> type.compare(o1, o2))
-                .get();
+                .min((o1, o2) -> type.compare(o1, o2));
+            var expected = optional.orElse(null);
 
             String expression = String.format(Locale.ENGLISH, "array_min(?::%s[])", type.getName());
             assertEvaluate(expression, expected, Literal.of(valuesToTest, new ArrayType<>(type)));

--- a/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
@@ -1,0 +1,118 @@
+package io.crate.expression.scalar;
+
+import io.crate.execution.engine.aggregation.impl.KahanSummationForDouble;
+import io.crate.expression.symbol.Literal;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static io.crate.testing.Asserts.assertThrows;
+
+public class ArraySumFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_array_returns_sum_of_elements() {
+
+        // This test picks up random numbers but controls that overflow will not happen (overflow case is checked in another test).
+
+        List<DataType> typesToTest = new ArrayList(DataTypes.NUMERIC_PRIMITIVE_TYPES);
+        typesToTest.add(DataTypes.NUMERIC);
+
+        for(DataType type: typesToTest) {
+            var valuesToTest = TestingHelpers.getRandomsOfType(1, 10, type);
+
+            DataType inputDependantOutputType = DataTypes.LONG;
+            if (type == DataTypes.FLOAT || type == DataTypes.DOUBLE || type == DataTypes.NUMERIC) {
+                inputDependantOutputType = type;
+            } else {
+                // check potential overflow and get rid of numbers causing overflow
+                long sum = 0;
+                for (int i = 0; i < valuesToTest.size(); i++) {
+                    if (valuesToTest.get(i) != null) {
+                        long nextNum = ((Number) valuesToTest.get(i)).longValue();
+                        try {
+                            sum = Math.addExact(sum, nextNum);
+                        } catch (ArithmeticException e) {
+                            valuesToTest = valuesToTest.subList(0, i); // excluding i
+                            break;
+                        }
+                    }
+                }
+            }
+            KahanSummationForDouble kahanSummationForDouble = new KahanSummationForDouble();
+            var optional = valuesToTest.stream()
+                .filter(Objects::nonNull)
+                .reduce((o1, o2) -> {
+                    if(o1 instanceof BigDecimal) {
+                        return ((BigDecimal) o1).add((BigDecimal) o2);
+                    } else if(o1 instanceof Double || o1 instanceof Float) {
+                        return kahanSummationForDouble.sum(((Number) o1).doubleValue(), ((Number) o2).doubleValue());
+                    } else {
+                        return DataTypes.LONG.implicitCast(o1) + DataTypes.LONG.implicitCast(o2);
+                    }
+                });
+            var expected= inputDependantOutputType.implicitCast(optional.orElse(null));
+
+
+            String expression = String.format(Locale.ENGLISH,"array_sum(?::%s[])", type.getName());
+            assertEvaluate(expression, expected, Literal.of(valuesToTest, new ArrayType<>(type)));
+        }
+    }
+
+    @Test
+    public void test_array_big_numbers_no_casting_results_in_exception() {
+        assertThrows(() -> assertEvaluate("array_sum(?)", null,
+                                Literal.of(List.of(Long.MAX_VALUE, Long.MAX_VALUE), new ArrayType<>(DataTypes.LONG))
+                            ),
+            ArithmeticException.class,
+            "long overflow");
+    }
+
+    @Test
+    public void test_array_big_numbers_casting_to_numeric_returns_sum() {
+        assertEvaluate("array_sum(cast(long_array as array(numeric)))",
+            new BigDecimal("18446744073709551614"),
+            Literal.of(List.of(Long.MAX_VALUE, Long.MAX_VALUE), new ArrayType<>(DataTypes.LONG))
+        );
+    }
+
+    @Test
+    public void test_array_first_element_null_returns_sum() {
+        assertEvaluate("array_sum([null, 1])", 1L);
+    }
+
+    @Test
+    public void test_all_elements_nulls_results_in_null() {
+        assertEvaluate("array_sum(cast([null, null] as array(integer)))", null);
+    }
+
+    @Test
+    public void test_null_array_results_in_null() {
+        assertEvaluate("array_sum(null::int[])", null);
+    }
+
+    @Test
+    public void test_null_array_given_directly_results_in_null() {
+        assertEvaluate("array_sum(null)", null);
+    }
+
+    @Test
+    public void test_empty_array_results_in_null() {
+        assertEvaluate("array_sum(cast([] as array(integer)))", null);
+    }
+
+    @Test
+    public void test_empty_array_given_directly_throws_exception() {
+        assertThrows(() -> assertEvaluate("array_sum([])", null),
+            UnsupportedOperationException.class,
+            "Unknown function: array_sum([]), no overload found for matching argument types: (undefined_array).");
+    }
+}

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -181,21 +181,20 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
         }
         LinkedList<Literal<?>> unusedLiterals = new LinkedList<>(Arrays.asList(literals));
         Function function = (Function) RefReplacer.replaceRefs(functionSymbol, r -> {
-            Literal<?> literal = unusedLiterals.pollFirst();
-            if (literal == null) {
+            if (unusedLiterals.isEmpty()) {
                 throw new IllegalArgumentException("No value literal for reference=" + r + ", please add more literals");
             }
+            Literal<?> literal = unusedLiterals.pollFirst(); //Can be null.
             return literal;
         });
-
         if(unusedLiterals.size() == literals.length) {
             // Currently it's supposed that literals will be either references or parameters.
             // One of replaceRefs and bindParameters does nothing and doesn't consume unusedLiterals.
             function = (Function) ParameterBinder.bindParameters(function, p -> {
-                Literal<?> literal = unusedLiterals.pollFirst();
-                if (literal == null) {
+                if (unusedLiterals.isEmpty()) {
                     throw new IllegalArgumentException("No value literal for parameter=" + p + ", please add more literals");
                 }
+                Literal<?> literal = unusedLiterals.pollFirst(); //Can be null.
                 return literal;
             });
         }
@@ -237,7 +236,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
      */
     public void assertEvaluate(String functionExpression, Object expectedValue, Literal<?>... literals) {
         if (expectedValue == null) {
-            assertEvaluate(functionExpression, nullValue());
+            assertEvaluate(functionExpression, nullValue(), literals);
         } else {
             assertEvaluate(functionExpression, is(expectedValue), literals);
         }

--- a/server/src/testFixtures/java/io/crate/expression/symbol/ParameterBinder.java
+++ b/server/src/testFixtures/java/io/crate/expression/symbol/ParameterBinder.java
@@ -43,6 +43,6 @@ public final class ParameterBinder extends FunctionCopyVisitor<Function<? super 
 
     @Override
     public Symbol visitParameterSymbol(ParameterSymbol parameter, Function<? super ParameterSymbol, ? extends Symbol> mapper) {
-        return requireNonNull(mapper.apply(parameter), "mapper function used in ParameterBinder must not return null values");
+        return mapper.apply(parameter);
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -441,16 +441,16 @@ public class TestingHelpers {
 
     public static <T> List<T> getRandomsOfType(int minLength, int maxLength, DataType<T> dataType) {
         var values = new ArrayList<T>();
-
-        boolean addNull = RandomizedTest.randomBoolean();
         int length  = RandomizedTest.randomIntBetween(minLength, maxLength);
-        if (addNull) {
-            length = length - 1;
-            values.add(null);
-        }
         var generator = DataTypeTesting.getDataGenerator(dataType);
+
         for (int i = 0; i < length; i++) {
-            values.add(dataType.sanitizeValue(generator.get()));
+            // 1/length chance
+            if (RandomizedTest.randomIntBetween(0, length-1) == 0) {
+                values.add(null);
+            } else {
+                values.add(dataType.sanitizeValue(generator.get()));
+            }
         }
         return values;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

ArraySum Scalar Function. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
