### PR TITLE
Overhaul `insert.rst`

### DIFF
--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -1,4 +1,4 @@
-.. _crate_standard_sql:
+.. _appendix-compatibility:
 
 =================
 SQL compatibility
@@ -14,9 +14,13 @@ you should be aware of some unique characteristics in CrateDB's SQL dialect.
    :local:
 
 
+.. _appendix-compat-notes:
+
 Implementation notes
 ====================
 
+
+.. _appendix-compat-data-types:
 
 Data types
 ----------
@@ -51,6 +55,8 @@ how data types of `standard SQL`_ map to CrateDB :ref:`data-types`.
 +-----------------------------------+-----------------------------+
 
 
+.. _appendix-compat-create-table:
+
 Create table
 ------------
 
@@ -58,12 +64,16 @@ Create table
 sharding, replication and routing of data, and does not support inheritance.
 
 
+.. _appendix-compat-alter-table:
+
 Alter table
 -----------
 
 ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported (see
 :ref:`sql-alter-table`).
 
+
+.. _appendix-compat-sys-info:
 
 System information tables
 -------------------------
@@ -74,6 +84,8 @@ schema information and can be queried to get real-time statistical data about
 the cluster, its nodes, and their shards.
 
 
+.. _appendix-compat-blob:
+
 BLOB support
 ------------
 
@@ -81,6 +93,8 @@ BLOB support
 OBJECT``. With CrateDB, Binary Data is instead stored in separate BLOB Tables
 (see :ref:`blob_support`) which can be sharded and replicated.
 
+
+.. _appendix-compat-transactions:
 
 Transactions (``BEGIN``, ``START``, ``COMMIT``, and ``ROLLBACK``)
 -----------------------------------------------------------------
@@ -95,6 +109,8 @@ the record is modified. This version number can be used to implement patterns
 like :ref:`sql_occ`, which can be used to solve many of the use cases that
 would otherwise require traditional transactions.
 
+
+.. _appendix-compat-unsupported:
 
 Unsupported features and functions
 ==================================

--- a/docs/appendices/glossary.rst
+++ b/docs/appendices/glossary.rst
@@ -402,7 +402,7 @@ S
 
 **Statement**
     Any valid SQL that serves as a database instruction (e.g., :ref:`CREATE
-    TABLE <sql-create-table>`, :ref:`INSERT <ref-insert>`, and :ref:`SELECT
+    TABLE <sql-create-table>`, :ref:`INSERT <sql-insert>`, and :ref:`SELECT
     <sql-select>`) instead of producing a value.
 
     Contrary to an :ref:`expression <gloss-expression>`.

--- a/docs/appendices/release-notes/3.2.8.rst
+++ b/docs/appendices/release-notes/3.2.8.rst
@@ -51,7 +51,7 @@ Fixes
 -----
 
 - Fixed the processing of ``LIMIT`` clauses within queries in the :ref:`INSERT
-  INTO <ref-insert>` statement. A query like ``INSERT INTO target (SELECT *
+  INTO <sql-insert>` statement. A query like ``INSERT INTO target (SELECT *
   FROM (SELECT * FROM source LIMIT 10) t)`` could insert more than 10 rows if
   there is more than 1 node in the cluster.  In addition, using ``LIMIT`` in
   the top level query of the ``INSERT INTO`` statement is now no longer

--- a/docs/appendices/release-notes/3.3.2.rst
+++ b/docs/appendices/release-notes/3.3.2.rst
@@ -52,7 +52,7 @@ Fixes
 -----
 
 - Fixed the processing of ``LIMIT`` clauses within queries in the :ref:`INSERT
-  INTO <ref-insert>` statement. A query like ``INSERT INTO target (SELECT *
+  INTO <sql-insert>` statement. A query like ``INSERT INTO target (SELECT *
   FROM (SELECT * FROM source LIMIT 10) t)`` could insert more than 10 rows if
   there is more than 1 node in the cluster.  In addition, using ``LIMIT`` in
   the top level query of the ``INSERT INTO`` statement is now no longer

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -240,7 +240,7 @@ Removed Functionality
   total counts and sum of durations as documented in :ref:`query_stats_mbean`
   should be used instead.
 
-- Removed the deprecated ``ON DUPLICATE KEY`` syntax of :ref:`ref-insert`
+- Removed the deprecated ``ON DUPLICATE KEY`` syntax of :ref:`sql-insert`
   statements. Users can migrate to the ``ON CONFLICT`` syntax.
 
 - Removed the ``index`` thread-pool and the ``bulk`` alias for the ``write``

--- a/docs/appendices/release-notes/4.2.0.rst
+++ b/docs/appendices/release-notes/4.2.0.rst
@@ -245,7 +245,7 @@ New statements and clauses
   that the values of certain columns must satisfy a :ref:`boolean expression
   <sql-literal-value>` on insert and update.
 
-- Introduced new optional ``RETURNING`` clause for :ref:`INSERT <ref-insert>`
+- Introduced new optional ``RETURNING`` clause for :ref:`INSERT <sql-insert>`
   and :ref:`UPDATE <ref-update>` to return specified values from each row
   written.
 

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -319,7 +319,7 @@ Bulk operations
 ---------------
 
 SQL DML Statements involving a huge amount of rows like :ref:`sql-copy-from`,
-:ref:`ref-insert` or :ref:`ref-update` can take an enormous amount of time and
+:ref:`sql-insert` or :ref:`ref-update` can take an enormous amount of time and
 resources. The following settings change the behaviour of those queries.
 
 .. _bulk.request_timeout:

--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -61,7 +61,7 @@ error message::
     policy <column_policy>`).
 
     However, you can configure the :ref:`column_policy <column_policy>` table
-    parameter so that the :ref:`INSERT <ref-insert>`, :ref:`UPDATE
+    parameter so that the :ref:`INSERT <sql-insert>`, :ref:`UPDATE
     <ref-update>`, and :ref:`COPY FROM <sql-copy-from>` statements can
     arbitrarily create new columns as needed (what's known as a *dynamic*
     column policy).

--- a/docs/general/ddl/partitioned-tables.rst
+++ b/docs/general/ddl/partitioned-tables.rst
@@ -131,7 +131,7 @@ partitions. Nonetheless does it behave like a *normal* table.
 
 When the value to partition by references one or more
 :ref:`sql-create-table-base-columns`, their values must be supplied upon
-:ref:`ref-insert` or :ref:`sql-copy-from`. Often these values are computed on
+:ref:`sql-insert` or :ref:`sql-copy-from`. Often these values are computed on
 client side. If this is not possible, a :ref:`generated column
 <sql-create-table-generated-columns>` can be used to create a suitable
 partition value from the given values on database-side::

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -1,21 +1,26 @@
 .. highlight:: psql
-.. _ref-insert:
+
+.. _sql-insert:
 
 ==========
 ``INSERT``
 ==========
 
-Create new rows in a table.
+You can use the ``INSERT`` :ref:`statement <gloss-statement>` to :ref:`insert
+new rows <dml-inserting-data>` into a table.
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
 
-.. _insert_synopsis:
+
+.. _sql-insert-synopsis:
 
 Synopsis
 ========
+
+CrateDB defines the full ``INSERT`` syntax as:
 
 ::
 
@@ -26,130 +31,210 @@ Synopsis
         ON CONFLICT [ ( column_ident [, ...] ) ] DO NOTHING ]
       [ RETURNING { * | output_expression [ [ AS ] output_name ] | relation.* } [, ...] ]
 
-Description
-===========
-
-``INSERT`` creates one or more rows specified by :ref:`value expressions
-<sql-value-expressions>`.
-
-The target column names can be listed in any order. If the target column names
-are omitted, they default to all columns of the table or up to N columns if
-there are fewer values in the ``VALUES`` clause or ``query``.
-
-Implicitly inferred column names are ordered by their ordinal value. The
-ordinal value depends on the ordering of the columns within the ``CREATE
-TABLE`` statement.
-
-The values supplied by the ``VALUES`` clause or ``query`` are associated with
-the explicit or implicit column list left-to-right.
-
-Each column not present in the explicit or implicit column list will not be
-filled.
-
-If the :ref:`expression <gloss-expression>` for any column is not of the
-correct data type, automatic type conversion will be attempted.
-
-The optional ``RETURNING`` clause causes ``INSERT`` to compute and return
-values based from each row actually inserted (or updated, if an ``ON
-CONFLICT DO UPDATE`` clause was used). This is primarily useful for obtaining
-values that were supplied by defaults, such as a :ref:`_id
-<sql_administration_system_column_id>`, also any expression using the table's
-columns is allowed.
-
-``ON CONFLICT DO UPDATE SET``
------------------------------
-
-This clause can be used to update a record if a conflicting record is
-encountered.
-
-::
-
-     ON CONFLICT (conflict_target) DO UPDATE SET { assignments }
-
-     WHERE
-
-      conflict_target := column_ident [, ... ]
-      assignments := column_ident = expression [, ... ]
 
 
-Within expressions in the ``DO UPDATE SET`` clause, you can use the special
-``excluded`` table to refer to column values from the INSERT statement values.
-For example:
-
-::
-
-     INSERT INTO t (col1, col2) VALUES (1, 41)
-     ON CONFLICT (col1) DO UPDATE SET col2 = excluded.col2 + 1
-
-The above statement would update ``col2`` to ``42`` if ``col1`` was a primary
-key and the value ``1`` already existed for ``col1``.
-
-``ON CONFLICT DO NOTHING``
---------------------------
-
-When ``ON CONFLICT DO NOTHING`` is specified, rows which caused a duplicate
-key conflict will not be inserted. No exception will be thrown. For example:
-
-::
-
-     INSERT INTO t (col1, col2) VALUES (1, 42)
-     ON CONFLICT DO NOTHING
-
-In the above statement, if ``col1`` had a primary key constraint and the value
-``1`` already existed for ``col1``, no insert would be performed. The conflict
-target after ``ON CONFLICT`` is optional.
-
-Insert from dynamic queries constraints
----------------------------------------
-
-In some cases ``SELECT`` statements produce invalid data. This opens a rare
-occasion for inconsistent outcomes. If the select statement produces data where
-a few rows contain invalid column names, or where you have rows which types are
-not compatible among themselves, some rows will be inserted while others will
-fail. In this case the errors are logged on the node. This could happen in the
-following cases:
-
-  * If you select invalid columns or incompatible data types with unnest
-    e.g.::
-
-        select unnest([{foo=2}, {foo='a string'}])
-
-    or::
-
-        select unnest([{_invalid_col='foo', valid_col='bar'}])
-
-  * If you select from an ignored object which contains different data
-    types for the same object column, e.g.::
-
-        insert into from_table (o) values ({col='foo'}),({col=1})
-        insert into to_table (i) (select o['col'] from t)
-
-Any updates which happened before the failure will be persisted, which will
-lead to inconsistent outcomes. So special care needs to be taken by the
-application when using statements which might produce dynamic data.
+.. _sql-insert-synopsis-params:
 
 Parameters
-==========
+----------
 
 :table_ident:
     The identifier (optionally schema-qualified) of an existing table.
 
 :column_ident:
-    The name of a column or field in the table pointed to by *table_ident*.
+    The name of a column or field in the ``table_ident`` table.
 
 :expression:
     An :ref:`expression <gloss-expression>` or value to assign to the
     corresponding column.
 
 :query:
-    A query (``SELECT`` statement) that supplies the rows to be inserted.
-    Refer to the ``SELECT`` statement for a description of the syntax.
+    A query (i.e., :ref:`SELECT <sql-select>`) that supplies rows for the
+    statement to insert.
 
 :output_expression:
-    An expression to be computed and returned by the ``INSERT`` command
-    after each row is updated. The expression can use any column names
-    of the table or use ``*`` to return all columns. :ref:`System columns
-    <sql_administration_system_columns>` can also be returned.
+    An expression to be computed and returned by the ``INSERT`` statement after
+    each row is updated. This expression can use any of the table column names,
+    the ``*`` character to return all table columns, as well as any
+    :ref:`system columns <sql_administration_system_columns>`.
 
 :output_name:
     A name to use for the result of the output expression.
+
+
+.. _sql-insert-desc:
+
+Description
+===========
+
+The ``INSERT`` :ref:`statement <gloss-statement>` creates one or more rows
+specified by :ref:`value expressions <sql-value-expressions>`.
+
+You can list target column names in any order. If you omit the target column
+names, they default to all columns of the table or up to *n* columns if there
+are fewer values in the ``VALUES`` clause or ``query``.
+
+CrateDB will order implicitly inferred column names by their ordinal value. The
+ordinal value depends on the ordering of the columns within the :ref:`CREATE
+TABLE <sql-create-table>` statement.
+
+The values supplied by the ``VALUES`` clause or ``query`` are associated with
+the explicit or implicit column list left-to-right.
+
+CrateDB will not fill any column not present in the explicit or implicit column
+list.
+
+If the :ref:`expression <gloss-expression>` for any column is not of the
+correct data type, CrateDB will attempt automatic :ref:`type conversion
+<type_conversion>`.
+
+The optional ``RETURNING`` clause causes the ``INSERT`` statement to compute
+and return values from each row inserted (or updated, in the case of ``ON
+CONFLICT DO UPDATE``). You can take advantage of this behavior to obtain values
+that CrateDB supplied from defaults, such as as :ref:`_id
+<sql_administration_system_column_id>`.
+
+
+.. _sql-insert-desc-dynamic:
+
+.. CAUTION::
+
+    Dynamic :ref:`SELECT <sql-select>` statements may produce inconsistent
+    values for insertion when used with the ``query`` parameter.
+
+    For example, this use of `unnest`_ produces a single column (``foo``) with
+    incompatible data types (:ref:`numeric <data-type-numeric>` and
+    :ref:`character <character-data-types>`, respectively)::
+
+        SELECT unnest([{foo=1}, {foo='a string'}])
+
+    The same problem could happen like this::
+
+        INSERT INTO table_a (obj_col) VALUES ({foo=1}), ({foo='a string'})
+        INSERT INTO table_a (int_col) (SELECT obj_col['foo'] FROM table_a)
+
+    In this example, problems will arise if ``valid_col`` is a valid column
+    name, but ``invalid_col`` is not::
+
+        SELECT unnest([{valid_col='foo', invalid_col='bar'}])
+
+    Any inserts that were successful before CrateDB encountered an error will
+    remain, but CrateDB will reject the rest, potentially leading to
+    inconsistent data.
+
+    Users need to take special care when inserting data from queries that might
+    produce dynamic values like the ones above.
+
+
+.. _sql-insert-on-conflict-do-update:
+
+``ON CONFLICT DO UPDATE SET``
+-----------------------------
+
+If your table has a primary key, you can use the ``ON CONFLICT DO UPDATE SET``
+clause to modify the existing record (instead of inserting a new one) if
+CrateDB encounters a primary key conflict during the ``INSERT`` operation.
+
+Syntax::
+
+     ON CONFLICT (conflict_target) DO UPDATE SET { assignments }
+
+Where ``conflict_target`` can be one or more column identifiers::
+
+    column_ident [, ... ]
+
+And ``assignments`` can be one or more column assignments::
+
+    assignments = expression [, ... ]
+
+.. NOTE::
+
+    CrateDB does not support unique constraints, foreign key constraints, or
+    exclusion constraints (see :ref:`SQL compatibility: Unsupported features
+    and functions <appendix-compat-unsupported>`). Therefore, the only
+    constraint capable of producing a conflict that CrateDB supports is a
+    :ref:`primary key <constraints-primary-key>` constraint.
+
+    When using the ``ON CONFLICT DO UPDATE SET`` clause with a primary key
+    constraint, the ``conflict_target`` must always match the primary key
+    definition.
+
+    For example, if ``my_table`` had a primary key ``col_a``, the correct
+    syntax would be::
+
+        ON CONFLICT (col_a) DO UPDATE SET { assignments }
+
+    However, if ``my_table`` had a primary key on both ``col_a`` and ``col_b``,
+    the correct syntax would be::
+
+        ON CONFLICT (col_a, col_b) DO UPDATE SET { assignments }
+
+For example::
+
+    cr> INSERT INTO uservisits (id, name, visits, last_visit) VALUES
+    ... (
+    ...     0,
+    ...     'Ford',
+    ...     1,
+    ...     '2015-09-12'
+    ... ) ON CONFLICT (id) DO UPDATE SET
+    ...     visits = visits + 1;
+    INSERT OK, 1 row affected (... sec)
+
+This statement instructs CrateDB to do the following:
+
+.. rst-class:: open
+
+- Attempt to insert a new ``uservisits`` record for user ID ``0``.
+
+- If the insert would cause a primary key conflict on ``id`` (i.e., the user
+  already has a record in the ``uservists`` table), update the existing record
+  by incrementing the ``visits`` count.
+
+You can also use a virtual table named ``excluded`` to reference values from
+the failed (i.e., *excluded*) ``INSERT`` record. For example::
+
+    cr> INSERT INTO uservisits (id, name, visits, last_visit) VALUES
+    ... (
+    ...     0,
+    ...     'Ford',
+    ...     1,
+    ...     '2015-09-12'
+    ... ) ON CONFLICT (id) DO UPDATE SET
+    ...     visits = visits + 1,
+    ...     last_visit = excluded.last_visit;
+    INSERT OK, 1 row affected (... sec)
+
+The addition of ``last_visit = excluded.last_visit`` instructs CrateDB to
+overwrite the existing value of ``last_visits`` with the attempted insert
+value.
+
+.. SEEALSO::
+
+    :ref:`Inserting data: Upserts <dml-inserting-upserts>`
+
+
+.. _sql-insert-on-conflict-do-nothing:
+
+``ON CONFLICT DO NOTHING``
+--------------------------
+
+If you use the ``ON CONFLICT DO NOTHING`` clause, CrateDB will silently ignore
+rows that would cause a duplicate key conflict (i.e., CrateDB will not insert
+them and will not produce an error). For example::
+
+     INSERT INTO my_table (col_a, col_b) VALUES (1, 42)
+     ON CONFLICT DO NOTHING
+
+In the statement above, if ``col_a`` had a primary key constraint and the value
+``1`` already existed for ``col_a``, CrateDB would not perform an insert.
+
+.. NOTE::
+
+    You may specify an explicit primary key as the ``conflict_target`` (i.e.,
+    ``ON CONFLICT (conflict_target) DO NOTHING``), as with :ref:`ON CONFLICT DO
+    UPDATE SET <sql-insert-on-conflict-do-update>`. However, doing so is
+    optional.
+
+
+.. _unnest: https://crate.io/docs/crate/howtos/en/latest/performance/inserts/methods.html#unnest

--- a/docs/sql/statements/values.rst
+++ b/docs/sql/statements/values.rst
@@ -37,7 +37,7 @@ An example::
    VALUES 3 rows in set (... sec)
 
 
-It is commonly used in :ref:`ref-insert` to provide values to insert into a
+It is commonly used in :ref:`sql-insert` to provide values to insert into a
 table.
 
 All :ref:`expressions <gloss-expression>` within the same column must have the


### PR DESCRIPTION
Specifically:

- Correct use of RST labels

- Restructure to make better sense

  - *Parameters* now appears under *Synopsis*

  - The caution about dynamic selects has been moved to an admonition further up the page (where it is more relevant)

- Copyedits for text to improve correctness, clarity, and style (e.g., referring to things as "statements", switches to active voice, resolving indeterminate references)

  - Fix ambiguous use of ``WITH`` in ``ON CONFLICT DO UPDATE SET`` section (closes https://github.com/crate/crate/issues/11387)

- Improve use of SQL examples

  - Consistent use of uppercase for SQL reserved words
  
  - Better (more descriptive) use of table names, column names, and so on