### PR TITLE
Fix create snapshot of concrete tables only

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -94,6 +94,12 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that resulted in more data being snapshot than expected if
+  only concrete tables were snapshot by the
+  ``CREATE SNAPSHOT ... TABLE [table, ...]``. Instead of just the concrete
+  tables, also the metadata of partitioned table, views, users, etc. were
+  falsely stored.
+
 - Fixed an issue that resulted in a non-executable plan if a windows function
   result from a sub-select is used inside a query filter. An example::
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.cluster.snapshots.create;
 
 import org.elasticsearch.ElasticsearchGenerationException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -68,6 +69,8 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
 
     private String[] indices = EMPTY_ARRAY;
 
+    private String[] templates = EMPTY_ARRAY;
+
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     private boolean partial = false;
@@ -98,6 +101,9 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
         repository = in.readString();
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (in.getVersion().after(Version.V_4_5_1)) {
+            templates = in.readStringArray();
+        }
         settings = readSettingsFromStream(in);
         includeGlobalState = in.readBoolean();
         waitForCompletion = in.readBoolean();
@@ -111,6 +117,9 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
         out.writeString(repository);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
+        if (out.getVersion().after(Version.V_4_5_1)) {
+            out.writeStringArray(templates);
+        }
         writeSettingsToStream(settings, out);
         out.writeBoolean(includeGlobalState);
         out.writeBoolean(waitForCompletion);
@@ -214,6 +223,15 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
     public CreateSnapshotRequest indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
         return this;
+    }
+
+    public CreateSnapshotRequest templates(List<String> templates) {
+        this.templates = templates.toArray(new String[0]);
+        return this;
+    }
+
+    public String[] templates() {
+        return templates;
     }
 
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -293,6 +293,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         request.includeGlobalState(), request.partial(),
                         State.INIT,
                         snapshotIndices,
+                        List.of(request.templates()),
                         threadPool.absoluteTimeInMillis(),
                         repositoryData.getGenId(),
                         null,
@@ -596,6 +597,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             Metadata.Builder builder = Metadata.builder();
             for (IndexId index : snapshot.indices()) {
                 builder.put(metadata.index(index.getName()), false);
+            }
+            for (String template : snapshot.templates()) {
+                builder.put(metadata.templates().get(template));
             }
             metadata = builder.build();
         }

--- a/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -194,6 +194,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
             e,
             "CREATE SNAPSHOT my_repo.my_snapshot TABLE users, locations " +
             "WITH (wait_for_completion=true)");
+        assertThat(request.includeGlobalState(), is(false));
         assertThat(request.indices(), arrayContainingInAnyOrder("users", "locations"));
         assertThat(request.repository(), is("my_repo"));
         assertThat(request.snapshot(), is("my_snapshot"));
@@ -258,6 +259,8 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
                 ".partitioned.parted.0400",
                 ".partitioned.parted.04732cpp6ksjcc9i60o30c1g")
         );
+        assertThat(request.includeGlobalState(), is(false));
+        assertThat(request.templates(), arrayContainingInAnyOrder(".partitioned.parted."));
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/cluster/SnapshotsInProgressTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SnapshotsInProgressTests.java
@@ -65,7 +65,7 @@ public class SnapshotsInProgressTests extends ESTestCase {
         // test no waiting shards in an index
         shards.put(new ShardId(idx3Name, idx3UUID, 0), new ShardSnapshotStatus(randomAlphaOfLength(2), randomNonWaitingState(), "", "1"));
         Entry entry = new Entry(snapshot, randomBoolean(), randomBoolean(), State.INIT,
-                                indices, System.currentTimeMillis(), randomLong(), shards.build(), randomBoolean());
+                                indices, List.of(), System.currentTimeMillis(), randomLong(), shards.build(), randomBoolean());
 
         ImmutableOpenMap<String, List<ShardId>> waitingIndices = entry.waitingIndices();
         assertEquals(2, waitingIndices.get(idx1Name).size());

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -60,6 +60,13 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
         for (int i = 0; i < numberOfIndices; i++) {
             indices.add(new IndexId(randomAlphaOfLength(10), randomAlphaOfLength(10)));
         }
+        List<String> templates = new ArrayList<>();
+        if (includeGlobalState == false) {
+            int numberOfTemplates = randomIntBetween(0, 5);
+            for (int i = 0; i < numberOfTemplates; i++) {
+                templates.add(randomAlphaOfLength(10));
+            }
+        }
         long startTime = randomLong();
         long repositoryStateId = randomLong();
         ImmutableOpenMap.Builder<ShardId, SnapshotsInProgress.ShardSnapshotStatus> builder = ImmutableOpenMap.builder();
@@ -79,7 +86,7 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
             }
         }
         ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards = builder.build();
-        return new Entry(snapshot, includeGlobalState, partial, state, indices, startTime, repositoryStateId, shards, randomBoolean());
+        return new Entry(snapshot, includeGlobalState, partial, state, indices, templates, startTime, repositoryStateId, shards, randomBoolean());
     }
 
     @Override


### PR DESCRIPTION
The ``CREATE SNAPSHOT`` logic always included the global meta state
even if only concrete (partitioned) tables or partitions were defined
to be stored.
Thus more metada data was stored as the user wanted to.

This commit changes the logic now to only include possible partition
table templates beside the concrete indices but no gobal meta state.
The global state is only stored if ``ALL`` is used.

Fixes #11365.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
