### PR TITLE
Remove phrase-/multiPhaseQuery from MappedFieldType

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -19,13 +19,11 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
@@ -249,14 +247,6 @@ public abstract class MappedFieldType extends FieldType {
     }
 
     public abstract Query existsQuery(QueryShardContext context);
-
-    public Query phraseQuery(String field, TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
-        throw new IllegalArgumentException("Attempted to build a phrase query with multiple terms against non-text field [" + name + "]");
-    }
-
-    public Query multiPhraseQuery(String field, TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
-        throw new IllegalArgumentException("Attempted to build a phrase query with multiple terms against non-text field [" + name + "]");
-    }
 
     /** A term query to use when parsing a query string. Can return {@code null}. */
     @Nullable

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -19,14 +19,11 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
+import java.util.List;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.FuzzyQuery;
-import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
@@ -35,10 +32,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.QueryShardContext;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /** Base class for {@link MappedFieldType} implementations that use the same
  * representation for internal index terms as the external representation so
@@ -88,64 +81,5 @@ public abstract class StringFieldType extends TermBasedFieldType {
             lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
             upperTerm == null ? null : indexedValueForSearch(upperTerm),
             includeLower, includeUpper);
-    }
-
-    @Override
-    public Query phraseQuery(String field, TokenStream stream, int slop, boolean enablePosIncrements) throws IOException {
-
-        PhraseQuery.Builder builder = new PhraseQuery.Builder();
-        builder.setSlop(slop);
-
-        TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
-        PositionIncrementAttribute posIncrAtt = stream.getAttribute(PositionIncrementAttribute.class);
-        int position = -1;
-
-        stream.reset();
-        while (stream.incrementToken()) {
-            if (enablePosIncrements) {
-                position += posIncrAtt.getPositionIncrement();
-            } else {
-                position += 1;
-            }
-            builder.add(new Term(field, termAtt.getBytesRef()), position);
-        }
-
-        return builder.build();
-    }
-
-    @Override
-    public Query multiPhraseQuery(String field, TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
-
-        MultiPhraseQuery.Builder mpqb = new MultiPhraseQuery.Builder();
-        mpqb.setSlop(slop);
-
-        TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
-
-        PositionIncrementAttribute posIncrAtt = stream.getAttribute(PositionIncrementAttribute.class);
-        int position = -1;
-
-        List<Term> multiTerms = new ArrayList<>();
-        stream.reset();
-        while (stream.incrementToken()) {
-            int positionIncrement = posIncrAtt.getPositionIncrement();
-
-            if (positionIncrement > 0 && multiTerms.size() > 0) {
-                if (enablePositionIncrements) {
-                    mpqb.add(multiTerms.toArray(new Term[0]), position);
-                } else {
-                    mpqb.add(multiTerms.toArray(new Term[0]));
-                }
-                multiTerms.clear();
-            }
-            position += positionIncrement;
-            multiTerms.add(new Term(field, termAtt.getBytesRef()));
-        }
-
-        if (enablePositionIncrements) {
-            mpqb.add(multiTerms.toArray(new Term[0]), position);
-        } else {
-            mpqb.add(multiTerms.toArray(new Term[0]));
-        }
-        return mpqb.build();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -19,10 +19,19 @@
 
 package org.elasticsearch.index.search;
 
+import static org.elasticsearch.common.lucene.search.Queries.newLenientFieldQuery;
+import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.miscellaneous.DisableGraphAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.ExtendedCommonTermsQuery;
@@ -53,11 +62,6 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.support.QueryParsers;
-
-import java.io.IOException;
-
-import static org.elasticsearch.common.lucene.search.Queries.newLenientFieldQuery;
-import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
 
 public class MatchQuery {
 
@@ -314,7 +318,7 @@ public class MatchQuery {
         protected Query analyzePhrase(String field, TokenStream stream, int slop) throws IOException {
             try {
                 checkForPositions(field);
-                Query query = mapper.phraseQuery(field, stream, slop, enablePositionIncrements);
+                Query query = phraseQuery(field, stream, slop, enablePositionIncrements);
                 if (query instanceof PhraseQuery) {
                     // synonyms that expand to multiple terms can return a phrase query.
                     return blendPhraseQuery((PhraseQuery) query, mapper);
@@ -337,7 +341,7 @@ public class MatchQuery {
         protected Query analyzeMultiPhrase(String field, TokenStream stream, int slop) throws IOException {
             try {
                 checkForPositions(field);
-                return mapper.multiPhraseQuery(field, stream, slop, enablePositionIncrements);
+                return multiPhraseQuery(field, stream, slop, enablePositionIncrements);
             } catch (IllegalStateException e) {
                 if (lenient) {
                     return newLenientFieldQuery(field, e);
@@ -506,5 +510,60 @@ public class MatchQuery {
             }
         }
         return termQuery(fieldType, term.bytes(), lenient);
+    }
+
+    private static Query multiPhraseQuery(String field, TokenStream stream, int slop, boolean enablePositionIncrements) throws IOException {
+        MultiPhraseQuery.Builder mpqb = new MultiPhraseQuery.Builder();
+        mpqb.setSlop(slop);
+
+        TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+
+        PositionIncrementAttribute posIncrAtt = stream.getAttribute(PositionIncrementAttribute.class);
+        int position = -1;
+
+        List<Term> multiTerms = new ArrayList<>();
+        stream.reset();
+        while (stream.incrementToken()) {
+            int positionIncrement = posIncrAtt.getPositionIncrement();
+
+            if (positionIncrement > 0 && multiTerms.size() > 0) {
+                if (enablePositionIncrements) {
+                    mpqb.add(multiTerms.toArray(new Term[0]), position);
+                } else {
+                    mpqb.add(multiTerms.toArray(new Term[0]));
+                }
+                multiTerms.clear();
+            }
+            position += positionIncrement;
+            multiTerms.add(new Term(field, termAtt.getBytesRef()));
+        }
+
+        if (enablePositionIncrements) {
+            mpqb.add(multiTerms.toArray(new Term[0]), position);
+        } else {
+            mpqb.add(multiTerms.toArray(new Term[0]));
+        }
+        return mpqb.build();
+    }
+
+    private static Query phraseQuery(String field, TokenStream stream, int slop, boolean enablePosIncrements) throws IOException {
+        PhraseQuery.Builder builder = new PhraseQuery.Builder();
+        builder.setSlop(slop);
+
+        TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
+        PositionIncrementAttribute posIncrAtt = stream.getAttribute(PositionIncrementAttribute.class);
+        int position = -1;
+
+        stream.reset();
+        while (stream.incrementToken()) {
+            if (enablePosIncrements) {
+                position += posIncrAtt.getPositionIncrement();
+            } else {
+                position += 1;
+            }
+            builder.add(new Term(field, termAtt.getBytesRef()), position);
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

These two methods are only used in the `MatchQuery` and were only
implemented in the StringFieldType.

It isn't necessary to have them in an abstract class that is used for
all types.

Motivated by https://github.com/crate/crate/issues/10025

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
