### PR TITLE
Mute flaky test_random_type_random_values

### DIFF
--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -149,6 +149,7 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    @AwaitsFix(bugUrl = "https://github.com/crate/crate/issues/11452")
     public void test_random_type_random_values() throws Exception {
         var validTypes =  DataTypes.PRIMITIVE_TYPES.stream()
             .filter(type -> !DataTypes.STORAGE_UNSUPPORTED.contains(type))


### PR DESCRIPTION
Let's mute it until there is a fix to allow other PRs from being merged without test hiccups
