### PR TITLE
Fix number_of_routing_shards validation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -86,4 +86,7 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue that caused valid values for ``number_of_routing_shards`` in
+  ``CREATE TABLE`` statements to be rejected because the validation always used
+  a fixed value of ``5`` instead of the actual number of shards declared within
+  the ``CREATE TABLE`` statement.

--- a/server/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/server/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -21,18 +21,20 @@
 
 package io.crate.analyze;
 
-import io.crate.sql.tree.GenericProperties;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_SETTING_PREFIX;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_SETTING_PREFIX;
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.sql.tree.GenericProperties;
 
 public class GenericPropertiesConverter {
 
@@ -205,7 +207,7 @@ public class GenericPropertiesConverter {
                 throw new IllegalArgumentException(
                     "Cannot change a dynamic group setting, only concrete settings allowed.");
             }
-            Settings.Builder singleSettingBuilder = Settings.builder();
+            Settings.Builder singleSettingBuilder = Settings.builder().put(builder.build());
             genericPropertyToSetting(singleSettingBuilder, setting.getKey(), valueSymbol);
             Object value = setting.get(singleSettingBuilder.build());
             if (value instanceof Settings) {

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1322,14 +1322,19 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void testNumberOfRoutingShardsCanBeSetAtCreateTable() {
-        BoundCreateTable stmt = analyze("create table t (x int) with (number_of_routing_shards = 10)");
+        BoundCreateTable stmt = analyze("""
+            create table t (x int)
+            clustered into 2 shards
+            with (number_of_routing_shards = 10)
+        """);
         assertThat(stmt.tableParameter().settings().get("index.number_of_routing_shards"), is("10"));
     }
 
     @Test
     public void testNumberOfRoutingShardsCanBeSetAtCreateTableForPartitionedTables() {
-        BoundCreateTable stmt = analyze("create table t (p int, x int) partitioned by (p) " +
-                                        "with (number_of_routing_shards = 10)");
+        BoundCreateTable stmt = analyze(
+            "create table t (p int, x int) clustered into 2 shards partitioned by (p) " +
+            "with (number_of_routing_shards = 10)");
         assertThat(stmt.tableParameter().settings().get("index.number_of_routing_shards"), is("10"));
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `numberOf_routing_shards` validation always used the default value of
`INDEX_NUMBER_OF_SHARDS_SETTING`, which is a fixed `5`

This adjusts the create table logic to set the effective
`number_of_shards` value eagerly to make it available for the
validation.

Closes https://github.com/crate/crate/issues/11346

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)