### PR TITLE
Deprecate the max_local_storage_nodes setting

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -207,10 +207,6 @@ auth:
 # here is an example:
 #node.attr.rack: rack314
 
-# By default, multiple nodes are not allowed to start from the same
-# installation location. To allow it, set the following to a higher value:
-#node.max_local_storage_nodes: 1
-
 # The setting indicates whether or not memory-mapping is allowed.
 # The default value is `true`.
 #node.store.allow_mmap: true

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -48,7 +48,8 @@ None
 Deprecations
 ============
 
-None
+- Deprecated the :ref:`node.max_local_storage_nodes
+  <node.max_local_storage_nodes>` setting.
 
 
 Changes

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -43,6 +43,10 @@ Basics
   Defines how many nodes are allowed to be started on the same machine using
   the same configured data path defined via `path.data`_.
 
+  This setting is deprecated and will be removed with CrateDB 5.0.  You should
+  instead set different `path.data`_ values if you intend to run multiple
+  CrateDB processes on the same machine.
+
 .. _node.store_allow_mmap:
 
 **node.store.allow_mmap**

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -163,7 +163,7 @@ public final class NodeEnvironment implements Closeable {
      * Maximum number of data nodes that should run in an environment.
      */
     public static final Setting<Integer> MAX_LOCAL_STORAGE_NODES_SETTING = Setting.intSetting("node.max_local_storage_nodes", 1, 1,
-        Property.NodeScope);
+        Property.NodeScope, Property.Deprecated);
 
     /**
      * Seed for determining a persisted unique uuid of this node. If the node has already a persisted uuid on disk,


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)