### PR TITLE
bp: Fix doc_stats and segment_stats of ReadOnlyEngine

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -490,7 +490,7 @@ should be crossed out as well.
 - [ ] 9ada5083479 Fix date_nanos in composite aggs (backport of #53315) (#53347)
 - [ ] ac721938c22 Allow joining node to trigger term bump (#53338)
 - [ ] 7189c57b6cb Record Force Merges in Live Commit Data (#52694) (#53372)
-- [ ] 24f114766fb Fix doc_stats and segment_stats of ReadOnlyEngine (#53345)
+- [x] 24f114766fb Fix doc_stats and segment_stats of ReadOnlyEngine (#53345)
 - [ ] 5c861cfe6e2 Upgrade to final lucene 8.5.0 snapshot (#53293)
 - [ ] 5e96d3e59ae Use given executor for global checkpoint listener (#53260)
 - [ ] c5738ae312a Notify refresh listeners on the calling thread (#53259)

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -33,6 +33,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.LockObtainFailedException;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -109,10 +110,16 @@ public class NoOpEngineTests extends EngineTestCase {
     @Test
     public void testNoOpEngineDocStats() throws Exception {
         IOUtils.close(engine, store);
+        Settings.Builder settings = Settings.builder()
+            .put(defaultSettings.getSettings())
+            .put(IndexSettings.INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING.getKey(), 0);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build());
+
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         try (Store store = createStore()) {
             Path translogPath = createTempDir();
-            EngineConfig config = config(defaultSettings, store, translogPath, NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            EngineConfig config = config(indexSettings, store, translogPath, NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
             final int numDocs = scaledRandomIntBetween(10, 3000);
             int deletions = 0;
             try (InternalEngine engine = createEngine(config)) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Test was flaky: https://wacklig.pipifein.dev/github/crate/crate/01F6PZEMJTA6KVFBAAHB85NYXA/01F6PZEMKAXAKARJ95S9AHWF9Z


https://github.com/crate/crate/commit/24f114766fb1dae17bb94146042d14152386882c


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
