### PR TITLE
Improve SQL docs for creating and dropping repositories

### DIFF
--- a/docs/admin/snapshots.rst
+++ b/docs/admin/snapshots.rst
@@ -26,7 +26,7 @@ Creating a repository
 
 Repositories are used to store, manage and restore snapshots.
 
-They are created using the :ref:`ref-create-repository` statement::
+They are created using the :ref:`sql-create-repository` statement::
 
     cr> CREATE REPOSITORY where_my_snapshots_go TYPE fs
     ... WITH (location='repo_path', compress=true);
@@ -35,7 +35,7 @@ They are created using the :ref:`ref-create-repository` statement::
 Repositories are uniquely identified by their name. Every repository has a
 specific type which determines how snapshots are stored.
 
-CrateDB supports different repository types, see :ref:`ref-create-repository-types`.
+CrateDB supports different repository types, see :ref:`sql-create-repo-types`.
 
 The creation of a repository configures it inside the CrateDB cluster. In
 general no data is written, no snapshots inside repositories changed or
@@ -97,7 +97,7 @@ Snapshots are **incremental**. Snapshots of the same cluster created later only
 store data not already contained in the repository.
 
 All examples above are used with the argument ``wait_for_completion`` set to
-*true*. As described in the :ref:`ref-create-repository` reference
+*true*. As described in the :ref:`sql-create-repository` reference
 documentation, by doing this, the statement will only respond (successfully or
 not) when the snapshot is fully created. Otherwise the snapshot will be created
 in the background and the statement will immediately respond as successful. The
@@ -241,12 +241,12 @@ Dropping repositories
     CREATE OK, 1 row affected (... sec)
 
 If a repository is not needed anymore, it can be dropped using the
-:ref:`ref-drop-repository` statement::
+:ref:`sql-drop-repository` statement::
 
     cr> DROP REPOSITORY "OldRepository";
     DROP OK, 1 row affected (... sec)
 
-This statement, like :ref:`ref-create-repository`, does not manipulate
+This statement, like :ref:`sql-create-repository`, does not manipulate
 repository contents but only deletes stored configuration for this repository
 in the cluster state, so it's not accessible any more.
 
@@ -266,11 +266,10 @@ in the cluster state, so it's not accessible any more.
 Requirements for using HDFS repositories
 ----------------------------------------
 
-CrateDB supports repositories of type
-:ref:`ref-create-repository-types-hdfs` type by default, but required
-`Hadoop`_ java client libraries are not included in any CrateDB distribution
-and need to be added to CrateDB's hdfs plugin folder. By default this is
-``$CRATE_HOME/plugins/es-repository-hdfs``
+CrateDB supports repositories of type :ref:`sql-create-repo-hdfs` by
+default, but required `Hadoop`_ java client libraries are not included in any
+CrateDB distribution and need to be added to CrateDB's hdfs plugin folder. By
+default this is ``$CRATE_HOME/plugins/es-repository-hdfs``
 
 Because some libraries `Hadoop`_ depends on are also required (and so deployed)
 by CrateDB, only the `Hadoop`_ libraries listed below must be copied into the

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1857,7 +1857,7 @@ used to create, manage and restore snapshots (see :ref:`snapshot-restore`).
 |               | repository has been created       |             |
 |               | with. The specific settings       |             |
 |               | depend on the repository type,    |             |
-|               | see :ref:`ref-create-repository`. |             |
+|               | see :ref:`sql-create-repository`. |             |
 +---------------+-----------------------------------+-------------+
 
 .. Hidden: create repository

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -296,7 +296,7 @@ Other Changes
   configured explicitly. Bucket regions are now inferred automatically.
 
   If you want to override this, you can use the :ref:`endpoint parameter
-  <ref-create-repository-types-s3>`.
+  <sql-create-repo-s3-endpoint>`.
 
 - Previously, the ``X-User`` HTTP header could be used to provide a username.
   This head is now deprecated in favour of the standard `HTTP Authorization

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -172,9 +172,9 @@ Removed Settings
 
 - Removed the possibility of configuring the AWS S3 repository client via the
   ``crate.yaml`` configuration file and command line arguments. Please, use the
-  :ref:`ref-create-repository` statement parameters for this purpose.
+  :ref:`sql-create-repository` statement parameters for this purpose.
 
-- Removed :ref:`HDFS repository setting<ref-create-repository-types-hdfs>`:
+- Removed :ref:`HDFS repository <sql-create-repo-hdfs>` setting:
   ``concurrent_streams`` as it is no longer supported.
 
 - The ``zen1`` related discovery settings mentioned in
@@ -369,11 +369,10 @@ Repositories and Snapshots
 --------------------------
 
 - Added support for the :ref:`Azure Storage repositories
-  <ref-create-repository-types-azure>`.
+  <sql-create-repo-azure>`.
 
 - Changed the default value of the ``fs`` repository type setting ``compress``,
-  to ``true``. See :ref:`fs repository
-  parameters<ref-create-repository-types-fs>`.
+  to ``true``. See :ref:`fs repository parameters <sql-create-repo-fs-params>`.
 
 - Improved resiliency of the :ref:`sql-create-snapshot` operation.
 

--- a/docs/appendices/release-notes/4.0.7.rst
+++ b/docs/appendices/release-notes/4.0.7.rst
@@ -78,5 +78,5 @@ Fixes
   upgrade to CrateDB 4.0+.
 
 - Changed the error message returned when a :ref:`CREATE REPOSITORY
-  <ref-create-repository>` statement fails so that it includes more information
+  <sql-create-repository>` statement fails so that it includes more information
   about the cause of the failure.

--- a/docs/appendices/release-notes/4.1.7.rst
+++ b/docs/appendices/release-notes/4.1.7.rst
@@ -41,8 +41,8 @@ Fixes
   <single_text_column> FROM <table>`` from working if used within a ``INSERT
   INTO`` statement.
 
-- Re-enabled the IAM role authentication for
-  :ref:`s3 repositories <ref-create-repository-types-s3>`
+- Re-enabled the IAM role authentication for :ref:`s3 repositories
+  <sql-create-repo-s3>`
 
 - Changed the required privileges to execute ``RESET`` statements to include
   the ``AL`` privilege. Users with ``AL`` could change settings using ``SET

--- a/docs/appendices/release-notes/4.1.8.rst
+++ b/docs/appendices/release-notes/4.1.8.rst
@@ -34,9 +34,8 @@ See the :ref:`version_4.1.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue where ``access_key`` and ``secret_key`` settings for
-  :ref:`s3 repositories <ref-create-repository-types-s3>` were exposed as
-  unmasked settings.
+- Fixed an issue where ``access_key`` and ``secret_key`` settings for :ref:`s3
+  repositories <sql-create-repo-s3>` were exposed as unmasked settings.
 
 - Fixed an issue that would prevent the :ref:`pg_stats <pg_stats>` table from
   querying if the ``most_common_vals`` or ``histogram_bounds`` columns contain

--- a/docs/appendices/release-notes/4.2.1.rst
+++ b/docs/appendices/release-notes/4.2.1.rst
@@ -40,8 +40,8 @@ Fixes
   target in ``ON CONFLICT`` clauses of ``INSERT`` statements.
 
 - Fixed an issue where :ref:`drop snapshot <ref-drop-snapshot>` on an
-  :ref:`azure repository <ref-create-repository-types-azure>` would not delete
-  all the related data.
+  :ref:`azure repository <sql-create-repo-azure>` would not delete all the
+  related data.
 
 - Fixed an issue that could lead to a ``Field is not streamable`` error message
   when using :ref:`window functions <window-functions>`.

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -279,14 +279,14 @@ Paths
   | *Runtime:* ``no``
 
   A list of filesystem or UNC paths where repositories of type
-  :ref:`ref-create-repository-types-fs` may be stored.
+  :ref:`sql-create-repo-fs` may be stored.
 
   Without this setting a CrateDB user could write snapshot files to any
   directory that is writable by the CrateDB process. To safeguard against this
   security issue, the possible paths have to be whitelisted here.
 
-  See also :ref:`location <ref-create-repository-types-fs-location>` setting of
-  repository type ``fs``.
+  See also :ref:`location <sql-create-repo-fs-location>` setting of repository
+  type ``fs``.
 
 .. SEEALSO::
 
@@ -719,8 +719,7 @@ Repositories are used to :ref:`backup <snapshot-restore>` a CrateDB cluster.
 **repositories.url.allowed_urls**
   | *Runtime:* ``no``
 
-  This setting only applies to repositories of type
-  :ref:`ref-create-repository-types-url`.
+  This setting only applies to repositories of type :ref:`sql-create-repo-url`.
 
   With this setting a list of urls can be specified which are allowed to be
   used if a repository of type ``url`` is created.
@@ -740,7 +739,7 @@ Repositories are used to :ref:`backup <snapshot-restore>` a CrateDB cluster.
   | *Runtime:* ``no``
 
   A list of protocols that are supported by repositories of type
-  :ref:`ref-create-repository-types-url`.
+  :ref:`sql-create-repo-url`.
 
   The ``jar`` protocol is used to access the contents of jar files. For more
   info, see the java `JarURLConnection documentation`_.

--- a/docs/sql/statements/drop-repository.rst
+++ b/docs/sql/statements/drop-repository.rst
@@ -1,16 +1,25 @@
 .. highlight:: psql
-.. _ref-drop-repository:
+
+.. _sql-drop-repository:
 
 ===================
 ``DROP REPOSITORY``
 ===================
 
-Unregister a repository.
+You can use the ``DROP REPOSITORY`` :ref:`statement <gloss-statement>` to
+de-register a repository.
+
+.. SEEALSO::
+
+    :ref:`CREATE REPOSITORY <sql-create-repository>`
 
 .. rubric:: Table of contents
 
 .. contents::
    :local:
+
+
+.. _sql-drop-repo-synopsis:
 
 Synopsis
 ========
@@ -19,20 +28,27 @@ Synopsis
 
     DROP REPOSITORY repository_name;
 
+
+.. _sql-drop-repo-desc:
+
 Description
 ===========
 
-DROP REPOSITORY will unregister an existing repository from the cluster.
-
-It cannot be used for creating, dropping or restoring snapshots anymore.
+When a repository is de-registered, it is no longer available for use.
 
 .. NOTE::
 
-   Already stored snapshots in the repository remain unchanged during this
-   operation.
+    When you drop a repository, CrateDB deletes the corresponding record from
+    :ref:`sys.repositories <sys-repositories>` but does not delete any
+    snapshots from the corresponding backend data storage. If you create a new
+    repository using the same backend data storage, any existing snapshots will
+    become available again.
+
+
+.. _sql-drop-repo-params:
 
 Parameters
 ==========
 
 :repository_name:
-  The name of the repository as identifier
+  The name of the repository to de-register.


### PR DESCRIPTION
Spotted an opportunity to tidy up the SQL syntax docs for `CREATE REPOSITORY` and went for it.

Specifically:

- For `create-repository.rst`:

  - Improve intro and add cross-references

  - Add missing ref labels and tidy up nomenclature of ref labels throughout the whole doc

  - General copyedits for clarity, style, grammar, and so on

  - Tidied up and improved section/headings hierarchy and use of TOCs

  - Converted all params to use definition-style markup

        **Example**
          This is an example of the style used.

  - Improved use of admonitions and expanded/reworked explanations where necessary to improve clarity

  - Minor edits for the statement synopsis to improve readability (i.e., `repository_parameter` renamed `parameter_name`)

  - Standardized wording of duplicate parameter definitions

  - Standardized ordering of parameters

  - Added external links where helpful (e.g., to specific Hadoop, AWS, and Azure resources)

  - Corrected `readonly` parameter to `url` for `url` type repositories

- For `drop-repository.rst`:

  - Changes to match the above

- For other files:

  - Update ref labels to match changes above
