### PR TITLE
Ensure group by or aggregates on rename can run on shard level

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -97,6 +97,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented aggregations or grouping operations on virtual
+  tables to run parallel on shard level, even if the inner query would support
+  it.
+
 - Fixed an issue that prevented ``INSERT INTO`` statements where the source is
   a query that selects an object column which contains a different set of
   columns than the target object column.

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -80,6 +80,11 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
             : "Rename operator must have the same number of outputs as the source. Got " + outputs + " and " + source.outputs();
     }
 
+    @Override
+    public boolean preferShardProjections() {
+        return source.preferShardProjections();
+    }
+
     public RelationName name() {
         return name;
     }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -21,9 +21,11 @@
 
 package io.crate.planner.operators;
 
+import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.TopNDistinctProjection;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.table.TableInfo;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;
@@ -368,12 +370,13 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             )
         );
         io.crate.planner.node.dql.Collect collect = sqlExecutor.plan(statement);
-        assertThat(
-            collect.collectPhase().projections(),
-            contains(
-                instanceOf(TopNDistinctProjection.class)
-            )
-        );
+        List<Projection> projections = collect.collectPhase().projections();
+        assertThat(projections, contains(
+            instanceOf(TopNDistinctProjection.class),
+            instanceOf(TopNDistinctProjection.class)
+        ));
+        assertThat(projections.get(0).requiredGranularity(), is(RowGranularity.SHARD));
+        assertThat(projections.get(1).requiredGranularity(), is(RowGranularity.CLUSTER));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/11443

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
