### PR TITLE
Fix pg_wire->execute message outbound handling, commandComplete must not flush

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -100,6 +100,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue at the PostgreSQL protocol message handling causing some
+  clients/drivers to fail on inserts using prepared statements.
+
 - Fixed an issue that prevented ``INSERT INTO`` statements where the source is
   a query that selects an object column which contains a different set of
   columns than the target object column.

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -105,7 +105,7 @@ public class Messages {
         buffer.writeByte('C');
         buffer.writeInt(length);
         writeCString(buffer, commandTagBytes);
-        ChannelFuture channelFuture = channel.writeAndFlush(buffer);
+        ChannelFuture channelFuture = channel.write(buffer);
         if (LOGGER.isTraceEnabled()) {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace("sentCommandComplete"));
         }

--- a/server/src/main/java/io/crate/protocols/postgres/NettyPoolWriteChannel.java
+++ b/server/src/main/java/io/crate/protocols/postgres/NettyPoolWriteChannel.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.SocketAddress;
+
+/**
+ * Channel implementation that always write messages inside the netty executor to ensure correct message ordering
+ **/
+public class NettyPoolWriteChannel implements Channel {
+
+    private static final Logger LOGGER = LogManager.getLogger(NettyPoolWriteChannel.class);
+
+    private final Channel delegate;
+    private final EventLoop executor;
+
+    public NettyPoolWriteChannel(Channel channel) {
+        this.delegate = channel;
+        this.executor = channel.eventLoop();
+    }
+
+    @Override
+    public <T> Attribute<T> attr(AttributeKey<T> key) {
+        return delegate.attr(key);
+    }
+
+    @Override
+    public <T> boolean hasAttr(AttributeKey<T> key) {
+        return delegate.hasAttr(key);
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress) {
+        return delegate.bind(localAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress) {
+        return delegate.connect(remoteAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return delegate.connect(remoteAddress, localAddress);
+    }
+
+    @Override
+    public ChannelFuture disconnect() {
+        return delegate.disconnect();
+    }
+
+    @Override
+    public ChannelFuture close() {
+        return delegate.close();
+    }
+
+    @Override
+    public ChannelFuture deregister() {
+        return delegate.deregister();
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+        return delegate.bind(localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        return delegate.connect(remoteAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        return delegate.connect(remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture disconnect(ChannelPromise promise) {
+        return delegate.disconnect(promise);
+    }
+
+    @Override
+    public ChannelFuture close(ChannelPromise promise) {
+        return delegate.close(promise);
+    }
+
+    @Override
+    public ChannelFuture deregister(ChannelPromise promise) {
+        return delegate.deregister(promise);
+    }
+
+    @Override
+    public ChannelFuture write(Object msg) {
+        return write(msg, newPromise());
+    }
+
+    @Override
+    public ChannelFuture write(Object msg, ChannelPromise promise) {
+        LOGGER.trace("write message type={}, channel={}",
+                     (char) ((ByteBuf) msg).getByte(0), this);
+        executor.execute(() -> {
+            delegate.write(msg, promise);
+
+        });
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        LOGGER.trace("write message type={}, channel={}",
+                     (char) ((ByteBuf) msg).getByte(0), this);
+        executor.execute(() -> {
+            delegate.writeAndFlush(msg, promise);
+
+        });
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg) {
+        return writeAndFlush(msg, newPromise());
+    }
+
+    @Override
+    public ChannelPromise newPromise() {
+        return delegate.newPromise();
+    }
+
+    @Override
+    public ChannelProgressivePromise newProgressivePromise() {
+        return delegate.newProgressivePromise();
+    }
+
+    @Override
+    public ChannelFuture newSucceededFuture() {
+        return delegate.newSucceededFuture();
+    }
+
+    @Override
+    public ChannelFuture newFailedFuture(Throwable cause) {
+        return delegate.newFailedFuture(cause);
+    }
+
+    @Override
+    public ChannelPromise voidPromise() {
+        return delegate.voidPromise();
+    }
+
+    @Override
+    public int compareTo(Channel o) {
+        return delegate.compareTo(o);
+    }
+
+    @Override
+    public ChannelId id() {
+        return delegate.id();
+    }
+
+    @Override
+    public EventLoop eventLoop() {
+        return delegate.eventLoop();
+    }
+
+    @Override
+    public Channel parent() {
+        return delegate.parent();
+    }
+
+    @Override
+    public ChannelConfig config() {
+        return delegate.config();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return delegate.isRegistered();
+    }
+
+    @Override
+    public boolean isActive() {
+        return delegate.isActive();
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return delegate.metadata();
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+        return delegate.localAddress();
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+        return delegate.remoteAddress();
+    }
+
+    @Override
+    public ChannelFuture closeFuture() {
+        return delegate.closeFuture();
+    }
+
+    @Override
+    public boolean isWritable() {
+        return delegate.isWritable();
+    }
+
+    @Override
+    public long bytesBeforeUnwritable() {
+        return delegate.bytesBeforeUnwritable();
+    }
+
+    @Override
+    public long bytesBeforeWritable() {
+        return delegate.bytesBeforeWritable();
+    }
+
+    @Override
+    public Unsafe unsafe() {
+        return delegate.unsafe();
+    }
+
+    @Override
+    public ChannelPipeline pipeline() {
+        return delegate.pipeline();
+    }
+
+    @Override
+    public ByteBufAllocator alloc() {
+        return delegate.alloc();
+    }
+
+    @Override
+    public Channel read() {
+        return delegate.read();
+    }
+
+    @Override
+    public Channel flush() {
+        return delegate.flush();
+    }
+}

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -292,7 +292,7 @@ public class PostgresWireProtocol {
 
         @Override
         public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
-            channel = new DelayableWriteChannel(ctx.channel());
+            channel = new DelayableWriteChannel(new NettyPoolWriteChannel(ctx.channel()));
         }
 
         @Override

--- a/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -21,16 +21,15 @@
 
 package io.crate.protocols.postgres;
 
-import java.util.List;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.auth.AccessControl;
 import io.crate.data.Row;
 import io.crate.protocols.postgres.types.PGType;
 import io.netty.channel.Channel;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
 
 class ResultSetReceiver extends BaseResultReceiver {
 
@@ -79,7 +78,10 @@ class ResultSetReceiver extends BaseResultReceiver {
         if (interrupted) {
             super.allFinished(true);
         } else {
-            Messages.sendCommandComplete(channel, query, rowCount).addListener(f -> super.allFinished(false));
+            // The returned channel promise will only complete, once the channel is flushed.
+            // But as commandComplete won't flush we must trigger the super method directly
+            Messages.sendCommandComplete(channel, query, rowCount);
+            super.allFinished(false);
         }
     }
 

--- a/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
@@ -55,7 +55,10 @@ class RowCountReceiver extends BaseResultReceiver {
 
     @Override
     public void allFinished(boolean interrupted) {
-        Messages.sendCommandComplete(channel, query, rowCount).addListener(f -> super.allFinished(interrupted));
+        // The returned channel promise will only complete, once the channel is flushed.
+        // But as commandComplete won't flush we must trigger the super method directly
+        Messages.sendCommandComplete(channel, query, rowCount);
+        super.allFinished(interrupted); // -> trigger possible delayed messages
     }
 
     @Override

--- a/server/src/test/java/io/crate/protocols/postgres/NettyPoolWriteChannelTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/NettyPoolWriteChannelTest.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import io.crate.types.StringType;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.Random;
+
+import static io.crate.testing.TestingHelpers.createReference;
+import static org.hamcrest.Matchers.is;
+
+public class NettyPoolWriteChannelTest extends ESTestCase {
+
+    private static final Random RANDOM = new Random();
+
+    @Test
+    public void test_writes_of_multiple_threads_retain_ordering() throws Exception {
+        var embeddedChannel = new EmbeddedChannel();
+        var channel = new NettyPoolWriteChannel(new AsyncTestChannel(embeddedChannel));
+
+        Messages.sendParseComplete(channel);
+        Messages.sendBindComplete(channel);
+        Messages.sendRowDescription(
+            channel,
+            List.of(createReference("foo", StringType.INSTANCE)),
+            null,
+            null
+        );
+        Messages.sendCommandComplete(channel, "SELECT foo FROM t1", 1);
+        Messages.sendReadyForQuery(channel, TransactionState.IDLE);
+        embeddedChannel.flushOutbound();
+
+        var outQueue = embeddedChannel.outboundMessages();
+        //assertThat(outQueue.size(), is(4));
+        assertThat((char) ((ByteBuf) outQueue.poll()).getByte(0), is('1'));
+        assertThat((char) ((ByteBuf) outQueue.poll()).getByte(0), is('2'));
+        assertThat((char) ((ByteBuf) outQueue.poll()).getByte(0), is('T'));
+        assertThat((char) ((ByteBuf) outQueue.poll()).getByte(0), is('C'));
+
+    }
+
+    private static class AsyncTestChannel implements Channel {
+
+        private final Channel delegate;
+
+        public AsyncTestChannel(Channel delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ChannelFuture write(Object msg) {
+            return invokeWrite(msg, newPromise(), false);
+        }
+
+        @Override
+        public ChannelFuture write(Object msg, ChannelPromise promise) {
+            return invokeWrite(msg, promise, false);
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg) {
+            return invokeWrite(msg, newPromise(), true);
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+            return invokeWrite(msg, promise, true);
+        }
+
+        private ChannelFuture invokeWrite(Object msg, ChannelPromise promise, boolean flush) {
+            if (RANDOM.nextBoolean()) {
+                delegate.write(msg, promise);
+                if (flush) {
+                    delegate.flush();
+                }
+            } else {
+                eventLoop().execute(() -> {
+                    delegate.write(msg, promise);
+                    if (flush) {
+                        delegate.flush();
+                    }
+                });
+            }
+            return promise;
+        }
+
+
+        @Override
+        public <T> Attribute<T> attr(AttributeKey<T> key) {
+            return delegate.attr(key);
+        }
+
+        @Override
+        public <T> boolean hasAttr(AttributeKey<T> key) {
+            return delegate.hasAttr(key);
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress) {
+            return delegate.bind(localAddress);
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress) {
+            return delegate.connect(remoteAddress);
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            return delegate.connect(remoteAddress, localAddress);
+        }
+
+        @Override
+        public ChannelFuture disconnect() {
+            return delegate.disconnect();
+        }
+
+        @Override
+        public ChannelFuture close() {
+            return delegate.close();
+        }
+
+        @Override
+        public ChannelFuture deregister() {
+            return delegate.deregister();
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+            return delegate.bind(localAddress, promise);
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+            return delegate.connect(remoteAddress, promise);
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            return delegate.connect(remoteAddress, localAddress, promise);
+        }
+
+        @Override
+        public ChannelFuture disconnect(ChannelPromise promise) {
+            return delegate.disconnect(promise);
+        }
+
+        @Override
+        public ChannelFuture close(ChannelPromise promise) {
+            return delegate.close(promise);
+        }
+
+        @Override
+        public ChannelFuture deregister(ChannelPromise promise) {
+            return delegate.deregister(promise);
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            return delegate.newPromise();
+        }
+
+        @Override
+        public ChannelProgressivePromise newProgressivePromise() {
+            return delegate.newProgressivePromise();
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            return delegate.newSucceededFuture();
+        }
+
+        @Override
+        public ChannelFuture newFailedFuture(Throwable cause) {
+            return delegate.newFailedFuture(cause);
+        }
+
+        @Override
+        public ChannelPromise voidPromise() {
+            return delegate.voidPromise();
+        }
+
+        @Override
+        public int compareTo(Channel o) {
+            return delegate.compareTo(o);
+        }
+
+        @Override
+        public ChannelId id() {
+            return delegate.id();
+        }
+
+        @Override
+        public EventLoop eventLoop() {
+            return delegate.eventLoop();
+        }
+
+        @Override
+        public Channel parent() {
+            return delegate.parent();
+        }
+
+        @Override
+        public ChannelConfig config() {
+            return delegate.config();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return delegate.isOpen();
+        }
+
+        @Override
+        public boolean isRegistered() {
+            return delegate.isRegistered();
+        }
+
+        @Override
+        public boolean isActive() {
+            return delegate.isActive();
+        }
+
+        @Override
+        public ChannelMetadata metadata() {
+            return delegate.metadata();
+        }
+
+        @Override
+        public SocketAddress localAddress() {
+            return delegate.localAddress();
+        }
+
+        @Override
+        public SocketAddress remoteAddress() {
+            return delegate.remoteAddress();
+        }
+
+        @Override
+        public ChannelFuture closeFuture() {
+            return delegate.closeFuture();
+        }
+
+        @Override
+        public boolean isWritable() {
+            return delegate.isWritable();
+        }
+
+        @Override
+        public long bytesBeforeUnwritable() {
+            return delegate.bytesBeforeUnwritable();
+        }
+
+        @Override
+        public long bytesBeforeWritable() {
+            return delegate.bytesBeforeWritable();
+        }
+
+        @Override
+        public Unsafe unsafe() {
+            return delegate.unsafe();
+        }
+
+        @Override
+        public ChannelPipeline pipeline() {
+            return delegate.pipeline();
+        }
+
+        @Override
+        public ByteBufAllocator alloc() {
+            return delegate.alloc();
+        }
+
+        @Override
+        public Channel read() {
+            return delegate.read();
+        }
+
+        @Override
+        public Channel flush() {
+            return delegate.flush();
+        }
+    }
+}


### PR DESCRIPTION
A `CommandComplete` outbound message should not flush, a `ReadyForQuery` is
expected at the end of the message flow which will flush.
Flushing in-between can cause problems with some clients as they will treat
a flush as the end of the message flow response and thus will treat such a
flow as invalid.
The proprietary Progress PgSQL ODBC DataDirect driver for example won't work
otherwise.

Fixes #11357.



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
