### PR TITLE
Ensure LIKE query on varchar columns use WildcardQuery

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -97,6 +97,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented ``LIKE`` operators from using the index if the
+  left operand was a varchar column with length limit, and the right operand a
+  literal.
+
 - Fixed an issue that resulted in more data being snapshot than expected if
   only concrete tables were snapshot by the
   ``CREATE SNAPSHOT ... TABLE [table, ...]``. Instead of just the concrete

--- a/server/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
@@ -32,6 +32,8 @@ import io.crate.types.DataTypes;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
@@ -39,6 +41,16 @@ public class CastFunctionResolver {
 
     public static final List<String> CAST_FUNCTION_NAMES = List.of(
         ExplicitCastFunction.NAME, ImplicitCastFunction.NAME, TryCastFunction.NAME);
+
+    @Nullable
+    public static CastMode getCastMode(String functionName) {
+        return switch (functionName) {
+            case ExplicitCastFunction.NAME -> CastMode.EXPLICIT;
+            case ImplicitCastFunction.NAME -> CastMode.IMPLICIT;
+            case TryCastFunction.NAME -> CastMode.TRY;
+            default -> null;
+        };
+    }
 
     public static Symbol generateCastFunction(Symbol sourceSymbol,
                                               DataType<?> targetType,

--- a/server/src/main/java/io/crate/lucene/LikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/LikeQuery.java
@@ -70,8 +70,7 @@ final class LikeQuery implements FunctionToQuery {
             // column doesn't exist on this index -> no match
             return Queries.newMatchNoDocsQuery("column does not exist in this index");
         }
-
-        if (dataType.equals(DataTypes.STRING)) {
+        if (dataType.id() == DataTypes.STRING.ID) {
             return createCaseAwareQuery(
                 fieldType.name(),
                 BytesRefs.toString(value),

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
@@ -87,7 +87,6 @@ public class Optimizer {
                     return null;
                 }
             };
-
         this.rules = Lists2.map(rules, r -> r.apply(functionResolver));
         this.minNodeVersionInCluster = minNodeVersionInCluster;
         this.nodeCtx = nodeCtx;

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -44,7 +44,9 @@ import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.spatial.prefix.IntersectsPrefixTreeQuery;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -526,5 +528,12 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     public void test_is_not_null_on_ignored_results_in_function_query() throws Exception {
         Query query = convert("obj_ignored is not null");
         assertThat(query.toString(), is("(NOT (_doc['obj_ignored'] IS NULL))"));
+    }
+
+    @Test
+    public void test_equal_on_varchar_column_uses_term_query() throws Exception {
+        Query query = convert("vchar_name = 'Trillian'");
+        assertThat(query.toString(), is("vchar_name:Trillian"));
+        assertThat(query, Matchers.instanceOf(TermQuery.class));
     }
 }

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -111,4 +111,11 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(convertSqlLikeToLuceneWildcard("\\_me"), is("_me"));
         assertThat(convertSqlLikeToLuceneWildcard("?me"), is("\\?me"));
     }
+
+    @Test
+    public void test_like_on_varchar_column_uses_wildcard_query() throws Exception {
+        Query query = convert("vchar_name LIKE 'Trillian%'");
+        assertThat(query.toString(), is("vchar_name:Trillian*"));
+        assertThat(query, instanceOf(WildcardQuery.class));
+    }
 }

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -65,7 +65,8 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
             " shape geo_shape," +
             " point geo_point," +
             " ts timestamp with time zone," +
-            " addr ip" +
+            " addr ip," +
+            " vchar_name varchar(40)" +
             ")"
         );
         queryTester = builder.build();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

LIKE is registered with a `text -> text -> boolean` signature. This
leads to implicit casts if a column has a varchar type with lengh limit:

    ref LIKE 'some_literal'

Changes to:

    _cast(ref, 'text') LIKE 'some_literal'

An optimization rule then tries to flip the cast:

    ref LIKE _cast('some_literal', 'text')

But because `text` != `varchar(n)` the function resolver
added back casts again. Because of that, the query builder wasn't able
to create a `WildcardQuery` but instead used a generic function filter,
which is expensive.

Fixes https://github.com/crate/crate/issues/11412

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
