### PR TITLE
Implement array_avg scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -71,6 +71,9 @@ Changes
 - Added the :ref:`array_sum <scalar-array-sum>` scalar function
   that returns the sum of all elements in an array.
 
+- Added the :ref:`array_avg <scalar-array-avg>` scalar function that returns
+  the sum of all elements in an array.
+
 - Added support for reading ``cgroup`` information in the ``cgroup v2`` format.
 
 - Improved the internal throttling mechanism used for ``INSERT FROM QUERY`` and

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2491,12 +2491,17 @@ function supports arrays of any of the :ref:`primitive types
 ``array_sum(array)``
 --------------------
 
-Returns the sum of array elements that are not ``NULL``.
-Depending on the argument type a suitable return type is chosen. For ``real``
-and ``double precison`` argument types the return type is equal to the argument
-type. For ``char``, ``smallint``, ``integer`` and ``bigint`` the return type
-changes to ``bigint``. If the range of ``bigint`` values (-2^64 to 2^64-1) gets
-exceeded an ``ArithmeticException`` will be raised.
+Returns the sum of array elements that are not ``NULL``. If ``array`` is
+``NULL`` or an empty array, the function returns ``NULL``. This function
+supports arrays of any :ref:`numeric types
+<data-type-numeric>`. 
+
+For ``real`` and ``double precison`` arguments, the return type is equal to the
+argument type. For ``char``, ``smallint``, ``integer``, and ``bigint``
+arguments, the return type changes to ``bigint``.
+
+If any ``bigint`` value exceeds range limits (-2^64 to 2^64-1), an
+``ArithmeticException`` will be raised.
 
 ::
 
@@ -2527,6 +2532,29 @@ we cast the array to the numeric data type:
     +----------------------+
     | 18446744073709551614 |
     +----------------------+
+    SELECT 1 row in set (... sec)
+
+.. _scalar-array-avg:
+
+``array_avg(array)``
+--------------------
+
+Returns the average of all values in ``array`` that are not ``NULL`` If
+``array`` is ``NULL`` or an empty array, the function returns ``NULL``. This
+function supports arrays of any :ref:`numeric types <data-type-numeric>`.
+
+For ``real`` and ``double precison`` arguments, the return type is equal to the
+argument type. For ``char``, ``smallint``, ``integer``, and ``bigint``
+arguments, the return type is ``numeric``.
+
+::
+
+    cr> SELECT array_avg([1,2,3]) AS avg;
+    +-----+
+    | avg |
+    +-----+
+    |   2 |
+    +-----+
     SELECT 1 row in set (... sec)
 
 .. _scalar-conditional-functions-expressions:

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.expression.scalar.array.ArraySummationFunctions;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class ArrayAvgFunction {
+
+    public static final String NAME = "array_avg";
+
+    private enum Operations {
+        FLOAT(
+            (Function<List<Float>, Float>) list -> {
+                if (list == null || list.isEmpty()) {
+                    return null;
+                }
+                long size = list.stream().filter(Objects::nonNull).count();
+                Float sum = (Float) ArraySummationFunctions.FLOAT.getFunction().apply(list);
+                return sum == null ? null : sum / size;
+            }
+        ),
+        DOUBLE(
+            (Function<List<Double>, Double>) list -> {
+                if (list == null || list.isEmpty()) {
+                    return null;
+                }
+                long size = list.stream().filter(Objects::nonNull).count();
+                Double sum = (Double) ArraySummationFunctions.DOUBLE.getFunction().apply(list);
+                return sum == null ? null : sum / size;
+            }
+        ),
+        NUMERIC(
+            (Function<List<BigDecimal>, BigDecimal>) list -> {
+                if (list == null || list.isEmpty()) {
+                    return null;
+                }
+                long size = list.stream().filter(Objects::nonNull).count();
+                BigDecimal sum = (BigDecimal) ArraySummationFunctions.NUMERIC.getFunction().apply(list);
+                return sum == null ? null : sum.divide(BigDecimal.valueOf(size), MathContext.DECIMAL128);
+            }
+        ),
+        INTEGRAL_PRIMITIVE(
+            (Function<List<Number>, Number>) list -> {
+                if (list == null || list.isEmpty()) {
+                    return null;
+                }
+                long size = list.stream().filter(Objects::nonNull).count();
+                BigDecimal sum = (BigDecimal) ArraySummationFunctions.PRIMITIVE_NON_FLOAT_NOT_OVERFLOWING.getFunction().apply(list);
+                return sum == null ? null : sum.divide(BigDecimal.valueOf(size), MathContext.DECIMAL128);
+            }
+        );
+
+        private final Function function;
+
+        Operations(Function function) {
+            this.function = function;
+        }
+
+        public Function getFunction() {
+            return function;
+        }
+    }
+
+    public static void register(ScalarFunctionModule module) {
+
+        // All types except float and double have numeric average
+        // https://www.postgresql.org/docs/13/functions-aggregate.html
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
+                DataTypes.NUMERIC.getTypeSignature()
+            ),
+            (signature, boundSignature) -> new UnaryScalar<>(
+                signature,
+                boundSignature,
+                new ArrayType(DataTypes.NUMERIC),
+                Operations.NUMERIC.getFunction())
+        );
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                new ArrayType(DataTypes.FLOAT).getTypeSignature(),
+                DataTypes.FLOAT.getTypeSignature()
+            ),
+            (signature, boundSignature) -> new UnaryScalar<>(
+                signature,
+                boundSignature,
+                new ArrayType(DataTypes.FLOAT),
+                Operations.FLOAT.getFunction())
+        );
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                new ArrayType(DataTypes.DOUBLE).getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            (signature, boundSignature) -> new UnaryScalar<>(
+                signature,
+                boundSignature,
+                new ArrayType(DataTypes.DOUBLE),
+                Operations.DOUBLE.getFunction())
+        );
+
+
+        for (var supportedType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            if (supportedType != DataTypes.FLOAT && supportedType != DataTypes.DOUBLE) {
+                module.register(
+                    Signature.scalar(
+                        NAME,
+                        new ArrayType(supportedType).getTypeSignature(),
+                        DataTypes.NUMERIC.getTypeSignature()
+                    ),
+                    (signature, boundSignature) -> new UnaryScalar<>(
+                        signature,
+                        boundSignature,
+                        new ArrayType(supportedType),
+                        Operations.INTEGRAL_PRIMITIVE.getFunction())
+                );
+            }
+        }
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -176,6 +176,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         ArrayMinFunction.register(this);
         ArrayMaxFunction.register(this);
         ArraySumFunction.register(this);
+        ArrayAvgFunction.register(this);
 
         CoalesceFunction.register(this);
         GreatestFunction.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/array/ArraySummationFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/array/ArraySummationFunctions.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.array;
+
+import io.crate.execution.engine.aggregation.impl.KahanSummationForDouble;
+import io.crate.execution.engine.aggregation.impl.KahanSummationForFloat;
+import io.crate.execution.engine.aggregation.impl.OverflowAwareMutableLong;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.function.Function;
+
+public enum ArraySummationFunctions {
+
+    NUMERIC(
+        (Function<List<BigDecimal>, BigDecimal>) bigDecimals -> {
+            BigDecimal sum = BigDecimal.ZERO;
+            boolean hasNotNull = false;
+            for (int i = 0; i < bigDecimals.size(); i++) {
+                var value = bigDecimals.get(i);
+                if (value != null) {
+                    hasNotNull = true;
+                    sum = sum.add(value);
+                }
+            }
+            return hasNotNull ? sum : null;
+        }
+    ),
+    FLOAT(
+        (Function<List<Float>, Float>) floats -> {
+            var kahanSummationForFloat = new KahanSummationForFloat();
+            float sum = 0;
+            boolean hasNotNull = false;
+            for (int i = 0; i < floats.size(); i++) {
+                var value = floats.get(i);
+                if (value != null) {
+                    hasNotNull = true;
+                    sum = kahanSummationForFloat.sum(sum, value);
+                }
+            }
+            return hasNotNull ? sum : null;
+        }
+    ),
+    DOUBLE(
+        (Function<List<Double>, Double>) list -> {
+            var kahanSummationForDouble = new KahanSummationForDouble();
+            double sum = 0;
+            boolean hasNotNull = false;
+            for (int i = 0; i < list.size(); i++) {
+                var value = list.get(i);
+                if (value != null) {
+                    hasNotNull = true;
+                    sum = kahanSummationForDouble.sum(sum, value);
+                }
+            }
+            return hasNotNull ? sum : null;
+        }
+    ),
+    PRIMITIVE_NON_FLOAT_OVERFLOWING(
+        // Covers Byte, Short, Integer, Long types.
+        (Function<List<Number>, Long>) list -> {
+            Long sum = 0L;
+            boolean hasNotNull = false;
+            for (int i = 0; i < list.size(); i++) {
+                var value = list.get(i);
+                if (value != null) {
+                    hasNotNull = true;
+                    sum = Math.addExact(sum, value.longValue());
+                }
+            }
+            return hasNotNull ? sum : null;
+        }
+    ),
+    PRIMITIVE_NON_FLOAT_NOT_OVERFLOWING(
+        // Covers Byte, Short, Integer, Long types.
+        // Used for nominator calculation in array_avg as average is not supposed to overflow for primitive types.
+        (Function<List<Number>, BigDecimal>) list -> {
+            var overflowAwareMutableLong = new OverflowAwareMutableLong(0L);
+            for (int i = 0; i < list.size(); i++) {
+                var value = list.get(i);
+                if (value != null) {
+                    overflowAwareMutableLong.add(value.longValue());
+                }
+            }
+            return overflowAwareMutableLong.hasValue() ? overflowAwareMutableLong.value() : null;
+        }
+    );
+
+    private final Function function;
+
+    ArraySummationFunctions(Function function) {
+        this.function = function;
+    }
+
+    public Function getFunction() {
+        return function;
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/OverflowAwareMutableLongTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/OverflowAwareMutableLongTest.java
@@ -38,7 +38,7 @@ public class OverflowAwareMutableLongTest {
 
         assertThat(value.hasValue(), is(true));
         assertThat(value.primitiveSum(), is(10L));
-        assertThat(value.bigDecimalSum(), is(nullValue()));
+        assertThat(value.bigDecimalSum(), is(BigDecimal.ZERO));
         assertThat(value.value(), is(BigDecimal.TEN));
     }
 
@@ -61,8 +61,12 @@ public class OverflowAwareMutableLongTest {
         value.add(5L);
 
         var expected = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.TEN);
+        //Last 5 summand is added after the overflow, it's kept in primitive
+        var expectedBigDecimal = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.valueOf(5));
+
         assertThat(value.hasValue(), is(true));
-        assertThat(value.bigDecimalSum(), is(expected));
+        assertThat(value.bigDecimalSum(), is(expectedBigDecimal));
+        assertThat(value.primitiveSum(), is(5L));
         assertThat(value.value(), is(expected));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
@@ -1,0 +1,98 @@
+package io.crate.expression.scalar;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static io.crate.testing.Asserts.assertThrows;
+
+public class ArrayAvgFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_array_avg_on_long_array_returns_numeric() {
+        assertEvaluate("array_avg(long_array)",
+            new BigDecimal(Long.MAX_VALUE),
+            Literal.of(List.of(Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE), new ArrayType<>(DataTypes.LONG))
+        );
+    }
+
+    @Test
+    public void test_array_avg_on_short_array_returns_numeric() {
+        assertEvaluate("array_avg(short_array)",
+            new BigDecimal(Short.MAX_VALUE),
+            Literal.of(List.of(Short.MAX_VALUE, Short.MAX_VALUE, Short.MAX_VALUE), new ArrayType<>(DataTypes.SHORT))
+        );
+    }
+
+    @Test
+    public void test_array_avg_on_byte_array_returns_numeric() {
+        assertEvaluate("array_avg(?)",
+            new BigDecimal(Byte.MAX_VALUE),
+            Literal.of(List.of(Byte.MAX_VALUE, Byte.MAX_VALUE, Byte.MAX_VALUE), new ArrayType<>(DataTypes.BYTE))
+        );
+    }
+
+    @Test
+    public void test_array_avg_on_int_array_returns_numeric() {
+        assertEvaluate("array_avg(?)",
+            new BigDecimal(Integer.MAX_VALUE),
+            Literal.of(List.of(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new ArrayType<>(DataTypes.INTEGER))
+        );
+    }
+
+    @Test
+    public void test_array_avg_on_float_array_returns_float() {
+        assertEvaluate("array_avg([1.0, 2.0] :: real[])",
+            1.5f);
+    }
+
+    @Test
+    public void test_array_avg_on_double_array_returns_double() {
+        assertEvaluate("array_avg([1.0, 2.0] :: double precision[])",
+            1.5d);
+    }
+
+    @Test
+    public void test_array_avg_on_numeric_array_returns_numeric() {
+        assertEvaluate("array_avg(?)",
+            new BigDecimal(5.5d),
+            Literal.of(List.of(BigDecimal.ONE, BigDecimal.TEN), new ArrayType<>(DataTypes.NUMERIC))
+        );
+    }
+
+    @Test
+    public void test_array_avg_ignores_null_element_values() {
+        assertEvaluate("array_avg([null, 1])", BigDecimal.ONE);
+    }
+
+    @Test
+    public void test_all_elements_nulls_results_in_null() {
+        assertEvaluate("array_avg([null, null]::integer[])", null);
+    }
+
+    @Test
+    public void test_null_array_results_in_null() {
+        assertEvaluate("array_avg(null::int[])", null);
+    }
+
+    @Test
+    public void test_array_avg_returns_null_for_null_values() {
+        assertEvaluate("array_avg(null)", null);
+    }
+
+    @Test
+    public void test_empty_array_results_in_null() {
+        assertEvaluate("array_avg(cast([] as array(integer)))", null);
+    }
+
+    @Test
+    public void test_array_avg_with_array_of_undefined_inner_type_throws_exception() {
+        assertThrows(() -> assertEvaluate("array_avg([])", null),
+            UnsupportedOperationException.class,
+            "Unknown function: array_avg([]), no overload found for matching argument types: (undefined_array).");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Reuse sum functions for computing average
Update OverflowAwareMutableLong to use BigDecimal only on each overflow and then reset and keep using primitive

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
