### PR TITLE
Allow non-superusers to run certain ALTER CLUSTER commands.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -105,6 +105,12 @@ Changes
 - Improved the performance of the :ref`hyperloglog_distinct
   <aggregation-hyperloglog-distinct>` aggregation function.
 
+- Users with AL privileges (or DDL on both tables) can now run the following
+  ALTER CLUSTER commands:
+  ``ALTER CLUSTER SWAP TABLE source TO target``,
+  ``ALTER CLUSTER REROUTE RETRY FAILED``,
+  ``ALTER CLUSTER GC DANGLING ARTIFACTS``.
+
 - Added an optimization that improves the performance of `count()` aggregations
   on object columns that have at least one inner column with a `NOT NULL`
   constraint.

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -397,10 +397,10 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         assertThat(response.rowCount(), is (0L));
 
         assertThrowsMatches(() -> executeAsNormalUser("alter cluster reroute retry failed"),
-                     isSQLError(containsString("User \"normal\" is not authorized to execute the statement"),
+                     isSQLError(containsString("Missing 'AL' privilege for user 'normal'"),
                                 INTERNAL_ERROR,
                                 UNAUTHORIZED,
-                                4010));
+                                4011));
     }
 
     @Test


### PR DESCRIPTION
Non superusers with AL privileges can run the following `ALTER CLUSTER` commands:

```
ALTER CLUSTER SWAP TABLE source TO target [ WITH ( expr = expr [ , ... ] ) ]
ALTER CLUSTER REROUTE RETRY FAILED
ALTER CLUSTER GC DANGLING ARTIFACTS
```


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
