### PR TITLE
Remove enabled flag from ObjectMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
@@ -59,13 +59,12 @@ public class ObjectArrayMapper extends ObjectMapper {
         protected ObjectMapper createMapper(String name,
                                             Integer position,
                                             String fullPath,
-                                            boolean enabled,
                                             Dynamic dynamic,
                                             Map<String, Mapper> mappers,
                                             @Nullable Settings settings) {
             return new ObjectArrayMapper(
                 name,
-                super.createMapper(name, position, fullPath, enabled, dynamic, mappers, settings),
+                super.createMapper(name, position, fullPath, dynamic, mappers, settings),
                 settings
             );
         }
@@ -77,7 +76,6 @@ public class ObjectArrayMapper extends ObjectMapper {
         super(name,
               innerMapper.position(),
               innerMapper.fullPath(),
-              innerMapper.isEnabled(),
               innerMapper.dynamic(),
               Collections.emptyMap(),
               settings);

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -75,11 +75,10 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         @Override
-        protected ObjectMapper createMapper(String name, Integer position, String fullPath, boolean enabled, Dynamic dynamic,
+        protected ObjectMapper createMapper(String name, Integer position, String fullPath, Dynamic dynamic,
                 Map<String, Mapper> mappers, @Nullable Settings settings) {
             return new RootObjectMapper(
                 name,
-                enabled,
                 dynamic,
                 mappers,
                 dynamicDateTimeFormatters,
@@ -167,13 +166,12 @@ public class RootObjectMapper extends ObjectMapper {
     private Explicit<DynamicTemplate[]> dynamicTemplates;
 
     RootObjectMapper(String name,
-                     boolean enabled,
                      Dynamic dynamic,
                      Map<String, Mapper> mappers,
                      Explicit<FormatDateTimeFormatter[]> dynamicDateTimeFormatters,
                      Explicit<DynamicTemplate[]> dynamicTemplates,
                      Settings settings) {
-        super(name, null, name, enabled, dynamic, mappers, settings);
+        super(name, null, name, dynamic, mappers, settings);
         this.dynamicTemplates = dynamicTemplates;
         this.dynamicDateTimeFormatters = dynamicDateTimeFormatters;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Cannot be disabled via SQL


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
