### PR TITLE
Fix optimizer rule moving filters beneath window aggregations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -89,6 +89,15 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that resulted in a non-executable plan if a windows function
+  result from a sub-select is used inside a query filter. An example::
+
+      SELECT * FROM (
+        SELECT ROW_NUMBER() OVER(PARTITION by col1) as row_num
+        FROM (VALUES('x')) t1
+      ) t2
+      WHERE row_num = 2;
+
 - Fixed an issue that caused valid values for ``number_of_routing_shards`` in
   ``CREATE TABLE`` statements to be rejected because the validation always used
   a fixed value of ``5`` instead of the actual number of shards declared within

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -170,4 +170,13 @@ public final class TableFunction implements LogicalPlan {
             .text(where.queryOrFallback().toString())
             .text("]");
     }
+
+    @Override
+    public String toString() {
+        return "TableFunction{" +
+            "relation=" + relation +
+            ", toCollect=" + toCollect +
+            ", where=" + where +
+            '}';
+    }
 }

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -21,21 +21,9 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.execution.dsl.phases.ExecutionPhases.executesOnHandler;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Function;
-
-import javax.annotation.Nullable;
-
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -55,6 +43,18 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.distribution.DistributionType;
 import io.crate.statistics.TableStats;
 
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static io.crate.execution.dsl.phases.ExecutionPhases.executesOnHandler;
+
 public class WindowAgg extends ForwardingLogicalPlan {
 
     final WindowDefinition windowDefinition;
@@ -62,7 +62,8 @@ public class WindowAgg extends ForwardingLogicalPlan {
     private final List<Symbol> standalone;
     private final List<Symbol> outputs;
 
-    static LogicalPlan create(LogicalPlan source, List<WindowFunction> windowFunctions) {
+    @VisibleForTesting
+    public static LogicalPlan create(LogicalPlan source, List<WindowFunction> windowFunctions) {
         if (windowFunctions.isEmpty()) {
             return source;
         }
@@ -126,7 +127,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
         return new WindowAgg(newSource, windowDefinition, List.copyOf(newWindowFunctions), newSource.outputs());
     }
 
-    List<WindowFunction> windowFunctions() {
+    public List<WindowFunction> windowFunctions() {
         return windowFunctions;
     }
 
@@ -239,6 +240,10 @@ public class WindowAgg extends ForwardingLogicalPlan {
 
     @Override
     public String toString() {
-        return "WindowAgg{[" + Lists2.joinOn(", ", windowFunctions, WindowFunction::toString) + "]}";
+        return "WindowAgg{" +
+            "source=" + source + ", " +
+            "windowDefinition=" + windowDefinition + ", " +
+            "windowFunctions=[" + Lists2.joinOn(", ", windowFunctions, WindowFunction::toString) + "]" +
+            "}";
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -22,9 +22,12 @@
 package io.crate.planner.optimizer.rule;
 
 import io.crate.analyze.WindowDefinition;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
+import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
@@ -32,6 +35,11 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 
 import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
@@ -55,16 +63,84 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter plan,
+    public LogicalPlan apply(Filter filter,
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx) {
         WindowAgg windowAgg = captures.get(windowAggCapture);
         WindowDefinition windowDefinition = windowAgg.windowDefinition();
-        if (windowDefinition.partitions().containsAll(extractColumns(plan.query()))) {
-            return transpose(plan, windowAgg);
+        List<WindowFunction> windowFunctions = windowAgg.windowFunctions();
+
+        Predicate<Symbol> containsWindowFunction =
+            symbol -> symbol instanceof WindowFunction && windowFunctions.contains(symbol);
+
+        Symbol predicate = filter.query();
+        List<Symbol> filterParts = AndOperator.split(predicate);
+
+        ArrayList<Symbol> remainingFilterSymbols = new ArrayList<>();
+        ArrayList<Symbol> windowPartitionedBasedFilters = new ArrayList<>();
+
+        for (Symbol part : filterParts) {
+            if (SymbolVisitors.any(containsWindowFunction, part) == false
+                && windowDefinition.partitions().containsAll(extractColumns(part))) {
+                windowPartitionedBasedFilters.add(part);
+            } else {
+                remainingFilterSymbols.add(part);
+            }
         }
-        return null;
+        assert remainingFilterSymbols.size() > 0 || windowPartitionedBasedFilters.size() > 0 :
+            "Splitting the filter symbol must result in at least one group";
+
+        /* SELECT ROW_NUMBER() OVER(PARTITION BY id)
+         * WHERE `x = 1`
+         *
+         * `x` is not the window partition column.
+         * We cannot push down the filter as it would change the window aggregation value
+         *
+         */
+        if (windowPartitionedBasedFilters.isEmpty()) {
+            return null;
+        }
+
+        /* SELECT ROW_NUMBER() OVER(PARTITION BY id)
+         * WHERE `id = 1`
+         * remainingFilterSymbols:                  []
+         * windowPartitionedBasedFilters:           [id = 1]
+         *
+         * Filter
+         *  |
+         * WindowsAgg
+         *
+         * transforms to
+         *
+         * WindowAgg
+         *  |
+         * Filter (id = 1)
+         */
+        if (remainingFilterSymbols.isEmpty()) {
+            return transpose(filter, windowAgg);
+        }
+
+        /* WHERE `ROW_NUMBER() OVER(PARTITION BY id) = 2 AND id = 1`
+         * remainingFilterSymbols:                  [ROW_NUMBER() OVER(PARTITION BY id) = 2]
+         * windowPartitionedBasedFilters:           [id = 1]
+         *
+         * Filter
+         *  |
+         * WindowsAgg
+         *
+         * transforms to
+         *
+         * Filter (ROW_NUMBER() OVER(PARTITION BY id) = 2)
+         *  |
+         * WindowAgg
+         *  |
+         * Filter (id = 1)
+         */
+        LogicalPlan newWindowAgg = windowAgg.replaceSources(
+            List.of(new Filter(windowAgg.source(), AndOperator.join(windowPartitionedBasedFilters))));
+
+        return new Filter(newWindowAgg, AndOperator.join(remainingFilterSymbols));
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.WindowFunction;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.WindowAgg;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t1 (id int, x int)")
+            .build();
+    }
+
+    @Test
+    public void test_filter_on_containing_windows_function_is_not_moved() {
+        var collect = e.logicalPlan("SELECT id FROM t1");
+
+        WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION by id)");
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+
+        Symbol query = e.asSymbol("ROW_NUMBER() OVER(PARTITION by id) = 2");
+        Filter filter = new Filter(windowAgg, query);
+
+        var rule = new MoveFilterBeneathWindowAgg();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent(), is(true));
+        assertThat(match.value(), Matchers.sameInstance(filter));
+
+        LogicalPlan newPlan = rule.apply(
+            match.value(),
+            match.captures(),
+            new TableStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx
+        );
+
+        assertThat(newPlan, nullValue());
+    }
+
+    @Test
+    public void test_filter_containing_columns_not_part_of_the_window_partition_cannot_be_moved() {
+        var collect = e.logicalPlan("SELECT id, x FROM t1");
+
+        WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION by id)");
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+
+        Symbol query = e.asSymbol("x = 1");
+        Filter filter = new Filter(windowAgg, query);
+
+        var rule = new MoveFilterBeneathWindowAgg();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent(), is(true));
+        assertThat(match.value(), Matchers.sameInstance(filter));
+
+        LogicalPlan newPlan = rule.apply(
+            match.value(),
+            match.captures(),
+            new TableStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx
+        );
+
+        assertThat(newPlan, nullValue());
+    }
+
+    @Test
+    public void test_filter_on_windows_function_partition_columns_is_moved() {
+        var collect = e.logicalPlan("SELECT id FROM t1");
+
+        WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id)");
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+
+        Symbol query = e.asSymbol("id = 10");
+        Filter filter = new Filter(windowAgg, query);
+
+        var rule = new MoveFilterBeneathWindowAgg();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent(), is(true));
+        assertThat(match.value(), Matchers.sameInstance(filter));
+
+        LogicalPlan newPlan = rule.apply(
+            match.value(),
+            match.captures(),
+            new TableStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx
+        );
+        var expectedPlan =
+            "WindowAgg[id, row_number() OVER (PARTITION BY id)]\n" +
+            "  └ Filter[(id = 10)]\n" +
+            "    └ Collect[doc.t1 | [id] | true]";
+
+        assertThat(newPlan, isPlan(expectedPlan));
+    }
+
+    @Test
+    public void test_filter_part_on_windows_function_partition_columns_is_moved() {
+        var collect = e.logicalPlan("SELECT id FROM t1");
+
+        WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id)");
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+
+        Symbol query = e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id) = 2 AND id = 10 AND x = 1");
+        Filter filter = new Filter(windowAgg, query);
+
+        var rule = new MoveFilterBeneathWindowAgg();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent(), is(true));
+        assertThat(match.value(), Matchers.sameInstance(filter));
+
+        LogicalPlan newPlan = rule.apply(
+            match.value(),
+            match.captures(),
+            new TableStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx
+        );
+        var expectedPlan =
+            "Filter[((row_number() OVER (PARTITION BY id) = 2) AND (x = 1))]\n" +
+            "  └ WindowAgg[id, row_number() OVER (PARTITION BY id)]\n" +
+            "    └ Filter[(id = 10)]\n" +
+            "      └ Collect[doc.t1 | [id] | true]";
+
+        assertThat(newPlan, isPlan(expectedPlan));
+    }
+
+    @Test
+    public void test_filters_combined_by_OR_cannot_be_moved() {
+        var collect = e.logicalPlan("SELECT id FROM t1");
+
+        WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id)");
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+
+        Symbol query = e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id) = 1 OR id = 10");
+        Filter filter = new Filter(windowAgg, query);
+
+        var rule = new MoveFilterBeneathWindowAgg();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent(), is(true));
+        assertThat(match.value(), Matchers.sameInstance(filter));
+
+        LogicalPlan newPlan = rule.apply(
+            match.value(),
+            match.captures(),
+            new TableStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx
+        );
+        assertThat(newPlan, nullValue());
+    }
+}


### PR DESCRIPTION
A filter symbol containing a window function of the window aggregation
must stay on top of the aggregation and must not moved down.

Fixes #11361.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
