### PR TITLE
Improve create tables doc, replication doc, and cluster settings doc

### DIFF
--- a/docs/appendices/glossary.rst
+++ b/docs/appendices/glossary.rst
@@ -349,7 +349,6 @@ S
 
         :ref:`sql_ddl_datatypes_primitives`
 
-
 .. _gloss-shard-allocation:
 
 **Shard allocation**
@@ -380,9 +379,9 @@ S
     shard.
 
     Shard recovery can happen during node startup, after node failure, when
-    :ref:`replicating <replication>` a primary shard, when moving a shard to
-    another node (i.e., when rebalancing the cluster), or during :ref:`snapshot
-    restoration <snapshot-restore>`.
+    :ref:`replicating <ddl-replication>` a primary shard, when moving a shard
+    to another node (i.e., when rebalancing the cluster), or during
+    :ref:`snapshot restoration <snapshot-restore>`.
 
     A shard that is being recovered cannot be queried until the recovery
     process is complete.

--- a/docs/concepts/resiliency.rst
+++ b/docs/concepts/resiliency.rst
@@ -26,11 +26,11 @@ unlikely to experience resiliency issues with CrateDB.
 .. contents::
    :local:
 
-Overview
-========
+
+.. _concept-resiliency-monitoring:
 
 Monitoring cluster status
--------------------------
+=========================
 
 .. figure:: resilience-status.png
    :alt:
@@ -47,8 +47,11 @@ The status is updated every few seconds (variable on your cluster `ping
 configuration
 <https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>`_).
 
+
+.. _concept-resiliency-consistency:
+
 Storage and consistency
------------------------
+=======================
 
 Code that expects the behavior of an `ACID
 <https://en.wikipedia.org/wiki/ACID>`_ compliant database like MySQL may not
@@ -58,9 +61,9 @@ CrateDB does not support ACID transactions, but instead has :ref:`atomic
 operations <concept-atomicity>` and :ref:`eventual consistency
 <concept-consistency>` at the row level. See also :ref:`concept-clustering`.
 
-Eventual consistency is the trade-off that CrateDB makes in exchange for high-
-availability that can tolerate most hardware and network failures. So you may
-observe data from different cluster nodes temporarily falling very briefly
+Eventual consistency is the trade-off that CrateDB makes in exchange for
+high-availability that can tolerate most hardware and network failures. So you
+may observe data from different cluster nodes temporarily falling very briefly
 out-of-sync with each other, although over time they will become consistent.
 
 For example, you know a row has been written as soon as you get the ``INSERT
@@ -70,8 +73,11 @@ typically occurs within one second).
 
 Your applications should be designed to work this storage and consistency model.
 
+
+.. _concept-resiliency-deployment:
+
 Deployment strategies
----------------------
+=====================
 
 When deploying CrateDB you should carefully weigh your need for
 high-availability and disaster recovery against operational complexity and

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -708,13 +708,82 @@ Routing allocation
 
   Defines how many concurrent recoveries are allowed on a node.
 
+
+.. _conf-routing-allocation-balance:
+
+Shard balancing
+...............
+
+You can configure how CrateDB attempts to balance shards across a cluster by
+specifying one or more property *weights*. CrateDB will consider a cluster to
+be balanced when no further allowed action can bring the weighted properties of
+each node closer together.
+
+.. NOTE::
+
+    Balancing may be restricted by other settings (e.g., :ref:`attribute-based
+    <conf-routing-allocation-awareness>` and :ref:`disk-based
+    <conf-routing-allocation-disk>` shard allocation).
+
+.. _cluster.routing.allocation.balance.shard:
+
+**cluster.routing.allocation.balance.shard**
+  | *Default:*   ``0.45f``
+  | *Runtime:*  ``yes``
+
+  Defines the weight factor for shards :ref:`allocated
+  <gloss-shard-allocation>` on a node (float). Raising this raises the tendency
+  to equalize the number of shards across all nodes in the cluster.
+
+.. _cluster.routing.allocation.balance.index:
+
+**cluster.routing.allocation.balance.index**
+  | *Default:*   ``0.55f``
+  | *Runtime:*  ``yes``
+
+  Defines a factor to the number of shards per index :ref:`allocated
+  <gloss-shard-allocation>` on a specific node (float). Increasing this value
+  raises the tendency to equalize the number of shards per index across all
+  nodes in the cluster.
+
+.. _cluster.routing.allocation.balance.threshold:
+
+**cluster.routing.allocation.balance.threshold**
+  | *Default:*   ``1.0f``
+  | *Runtime:*  ``yes``
+
+  Minimal optimization value of operations that should be performed (non
+  negative float). Increasing this value will cause the cluster to be less
+  aggressive about optimising the shard balance.
+
+
+.. _conf-routing-allocation-attributes:
+
+Attribute-based shard allocation
+................................
+
+You can control how shards are allocated to specific nodes by setting
+:ref:`custom attributes <conf-node-attributes>` on each node (e.g., server rack
+ID or node availability zone). After doing this, you can define
+:ref:`cluster-wide attribute awareness <conf-routing-allocation-awareness>` and
+then configure :ref:`cluster-wide attribute filtering
+<conf-routing-allocation-filtering>`.
+
+.. SEEALSO::
+
+    For an in-depth example of using custom node attributes, check out the
+    `multi-zone setup how-to guide`_.
+
+
 .. _conf-routing-allocation-awareness:
 
-Awareness
-.........
+Cluster-wide attribute awareness
+`````````````````````````````````
 
-Cluster allocation awareness allows to configure :ref:`shard allocation
-<gloss-shard-allocation>` across generic attributes associated with nodes.
+To make use of :ref:`custom attributes <conf-node-attributes>` for
+:ref:`attribute-based <conf-routing-allocation-attributes>` :ref:`shard
+allocation <gloss-shard-allocation>`, you must configure *cluster-wide
+attribute awareness*.
 
 .. _cluster.routing.allocation.awareness.attributes:
 
@@ -756,74 +825,22 @@ Cluster allocation awareness allows to configure :ref:`shard allocation
   when when we start one or more nodes with ``node.attr.zone`` set to
   ``zone2``.
 
-.. SEEALSO::
-
-    For a more in-depth example that uses custom node attributes, check out the
-    `multi-zone setup how-to guide`_.
-
-
-.. _conf-routing-allocation-balance:
-
-Balanced shards
-...............
-
-CrateDB will attempt to balance a cluster using the weights described in this
-subsection. The cluster is considered balanced when no further allowed action
-can bring the respective properties of each node closer together.
-
-.. NOTE::
-
-    Balancing may be restricted by other settings (e.g., forced :ref:`awareness
-    <conf-routing-allocation-awareness>`, :ref:`allocation filtering
-    <conf-routing-allocation-filtering>`, and :ref:`disk-based allocation
-    <cluster.routing.allocation.disk>`).
-
-.. _cluster.routing.allocation.balance.shard:
-
-**cluster.routing.allocation.balance.shard**
-  | *Default:*   ``0.45f``
-  | *Runtime:*  ``yes``
-
-  Defines the weight factor for shards :ref:`allocated
-  <gloss-shard-allocation>` on a node (float). Raising this raises the tendency
-  to equalize the number of shards across all nodes in the cluster.
-
-.. _cluster.routing.allocation.balance.index:
-
-**cluster.routing.allocation.balance.index**
-  | *Default:*   ``0.55f``
-  | *Runtime:*  ``yes``
-
-  Defines a factor to the number of shards per index :ref:`allocated
-  <gloss-shard-allocation>` on a specific node (float). Increasing this value
-  raises the tendency to equalize the number of shards per index across all
-  nodes in the cluster.
-
-.. _cluster.routing.allocation.balance.threshold:
-
-**cluster.routing.allocation.balance.threshold**
-  | *Default:*   ``1.0f``
-  | *Runtime:*  ``yes``
-
-  Minimal optimization value of operations that should be performed (non
-  negative float). Increasing this value will cause the cluster to be less
-  aggressive about optimising the shard balance.
-
 
 .. _conf-routing-allocation-filtering:
 
-Cluster-wide allocation filtering
-.................................
+Cluster-wide attribute filtering
+````````````````````````````````
 
-Control which shards are :ref:`allocated <gloss-shard-allocation>` to which
-nodes.
+To control how CrateDB uses :ref:`custom attributes <conf-node-attributes>` for
+:ref:`attribute-based <conf-routing-allocation-attributes>` :ref:`shard
+allocation <gloss-shard-allocation>`, you must configure *cluster-wide
+attribute filtering*.
 
-Filter definitions are retroactively enforced. If a filter prevents matching
-shards from being newly allocated to a node, existing matching shards will also
-be moved away.
+.. NOTE::
 
-E.g., this could be used to only allocate shards on nodes with specific IP
-addresses.
+    CrateDB will retroactively enforce filter definitions. If a new filter
+    would prevent newly created matching shards from being allocated to a node,
+    CrateDB would also move any *existing* matching shards away from that node.
 
 .. _cluster.routing.allocation.include.*:
 
@@ -859,7 +876,7 @@ addresses.
   contrast to include which will include a node if ANY rule matches.
 
 
-.. _cluster.routing.allocation.disk:
+.. _conf-routing-allocation-disk:
 
 Disk-based shard allocation
 ...........................

--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -1,47 +1,76 @@
-.. _sql_ddl_create:
+.. _ddl-create-table:
 
 ===============
 Creating tables
 ===============
+
+Tables are the basic building blocks of a relational database. A table can hold
+multiple rows (i.e., records), with each row having multiple columns and each
+column holding a single data element (i.e., value). You can :ref:`query <dql>`
+tables to :ref:`insert data <inserting_data>`, :ref:`select <sql_dql_queries>`
+(i.e., retrieve) data, and :ref:`delete data <dml_deleting_data>`.
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
-Basics
-======
 
-To create a table use the :ref:`sql-create-table` command. You must at least
-specify a name for the table and names and types of the columns.
+.. _ddl-create-table-definition:
 
-See :ref:`data-types` for information about the supported data types.
+Table definition
+================
 
-This query creates a simple table with two columns of type ``integer`` and
-``text``::
+To create a table, use the :ref:`sql-create-table` :ref:`statement
+<gloss-statement>`.
 
-    cr> create table my_table (
+At a minimum, you must specify a table name and one or more column
+definitions. A column definition must specify a column name and a corresponding
+:ref:`data type <data-types>`.
+
+Here's an example statement::
+
+    cr> CREATE TABLE my_table (
     ...   first_column integer,
     ...   second_column text
     ... );
     CREATE OK, 1 row affected (... sec)
 
-A table can be removed by using the :ref:`drop-table` command::
+This statement creates a table named ``my_table`` with two columns named
+``first_column`` and ``second_column`` with types :ref:`integer
+<data-type-numeric>` and :ref:`text <data-type-text>`.
 
-    cr> drop table my_table;
+A table can be dropped (i.e., deleted) by using the :ref:`drop-table`
+statement::
+
+    cr> DROP TABLE my_table;
     DROP OK, 1 row affected (... sec)
 
-The :ref:`drop-table` command takes the optional clause ``IF EXISTS`` which
-prevents the generation of an error if the specified table does not exist::
+If the ``my_table`` table did not exist, the ``DROP TABLE`` statement above
+would return an error message. If you specify the ``IF EXISTS`` clause, the
+instruction is conditional on the table's existence and would not return an
+error message::
 
-    cr> drop table if exists my_table;
+    cr> DROP TABLE IF EXISTS my_table;
     DROP OK, 0 rows affected (... sec)
 
+.. TIP::
 
-.. _sql_ddl_schemas:
+    By default, CrateDB will enforce the column definitions you specified with
+    the ``CREATE TABLE`` statement (what's known as a *strict* :ref:`column
+    policy <column_policy>`).
+
+    However, you can configure the :ref:`column_policy <column_policy>` table
+    parameter so that the :ref:`INSERT <ref-insert>`, :ref:`UPDATE
+    <ref-update>`, and :ref:`COPY FROM <sql-copy-from>` statements can
+    arbitrarily create new columns as needed (what's known as a *dynamic*
+    column policy).
+
+
+.. _ddl-create-table-schemas:
 
 Schemas
-=======
+-------
 
 Tables can be created in different schemas. These are created implicitly on
 table creation and cannot be created explicitly. If a schema did not exist yet,
@@ -71,16 +100,16 @@ We can confirm this by looking up this table in the
 
 The following schema names are reserved and may not be used:
 
- - blob
- - information_schema
- - sys
+- ``blob``
+- ``information_schema``
+- ``sys``
 
 .. TIP::
 
    Schemas are primarily namespaces for tables. You can use :ref:`privileges
    <administration-privileges>` to control access to schemas.
 
-A user created schema exists as long as there are tables with the same schema
+A user-created schema exists as long as there are tables with the same schema
 name. If the last table with that schema is dropped, the schema is gone (except
 for the ``blob`` and ``doc`` schema)::
 
@@ -112,10 +141,11 @@ the ``doc`` schema::
     cr> drop table my_doc_table;
     DROP OK, 1 row affected (... sec)
 
-.. _sql_ddl_naming_restrictions:
+
+.. _ddl-create-table-naming:
 
 Naming restrictions
-===================
+-------------------
 
 Table, schema and column identifiers cannot have the same names as reserved key
 words. Please refer to the :ref:`sql_lexical` section for more information
@@ -147,15 +177,76 @@ Column names are restricted in terms of patterns:
     :ref:`subscript notation <sql_dql_object_arrays>` (e.g. ``col['id']``) are
     not allowed.
 
-Advanced use
-============
 
-Tables can be:
+.. _ddl-create-table-configuration:
 
-- :ref:`Clustered <sql-create-table-clustered>` into multiple :ref:`shards
-  <ddl-sharding>`
-- :ref:`sql-create-table-partitioned-by` one or more columns (to create
-  :ref:`partitioned tables <partitioned-tables>`)
-- Fine-tuned with :ref:`table paramaters <sql-create-table-with>` (e.g., to
-  configure :ref:`replication <replication>`)
+Table configuration
+===================
 
+You can configure tables in many different ways to take advantage of the range
+of functionality that CrateDB supports. For example:
+
+.. rst-class:: open
+
+- CrateDB transparently segments the underlying storage of table data into
+  :ref:`shards <ddl-sharding>` (four by default). You can configure the number
+  of shards with the :ref:`CLUSTERED BY <sql-create-table-clustered>`
+  clause. You control how CrateDB routes table rows to shards by specifying a
+  :ref:`routing column <gloss-routing-column>`.
+
+  You can use :ref:`cluster settings <conf_routing>` to configure how shards
+  are :ref:`balanced <conf-routing-allocation-balance>` across a cluster and
+  :ref:`allocated <ddl_shard_allocation>` to nodes (with :ref:`attribute-based
+  allocation <conf-routing-allocation-attributes>`, :ref:`disk-based allocation
+  <conf-routing-allocation-disk>`, or both).
+
+  .. SEEALSO::
+
+      `How-to guides: Tuning sharding performance`_
+
+- You can :ref:`replicate <ddl-replication>` shards :ref:`WITH
+  <sql-create-table-with>` the :ref:`number_of_replicas
+  <sql-create-table-number-of-replicas>` table setting. CrateDB will split
+  replicated partitions into primary shards, with each primary shard having one
+  or more replica shards.
+
+  When you lose a primary shard (e.g., due to node failure), CrateDB will
+  promote a replica shard to primary. More table replicas mean a smaller chance
+  of permanent data loss (through increased `data redundancy`_) in exchange for
+  more disk space utilization and intra-cluster network traffic.
+
+  Replication can also improve read performance because any increase in the
+  number of shards distributed across a cluster also increases the
+  opportunities for CrateDB to `parallelize`_ query execution across multiple
+  nodes.
+
+- You can :ref:`partition <partitioned-tables>` a table into one or more
+  partitions with the :ref:`PARTITIONED BY <sql-create-table-partitioned-by>`
+  clause. You control how tables are partitioned by specifying one or more
+  :ref:`partition columns <gloss-partition-column>`. Each unique combination of
+  partition column values results in a new partition.
+
+  By partitioning a table, you can segment some :ref:`SQL statements
+  <gloss-statement>` (e.g., those used for :ref:`table optimization
+  <optimize>`, :ref:`import and export <importing_data>`, and :ref:`backup and
+  restore <snapshot-restore>`) by constraining them to one or more partitions.
+
+  .. SEEALSO::
+
+      `How-to guides: Tuning partitions for insert performance`_
+
+- You can fine-tune table operation by setting table parameters using the
+  :ref:`WITH <sql-create-table-with>` clause. Available parameters include
+  those used to configure replication, sharding, :ref:`refresh interval
+  <sql-create-table-refresh-interval>`, read and write operations, soft
+  deletes, :ref:`durability <concept-durability>`, :ref:`column policy
+  <column_policy>`, and more.
+
+
+.. _data availability: https://en.wikipedia.org/wiki/High_availability
+.. _data redundancy: https://en.wikipedia.org/wiki/Data_redundancy
+.. _disaster recovery: https://en.wikipedia.org/wiki/Disaster_recovery
+.. _How-to guides\: Tuning partitions for insert performance: https://crate.io/docs/crate/howtos/en/latest/performance/inserts/bulk.html#split-your-tables-into-partitions
+.. _How-to guides\: Tuning sharding performance: https://crate.io/docs/crate/howtos/en/latest/performance/sharding.html
+.. _parallelize: https://en.wikipedia.org/wiki/Distributed_computing
+.. _service resilience: https://en.wikipedia.org/wiki/Resilience_(network)

--- a/docs/general/ddl/partitioned-tables.rst
+++ b/docs/general/ddl/partitioned-tables.rst
@@ -97,7 +97,7 @@ Partitioned tables have the following disadvantages:
     - An internal overhead of 14 bytes
 
     Altogether, the table name length must not exceed the :ref:`255 bytes
-    length limitation <sql_ddl_naming_restrictions>`.
+    length limitation <ddl-create-table-naming>`.
 
 .. CAUTION::
 

--- a/docs/general/ddl/replication.rst
+++ b/docs/general/ddl/replication.rst
@@ -1,73 +1,180 @@
-.. _replication:
+.. _ddl-replication:
 
 ===========
 Replication
 ===========
 
-Replication of a table in CrateDB means that each primary shard of a table is
-stored additionally on so called secondary shards. This can be useful for
-better read performance and high availability.
+You can configure CrateDB to *replicate* tables. When you configure
+replication, CrateDB will try to ensure that every table :ref:`shard
+<ddl-sharding>` has one or more copies available at all times.
 
-If not specified, CrateDB creates zero to one replica depending on the number
-of available nodes at the cluster. At a single-node cluster, replicas are set
-to zero to allow fast write operations with the default setting of
-:ref:`sql-create-table-write-wait-for-active-shards`.
+When there are multiple copies of the same shard, CrateDB will mark one as the
+*primary shard* and treat the rest as *replica shards*. Write operations
+always go to the primary shard, whereas read operations can go to any
+shard. CrateDB continually synchronizes data from the primary shard to all
+replica shards (through a process known as :ref:`shard recovery
+<gloss-shard-recovery>`).
+
+When a primary shard is lost (e.g., due to node failure), CrateDB will promote
+a replica shard to primary. Hence, more table replicas mean a smaller chance of
+permanent data loss (through increased `data redundancy`) in exchange for more
+disk space utilization and intra-cluster network traffic.
+
+Replication can also improve read performance because any increase in the
+number of shards distributed across a cluster also increases the opportunities
+for CrateDB to `parallelize`_ query execution across multiple nodes.
 
 .. rubric:: Table of contents
 
 .. contents::
-    :local:
+   :local:
 
-Configuration
-=============
 
-Defining the number of replicas is done using the
-:ref:`sql-create-table-number-of-replicas` property.
+.. _ddl-replication-config:
 
-Example::
+Table configuration
+===================
 
-    cr> create table my_table10 (
+You can configure the number of per-shard replicas :ref:`WITH
+<sql-create-table-with>` the :ref:`sql-create-table-number-of-replicas` table
+setting.
+
+For example::
+
+    cr> CREATE TABLE my_table (
     ...   first_column integer,
     ...   second_column text
-    ... ) with (number_of_replicas = 0);
+    ... ) WITH (number_of_replicas = 0);
     CREATE OK, 1 row affected (... sec)
 
-The ``number_of_replicas`` property also accepts an string as parameter that
-contains a ``range``.
+As well as being able to configure a fixed number of replicas, you can
+configure a range of values by using a string to specify a minimum and a
+maximum (dependent on the number of nodes in the cluster).
 
-A range is a definition of minimum number of replicas to maximum number of
-replicas depending on the number of nodes in the cluster. The table below shows
-some examples.
+Here are some examples of replica ranges:
 
-===== =========================================================================
-Range Explanation
-===== =========================================================================
-0-1   Will create no replicas if only one node. This will result in a yellow
-      cluster health.
+========= =====================================================================
+Range     Explanation
+========= =====================================================================
+``0-1``   If you only have one node, CrateDB will not create any replicas. If
+          you have more than one node, CreateDB will create one replica per
+          shard.
 
-      One replica if more than one node.
------ -------------------------------------------------------------------------
-2-4   Table requires at least two replicas to be fully replicated.
+          This range is the default value.
+--------- ---------------------------------------------------------------------
+``2-4``   Each table will require at least two replicas for CrateDB to consider
+          it fully replicated (i.e., a *green* replication :ref:`health status
+          <sys-health-def>`).
 
-      Will create up to four replicas if nodes are added.
+          If the cluster has five nodes, CrateDB will create four replicas and
+          allocate each one to a node that does not hold the corresponding
+          primary.
 
-      If you have less than three nodes, one or more replica shards will be
-      located on the same node as the primary shard. This will result in a
-      yellow cluster health.
------ -------------------------------------------------------------------------
-0-all Will expand the number of replicas to the available number of nodes.
-===== =========================================================================
+          Suppose a cluster has four nodes or fewer. In that case, CrateDB will
+          be unable to allocate every replica to a node that does not hold the
+          corresponding primary, putting the table into :ref:`underreplication
+          <ddl-replication-underreplication>`. As a result, CrateDB will give
+          the table a *yellow* replication :ref:`health status
+          <sys-health-def>`.
+--------- ---------------------------------------------------------------------
+``0-all`` CrateDB will create one replica shard for every node that is
+          available in addition to the node that holds the primary shard.
+========= =====================================================================
 
-For details of the range syntax refer to :ref:`the CREATE TABLE
-documentation <sql-create-table-number-of-replicas>`.
+If you do not specify a ``number_of_replicas``, CrateDB will create one or zero
+replicas, depending on the number of available nodes at the cluster (e.g., on a
+single-node cluster, ``number_of_replicas`` will be set to zero to allow fast
+write operations with the default setting of
+:ref:`sql-create-table-write-wait-for-active-shards`).
 
-.. NOTE::
-
-    The number of replicas can be changed at any time.
+You can change the :ref:`sql-create-table-number-of-replicas` setting at any
+time.
 
 .. SEEALSO::
 
-    The `Admin UI`_ indicates the health of your data.  This information call
-    also be queried via the :ref:`sys.health <sys-health>` table.
+    :ref:`CREATE TABLE: WITH clause <sql-create-table-number-of-replicas>`
 
-.. _Admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
+
+.. _ddl-replication-recovery:
+
+Shard recovery
+==============
+
+CrateDB :ref:`allocates <gloss-shard-allocation>` each primary and replica
+shard to a specific node. You can control this behavior by configuring the
+:ref:`allocation <conf_routing>` settings.
+
+If one or more nodes become unavailable (e.g., due to hardware failure or
+network issues), CrateDB will try to recover a replicated table by doing the
+following:
+
+.. rst-class:: open
+
+- For every lost primary shard, locate a replica and promote it to primary.
+
+  When CrateDB promotes a replica to primary, it can no longer function as a
+  replica, and so the total number of replicas decreases by one. Because each
+  primary requires a fixed :ref:`sql-create-table-number-of-replicas`, a new
+  replica has to be created (see next item).
+
+- For every primary with too few replicas (due to node loss or replica
+  promotion), use the primary shard to :ref:`recover <gloss-shard-recovery>`
+  the required number of replicas.
+
+Shard recovery is one of the features that allows CrateDB to provide continuous
+`availability`_ and `partition tolerance`_ in exchange for some
+:ref:`consistency trade-offs <concept-resiliency-consistency>`.
+
+.. SEEALSO::
+
+    `Wikipedia: CAP theorem`_
+
+.. _ddl-replication-underreplication:
+
+Underreplication
+================
+
+Having more replicas per primary and distributing shards as thinly as possible
+(i.e., fewer shards per node) can both increase chances of a :ref:`successful
+recovery <ddl-replication-recovery>` in the event of node loss.
+
+Although not ideal, a single node can hold multiple shards belonging to the
+same table. For example, suppose a table has more shards (primaries and
+replicas) than nodes available in the cluster. In that case, CrateDB
+will determine the safest way to allocate all shards to the nodes available.
+
+However, there is one restriction. Suppose a single node held the primary and a
+replica of the same shard. If that node were lost, CrateDB would be unable to
+use either copy of the shard for :ref:`recovery <ddl-replication-recovery>`,
+effectively nullifying the purpose of the replica. In addition, if the shard
+had no other replicas and no :ref:`backups <snapshot-restore>` exist, the data
+contained in that shard may be permanently lost.
+
+For this reason, CrateDB will never allocate the primary and a replica of the
+same shard to a single node.
+
+The above rule means that for *one* shard and *n* replicas, a cluster must have
+at least *n + 1* available nodes for CrateDB to fully replicate all
+shards. When CrateDB cannot fully replicate all shards, the table enters a state
+known as *underreplication*.
+
+CrateDB gives underreplicated tables a *yellow* :ref:`health status
+<sys-health-def>`.
+
+.. TIP::
+
+    The `CrateDB Admin UI`_ provides visual indicators of cluster health that
+    take replication status into account.
+
+    Alternatively, you can query health information directly from the
+    :ref:`sys.health <sys-health>` table and replication information from the
+    :ref:`sys.shards <sys-shards>` and :ref:`sys.allocations <sys-allocations>`
+    tables.
+
+
+.. _availability: https://en.wikipedia.org/wiki/Availability
+.. _CrateDB Admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
+.. _data redundancy: https://en.wikipedia.org/wiki/Data_redundancy
+.. _parallelize: https://en.wikipedia.org/wiki/Distributed_computing
+.. _partition tolerance: https://en.wikipedia.org/wiki/Network_partitioning
+.. _Wikipedia\: CAP theorem: https://en.wikipedia.org/wiki/CAP_theorem

--- a/docs/sql/statements/create-snapshot.rst
+++ b/docs/sql/statements/create-snapshot.rst
@@ -44,8 +44,8 @@ must be unique per repository.
 
 .. NOTE::
 
-   For snapshot names the same :ref:`restrictions
-   <sql_ddl_naming_restrictions>` as for table names apply.
+   For snapshot names the same :ref:`restrictions <ddl-create-table-naming>` as
+   for table names apply.
 
    This is mainly because snapshot names will likely become stored as file or
    directory on disc and hence must be valid filenames.

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -95,7 +95,7 @@ use when the constraint only affects one column.
 
 .. SEEALSO::
 
-    :ref:`Data definition: Creating tables <sql_ddl_create>`
+    :ref:`Data definition: Creating tables <ddl-create-table>`
 
 
 .. _sql-create-table-elements:
@@ -356,7 +356,7 @@ The number of replicas is defined like this::
 
 .. SEEALSO::
 
-    :ref:`replication`
+    :ref:`ddl-replication`
 
 
 .. _sql-create-table-number-of-routing-shards:
@@ -479,7 +479,7 @@ Allows to have a read only table that additionally can be deleted.
 .. SEEALSO::
 
     :ref:`Cluster-wide settings: Disk-based shard allocation
-    <cluster.routing.allocation.disk>`
+    <conf-routing-allocation-disk>`
 
 
 .. _sql-create-table-blocks-read:
@@ -853,8 +853,6 @@ The column policy is defined like this::
 .. SEEALSO::
 
     :ref:`Data definition: Column policy <column_policy>`
-
-    :ref:`config`
 
 
 .. _sql-create-table-max-ngram-diff:


### PR DESCRIPTION
this PR replaces https://github.com/crate/crate/pull/11319 (see comments for details)

once review is finished, I will update the commit message to reflect the changes made

---

Closes <#11238>.

Specifically:

- Reworked the "Creating tables" page:

  - Added a proper introduction to the topic

  - Renamed the "Basics" section to "Table definition" and moved the "Schemas" and "Naming restrictions" under it as subsections.

  - A new admonition specifically to advertise the `column_policy` table setting (because I think dynamic columns are a key feature of CrateDB and this is relevant to table schema definition).

  - Reworded a lot of the text.

  - Improved use of RST labels and some minor RST reformatting.

  - Renamed the "Advanced use" use section to "Table configuration" and expanded the section by quite a bit to highlight what I think as some of the key features related to table settings (and table creation more generally).

    I added lots of explanation because I noticed that some of this is not really made explicit anywhere else.

- Completely reworked the "Replication" page:

  - While working on the "Creating tables" page I was trying to explain the benefits of replication and I could not find anything in the docs that explicitly talks about the fact that one of the primary benefits of replication is the fact that replica shards can be promoted to primary in the case of node loss.

    I thought this issue was important enough (and related to my other work) that I should address it immediately.

  - Reworded and expanded the intro. Reworded and moved a note about cluster health here.

  - Removed the TOC and the single "Configuration" header. There is no need to add either if there is only one section on the page.

    Reworded the rest of the content that was under this heading.

- Improvements for the "Cluster settings" page:

  - Moved "Shard balancing" to the top of the "Routing allocation" section because the rest of the subsections are closely related to each other and I think they benefit from being ordered sequentially.

  - Created a new subsection called "Attribute-based shard allocation" that groups together the next two sections:

    - "Cluster-wide attribute awareness" (renamed from "Awareness")
    - "Cluster-wide attribute filtering" (renamed from "Cluster-wide allocation filtering")

    My hope for the renaming is that overall it makes it more clear what these things do (putting custom attributes to work) and how they relate to each other (see next item).

  - Added intros to all three sections mentioned above.

    I wanted to better advertise the custom attribute functionality. Prior to this change:

    - There was no *clear* connection made between custom attributes and "awareness" or "allocation filtering" making it difficult to understand what the latter two configuration options were for.

    - It was difficult to grasp what custom attributes are useful for.

    While not specifically related to table settings, I did this because I think this is a key feature of CrateDB that deserves better highlighting.

- Other files:

    - Minor updates to reflect renamed RST labels

