### PR TITLE
Fix incorrect classification for DELETE/UPDATE with sub-select

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -113,3 +113,6 @@ Fixes
   ``CREATE TABLE`` statements to be rejected because the validation always used
   a fixed value of ``5`` instead of the actual number of shards declared within
   the ``CREATE TABLE`` statement.
+
+- Fixed an issue that caused incorrect classification for DELETE and UPDATE
+  queries with sub-select. Statement type for those queries was always SELECT.

--- a/server/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/server/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -66,7 +66,7 @@ public class MultiPhasePlan implements Plan {
 
     @Override
     public StatementType type() {
-        return StatementType.SELECT;
+        return rootPlan.type();
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
+++ b/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 
 import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
@@ -131,5 +132,21 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
         classification = StatementClassifier.classify(plan);
         assertThat(classification.type(), is(Plan.StatementType.INSERT));
         assertThat(classification.labels(), contains("TableFunction"));
+    }
+
+    @Test
+    public void test_classify_multiphase_delete_statement() {
+        Plan plan = e.plan("DELETE FROM users WHERE id in (SELECT id from users)");
+        StatementClassifier.Classification classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.DELETE));
+        assertThat(classification.labels(), is(empty()));
+    }
+
+    @Test
+    public void test_classify_multiphase_update_statement() {
+        Plan plan = e.plan("UPDATE users set name = 'a' WHERE id in (SELECT id from users)");
+        StatementClassifier.Classification classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.UPDATE));
+        assertThat(classification.labels(), is(empty()));
     }
 }


### PR DESCRIPTION
Fix incorrect classification for DELETE/UPDATE queries with sub-select in sys.jobs_log

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
