### PR TITLE
Ensure default expressions are evaluated per record

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -100,6 +100,11 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented ``DEFAULT`` clauses from being evaluated per
+  record in ``INSERT`` statements with multiple source values. This resulted in
+  the same values being inserted when using nondeterministic functions like
+  ``gen_random_text_uuid`` as default expression.
+
 - Fixed an issue that prevented aggregations or grouping operations on virtual
   tables to run parallel on shard level, even if the inner query would support
   it.

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -21,15 +21,16 @@
 
 package io.crate.execution.dml.upsert;
 
-import io.crate.analyze.SymbolEvaluator;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Maps;
 import io.crate.data.BiArrayRow;
+import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.expression.InputFactory;
+import io.crate.expression.InputFactory.Context;
 import io.crate.expression.ValueExtractors;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.metadata.ColumnIdent;
@@ -48,12 +49,17 @@ import java.util.Map;
 
 public final class InsertSourceFromCells implements InsertSourceGen {
 
+    private static final Object[] EMPTY_ARRAY = new Object[0];
+
     private final List<Reference> targets;
     private final BiArrayRow row = new BiArrayRow();
     private final CheckConstraints<Map<String, Object>, CollectExpression<Map<String, Object>, ?>> checks;
     private final GeneratedColumns<Row> generatedColumns;
-    private final Object[] defaultValues;
+    private final List<Input<?>> defaultValues;
     private final List<Reference> partitionedByColumns;
+
+    // This is re-used per document to hold the default values
+    private final Object[] defaultValuesCells;
 
     public InsertSourceFromCells(TransactionContext txnCtx,
                                  NodeContext nodeCtx,
@@ -61,10 +67,12 @@ public final class InsertSourceFromCells implements InsertSourceGen {
                                  String indexName,
                                  GeneratedColumns.Validation validation,
                                  List<Reference> targets) {
-        Tuple<List<Reference>, Object[]> allTargetColumnsAndDefaults = addDefaults(targets, table, txnCtx, nodeCtx);
+        Tuple<List<Reference>, List<Input<?>>> allTargetColumnsAndDefaults = addDefaults(targets, table, txnCtx, nodeCtx);
         this.targets = allTargetColumnsAndDefaults.v1();
         this.defaultValues = allTargetColumnsAndDefaults.v2();
+        this.defaultValuesCells = defaultValues.isEmpty() ? EMPTY_ARRAY : new Object[defaultValues.size()];
         this.partitionedByColumns = table.partitionedByColumns();
+        this.row.secondCells(defaultValuesCells);
 
         ReferencesFromInputRow referenceResolver = new ReferencesFromInputRow(
             this.targets,
@@ -95,7 +103,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
     @Override
     public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) {
         row.firstCells(values);
-        row.secondCells(defaultValues);
+        evaluateDefaultValues();
 
         HashMap<String, Object> source = new HashMap<>();
         for (int i = 0; i < targets.size(); i++) {
@@ -132,17 +140,27 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         return source;
     }
 
-    private static Tuple<List<Reference>, Object[]> addDefaults(List<Reference> targets,
-                                                                DocTableInfo table,
-                                                                TransactionContext txnCtx,
-                                                                NodeContext nodeCtx) {
+    private void evaluateDefaultValues() {
+        for (int i = 0; i < defaultValuesCells.length; i++) {
+            defaultValuesCells[i] = defaultValues.get(i).value();
+        }
+    }
+
+    private static Tuple<List<Reference>, List<Input<?>>> addDefaults(List<Reference> targets,
+                                                                      DocTableInfo table,
+                                                                      TransactionContext txnCtx,
+                                                                      NodeContext nodeCtx) {
+        if (table.defaultExpressionColumns().isEmpty()) {
+            return new Tuple<>(targets, List.of());
+        }
+        InputFactory inputFactory = new InputFactory(nodeCtx);
+        Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         ArrayList<Reference> defaultColumns = new ArrayList<>(table.defaultExpressionColumns().size());
-        ArrayList<Object> defaultValues = new ArrayList<>();
+        ArrayList<Input<?>> defaultValues = new ArrayList<>();
         for (Reference ref : table.defaultExpressionColumns()) {
             if (targets.contains(ref) == false) {
                 defaultColumns.add(ref);
-                Object val = SymbolEvaluator.evaluateWithoutParams(txnCtx, nodeCtx, ref.defaultExpression());
-                defaultValues.add(val);
+                defaultValues.add(ctx.add(ref.defaultExpression()));
             }
         }
         List<Reference> allColumns;
@@ -151,7 +169,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         } else {
             allColumns = Lists2.concat(targets, defaultColumns);
         }
-        return new Tuple<>(allColumns, defaultValues.toArray(new Object[0]));
+        return new Tuple<>(allColumns, defaultValues);
     }
 
     private static class ReferencesFromInputRow implements ReferenceResolver<CollectExpression<Row, ?>> {

--- a/server/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -403,4 +403,28 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> source = sourceGen.generateSourceAndCheckConstraints(new Object[] { "foo", null });
         assertThat(source, not(Matchers.hasKey("model")));
     }
+
+    @Test
+    public void test_default_clauses_are_evaluated_per_row() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (id text default gen_random_text_uuid(), x int)")
+            .build();
+        Reference x = (Reference) e.asSymbol("tbl.x");
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        InsertSourceGen sourceGen = InsertSourceGen.of(
+            txnCtx,
+            e.nodeCtx,
+            tbl,
+            tbl.concreteIndices()[0],
+            GeneratedColumns.Validation.NONE,
+            List.of(x)
+        );
+        Map<String, Object> result;
+        result = sourceGen.generateSourceAndCheckConstraints(new Object[] { 10 });
+        var id1 = result.get("id");
+        result = sourceGen.generateSourceAndCheckConstraints(new Object[] { 20 });
+        var id2 = result.get("id");
+        assertThat(id1, Matchers.notNullValue());
+        assertThat(id1, Matchers.not(is(id2)));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11450

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
