### PR TITLE
bp: Fix testKeepTranslogAfterGlobalCheckpoint

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -431,6 +431,7 @@ should be crossed out as well.
 - [ ] 8a565c4fa61 Voting config exclusions should work with absent nodes (#55291)
 - [ ] 2f91e2aab78 Fix Race in Snapshot Abort (#54873) (#55233)
 - [ ] d8b43c62838 Make Snapshot Deletes Less Racy (#54765) (#55226)
+- [x] 156e5aa77f0 Fix testKeepTranslogAfterGlobalCheckpoint (#55868)
 - [ ] e164c9aaee5 Remove Redundant Cluster State during Snapshot INIT + Master Failover (#54420) (#55208)
 - [ ] 48048646e79 Move Snapshot Status Related Method to Appropriate Places (#54558) (#55209)
 - [ ] a610513ec76 Provide repository-level stats for searchable snapshots (#55051)

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -4911,9 +4911,11 @@ public class InternalEngineTests extends EngineTestCase {
 
         final EngineConfig engineConfig = config(indexSettings, store, translogPath,
                                                  NoMergePolicy.INSTANCE, null, null, () -> globalCheckpoint.get());
+        final AtomicLong lastSyncedGlobalCheckpointBeforeCommit = new AtomicLong(Translog.readGlobalCheckpoint(translogPath, translogUUID));
         try (InternalEngine engine = new InternalEngine(engineConfig) {
             @Override
             protected void commitIndexWriter(IndexWriter writer, Translog translog, String syncId) throws IOException {
+                lastSyncedGlobalCheckpointBeforeCommit.set(Translog.readGlobalCheckpoint(translogPath, translogUUID));
                 // Advance the global checkpoint during the flush to create a lag between a persisted global checkpoint in the translog
                 // (this value is visible to the deletion policy) and an in memory global checkpoint in the SequenceNumbersService.
                 if (rarely()) {
@@ -4934,21 +4936,20 @@ public class InternalEngineTests extends EngineTestCase {
                 }
                 if (frequently()) {
                     engine.flush(randomBoolean(), true);
-                    final long lastSyncedGlobalCheckpoint = Translog.readGlobalCheckpoint(translogPath, translogUUID);
                     final List<IndexCommit> commits = DirectoryReader.listCommits(store.directory());
                     // Keep only one safe commit as the oldest commit.
                     final IndexCommit safeCommit = commits.get(0);
-                    if (lastSyncedGlobalCheckpoint == UNASSIGNED_SEQ_NO) {
+                    if (lastSyncedGlobalCheckpointBeforeCommit.get() == UNASSIGNED_SEQ_NO) {
                         // If the global checkpoint is still unassigned, we keep an empty(eg. initial) commit as a safe commit.
                         assertThat(Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.MAX_SEQ_NO)),
                                    equalTo(SequenceNumbers.NO_OPS_PERFORMED));
                     } else {
                         assertThat(Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.MAX_SEQ_NO)),
-                                   lessThanOrEqualTo(lastSyncedGlobalCheckpoint));
+                                   lessThanOrEqualTo(lastSyncedGlobalCheckpointBeforeCommit.get()));
                     }
                     for (int i = 1; i < commits.size(); i++) {
                         assertThat(Long.parseLong(commits.get(i).getUserData().get(SequenceNumbers.MAX_SEQ_NO)),
-                                   greaterThan(lastSyncedGlobalCheckpoint));
+                                   greaterThan(lastSyncedGlobalCheckpointBeforeCommit.get()));
                     }
                     // Make sure we keep all translog operations after the local checkpoint of the safe commit.
                     long localCheckpointFromSafeCommit = Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));


### PR DESCRIPTION
`InternalEngineTests.testKeepTranslogAfterGlobalCheckpoint` is still flaky see:
 https://wacklig.pipifein.dev/github/crate/crate/case/org.elasticsearch.index.engine.InternalEngineTests/testKeepTranslogAfterGlobalCheckpoint

I was running the test locally for ~ 10 minutes and did not fail now.

https://github.com/elastic/elasticsearch/commit/156e5aa77f0449a8671cfe440aa7d0c4db49e136

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
