### PR TITLE
bp: Make FieldTypeLookup immutable

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -318,7 +318,7 @@ should be crossed out as well.
 - [ ] 8ebd341710e Add text search information to MappedFieldType (#58230) (#58432)
 - [ ] 943efb78fd7 Save Shard ID Serializations in Bulk Requests (#56209) (#58414)
 - [ ] 256b660f0a0 Remove anonymous PublicationContext implementation (#58412)
-- [ ] 519d1278e23 Make FieldTypeLookup immutable (#58162) (#58411)
+- [x] 519d1278e23 Make FieldTypeLookup immutable (#58162) (#58411)
 - [ ] a44dad9fbb4 [7.x] Add support for snapshot and restore to data streams (#57675) (#58371)
 - [ ] 4b8cf2af6a8 Add serialization test for FieldMappers when include_defaults=true (#58235) (#58328)
 - [ ] ca2d12d039b Remove Settings parameter from FieldMapper base class (#58237)

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperMergeValidator.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperMergeValidator.java
@@ -36,11 +36,9 @@ class MapperMergeValidator {
      * @param objectMappers The newly added object mappers.
      * @param fieldMappers The newly added field mappers.
      * @param fieldAliasMappers The newly added field alias mappers.
-     * @param fieldTypes Any existing field and field alias mappers, collected into a lookup structure.
      */
     public static void validateNewMappers(Collection<ObjectMapper> objectMappers,
-                                          Collection<FieldMapper> fieldMappers,
-                                          FieldTypeLookup fieldTypes) {
+                                          Collection<FieldMapper> fieldMappers) {
         Set<String> objectFullNames = new HashSet<>();
         for (ObjectMapper objectMapper : objectMappers) {
             String fullPath = objectMapper.fullPath();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -315,12 +315,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         Collections.addAll(fieldMappers, metadataMappers);
         MapperUtils.collect(newMapper.mapping().root(), objectMappers, fieldMappers);
 
-        FieldTypeLookup fieldTypes = this.fieldTypes;
-        MapperMergeValidator.validateNewMappers(objectMappers, fieldMappers, fieldTypes);
+        MapperMergeValidator.validateNewMappers(objectMappers, fieldMappers);
         checkPartitionedIndexConstraints(newMapper);
 
-        // update lookup data-structures
-        fieldTypes = fieldTypes.copyAndAddAll(newMapper.type(), fieldMappers);
+        this.fieldTypes = new FieldTypeLookup(fieldMappers);
 
         for (ObjectMapper objectMapper : objectMappers) {
             if (fullPathObjectMappers == this.fullPathObjectMappers) {
@@ -350,7 +348,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         if (newMapper != null) {
             this.mapper = newMapper;
         }
-        this.fieldTypes = fieldTypes;
         this.fullPathObjectMappers = fullPathObjectMappers;
 
         assert newMapper == null || assertSerialization(newMapper);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/elastic/elasticsearch/commit/519d1278e231649fc67c5a207fe12da21c7a8ed5


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
