### PR TITLE
Implement DocValueAggregator for HLL DISTINCT.

### DIFF
--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -141,7 +141,7 @@ public class HyperLogLogDistinctAggregationBenchmark {
         for (int i = 0; i < rows.size(); i++) {
             String value = DataTypes.STRING.sanitizeValue(rows.get(i).get(0));
             byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-            hyperLogLogPlusPlus.collect(MurmurHash3.hash64(bytes, bytes.length));
+            hyperLogLogPlusPlus.collect(MurmurHash3.hash64(bytes, 0, bytes.length));
         }
         return hyperLogLogPlusPlus.cardinality();
     }

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -94,6 +94,9 @@ Changes
 - Added support for directory-level wild card expansion for URIs passed to
   ``COPY FROM`` statements.
 
+- Improved the performance of the :ref`hyperloglog_distinct
+  <aggregation-hyperloglog-distinct>` aggregation function.
+
 Fixes
 =====
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -23,6 +23,7 @@ package io.crate.execution.engine.aggregation;
 
 import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.types.DataType;
@@ -114,7 +115,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     }
 
     @Nullable
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes, List<MappedFieldType> fieldTypes) {
+    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes, List<MappedFieldType> fieldTypes, List<Literal<?>> optionalParams) {
         return null;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
@@ -26,11 +26,13 @@ import java.io.IOException;
 import javax.annotation.Nullable;
 
 import io.crate.breaker.RamAccounting;
+import io.crate.memory.MemoryManager;
 import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.Version;
 
 public interface DocValueAggregator<T> {
 
-    public T initialState(RamAccounting ramAccounting);
+    public T initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion);
 
     public void loadDocValues(LeafReader reader) throws IOException;
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -28,6 +28,7 @@ import io.crate.common.MutableObject;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
@@ -132,7 +133,8 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     @Nullable
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         var dataType = argumentTypes.get(0);
         switch (dataType.id()) {
             case ByteType.ID:
@@ -248,7 +250,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
         }
 
         @Override
-        public MutableObject initialState(RamAccounting ramAccounting) {
+        public MutableObject initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             return new MutableObject();
         }
 
@@ -285,7 +287,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
         }
 
         @Override
-        public MutableObject initialState(RamAccounting ramAccounting) {
+        public MutableObject initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             return new MutableObject();
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -27,6 +27,8 @@ import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
@@ -273,7 +275,8 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:
@@ -281,7 +284,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             case LongType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
                         return new AverageState();
                     },
@@ -293,7 +296,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
                         return new AverageState();
                     },
@@ -306,7 +309,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
                         return new AverageState();
                     },

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -27,6 +27,8 @@ import io.crate.common.MutableLong;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.BinaryDocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -237,7 +239,8 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         if (argumentTypes.size() == 1) {
             switch (argumentTypes.get(0).id()) {
                 case ByteType.ID:
@@ -251,7 +254,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                 case GeoPointType.ID:
                     return new SortedNumericDocValueAggregator<>(
                         fieldTypes.get(0).name(),
-                        (ramAccounting) -> {
+                        (ramAccounting, memoryManager, minNodeVersion) -> {
                             ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
                             return new MutableLong(0L);
                         },
@@ -261,7 +264,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                 case StringType.ID:
                     return new BinaryDocValueAggregator<>(
                         fieldTypes.get(0).name(),
-                        (ramAccounting) -> {
+                        (ramAccounting, memoryManager, minNodeVersion) -> {
                             ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
                             return new MutableLong(0L);
                         },

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -28,6 +28,8 @@ import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
@@ -290,7 +292,8 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:
@@ -300,7 +303,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
                     },
@@ -309,7 +312,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
                     },
@@ -321,7 +324,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
                     },

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -27,6 +27,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import io.crate.common.MutableFloat;
+import io.crate.expression.symbol.Literal;
 import io.crate.types.ByteType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
@@ -89,7 +90,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableLong initialState(RamAccounting ramAccounting) {
+        public MutableLong initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.LONG.fixedSize());
             return new MutableLong(Long.MIN_VALUE);
         }
@@ -130,7 +131,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableDouble initialState(RamAccounting ramAccounting) {
+        public MutableDouble initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
             return new MutableDouble(- Double.MAX_VALUE);
         }
@@ -171,7 +172,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableFloat initialState(RamAccounting ramAccounting) {
+        public MutableFloat initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
             return new MutableFloat(- Float.MAX_VALUE);
         }
@@ -212,7 +213,8 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                           List<MappedFieldType> fieldTypes) {
+                                                           List<MappedFieldType> fieldTypes,
+                                                           List<Literal<?>> optionalParams) {
             DataType<?> arg = argumentTypes.get(0);
             switch (arg.id()) {
                 case ByteType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -27,6 +27,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import io.crate.common.MutableFloat;
+import io.crate.expression.symbol.Literal;
 import io.crate.types.ByteType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
@@ -88,7 +89,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableLong initialState(RamAccounting ramAccounting) {
+        public MutableLong initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.LONG.fixedSize());
             return new MutableLong(Long.MAX_VALUE);
         }
@@ -129,7 +130,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableDouble initialState(RamAccounting ramAccounting) {
+        public MutableDouble initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
             return new MutableDouble(Double.MAX_VALUE);
         }
@@ -169,7 +170,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
         }
 
         @Override
-        public MutableFloat initialState(RamAccounting ramAccounting) {
+        public MutableFloat initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
             return new MutableFloat(Float.MAX_VALUE);
         }
@@ -248,7 +249,8 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
 
         @Override
         public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                           List<MappedFieldType> fieldTypes) {
+                                                           List<MappedFieldType> fieldTypes,
+                                                           List<Literal<?>> optionalParams) {
             DataType<?> arg = argumentTypes.get(0);
             switch (arg.id()) {
                 case ByteType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -26,6 +26,7 @@ import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
@@ -168,7 +169,8 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         return switch (argumentTypes.get(0).id()) {
             case ByteType.ID, ShortType.ID, IntegerType.ID, LongType.ID ->
                 new SumLong(returnType, fieldTypes.get(0).name());
@@ -190,7 +192,7 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
         }
 
         @Override
-        public OverflowAwareMutableLong initialState(RamAccounting ramAccounting) {
+        public OverflowAwareMutableLong initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(INIT_BIG_DECIMAL_SIZE);
             return new OverflowAwareMutableLong(0L);
         }
@@ -234,7 +236,7 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
         }
 
         @Override
-        public BigDecimalValueWrapper initialState(RamAccounting ramAccounting) {
+        public BigDecimalValueWrapper initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(INIT_BIG_DECIMAL_SIZE);
             return new BigDecimalValueWrapper(BigDecimal.ZERO);
         }
@@ -281,7 +283,7 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
         }
 
         @Override
-        public BigDecimalValueWrapper initialState(RamAccounting ramAccounting) {
+        public BigDecimalValueWrapper initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(INIT_BIG_DECIMAL_SIZE);
             return new BigDecimalValueWrapper(BigDecimal.ZERO);
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -27,7 +27,9 @@ import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.execution.engine.aggregation.statistics.StandardDeviation;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
@@ -211,7 +213,8 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:
@@ -221,7 +224,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
                         return new StandardDeviation();
                     },
@@ -230,7 +233,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
                         return new StandardDeviation();
                     },
@@ -242,7 +245,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
                         return new StandardDeviation();
                     },

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -29,6 +29,7 @@ import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.functions.Signature;
@@ -181,7 +182,8 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:
@@ -236,7 +238,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public MutableLong initialState(RamAccounting ramAccounting) {
+        public MutableLong initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.LONG.fixedSize());
             return new MutableLong(0L);
         }
@@ -270,7 +272,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public MutableDouble initialState(RamAccounting ramAccounting) {
+        public MutableDouble initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
             return new MutableDouble(.0d);
         }
@@ -308,7 +310,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         }
 
         @Override
-        public MutableFloat initialState(RamAccounting ramAccounting) {
+        public MutableFloat initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
             ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
             return new MutableFloat(.0f);
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -27,7 +27,9 @@ import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.execution.engine.aggregation.statistics.Variance;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
@@ -213,7 +215,8 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
     @Override
     public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes) {
+                                                       List<MappedFieldType> fieldTypes,
+                                                       List<Literal<?>> optionalParams) {
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:
@@ -223,7 +226,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
                     },
@@ -232,7 +235,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
                     },
@@ -244,7 +247,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
                     fieldTypes.get(0).name(),
-                    (ramAccounting) -> {
+                    (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
                     },

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/templates/BinaryDocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/templates/BinaryDocValueAggregator.java
@@ -19,43 +19,46 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.execution.engine.aggregation.impl;
+package io.crate.execution.engine.aggregation.impl.templates;
 
 import io.crate.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.memory.MemoryManager;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.TriFunction;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.function.Function;
 
-public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T> {
+public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
 
     private final String columnName;
-    private final Function<RamAccounting, T> stateInitializer;
-    private final CheckedBiConsumer<SortedNumericDocValues, T, IOException> docValuesConsumer;
+    private final TriFunction<RamAccounting, MemoryManager, Version, T> stateInitializer;
+    private final CheckedBiConsumer<SortedBinaryDocValues, T, IOException> docValuesConsumer;
 
-    private SortedNumericDocValues values;
+    protected SortedBinaryDocValues values;
 
-    public SortedNumericDocValueAggregator(String columnName,
-                                           Function<RamAccounting, T> stateInitializer,
-                                           CheckedBiConsumer<SortedNumericDocValues, T, IOException> docValuesConsumer) {
+    public BinaryDocValueAggregator(String columnName,
+                                    TriFunction<RamAccounting, MemoryManager, Version, T> stateInitializer,
+                                    CheckedBiConsumer<SortedBinaryDocValues, T, IOException> docValuesConsumer) {
         this.columnName = columnName;
         this.stateInitializer = stateInitializer;
         this.docValuesConsumer = docValuesConsumer;
     }
 
     @Override
-    public T initialState(RamAccounting ramAccounting) {
-        return stateInitializer.apply(ramAccounting);
+    public T initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
+        return stateInitializer.apply(ramAccounting, memoryManager, minNodeVersion);
     }
 
     @Override
     public void loadDocValues(LeafReader reader) throws IOException {
-        values = DocValues.getSortedNumeric(reader, columnName);
+        values = FieldData.toString(DocValues.getSortedSet(reader, columnName));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
+++ b/server/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
@@ -65,34 +65,35 @@ public enum MurmurHash3 {
      * @param length - length of array
      * @return - hashcode
      */
-    public static long hash64(byte[] data, int length) {
-        return hash64(data, length, DEFAULT_SEED);
+    public static long hash64(byte[] data, int offset, int length) {
+        return hash64(data, offset, length, DEFAULT_SEED);
     }
 
     /**
      * Murmur3 64-bit variant. This is essentially MSB 8 bytes of Murmur3 128-bit variant.
      *
      * @param data   - input byte array
-     * @param length - length of array
+     * @param offset - starting position.
+     * @param length - length of processed bytes starting from the offset.
      * @param seed   - seed.
      * @return - hashcode
      */
     @SuppressWarnings("fall through")
-    public static long hash64(byte[] data, int length, int seed) {
+    public static long hash64(byte[] data, int offset, int length, int seed) {
         long hash = seed;
         final int nblocks = length >> 3;
 
         // body
         for (int i = 0; i < nblocks; i++) {
-            final int i8 = i << 3;
+            final int i8 = (i << 3) + offset;
             long k = ((long) data[i8] & 0xff)
-                     | (((long) data[i8 + 1] & 0xff) << 8)
-                     | (((long) data[i8 + 2] & 0xff) << 16)
-                     | (((long) data[i8 + 3] & 0xff) << 24)
-                     | (((long) data[i8 + 4] & 0xff) << 32)
-                     | (((long) data[i8 + 5] & 0xff) << 40)
-                     | (((long) data[i8 + 6] & 0xff) << 48)
-                     | (((long) data[i8 + 7] & 0xff) << 56);
+                | (((long) data[i8 + 1] & 0xff) << 8)
+                | (((long) data[i8 + 2] & 0xff) << 16)
+                | (((long) data[i8 + 3] & 0xff) << 24)
+                | (((long) data[i8 + 4] & 0xff) << 32)
+                | (((long) data[i8 + 5] & 0xff) << 40)
+                | (((long) data[i8 + 6] & 0xff) << 48)
+                | (((long) data[i8 + 7] & 0xff) << 56);
 
             // mix functions
             k *= C1;
@@ -104,8 +105,8 @@ public enum MurmurHash3 {
 
         // tail
         long k1 = 0;
-        int tailStart = nblocks << 3;
-        switch (length - tailStart) {
+        int tailStart = (nblocks << 3) + offset;
+        switch (length - (nblocks << 3)) {
             case 7:
                 k1 ^= ((long) data[tailStart + 6] & 0xff) << 48;
                 // fall through

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -43,7 +43,8 @@ public class ArbitraryAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 argumentType.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -45,7 +45,8 @@ public class ArrayAggTest extends AggregationTestCase {
                 new Object[]{42},
                 new Object[]{24}
             },
-            true
+            true,
+            List.of()
         );
         assertThat((List<Object>) result, Matchers.contains(20, null, 42, 24));
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -43,7 +43,8 @@ public class AverageAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -50,7 +50,8 @@ public class CollectSetAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 new ArrayType<>(argumentType).getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -45,7 +45,8 @@ public class CountAggregationTest extends AggregationTestCase {
             List.of(argumentType),
             DataTypes.LONG,
             data,
-            true
+            true,
+            List.of()
         );
     }
 
@@ -122,7 +123,7 @@ public class CountAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_count_star() throws Exception {
-        assertThat(executeAggregation(CountAggregation.COUNT_STAR_SIGNATURE, new Object[][]{{}, {}}), is(2L));
+        assertThat(executeAggregation(CountAggregation.COUNT_STAR_SIGNATURE, new Object[][]{{}, {}}, List.of()), is(2L));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -46,7 +46,8 @@ public class GeometricMeanAggregationtest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -40,7 +40,8 @@ public class MaximumAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 argumentType.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -40,7 +40,8 @@ public class MinimumAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 argumentType.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -51,7 +51,8 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            rows
+            rows,
+            List.of()
         );
     }
 
@@ -63,7 +64,8 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature()
             ),
-            rows
+            rows,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -46,7 +46,8 @@ public class StdDevAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -27,6 +27,8 @@ import org.elasticsearch.Version;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.hamcrest.Matchers.is;
 
 public class StringAggTest extends AggregationTestCase {
@@ -38,7 +40,8 @@ public class StringAggTest extends AggregationTestCase {
                 new Object[]{null, null},
                 new Object[]{null, null},
                 new Object[]{null, null},
-            }
+            },
+            List.of()
         );
         assertThat(result, Matchers.nullValue());
     }
@@ -50,7 +53,8 @@ public class StringAggTest extends AggregationTestCase {
                 new Object[]{"a", ","},
                 new Object[]{"b", null},
                 new Object[]{"c", ","},
-            });
+            },
+            List.of());
         assertThat(result, is("ab,c"));
     }
 
@@ -61,7 +65,8 @@ public class StringAggTest extends AggregationTestCase {
                 new Object[]{"a", ";"},
                 new Object[]{null, ","},
                 new Object[]{"c", ","},
-            });
+            },
+            List.of());
         assertThat(result, is("a,c"));
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -31,6 +31,7 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 import io.crate.types.NumericType;
+import org.elasticsearch.Version;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -49,7 +50,8 @@ public class SumAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 returnType.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 
@@ -118,7 +120,8 @@ public class SumAggregationTest extends AggregationTestCase {
             signature.getArgumentDataTypes(),
             signature.getReturnType().createType(),
             rows,
-            false
+            false,
+            List.of()
         );
         assertThat(result, is(1.4f));
     }
@@ -173,13 +176,18 @@ public class SumAggregationTest extends AggregationTestCase {
     @Test
     public void test_sum_numeric_on_long_non_doc_values_field() {
         //noinspection rawtypes
+        Version minNodeVersion = randomBoolean()
+            ? Version.CURRENT
+            : Version.V_4_0_9;
         var result = execPartialAggregationWithoutDocValues(
             (AggregationFunction) nodeCtx.functions().getQualified(
                 NumericSumAggregation.SIGNATURE,
                 List.of(DataTypes.NUMERIC),
                 DataTypes.NUMERIC
             ), new Object[][]{{1L}, {2L}, {3L}},
-            true
+            true,
+            minNodeVersion
+
         );
         assertThat(result, is(BigDecimal.valueOf(6)));
     }
@@ -187,13 +195,17 @@ public class SumAggregationTest extends AggregationTestCase {
     @Test
     public void test_sum_numeric_on_long_non_doc_values_field_with_overflow() {
         //noinspection rawtypes
+        Version minNodeVersion = randomBoolean()
+            ? Version.CURRENT
+            : Version.V_4_0_9;
         var result = execPartialAggregationWithoutDocValues(
             (AggregationFunction) nodeCtx.functions().getQualified(
                 NumericSumAggregation.SIGNATURE,
                 List.of(DataTypes.NUMERIC),
                 DataTypes.NUMERIC
             ), new Object[][]{{Long.MAX_VALUE}, {10L}},
-            true
+            true,
+            minNodeVersion
         );
         assertThat(result, is(BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.TEN)));
     }
@@ -201,13 +213,17 @@ public class SumAggregationTest extends AggregationTestCase {
     @Test
     public void test_sum_numeric_on_floating_point_non_doc_values_field() {
         //noinspection rawtypes
+        Version minNodeVersion = randomBoolean()
+            ? Version.CURRENT
+            : Version.V_4_0_9;
         var result = execPartialAggregationWithoutDocValues(
             (AggregationFunction) nodeCtx.functions().getQualified(
                 NumericSumAggregation.SIGNATURE,
                 List.of(DataTypes.NUMERIC),
                 DataTypes.NUMERIC
             ), new Object[][]{{1d}, {1d}},
-            true
+            true,
+            minNodeVersion
         );
         assertThat(result, is(BigDecimal.valueOf(2.0)));
     }
@@ -219,6 +235,9 @@ public class SumAggregationTest extends AggregationTestCase {
         assertThat(expected.toString(), is("12.44"));
 
         //noinspection rawtypes
+        Version minNodeVersion = randomBoolean()
+            ? Version.CURRENT
+            : Version.V_4_0_9;
         var result = execPartialAggregationWithoutDocValues(
             (AggregationFunction) nodeCtx.functions().getQualified(
                 NumericSumAggregation.SIGNATURE,
@@ -226,7 +245,8 @@ public class SumAggregationTest extends AggregationTestCase {
                 DataTypes.NUMERIC
             ),
             new Object[][]{{12d}, {0.4357d}},
-            true
+            true,
+            minNodeVersion
         );
         assertThat(result.toString(), is(expected.toString()));
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -42,7 +42,8 @@ public class VarianceAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
             ),
-            data
+            data,
+            List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -63,6 +63,8 @@ import java.util.function.Consumer;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTest {
 
@@ -108,7 +110,8 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
         var aggregationField = new NumberFieldMapper.NumberFieldType("z", NumberFieldMapper.NumberType.LONG);
         var sumDocValuesAggregator = sumAggregation.getDocValueAggregator(
             List.of(DataTypes.LONG),
-            List.of(aggregationField)
+            List.of(aggregationField),
+            List.of()
         );
 
         var keyExpressions = List.of(new LongColumnReference("y"));
@@ -124,6 +127,8 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             ),
             keyExpressions,
             RamAccounting.NO_ACCOUNTING,
+            null,
+            null,
             new MatchAllDocsQuery(),
             new CollectorContext()
         );
@@ -150,7 +155,8 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
         var aggregationField = new NumberFieldMapper.NumberFieldType("z", NumberFieldMapper.NumberType.LONG);
         var sumDocValuesAggregator = sumAggregation.getDocValueAggregator(
             List.of(DataTypes.LONG),
-            List.of(aggregationField)
+            List.of(aggregationField),
+            List.of()
         );
         var keyExpressions = List.of(new BytesRefColumnReference("x"), new LongColumnReference("y"));
         var keyRefs = List.of(
@@ -169,13 +175,14 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 null
             )
         );
-
         var it = DocValuesGroupByOptimizedIterator.GroupByIterator.forManyKeys(
             List.of(sumDocValuesAggregator),
             indexSearcher,
             keyRefs,
             keyExpressions,
             RamAccounting.NO_ACCOUNTING,
+            null,
+            null,
             new MatchAllDocsQuery(),
             new CollectorContext()
         );
@@ -251,7 +258,9 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                     return null;
                 }
             }),
-            RamAccounting.NO_ACCOUNTING,
+            null,
+            null,
+            null,
             (states, key) -> {
             },
             (expressions) -> expressions.get(0).value(),

--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -46,6 +46,8 @@ import io.crate.types.RegclassType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.joda.time.Period;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
@@ -93,9 +95,9 @@ public class DataTypeTesting {
             case IpType.ID:
                 return () -> {
                     if (random.nextBoolean()) {
-                        return (T) randomIPv4Address(random);
+                        return (T) NetworkAddress.format(InetAddresses.forString(randomIPv4Address(random)));
                     } else {
-                        return (T) randomIPv6Address(random);
+                        return (T) NetworkAddress.format(InetAddresses.forString(randomIPv6Address(random)));
                     }
                 };
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Result of running `./compare_run.py --v1 branch:master --v2 branch:baur/hll-docvalueaggregator --spec specs/select/hyperloglog.toml --forks 2 --env CRATE_HEAP_SIZE=2g -s path.data=/Users/baur/benchmark-data`

```
# Results (server side duration in ms)
V1: 4.6.0-41b3579b7049130cedd542077eabddb666ff7311
V2: 4.6.0-a40419673ac591c22d72252cea1d769b611699c3

Q: select hyperloglog_distinct("cCode") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      422.632 ±  171.659 |    373.643 |    393.606 |    401.293 |   1596.161 |
|   V2    |      338.015 ±  166.400 |    300.876 |    304.461 |    314.744 |   1464.700 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  22.25%                           -  25.54%   
There is a 98.60% probability that the observed difference is not random, and the best estimate of that difference is 22.25%
The test has statistical significance

Q: select hyperloglog_distinct("visitDate") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      101.696 ±   36.188 |     90.875 |     96.032 |     98.174 |    351.191 |
|   V2    |       42.695 ±   22.822 |     37.574 |     38.818 |     39.590 |    199.010 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  81.72%                           -  84.85%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 81.72%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |   36     2.76     1.74 |   12    39.74    37.11 |     2147       66 |     0.00          0
 V2 |    7     3.56     2.70 |    3    37.83    40.72 |     2147      101 |     0.00          0
    
V1 top allocation frames
  ByteBuffer.get(...):2958
  MurmurHash3.hash64(...):567
  UnicodeUtil.UTF8toUTF16(...):519
  AggregateCollector.iterate(...):507
  InputRow.get(int):440
V2 top allocation frames
  ByteBuffer.get(...):2734
  MurmurHash3.hash64(...):441
  Buffer.position(int):320
  ScopedMemoryAccess.getByteInternal(...):316
  DocValuesAggregates.getRow(...):280
```

Updated results - hash method with offset, no array copy + separate implementation for integral types
```
V1: 4.6.0-5f40784cdcde85ce6a3cb5f7bade37911d1b5ec4
V2: 4.6.0-a5892e92235534dfff983c742b6b7d2c78602dd4

Q: select hyperloglog_distinct("cCode") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      445.569 ±  141.618 |    405.673 |    421.316 |    433.674 |   1416.460 |
|   V2    |      295.680 ±  138.544 |    267.682 |    273.738 |    278.858 |   1254.050 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  40.44%                           -  42.47%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 40.44%
The test has statistical significance

Q: select hyperloglog_distinct("visitDate") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      128.962 ±   45.780 |    111.293 |    115.108 |    127.359 |    409.681 |
|   V2    |       50.332 ±   67.537 |     38.114 |     39.676 |     41.148 |    517.950 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  87.71%                           -  97.47%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 87.71%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |   36     2.67     3.36 |   11    34.78    40.44 |     2147      142 |     0.00          0
 V2 |    0     0.00     0.00 |    0     0.00     0.00 |     2147        0 |     0.00          0
    
V1 top allocation frames
  ByteBuffer.get(...):2510
  DataInput.readVInt():1027
  MurmurHash3.hash64(...):577
  AggregateCollector.iterate(...):564
  InputRow.get(int):533
V2 top allocation frames
  ByteBuffer.get(...):2682
  MurmurHash3.hash64(...):403
  DocValuesAggregates.getRow(...):395
  Lucene80DocValuesProducer$TermsDict.seekExact(long):318
  BufferedIndexInput.readByte(long):217

```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
