### PR TITLE
Don't prune unused table functions

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -83,6 +83,13 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause queries on virtual tables to return an
+  incorrect result if a table function is used in the select-list of a
+  sub-query, but not used in the outputs of the parent relation. An example:
+
+      SELECT name FROM (SELECT name, unnest(tags) FROM metrics) m;
+
+
 - Updated the bundled JDK to 16.0.1+9
 
 - Fixed an issue that would cause columns of type ``varchar`` with a length

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -143,20 +143,18 @@ public class ProjectSet extends ForwardingLogicalPlan {
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         HashSet<Symbol> toKeep = new HashSet<>();
         LinkedHashSet<Symbol> newStandalone = new LinkedHashSet<>();
-        LinkedHashSet<Function> newTableFunctions = new LinkedHashSet<>();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, standalone, newStandalone::add);
-            SymbolVisitors.intersection(outputToKeep, tableFunctions, newTableFunctions::add);
         }
-        for (Function newTableFunction : newTableFunctions) {
-            SymbolVisitors.intersection(newTableFunction, source.outputs(), toKeep::add);
+        for (Function tableFunction : tableFunctions) {
+            SymbolVisitors.intersection(tableFunction, source.outputs(), toKeep::add);
         }
         toKeep.addAll(newStandalone);
         LogicalPlan newSource = source.pruneOutputsExcept(tableStats, toKeep);
         if (newSource == source) {
             return this;
         }
-        return new ProjectSet(newSource, List.copyOf(newTableFunctions), List.copyOf(newStandalone));
+        return new ProjectSet(newSource, tableFunctions, List.copyOf(newStandalone));
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -407,6 +407,18 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
     }
 
+    @Test
+    public void test_unused_table_function_in_subquery_is_not_pruned() {
+        LogicalPlan plan = plan("select name from (select name, unnest(counters), text from users) u");
+        assertThat(plan, isPlan(
+            "Eval[name]\n" +
+            "  └ Rename[name] AS u\n" +
+            "    └ Eval[name]\n" +
+            "      └ ProjectSet[unnest(counters), name]\n" +
+            "        └ Collect[doc.users | [counters, name] | true]"
+        ));
+    }
+
     public static Matcher<LogicalPlan> isPlan(String expectedPlan) {
         return new FeatureMatcher<>(equalTo(expectedPlan), "same output", "output ") {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We always need to evaluate the functions so that the result-set is
extended to the amount of rows returned by the table functions.

Closes https://github.com/crate/crate/issues/11333

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)