### PR TITLE
bp: MappedFieldType no longer requires equals/hashCode/clone

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -277,7 +277,7 @@ should be crossed out as well.
 - [ ] 08b54feaaf2 Remove Snapshot INIT Step (#55918) (#59374)
 - [ ] c810a4a12e8 Continue to accept unused 'universal' params in <8.0 indexes (#59381)
 - [ ] 483386136d9 Move all Snapshot Master Node Steps to SnapshotsService (#56365) (#59373)
-- [ ] f4caadd239f MappedFieldType no longer requires equals/hashCode/clone (#59212)
+- [x] f4caadd239f MappedFieldType no longer requires equals/hashCode/clone (#59212)
 - [ ] d56fc72ee5b Fix node health-check-related test failures (#59277)
 - [ ] 67a27e2b9d4 Add declarative parameters to FieldMappers (#58663)
 - [ ] 6a0f7411e25 Do not release safe commit with CancellableThreads (#59182)

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayFieldType.java
@@ -30,14 +30,9 @@ import org.joda.time.DateTimeZone;
 
 import java.util.List;
 
-class ArrayFieldType extends MappedFieldType implements Cloneable {
+class ArrayFieldType extends MappedFieldType {
 
     private final MappedFieldType innerFieldType;
-
-    private ArrayFieldType(ArrayFieldType ref) {
-        super(ref);
-        this.innerFieldType = ref.innerFieldType;
-    }
 
     ArrayFieldType(MappedFieldType innerFieldType) {
         super(innerFieldType.name(), innerFieldType.isSearchable(), innerFieldType.hasDocValues());
@@ -47,12 +42,6 @@ class ArrayFieldType extends MappedFieldType implements Cloneable {
     @Override
     public String name() {
         return innerFieldType.name();
-    }
-
-    @SuppressWarnings("CloneDoesntCallSuperClone")
-    @Override
-    public MappedFieldType clone() {
-        return new ArrayFieldType(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -128,15 +128,6 @@ public class BooleanFieldMapper extends FieldMapper {
             this(name, true, true);
         }
 
-        protected BooleanFieldType(BooleanFieldType ref) {
-            super(ref);
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new BooleanFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -183,29 +183,6 @@ public class DateFieldMapper extends FieldMapper {
             this.dateTimeFormatter = formatter;
         }
 
-        DateFieldType(DateFieldType other) {
-            super(other);
-            this.dateTimeFormatter = other.dateTimeFormatter;
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new DateFieldType(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!super.equals(o)) return false;
-            DateFieldType that = (DateFieldType) o;
-            return Objects.equals(dateTimeFormatter.format(), that.dateTimeFormatter.format()) &&
-                   Objects.equals(dateTimeFormatter.locale(), that.dateTimeFormatter.locale());
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), dateTimeFormatter.format(), dateTimeFormatter.locale());
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -107,28 +106,6 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
 
         public FieldNamesFieldType() {
             super(Defaults.NAME, true, false);
-        }
-
-        protected FieldNamesFieldType(FieldNamesFieldType ref) {
-            super(ref);
-            this.enabled = ref.enabled;
-        }
-
-        @Override
-        public FieldNamesFieldType clone() {
-            return new FieldNamesFieldType(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!super.equals(o)) return false;
-            FieldNamesFieldType that = (FieldNamesFieldType) o;
-            return enabled == that.enabled;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), enabled);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -128,18 +128,9 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
             super(name, indexed, hasDocValues);
         }
 
-        GeoPointFieldType(GeoPointFieldType ref) {
-            super(ref);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new GeoPointFieldType(this);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -273,49 +272,6 @@ public class GeoShapeFieldMapper extends FieldMapper {
             this.precisionInMeters = precisionInMeters;
             this.distanceErrorPct = distanceErrorPct;
             this.orientation = orientation;
-        }
-
-        protected GeoShapeFieldType(GeoShapeFieldType ref) {
-            super(ref);
-            this.tree = ref.tree;
-            this.strategyName = ref.strategyName;
-            this.pointsOnly = ref.pointsOnly;
-            this.treeLevels = ref.treeLevels;
-            this.precisionInMeters = ref.precisionInMeters;
-            this.distanceErrorPct = ref.distanceErrorPct;
-            this.orientation = ref.orientation;
-        }
-
-        @Override
-        public GeoShapeFieldType clone() {
-            return new GeoShapeFieldType(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!super.equals(o)) return false;
-            GeoShapeFieldType that = (GeoShapeFieldType) o;
-            return treeLevels == that.treeLevels &&
-                precisionInMeters == that.precisionInMeters &&
-                Objects.equals(tree, that.tree) &&
-                Objects.equals(strategyName, that.strategyName) &&
-                pointsOnly == that.pointsOnly &&
-                Objects.equals(distanceErrorPct, that.distanceErrorPct) &&
-                orientation == that.orientation;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(
-                super.hashCode(),
-                tree,
-                strategyName,
-                pointsOnly,
-                treeLevels,
-                precisionInMeters,
-                distanceErrorPct,
-                orientation
-            );
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -85,15 +85,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
             setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
-        protected IdFieldType(IdFieldType ref) {
-            super(ref);
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new IdFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -127,15 +127,6 @@ public class IpFieldMapper extends FieldMapper {
             this(name, true, true);
         }
 
-        IpFieldType(IpFieldType other) {
-            super(other);
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new IpFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -193,37 +193,6 @@ public final class KeywordFieldMapper extends FieldMapper {
             this(name, true, true);
         }
 
-        protected KeywordFieldType(KeywordFieldType ref) {
-            super(ref);
-            this.hasNorms = ref.hasNorms;
-            setIndexAnalyzer(ref.indexAnalyzer());
-            setSearchAnalyzer(ref.searchAnalyzer());
-        }
-
-        @Override
-        public KeywordFieldType clone() {
-            return new KeywordFieldType(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            if (!super.equals(o)) {
-                return false;
-            }
-            KeywordFieldType that = (KeywordFieldType) o;
-            return Objects.equals(lengthLimit, that.lengthLimit);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), lengthLimit);
-        }
 
         @Override
         public String typeName() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -51,56 +51,11 @@ public abstract class MappedFieldType {
     protected boolean hasPositions;
     private boolean eagerGlobalOrdinals;
 
-    protected MappedFieldType(MappedFieldType ref) {
-        this.name = ref.name();
-        this.boost = ref.boost();
-        this.isIndexed = ref.isIndexed;
-        this.docValues = ref.hasDocValues();
-        this.indexAnalyzer = ref.indexAnalyzer();
-        this.searchAnalyzer = ref.searchAnalyzer();
-        this.searchQuoteAnalyzer = ref.searchQuoteAnalyzer();
-        this.eagerGlobalOrdinals = ref.eagerGlobalOrdinals;
-        this.hasPositions = ref.hasPositions;
-    }
-
     public MappedFieldType(String name, boolean isIndexed, boolean hasDocValues) {
         setBoost(1.0f);
         this.name = Objects.requireNonNull(name);
         this.isIndexed = isIndexed;
         this.docValues = hasDocValues;
-    }
-
-    @Override
-    public abstract MappedFieldType clone();
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        MappedFieldType fieldType = (MappedFieldType) o;
-
-        return boost == fieldType.boost &&
-            docValues == fieldType.docValues &&
-            Objects.equals(name, fieldType.name) &&
-            Objects.equals(indexAnalyzer, fieldType.indexAnalyzer) &&
-            Objects.equals(searchAnalyzer, fieldType.searchAnalyzer) &&
-            Objects.equals(searchQuoteAnalyzer(), fieldType.searchQuoteAnalyzer()) &&
-            Objects.equals(eagerGlobalOrdinals, fieldType.eagerGlobalOrdinals);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-            super.hashCode(),
-            name,
-            boost,
-            docValues,
-            indexAnalyzer,
-            searchAnalyzer,
-            searchQuoteAnalyzer,
-            eagerGlobalOrdinals
-        );
     }
 
     /** Returns the name of this type, as would be specified in mapping properties */

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -783,16 +783,6 @@ public class NumberFieldMapper extends FieldMapper {
             this(name, type, true, true);
         }
 
-        private NumberFieldType(NumberFieldType other) {
-            super(other);
-            this.type = other.type;
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new NumberFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return type.name;
@@ -845,19 +835,6 @@ public class NumberFieldMapper extends FieldMapper {
             return type.valueForSearch((Number) value);
         }
 
-        @Override
-        public boolean equals(Object o) {
-            if (super.equals(o) == false) {
-                return false;
-            }
-            NumberFieldType that = (NumberFieldType) o;
-            return type == that.type;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), type);
-        }
     }
 
     private Explicit<Boolean> coerce;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -117,15 +117,6 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
             setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
-        protected RoutingFieldType(RoutingFieldType ref) {
-            super(ref);
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new RoutingFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -122,15 +122,6 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
             super(NAME, true, true);
         }
 
-        protected SeqNoFieldType(SeqNoFieldType ref) {
-            super(ref);
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new SeqNoFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/SimpleMappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SimpleMappedFieldType.java
@@ -33,10 +33,6 @@ public abstract class SimpleMappedFieldType extends MappedFieldType {
         super(name, isSearchable, hasDocValues);
     }
 
-    protected SimpleMappedFieldType(MappedFieldType ref) {
-        super(ref);
-    }
-
     @Override
     public final Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
                                   ShapeRelation relation, DateTimeZone timeZone, QueryShardContext context) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -112,15 +112,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
             super(NAME, false, false);
         }
 
-        protected SourceFieldType(SourceFieldType ref) {
-            super(ref);
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new SourceFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -33,10 +33,6 @@ public abstract class StringFieldType extends TermBasedFieldType {
         super(name, isSearchable, hasDocValues);
     }
 
-    protected StringFieldType(MappedFieldType ref) {
-        super(ref);
-    }
-
     @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
         failIfNotIndexed();

--- a/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
@@ -38,10 +38,6 @@ abstract class TermBasedFieldType extends SimpleMappedFieldType {
         super(name, isSearchable, hasDocValues);
     }
 
-    protected TermBasedFieldType(MappedFieldType ref) {
-        super(ref);
-    }
-
     /** Returns the indexed value used to construct search "values".
      *  This method is used for the default implementations of most
      *  query factory methods such as {@link #termQuery}. */

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -136,25 +136,6 @@ public class TextFieldMapper extends FieldMapper {
             this(name, true, true);
         }
 
-        protected TextFieldType(TextFieldType ref) {
-            super(ref);
-            this.hasPositions = ref.hasPositions;
-        }
-
-        public TextFieldType clone() {
-            return new TextFieldType(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return super.equals(o);
-        }
-
-        @Override
-        public int hashCode() {
-            return super.hashCode();
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -77,15 +77,6 @@ public class VersionFieldMapper extends MetadataFieldMapper {
             super(NAME, false, true);
         }
 
-        protected VersionFieldType(VersionFieldType ref) {
-            super(ref);
-        }
-
-        @Override
-        public MappedFieldType clone() {
-            return new VersionFieldType(this);
-        }
-
         @Override
         public String typeName() {
             return CONTENT_TYPE;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/elastic/elasticsearch/commit/f4caadd239fe9f3bfd8d14cb576a830ca22a4efb

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
