### PR TITLE
Move object[] mapping changes entry to 4.1.0

### DIFF
--- a/docs/appendices/release-notes/4.1.0.rst
+++ b/docs/appendices/release-notes/4.1.0.rst
@@ -34,6 +34,16 @@ Breaking Changes
   types ``integer`` and ``bigint`` to throw an exception instead of rolling
   over from positive to negative or the other way around.
 
+- Remap CrateDB :ref:`object_data_type` array data type from the PostgreSQL
+  JSON to JSON array type. That might effect some drivers that use the
+  PostgreSQL wire protocol to insert data into tables with object array typed
+  columns. For instance, when using the ``Npgsql`` driver, it is not longer
+  possible to insert an array of objects into a column of the object array data
+  type by using the parameter of a SQL statement that has the JSON data type
+  and an array of CLR as its value. Instead, use a string array with JSON
+  strings that represent the objects. See the ``Npgsql`` documentation for more
+  details.
+
 - Changed how columns of type :ref:`geo_point_data_type` are being communicated
   to PostgreSQL clients.
 

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -50,16 +50,6 @@ Breaking Changes
     | [1.0, 2.0] |
     +------------+
 
-- Remap CrateDB :ref:`object_data_type` array data type from the PostgreSQL
-  JSON to JSON array type. That might effect some drivers that use the
-  PostgreSQL wire protocol to insert data into tables with object array typed
-  columns. For instance, when using the ``Npgsql`` driver, it is not longer
-  possible to insert an array of objects into a column of the object array data
-  type by using the parameter of a SQL statement that has the JSON data type
-  and an array of CLR as its value. Instead, use a string array with JSON
-  strings that represent the objects. See the ``Npgsql`` documentation for more
-  details.
-
 - Bulk ``INSERT INTO ... VALUES (...)`` statements do not throw an exception
   any longer when one of the bulk operations fails. The result of the execution
   is only available via the ``results`` array represented by a row count for


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The change was made with the 4.1.0 release, but the changes entry
accidentally ended up in 4.2.0.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)