### PR TITLE
optimize count on object to count on its not-null-subcolumns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -99,6 +99,10 @@ Changes
 - Improved the performance of the :ref`hyperloglog_distinct
   <aggregation-hyperloglog-distinct>` aggregation function.
 
+- Added an optimization that improves the performance of `count()` aggregations
+  on object columns that have at least one inner column with a `NOT NULL`
+  constraint.
+
 Fixes
 =====
 

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -25,13 +25,18 @@ import com.carrotsearch.hppc.BitMixer;
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.annotations.VisibleForTesting;
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.module.ExtraFunctionsModule;
 import io.crate.types.BooleanType;
@@ -65,6 +70,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.function.Function;
 
 import static java.lang.Double.doubleToLongBits;
 
@@ -160,9 +166,17 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes,
+    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                       Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                       DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
+        var fieldTypes = getMappedFieldTypes.apply(
+            Lists2.map(aggregationReferences, s -> ((Reference)s).column().fqn())
+        );
+        if (fieldTypes == null) {
+            return null;
+        }
+        var argumentTypes = Symbols.typeView(aggregationReferences);
         var dataType = argumentTypes.get(0);
         switch (dataType.id()) {
             case ByteType.ID:

--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -35,8 +35,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.common.network.NetworkAddress;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -24,8 +24,10 @@ package io.crate.execution.engine.aggregation;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.DataType;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -33,6 +35,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * A special FunctionImplementation that compute a single result from a set of input values
@@ -115,7 +118,10 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     }
 
     @Nullable
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes, List<MappedFieldType> fieldTypes, List<Literal<?>> optionalParams) {
+    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                       Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                       DocTableInfo table,
+                                                       List<Literal<?>> optionalParams) {
         return null;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -25,11 +25,16 @@ import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.common.MutableObject;
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -54,6 +59,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 
 public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
@@ -132,9 +138,17 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes,
+    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                       Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                       DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
+        var fieldTypes = getMappedFieldTypes.apply(
+            Lists2.map(aggregationReferences, s -> ((Reference)s).column().fqn())
+        );
+        if (fieldTypes == null) {
+            return null;
+        }
+        var argumentTypes = Symbols.typeView(aggregationReferences);
         var dataType = argumentTypes.get(0);
         switch (dataType.id()) {
             case ByteType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -30,7 +30,11 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -55,6 +59,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
 public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanAggregation.GeometricMeanState, Double> {
 
@@ -290,10 +295,19 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
         return boundSignature;
     }
 
+    @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes,
+    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                       Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                       DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
+        var fieldTypes = getMappedFieldTypes.apply(
+            Lists2.map(aggregationReferences, s -> ((Reference)s).column().fqn())
+        );
+        if (fieldTypes == null) {
+            return null;
+        }
+        var argumentTypes = Symbols.typeView(aggregationReferences);
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -23,11 +23,17 @@ package io.crate.execution.engine.aggregation.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
 import io.crate.common.MutableFloat;
+import io.crate.common.collections.Lists2;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.ByteType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
@@ -247,10 +253,19 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
             size = ((FixedWidthType) partialType()).fixedSize();
         }
 
+        @Nullable
         @Override
-        public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                           List<MappedFieldType> fieldTypes,
+        public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                           Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                           DocTableInfo table,
                                                            List<Literal<?>> optionalParams) {
+            var fieldTypes = getMappedFieldTypes.apply(
+                Lists2.map(aggregationReferences, s -> ((Reference)s).column().fqn())
+            );
+            if (fieldTypes == null) {
+                return null;
+            }
+            var argumentTypes = Symbols.typeView(aggregationReferences);
             DataType<?> arg = argumentTypes.get(0);
             switch (arg.id()) {
                 case ByteType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -23,11 +23,16 @@ package io.crate.execution.engine.aggregation.impl;
 
 import io.crate.breaker.RamAccounting;
 import io.crate.common.annotations.VisibleForTesting;
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -50,6 +55,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.function.Function;
 
 public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDecimal> {
 
@@ -167,10 +173,19 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
         return previousAggState;
     }
 
+    @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes,
+    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                       Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                       DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
+        var fieldTypes = getMappedFieldTypes.apply(
+            Lists2.map(aggregationReferences, s -> ((Reference)s).column().fqn())
+        );
+        if (fieldTypes == null) {
+            return null;
+        }
+        var argumentTypes = Symbols.typeView(aggregationReferences);
         return switch (argumentTypes.get(0).id()) {
             case ByteType.ID, ShortType.ID, IntegerType.ID, LongType.ID ->
                 new SumLong(returnType, fieldTypes.get(0).name());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -30,7 +30,11 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.execution.engine.aggregation.statistics.StandardDeviation;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -52,6 +56,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 
 public class StandardDeviationAggregation extends AggregationFunction<StandardDeviation, Double> {
 
@@ -211,10 +216,19 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
         return StdDevStateType.INSTANCE;
     }
 
+    @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes,
+    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                       Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                       DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
+        var fieldTypes = getMappedFieldTypes.apply(
+            Lists2.map(aggregationReferences, s -> ((Reference)s).column().fqn())
+        );
+        if (fieldTypes == null) {
+            return null;
+        }
+        var argumentTypes = Symbols.typeView(aggregationReferences);
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -30,7 +30,11 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.execution.engine.aggregation.statistics.Variance;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -52,6 +56,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 
 public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
@@ -213,10 +218,19 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
         return boundSignature;
     }
 
+    @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<DataType<?>> argumentTypes,
-                                                       List<MappedFieldType> fieldTypes,
+    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+                                                       Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
+                                                       DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
+        var fieldTypes = getMappedFieldTypes.apply(
+            Lists2.map(aggregationReferences, s -> ((Reference)s).column().fqn())
+        );
+        if (fieldTypes == null) {
+            return null;
+        }
+        var argumentTypes = Symbols.typeView(aggregationReferences);
         switch (argumentTypes.get(0).id()) {
             case ByteType.ID:
             case ShortType.ID:

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -126,7 +126,8 @@ final class DocValuesGroupByOptimizedIterator {
             groupProjection.values(),
             fieldTypeLookup,
             collectPhase.toCollect(),
-            collectTask.txnCtx().sessionSettings().searchPath()
+            collectTask.txnCtx().sessionSettings().searchPath(),
+            table
         );
         if (aggregators == null) {
             return null;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -48,7 +48,7 @@ public class MaximumAggregationTest extends AggregationTestCase {
     @Test
     public void test_function_implements_doc_values_aggregator_for_numeric_types() {
         for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
-            assertHasDocValueAggregator(MinimumAggregation.NAME, List.of(dataType));
+            assertHasDocValueAggregator(MaximumAggregation.NAME, List.of(dataType));
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -35,6 +35,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
@@ -64,7 +65,6 @@ import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTest {
 
@@ -109,11 +109,17 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
 
         var aggregationField = new NumberFieldMapper.NumberFieldType("z", NumberFieldMapper.NumberType.LONG);
         var sumDocValuesAggregator = sumAggregation.getDocValueAggregator(
-            List.of(DataTypes.LONG),
-            List.of(aggregationField),
+            List.of(new Reference(
+                new ReferenceIdent(RelationName.fromIndexName("test"), "z"),
+                RowGranularity.DOC,
+                DataTypes.LONG,
+                0,
+                null)
+            ),
+            (x) -> List.of(aggregationField),
+            mock(DocTableInfo.class),
             List.of()
         );
-
         var keyExpressions = List.of(new LongColumnReference("y"));
         var it = DocValuesGroupByOptimizedIterator.GroupByIterator.forSingleKey(
             List.of(sumDocValuesAggregator),
@@ -154,8 +160,17 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
 
         var aggregationField = new NumberFieldMapper.NumberFieldType("z", NumberFieldMapper.NumberType.LONG);
         var sumDocValuesAggregator = sumAggregation.getDocValueAggregator(
-            List.of(DataTypes.LONG),
-            List.of(aggregationField),
+            List.of(new Reference(
+                new ReferenceIdent(
+                    RelationName.fromIndexName("test"),
+                    "z"),
+                RowGranularity.DOC,
+                DataTypes.LONG,
+                0,
+                null)
+            ),
+            (x) -> List.of(aggregationField),
+            mock(DocTableInfo.class),
             List.of()
         );
         var keyExpressions = List.of(new BytesRefColumnReference("x"), new LongColumnReference("y"));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`count(object)` with not-null subcolumns will utilize `DocValueAggregators` of its not-null subcolumns 

closes #10629


performed a quick performance measurements with a toy spec, 

`./compare_run.py --v1 branch:master --v2 branch:jeeminso/count-on-object --spec specs/mysample.toml`

**cat specs/mysample.toml**
```sql
[setup]
statements = [
  "create table tbl (device int not null, payload object as (col int not null)) clustered into 1 shards"
]

  [[setup.data_files]]
  target = "tbl"
  source = "data/mysample.json"

[[queries]]
statement = "select device, count(payload) from tbl group by 1"
iterations = 200

[teardown]
statements = [
  "drop table tbl"
]
```

**head specs/data/mysample.json && wc -l specs/data/mysample.json** 
```sql
{"payload":{"col":2},"device":1}
{"payload":{"col":2},"device":1}
{"payload":{"col":2},"device":0}
{"payload":{"col":1},"device":6}
{"payload":{"col":7},"device":4}
{"payload":{"col":6},"device":4}
{"payload":{"col":4},"device":10}
{"payload":{"col":2},"device":6}
{"payload":{"col":4},"device":6}
{"payload":{"col":4},"device":5}
6800 specs/data/mysample.json
```

**Results**
```
# Results (server side duration in ms)
V1: 4.6.0-41976d829b636e0cc3331f1e1fce0f8a9b37c3f2
V2: 4.6.0-3533ba202785784f3494def28b9a8438c19b3b54

Q: select device, count(payload) from tbl group by 1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       31.789 ±   28.498 |     27.010 |     28.194 |     29.466 |    424.894 |
|   V2    |        3.102 ±   16.245 |      0.986 |      1.652 |      2.299 |    231.291 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 164.43%                           - 177.86%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 164.43%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |   53     2.19     1.37 |    0     0.00     0.00 |      268       37 |     0.00          0
 V2 |    0     0.00     0.00 |    0     0.00     0.00 |      268        0 |     0.00          0
    
V1 top allocation frames
  LZ4.decompress(...):95
  ByteBufferGuard.getBytes(...):77
  ByteBuffer.get(...):51
  ByteSourceJsonBootstrapper.ensureLoaded(int):22
  BytesReferenceStreamInput.maybeNextSlice():14
V2 top allocation frames
  DocValuesGroupByOptimizedIterator$GroupByIterator.applyAggregatesGroupedByKey(...):4
  ShardRouting.getIndexName():1
  InputFactory$InputColumnVisitor.visitInputColumn(...):1
  JsonGeneratorImpl._verifyPrettyValueWrite(...):1
  RootTask.<init>(...):1
```


Although this is a very simple object, it is enough to show that the feature is worth merging and I expect wider objects will see even more gains.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
