### PR TITLE
Fix duplicate column handling in DocValuesGroupByOptimizedIterator

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -97,6 +97,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could lead to errors when using ``DISTINCT`` or ``GROUP
+  BY`` with duplicate columns.
+
 - Fixed an issue that could cause ``GROUP BY`` queries with a ``LIMIT`` clause
   and aliased columns to fail.
 

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -138,9 +138,10 @@ final class DocValuesGroupByOptimizedIterator {
 
         InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx
             = docInputFactory.getCtx(collectTask.txnCtx());
-        docCtx.add(columnKeyRefs);
-        List<? extends LuceneCollectorExpression<?>> keyExpressions = docCtx.expressions();
-
+        List<LuceneCollectorExpression<?>> keyExpressions = new ArrayList<>();
+        for (var keyRef : columnKeyRefs) {
+            keyExpressions.add((LuceneCollectorExpression<?>) docCtx.add(keyRef));
+        }
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -40,6 +40,8 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 
+import java.util.Arrays;
+
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
 public class GroupByAggregateTest extends SQLIntegrationTestCase {
 
@@ -1334,5 +1336,26 @@ public class GroupByAggregateTest extends SQLIntegrationTestCase {
         );
         execute("select name, count(x), count(x) from doc.tbl group by name");
         assertThat(printedTable(response.rows()), Is.is("Apple| 3| 3\n"));
+    }
+
+    @Test
+    @UseJdbc(1)
+    public void test_group_by_on_duplicate_keys() throws Exception {
+        execute("create table tbl (city text, name text, id text, location geo_point)");
+        execute(
+            "insert into tbl (id, name, location, city) values " +
+            " ('122021430M', 'Rue Penavayre', [2.573609,44.35007], 'Rodez'), " +
+            " ('013440476U', 'Avenue de Trévoux ', [5.201722,46.20096], 'Saint-Denis-lès-Bourg'), " +
+            " ('021140050C', 'Rue Paul Doumer ', [3.426928,49.04915], 'Brasles') ");
+        execute("refresh table tbl");
+        execute("SELECT DISTINCT id, name, id, location, city FROM tbl");
+
+        // Ensure deterministic order for assertion → sort by id
+        Arrays.sort(response.rows(), (a, b) -> ((String) a[0]).compareTo((String) b[0]));
+        assertThat(printedTable(response.rows()), is(
+            "013440476U| Avenue de Trévoux | 013440476U| Pt(x=5.20172193646431,y=46.200959966517985)| Saint-Denis-lès-Bourg\n" +
+            "021140050C| Rue Paul Doumer | 021140050C| Pt(x=3.426927952095866,y=49.04914998449385)| Brasles\n" +
+            "122021430M| Rue Penavayre| 122021430M| Pt(x=2.573608970269561,y=44.35006999410689)| Rodez\n"
+        ));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `docInputFactory` de-duplicates key expressions. Usually that's a
good thing as it avoids duplicated value lookups, but in the case of the
DocValuesGroupByOptimizedIterator the expressions map directly to the
key values.

`GROUP BY x, y, x` must output three values, not less.

Fixes https://github.com/crate/crate/issues/11428

The ClassCastException mentioned in the referenced issue occurred
because the key types (based on the key references) didn't match with
the de-duplicated expressions.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
