### PR TITLE
Fix columnStoreDisabled parameter names 

### DIFF
--- a/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
@@ -42,7 +42,7 @@ public class DynamicReference extends Reference {
     }
 
     public DynamicReference(ReferenceIdent ident, RowGranularity granularity, ColumnPolicy columnPolicy, int position) {
-        super(ident, granularity, DataTypes.UNDEFINED, columnPolicy, IndexType.NOT_ANALYZED, true, position, null);
+        super(ident, granularity, DataTypes.UNDEFINED, columnPolicy, IndexType.NOT_ANALYZED, true, false, position, null);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -56,19 +56,19 @@ public class GeneratedReference extends Reference {
     public GeneratedReference(int position,
                               ReferenceIdent ident,
                               RowGranularity granularity,
-                              DataType type,
+                              DataType<?> type,
                               ColumnPolicy columnPolicy,
                               IndexType indexType,
                               String formattedGeneratedExpression,
                               boolean nullable) {
-        super(ident, granularity, type, columnPolicy, indexType, nullable, position, null);
+        super(ident, granularity, type, columnPolicy, indexType, nullable, false, position, null);
         this.formattedGeneratedExpression = formattedGeneratedExpression;
     }
 
     public GeneratedReference(int position,
                               ReferenceIdent ident,
                               RowGranularity granularity,
-                              DataType type,
+                              DataType<?> type,
                               String formattedGeneratedExpression) {
         super(ident, granularity, type, position, null);
         this.formattedGeneratedExpression = formattedGeneratedExpression;

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -90,24 +90,6 @@ public class Reference extends Symbol {
              ColumnPolicy.DYNAMIC,
              IndexType.NOT_ANALYZED,
              true,
-             position,
-             defaultExpression);
-    }
-
-    public Reference(ReferenceIdent ident,
-                     RowGranularity granularity,
-                     DataType<?> type,
-                     ColumnPolicy columnPolicy,
-                     IndexType indexType,
-                     boolean nullable,
-                     int position,
-                     @Nullable Symbol defaultExpression) {
-        this(ident,
-             granularity,
-             type,
-             columnPolicy,
-             indexType,
-             nullable,
              false,
              position,
              defaultExpression);

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -291,6 +291,7 @@ public final class SystemTable<T> implements TableInfo {
                         ColumnPolicy.DYNAMIC,
                         IndexType.NOT_ANALYZED,
                         column.isNullable,
+                        false,
                         position,
                         null
                     )

--- a/server/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -97,6 +97,7 @@ public class DocSysColumns {
                              ColumnPolicy.STRICT,
                              Reference.IndexType.NOT_ANALYZED,
                              false,
+                             false,
                              position,
                              null
         );

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -63,6 +63,7 @@ public class ReferenceTest extends ESTestCase {
             ColumnPolicy.STRICT,
             Reference.IndexType.ANALYZED,
             false,
+            true,
             0,
             Literal.of(Map.of("f", 10)
             )
@@ -88,6 +89,7 @@ public class ReferenceTest extends ESTestCase {
             ColumnPolicy.STRICT,
             Reference.IndexType.ANALYZED,
             false,
+            true,
             0,
             Literal.of(Map.of("f", 10)
             )

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -104,6 +104,7 @@ public class DocTableInfoTest extends ESTestCase {
             ColumnPolicy.STRICT,
             Reference.IndexType.NOT_ANALYZED,
             true,
+            false,
             1,
             null
         );


### PR DESCRIPTION
The `columnStoreDisabled` value was passed to a function where the
parameter was called `columnStoreEnabled`.