### PR TITLE
bp: Fix testPrepareIndexForPeerRecovery

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -513,6 +513,7 @@ should be crossed out as well.
 - [ ] 0a09e159594 Add Caching for RepositoryData in BlobStoreRepository (#52341) (#52566)
 - [ ] 4bb780bc373 Refactor Inflexible Snapshot Repository BwC (#52365) (#52557)
 - [ ] 3afb5ca1330 Fix synchronization in ByteSizeCachingDirectory (#52512)
+- [x] 0c7ae0217de Fix testPrepareIndexForPeerRecovery (#52245)
 - [x] 5aa612c2759 Fix testRestoreLocalHistoryFromTranslog (#52441)
 - [ ] 8d2261fe479 Refactor GeoShapeIndexer by extracting polygon / line decomposers (#52422) (#52506)
 - [ ] 9d40277d4cb Deciders should not by default collect yes'es (#52438)

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -192,11 +192,13 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         Optional<SequenceNumbers.CommitInfo> safeCommit = shard.store().findSafeIndexCommit(globalCheckpoint);
         assertTrue(safeCommit.isPresent());
         int expectedTotalLocal = 0;
-        try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshot(safeCommit.get().localCheckpoint + 1, globalCheckpoint)) {
-            Translog.Operation op;
-            while ((op = snapshot.next()) != null) {
-                if (op.seqNo() <= globalCheckpoint) {
-                    expectedTotalLocal++;
+        if (safeCommit.get().localCheckpoint < globalCheckpoint) {
+            try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshot(safeCommit.get().localCheckpoint + 1, globalCheckpoint)) {
+                Translog.Operation op;
+                while ((op = snapshot.next()) != null) {
+                    if (op.seqNo() <= globalCheckpoint) {
+                        expectedTotalLocal++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://wacklig.pipifein.dev/github/crate/crate/case/org.elasticsearch.indices.recovery.PeerRecoveryTargetServiceTests/testPrepareIndexForPeerRecovery

https://github.com/elastic/elasticsearch/commit/0c7ae0217de9c5aacfcb2e52b6255f7e3c074a46


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
