### PR TITLE
Update junit

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -41,8 +41,8 @@ jna=5.6.0
 
 # ES test
 randomizedrunner=2.7.7
-junit5=5.6.0
-junit=4.12
+junit5=5.7.2
+junit=4.13.2
 httpclient=4.5.12
 httpcore=4.4.12
 commonslogging=1.1.3

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
@@ -22,7 +22,7 @@
 package io.crate.analysis.common;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
@@ -138,7 +138,7 @@ public class FulltextITest extends SQLIntegrationTestCase{
         execute("select * from matchbox where match(o['m'], 'Ford')");
         assertThat(response.rowCount(), is(1L));
 
-        assertThrows(() -> execute("select * from matchbox where match(o_ignored['a'], 'Ford')"),
+        assertThrowsMatches(() -> execute("select * from matchbox where match(o_ignored['a'], 'Ford')"),
                      isSQLError(is("Can only use MATCH on columns of type STRING or GEO_SHAPE, not on 'undefined'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -26,7 +26,7 @@ import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.CHAR_FILTER;
 import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKENIZER;
 import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKEN_FILTER;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.SettingMatcher.hasEntry;
 import static io.crate.testing.SettingMatcher.hasKey;
@@ -463,7 +463,7 @@ public class FulltextAnalyzerResolverTest extends SQLIntegrationTestCase {
                 "    \"token_chars\"=['letter', 'digit']" +
                 "  )" +
                 ")");
-        assertThrows(() -> execute("CREATE ANALYZER a10 (TOKENIZER a9tok)"),
+        assertThrowsMatches(() -> execute("CREATE ANALYZER a10 (TOKENIZER a9tok)"),
                      isSQLError(endsWith("Non-existing tokenizer 'a9tok'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.is;
@@ -103,7 +103,7 @@ public class AzureSnapshotIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void test_invalid_settings_to_create_azure_repository() throws Throwable {
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "CREATE REPOSITORY r1 TYPE AZURE WITH (container = 'invalid', " +
             "account = 'devstoreaccount1', " +
             "key = 'ZGV2c3RvcmVhY2NvdW50MQ=='," +

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryIntegrationTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryIntegrationTest.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.startsWith;
@@ -45,7 +45,7 @@ public class S3RepositoryIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void test_unable_to_create_s3_repository() throws Throwable {
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "create repository test123 type s3 with (bucket='bucket', endpoint='https://s3.region.amazonaws.com', " +
             "protocol='https', access_key='access',secret_key='secret', base_path='test123')"),
                      isSQLError(

--- a/plugins/es-repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryITest.java
+++ b/plugins/es-repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryITest.java
@@ -2,7 +2,7 @@
 package org.elasticsearch.repositories.url;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.is;
@@ -60,7 +60,7 @@ public class URLRepositoryITest extends SQLIntegrationTestCase {
             new Object[]{defaultRepositoryLocation.toURI().toString()});
         waitNoPendingTasksOnAll();
 
-        assertThrows(() -> execute("CREATE SNAPSHOT uri_repo.my_snapshot ALL WITH (wait_for_completion=true)"),
+        assertThrowsMatches(() -> execute("CREATE SNAPSHOT uri_repo.my_snapshot ALL WITH (wait_for_completion=true)"),
                      isSQLError(is("[uri_repo] cannot create snapshot in a readonly repository"),
                          INTERNAL_ERROR,
                          INTERNAL_SERVER_ERROR,

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -21,6 +21,32 @@
 
 package io.crate.action.sql;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.elasticsearch.threadpool.ThreadPool;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.Relations;
@@ -43,33 +69,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.mockito.Answers;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
@@ -138,7 +137,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             SessionContext.systemSessionContext());
 
         session.parse("S_1", "Select 1 + ? + ?;", Collections.emptyList());
-        assertThrows(
+        Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> session.getParamType("S_1", 3),
             "foo"

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -84,7 +84,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.RelationMatchers.isDocTable;
 import static io.crate.testing.SymbolMatchers.isAlias;
 import static io.crate.testing.SymbolMatchers.isField;
@@ -2377,7 +2377,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_aliased_table_function_in_group_by_is_prohibited() throws Exception {
         var executor = SQLExecutor.builder(clusterService).build();
-        assertThrows(
+        assertThrowsMatches(
             () -> executor.analyze("select unnest([1]) as a from sys.cluster group by 1"),
             IllegalArgumentException.class,
             "Table functions are not allowed in GROUP BY"

--- a/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -59,7 +59,7 @@ import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINIT
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION;
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -450,7 +450,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_restore_unknown_metadata() {
-        assertThrows(
+        assertThrowsMatches(
             () -> analyze(e, "RESTORE SNAPSHOT my_repo.my_snapshot UNKNOWN_META"),
             IllegalArgumentException.class,
             "Unknown metadata type 'UNKNOWN_META'"

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -383,7 +383,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         var e = SQLExecutor.builder(clusterService)
             .addTable("create table tbl (obj object as (x int))")
             .build();
-        Asserts.assertThrows(
+        Asserts.assertThrowsMatches(
             () -> e.asSymbol("obj = {x = 'foo'}"),
             ConversionException.class,
             "Cannot cast object element `x` with value `foo` to type `integer`"

--- a/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
@@ -42,7 +42,7 @@ import java.util.Locale;
 import java.util.Properties;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INVALID_AUTHORIZATION_SPECIFICATION;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isPGError;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -113,7 +113,7 @@ public class AuthenticationIntegrationTest extends SQLIntegrationTestCase {
     public void testInvalidUser() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("user", "me");
-        assertThrows(() -> DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties),
+        assertThrowsMatches(() -> DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties),
                      isPGError(is("No valid auth.host_based entry found for host \"127.0.0.1\", user \"me\". Did you enable TLS in your client?"),
                                INVALID_AUTHORIZATION_SPECIFICATION));
 
@@ -123,7 +123,7 @@ public class AuthenticationIntegrationTest extends SQLIntegrationTestCase {
     public void testUserInHbaThatDoesNotExist() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("user", "cr8");
-        assertThrows(() -> DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties),
+        assertThrowsMatches(() -> DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties),
                      isPGError(is("trust authentication failed for user \"cr8\""),
                                INVALID_AUTHORIZATION_SPECIFICATION));
     }
@@ -132,7 +132,7 @@ public class AuthenticationIntegrationTest extends SQLIntegrationTestCase {
     public void testInvalidAuthenticationMethod() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("user", "foo");
-        assertThrows(() -> DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties),
+        assertThrowsMatches(() -> DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties),
                      isPGError(is("No valid auth.host_based entry found for host \"127.0.0.1\", user \"foo\". Did you enable TLS in your client?"),
                                INVALID_AUTHORIZATION_SPECIFICATION));
     }

--- a/server/src/test/java/io/crate/auth/AuthenticationWithSSLIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationWithSSLIntegrationTest.java
@@ -22,7 +22,7 @@
 package io.crate.auth;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INVALID_AUTHORIZATION_SPECIFICATION;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isPGError;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -135,7 +135,7 @@ public class AuthenticationWithSSLIntegrationTest extends SQLIntegrationTestCase
         properties.setProperty("user", "localhost");
         properties.setProperty("ssl", "true");
 
-        assertThrows(() -> { try (Connection ignored = DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties)) {}},
+        assertThrowsMatches(() -> { try (Connection ignored = DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties)) {}},
                      isPGError(is("Client certificate authentication failed for user \"localhost\""),
                                INVALID_AUTHORIZATION_SPECIFICATION));
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.util.List;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 
 public class ArrayAvgFunctionTest extends ScalarTestCase {
 
@@ -91,7 +91,7 @@ public class ArrayAvgFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_array_avg_with_array_of_undefined_inner_type_throws_exception() {
-        assertThrows(() -> assertEvaluate("array_avg([])", null),
+        assertThrowsMatches(() -> assertEvaluate("array_avg([])", null),
             UnsupportedOperationException.class,
             "Unknown function: array_avg([]), no overload found for matching argument types: (undefined_array).");
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 
 public class ArrayMaxFunctionTest extends ScalarTestCase {
 
@@ -60,7 +60,7 @@ public class ArrayMaxFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_empty_array_given_directly_throws_exception() {
-        assertThrows(() -> assertEvaluate("array_max([])", null),
+        assertThrowsMatches(() -> assertEvaluate("array_max([])", null),
             UnsupportedOperationException.class,
             "Unknown function: array_max([]), no overload found for matching argument types: (undefined_array).");
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 
 public class ArrayMinFunctionTest extends ScalarTestCase {
 
@@ -60,7 +60,7 @@ public class ArrayMinFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_empty_array_given_directly_throws_exception() {
-        assertThrows(() -> assertEvaluate("array_min([])", null),
+        assertThrowsMatches(() -> assertEvaluate("array_min([])", null),
             UnsupportedOperationException.class,
             "Unknown function: array_min([]), no overload found for matching argument types: (undefined_array).");
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 
 public class ArraySumFunctionTest extends ScalarTestCase {
 
@@ -69,7 +69,7 @@ public class ArraySumFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_array_big_numbers_no_casting_results_in_exception() {
-        assertThrows(() -> assertEvaluate("array_sum(?)", null,
+        assertThrowsMatches(() -> assertEvaluate("array_sum(?)", null,
                                 Literal.of(List.of(Long.MAX_VALUE, Long.MAX_VALUE), new ArrayType<>(DataTypes.LONG))
                             ),
             ArithmeticException.class,
@@ -111,7 +111,7 @@ public class ArraySumFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_empty_array_given_directly_throws_exception() {
-        assertThrows(() -> assertEvaluate("array_sum([])", null),
+        assertThrowsMatches(() -> assertEvaluate("array_sum([])", null),
             UnsupportedOperationException.class,
             "Unknown function: array_sum([]), no overload found for matching argument types: (undefined_array).");
     }

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
@@ -28,6 +28,7 @@ import io.crate.metadata.Schemas;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
@@ -124,7 +125,7 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
             .addTable("create table doc.t1 (id int, gen as foo(id))")
             .build();
 
-        assertThrows(
+        Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> executor.udfService().validateFunctionIsNotInUseByGeneratedColumn(
                 Schemas.DOC_SCHEMA_NAME,
@@ -145,7 +146,7 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
             .addPartitionedTable("create table doc.p1 (id int, p int, gen as foo(id)) partitioned by (p)")
             .build();
 
-        assertThrows(
+        Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> executor.udfService().validateFunctionIsNotInUseByGeneratedColumn(
                 Schemas.DOC_SCHEMA_NAME,

--- a/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -317,7 +317,7 @@ public class ArithmeticIntegrationTest extends SQLIntegrationTestCase {
         ensureYellow();
         execute("insert into t (i, l, d) values (1, 2, 90.5)");
         refresh();
-        assertThrows(() -> execute("select log(d, l) from t where log(d, -1) >= 0"),
+        assertThrowsMatches(() -> execute("select log(d, l) from t where log(d, -1) >= 0"),
                      isSQLError(is("log(x, b): given arguments would result in: 'NaN'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -331,7 +331,7 @@ public class ArithmeticIntegrationTest extends SQLIntegrationTestCase {
         execute("insert into t (i, l, d) values (1, 2, 90.5), (0, 4, 100)");
         execute("refresh table t");
 
-        assertThrows(() -> execute("select log(d, l) from t where log(d, -1) >= 0 group by log(d, l)"),
+        assertThrowsMatches(() -> execute("select log(d, l) from t where log(d, -1) >= 0 group by log(d, l)"),
                      isSQLError(is("log(x, b): given arguments would result in: 'NaN'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -71,7 +71,7 @@ public class CircuitBreakerIntegrationTest extends SQLIntegrationTestCase {
 
         execute("set global \"indices.breaker.query.limit\"='100b'");
 
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("select text from t1 group by text"),
             isSQLError(
                 Matchers.allOf(

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import static io.crate.metadata.table.ColumnPolicies.decodeMappingValue;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
@@ -94,7 +94,7 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
         assertThat(response.cols(), is(arrayContaining("id", "name")));
         assertThat(response.rows()[0], is(Matchers.<Object>arrayContaining(1, "Ford")));
 
-        assertThrows(() -> execute("insert into strict_table (id, name, boo) values (2, 'Trillian', true)"),
+        assertThrowsMatches(() -> execute("insert into strict_table (id, name, boo) values (2, 'Trillian', true)"),
                      isSQLError(is("Column boo unknown"),
                                 UNDEFINED_COLUMN,
                                 NOT_FOUND,
@@ -116,7 +116,7 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
         assertThat(response.cols(), is(arrayContaining("id", "name")));
         assertThat(response.rows()[0], is(Matchers.<Object>arrayContaining(1, "Ford")));
 
-        assertThrows(() -> execute("update strict_table set name='Trillian', boo=true where id=1"),
+        assertThrowsMatches(() -> execute("update strict_table set name='Trillian', boo=true where id=1"),
                      isSQLError(is("Column boo unknown"), UNDEFINED_COLUMN, NOT_FOUND,4043));
     }
 
@@ -270,7 +270,7 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
                 authorMap
             });
         execute("refresh table books");
-        assertThrows(() -> execute("insert into books (title, author) values (?,?)",
+        assertThrowsMatches(() -> execute("insert into books (title, author) values (?,?)",
             new Object[]{
                 "Life, the Universe and Everything",
                 Map.of("name", Map.of("first_name", "Douglas", "middle_name", "Noel"))
@@ -399,7 +399,7 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
             new PartitionName(new RelationName("doc", "numbers"), Arrays.asList("true")).asIndexName());
         assertThat(decodeMappingValue(sourceMap.get("dynamic")), is(ColumnPolicy.STRICT));
 
-        assertThrows(() -> execute("insert into numbers (num, odd, prime, perfect) values (?, ?, ?, ?)",
+        assertThrowsMatches(() -> execute("insert into numbers (num, odd, prime, perfect) values (?, ?, ?, ?)",
                                    new Object[]{28, true, false, true}),
                      isSQLError(is("Column perfect unknown"),
                                 UNDEFINED_COLUMN,
@@ -437,7 +437,7 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
             new PartitionName(new RelationName("doc", "numbers"), Arrays.asList("true")).asIndexName());
         assertThat(decodeMappingValue(sourceMap.get("dynamic")), is(ColumnPolicy.STRICT));
 
-        assertThrows(() -> execute("update numbers set num=?, perfect=? where num=6",
+        assertThrowsMatches(() -> execute("update numbers set num=?, perfect=? where num=6",
                                    new Object[]{28, true}),
                      isSQLError(is("Column perfect unknown"),
                                 UNDEFINED_COLUMN,
@@ -502,7 +502,7 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
         ensureYellow();
         execute("alter table dynamic_table set (column_policy = 'strict')");
         waitNoPendingTasksOnAll();
-        assertThrows(() -> execute("insert into dynamic_table (id, score, new_col) values (1, 4656234.345, 'hello')"),
+        assertThrowsMatches(() -> execute("insert into dynamic_table (id, score, new_col) values (1, 4656234.345, 'hello')"),
                      isSQLError(is("Column new_col unknown"), UNDEFINED_COLUMN, NOT_FOUND,4043));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -50,7 +50,7 @@ import java.util.UUID;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.newTempDir;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -368,7 +368,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         execute("create table singleshard (name string) clustered into 1 shards with (number_of_replicas = 0)");
         ensureYellow();
 
-        assertThrows(() -> execute("copy singleshard to '/tmp/file.json'"),
+        assertThrowsMatches(() -> execute("copy singleshard to '/tmp/file.json'"),
                      isSQLError(containsString("Using COPY TO without specifying a DIRECTORY is not supported"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -22,7 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.core.Is.is;
@@ -76,7 +76,7 @@ public class CountStarIntegrationTest extends SQLIntegrationTestCase {
     @Test
     public void testSelectCountStarWithWhereClauseForUnknownCol() throws Exception {
         execute("create table test (\"name\" string) with (number_of_replicas=0)");
-        assertThrows(() -> execute("select count(*) from test where non_existant = 'Some Value'"),
+        assertThrowsMatches(() -> execute("select count(*) from test where non_existant = 'Some Value'"),
                      isSQLError(is("Column non_existant unknown"),
                                 UNDEFINED_COLUMN,
                                 NOT_FOUND,

--- a/server/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
@@ -22,7 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -60,7 +60,7 @@ public class FulltextIntegrationTest extends SQLIntegrationTestCase  {
     @Test
     public void testMatchUnsupportedInSelect() {
         execute("create table quotes (quote string)");
-        assertThrows(() -> execute("select match(quote, 'the quote') from quotes"),
+        assertThrowsMatches(() -> execute("select match(quote, 'the quote') from quotes"),
                      isSQLError(is("match predicate cannot be selected"),
                                 INTERNAL_ERROR, BAD_REQUEST, 4004));
     }

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -26,7 +26,7 @@ import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.is;
@@ -43,7 +43,7 @@ public class GroupByAggregateBreakerTest extends SQLIntegrationTestCase {
 
     @Test
     public void selectGroupByWithBreaking() throws Exception {
-        assertThrows(() -> execute("select region, count(*) from sys.summits group by 1"),
+        assertThrowsMatches(() -> execute("select region, count(*) from sys.summits group by 1"),
                      isSQLError(is("[query] Data too large, data for [collect: 0] would be [280/280b], " +
                                    "which is larger than the limit of [256/256b]"),
                                 INTERNAL_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -1116,7 +1116,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
 
     @Test
     public void testScalarEvaluatesInErrorOnInformationSchema() {
-        assertThrows(() -> execute("select 1/0 from information_schema.tables"),
+        assertThrowsMatches(() -> execute("select 1/0 from information_schema.tables"),
                      isSQLError(is("/ by zero"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -41,7 +41,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNIQUE_VIOLATION;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -190,7 +190,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
     public void testInsertBadIPAddress() throws Exception {
         execute("create table t (i ip) with (number_of_replicas=0)");
         ensureYellow();
-        assertThrows(() -> execute("insert into t (i) values ('192.168.1.2'), ('192.168.1.3'),('192.168.1.500')"),
+        assertThrowsMatches(() -> execute("insert into t (i) values ('192.168.1.2'), ('192.168.1.3'),('192.168.1.500')"),
                      isSQLError(is("Cannot cast `'192.168.1.500'` of type `text` to type `ip`"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -320,7 +320,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
             "A towel is about the most massively useful thing an interstellar hitch hiker can have."});
         refresh();
 
-        assertThrows(() -> execute("insert into test (pk_col, message) values (?, ?)", new Object[]{"1",
+        assertThrowsMatches(() -> execute("insert into test (pk_col, message) values (?, ?)", new Object[]{"1",
                          "I always thought something was fundamentally wrong with the universe."}),
                      isSQLError(is("A document with the same primary key exists already"),
                                 UNIQUE_VIOLATION,
@@ -361,7 +361,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
         ensureYellow();
 
         Object[] args = new Object[]{"1", null};
-        assertThrows(() -> execute("insert into t (pk_col, message) values (?, ?)", args),
+        assertThrowsMatches(() -> execute("insert into t (pk_col, message) values (?, ?)", args),
                      isSQLError(is("\"message\" must not be null"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 
@@ -373,7 +373,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
                 ") not null)");
         ensureYellow();
 
-        assertThrows(() -> execute("insert into test (stuff) values('{\"other_field\":\"value\"}')"),
+        assertThrowsMatches(() -> execute("insert into test (stuff) values('{\"other_field\":\"value\"}')"),
                      isSQLError(is("\"stuff['level1']\" must not be null"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 
@@ -387,7 +387,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
                 ") not null)");
         ensureYellow();
 
-        assertThrows(() ->execute("insert into test (stuff) values('{\"level1\":{\"other_field\":\"value\"}}')"),
+        assertThrowsMatches(() ->execute("insert into test (stuff) values('{\"level1\":{\"other_field\":\"value\"}}')"),
                      isSQLError(is("\"stuff['level1']['level2']\" must not be null"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 
@@ -400,7 +400,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
         };
         execute("insert into test (pk_col, message) values (?, ?)", args);
 
-        assertThrows(() -> execute("insert into test (pk_col, message) values (?, ?)", new Object[]{
+        assertThrowsMatches(() -> execute("insert into test (pk_col, message) values (?, ?)", new Object[]{
                          "1", "I always thought something was fundamentally wrong with the universe"}),
                      isSQLError(is("A document with the same primary key exists already"),
                                 UNIQUE_VIOLATION,
@@ -418,7 +418,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
             "This has made a lot of people very angry and been widely regarded as a bad move."
         };
 
-        assertThrows(() -> execute("insert into test (message) values (?)", args),
+        assertThrowsMatches(() -> execute("insert into test (message) values (?)", args),
                      isSQLError(is("Column `pk_col` is required but is missing from the insert statement"),
                                 INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
@@ -429,7 +429,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
                 "with (number_of_replicas=0)");
         ensureYellow();
 
-        assertThrows(() -> execute("insert into quotes (id, quote) values(?, ?)",
+        assertThrowsMatches(() -> execute("insert into quotes (id, quote) values(?, ?)",
                                    new Object[]{null, "I'd far rather be happy than right any day."}),
                      isSQLError(is("Clustered by value must not be NULL"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
@@ -439,7 +439,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
         execute("create table quotes (id integer, quote string) clustered by(id) " +
                 "with (number_of_replicas=0)");
 
-        assertThrows(() -> execute("insert into quotes (quote) values(?)",
+        assertThrowsMatches(() -> execute("insert into quotes (quote) values(?)",
                                    new Object[]{"I'd far rather be happy than right any day."}),
                      isSQLError(is("Column `id` is required but is missing from the insert statement"),
                                 INTERNAL_ERROR,
@@ -824,7 +824,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
     public void testInsertFromSubQueryWithVersion() throws Exception {
         execute("create table users (name string) clustered into 1 shards");
 
-        assertThrows(() -> execute("insert into users (name) (select name from users where _version = 1)"),
+        assertThrowsMatches(() -> execute("insert into users (name) (select name from users where _version = 1)"),
                      isSQLError(containsString(VersioninigValidationException.VERSION_COLUMN_USAGE_MSG),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -1099,7 +1099,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
                 ") with (number_of_replicas=0)");
         ensureYellow();
 
-        assertThrows(() -> execute("insert into generated_column (id, ts) values (1, null)"),
+        assertThrowsMatches(() -> execute("insert into generated_column (id, ts) values (1, null)"),
                      isSQLError(is("\"gen_col\" must not be null"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 
@@ -1112,7 +1112,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
                 ") with (number_of_replicas=0)");
         ensureYellow();
 
-        assertThrows(() -> execute("insert into generated_column (id, gen_col) values (1, null)"),
+        assertThrowsMatches(() -> execute("insert into generated_column (id, gen_col) values (1, null)"),
                      isSQLError(is("\"gen_col\" must not be null"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 
@@ -1235,7 +1235,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
         assertThat(response.rows()[0][0], is(4));
 
         // wrong value
-        assertThrows(() -> execute("insert into test(col1, col2) values (1, 0)"),
+        assertThrowsMatches(() -> execute("insert into test(col1, col2) values (1, 0)"),
                      isSQLError(is("Given value 0 for generated column col2 does not match calculation (col1 + 3) = 4"),
                                 INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
@@ -1247,7 +1247,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
         ensureYellow();
         execute("insert into source (col1) values (1)");
         refresh();
-        assertThrows(() -> execute("insert into target (col1) (select col1 from source)"),
+        assertThrowsMatches(() -> execute("insert into target (col1) (select col1 from source)"),
                      isSQLError(containsString("Column \"col2\" is required but is missing from the insert statement"),
                                 INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
@@ -1309,7 +1309,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
     @Test
     public void testGeneratedColumnAsPrimaryKeyValueEvaluateToNull() throws Exception {
         execute("CREATE TABLE test (col1 TEXT, col2 AS try_cast(col1 AS INT) PRIMARY KEY)");
-        assertThrows(() -> execute("insert into test (col1) values ('a')"),
+        assertThrowsMatches(() -> execute("insert into test (col1) values ('a')"),
                      isSQLError(is("Primary key value must not be NULL"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 
@@ -1364,7 +1364,7 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
         ensureYellow();
         execute("insert into test (id, name) values (1, 'foo')");
         assertThat(response.rowCount(), is(1L));
-        assertThrows(() -> execute("insert into test (id, name) values (1, 'bar')"),
+        assertThrowsMatches(() -> execute("insert into test (id, name) values (1, 'bar')"),
                      isSQLError(containsString("A document with the same primary key exists already"),
                                 UNIQUE_VIOLATION,
                                 CONFLICT,

--- a/server/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.containsString;
@@ -75,13 +75,13 @@ public class JobIntegrationTest extends SQLIntegrationTestCase {
         execute("create table users (name string) clustered into 1 shards with (number_of_replicas=0)");
         ensureYellow();
 
-        assertThrows(() -> execute("insert into users (name) (select name from users where _version = 1)"),
+        assertThrowsMatches(() -> execute("insert into users (name) (select name from users where _version = 1)"),
                      isSQLError(containsString(VersioninigValidationException.VERSION_COLUMN_USAGE_MSG),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
                                 4000));
 
-        assertThrows(() -> execute("select name from users where _version = 1"),
+        assertThrowsMatches(() -> execute("select name from users where _version = 1"),
                      isSQLError(containsString(VersioninigValidationException.VERSION_COLUMN_USAGE_MSG),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -46,7 +46,7 @@ import java.util.Map;
 import java.util.Random;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printRows;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -692,7 +692,7 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
         PlanForNode plan = plan("select * from t1, t2 where t1.x = t2.x");
         execute("drop table t2");
 
-        assertThrows(() -> execute(plan).getResult(), instanceOf(IndexNotFoundException.class));
+        assertThrowsMatches(() -> execute(plan).getResult(), instanceOf(IndexNotFoundException.class));
     }
 
     @Test
@@ -745,7 +745,7 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
     @Test
     public void testFailureOfJoinDownstream() throws Exception {
         // provoke an exception when the NL emits a row, must bubble up and NL must stop
-        assertThrows(() -> execute("select cast(R.col2 || ' ' || L.col2 as integer)" +
+        assertThrowsMatches(() -> execute("select cast(R.col2 || ' ' || L.col2 as integer)" +
                                    "   from " +
                                    "       unnest(['hello', 'world'], [1, 2]) L " +
                                    "   inner join " +

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
@@ -125,7 +125,7 @@ public class ObjectColumnTest extends SQLIntegrationTestCase {
                 "middle_name", "Noel",
                 "last_name", "Adams"),
             "age", 49);
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "insert into ot (title, author) values (?, ?)",
             new Object[]{"Life, the Universe and Everything", authorMap}),
                      isSQLError(containsString("dynamic introduction of [middle_name] within [author.name] is not allowed"),
@@ -174,7 +174,7 @@ public class ObjectColumnTest extends SQLIntegrationTestCase {
 
     @Test
     public void updateToStrictObject() throws Exception {
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update ot set author['name']['middle_name']='Noel' where author['name']['first_name']='Douglas' " +
             "and author['name']['last_name']='Adams'"),
                      isSQLError(is("Column author['name']['middle_name'] unknown"),

--- a/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.BAD_REQUEST;
@@ -47,7 +47,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void test_open_missing_table() {
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("alter table test open"),
             isSQLError(
                 is("Relation 'test' unknown"),
@@ -230,7 +230,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testClosePreventsInsert() throws Exception {
-        assertThrows(() -> execute("insert into t values (1), (2), (3)"),
+        assertThrowsMatches(() -> execute("insert into t values (1), (2), (3)"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow INSERT operations," +
                                                  " as it is currently closed.", getFqn("t"))),
                          INTERNAL_ERROR,
@@ -240,7 +240,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testClosePreventsSelect() throws Exception {
-        assertThrows(() -> execute("select * from t"),
+        assertThrowsMatches(() -> execute("select * from t"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow READ operations, " +
                                                  "as it is currently closed.", getFqn("t"))),
                          INTERNAL_ERROR,
@@ -250,7 +250,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testClosePreventsDrop() throws Exception {
-        assertThrows(() -> execute("drop table t"),
+        assertThrowsMatches(() -> execute("drop table t"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow DROP operations, " +
                                                  "as it is currently closed.", getFqn("t"))),
                          INTERNAL_ERROR,
@@ -260,7 +260,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testClosePreventsAlter() throws Exception {
-        assertThrows(() -> execute("alter table t add column x string"),
+        assertThrowsMatches(() -> execute("alter table t add column x string"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow ALTER operations, " +
                                                  "as it is currently closed.", getFqn("t"))),
                          INTERNAL_ERROR,
@@ -270,7 +270,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testClosePreventsRefresh() throws Exception {
-        assertThrows(() -> execute("refresh table t"),
+        assertThrowsMatches(() -> execute("refresh table t"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow REFRESH operations, as " +
                                           "it is currently closed.", getFqn("t"))),
                          INTERNAL_ERROR,
@@ -280,7 +280,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testClosePreventsShowCreate() throws Exception {
-        assertThrows(() -> execute("show create table t"),
+        assertThrowsMatches(() -> execute("show create table t"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow SHOW CREATE operations," +
                                           " as it is currently closed.", getFqn("t"))),
                          INTERNAL_ERROR,
@@ -290,7 +290,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testClosePreventsOptimize() throws Exception {
-        assertThrows(() -> execute("optimize table t"),
+        assertThrowsMatches(() -> execute("optimize table t"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow OPTIMIZE operations, " +
                                                  "as it is currently closed.", getFqn("t"))),
                          INTERNAL_ERROR,
@@ -318,7 +318,7 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
         execute("insert into partitioned_table values (1), (2), (3), (4), (5)");
         refresh();
         execute("alter table partitioned_table close");
-        assertThrows(() -> execute("select i from partitioned_table"),
+        assertThrowsMatches(() -> execute("select i from partitioned_table"),
                      isSQLError(is(String.format("The relation \"%s\" doesn't support or allow READ operations, " +
                                                  "as it is currently closed.", getFqn("partitioned_table"))),
                          INTERNAL_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.Matchers.allOf;
@@ -112,7 +112,7 @@ public class OptimizeTableIntegrationTest extends SQLHttpIntegrationTest {
             ") partitioned by (date) with (refresh_interval=0)");
         ensureYellow();
 
-        assertThrows(() -> execute("optimize table parted partition(date=0)"),
+        assertThrowsMatches(() -> execute("optimize table parted partition(date=0)"),
                      isSQLError(is(String.format("No partition for table '%s' with ident '04130' exists", getFqn("parted"))),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,

--- a/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
@@ -28,7 +28,7 @@ import org.postgresql.util.PSQLException;
 
 import java.sql.PreparedStatement;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 
 @UseJdbc(value = 1)
 public class PostgresCompatIntegrationTest extends SQLIntegrationTestCase {
@@ -41,7 +41,7 @@ public class PostgresCompatIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testStartTransactionStatement() {
-        assertThrows(() -> execute("START"), PSQLException.class, "ERROR: line 1:6: missing 'TRANSACTION'");
+        assertThrowsMatches(() -> execute("START"), PSQLException.class, "ERROR: line 1:6: missing 'TRANSACTION'");
 
         execute("START TRANSACTION");
         assertNoErrorResponse(response);

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -24,7 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.protocols.postgres.PostgresNetty.PSQL_PORT_SETTING;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isPGError;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
@@ -174,7 +174,7 @@ public class PostgresITest extends SQLIntegrationTestCase {
         try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
             PreparedStatement stmt = conn.prepareStatement("select ? from sys.cluster");
             stmt.setObject(1, UUID.randomUUID());
-            assertThrows(() -> stmt.executeQuery(), isPGError(is("Can't map PGType with oid=2950 to Crate type"), INTERNAL_ERROR));
+            assertThrowsMatches(() -> stmt.executeQuery(), isPGError(is("Can't map PGType with oid=2950 to Crate type"), INTERNAL_ERROR));
         }
     }
 
@@ -663,7 +663,7 @@ public class PostgresITest extends SQLIntegrationTestCase {
         try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
             conn.setAutoCommit(true);
             PreparedStatement stmt = conn.prepareStatement("select name fro sys.cluster");
-            assertThrows(() -> stmt.executeQuery(),
+            assertThrowsMatches(() -> stmt.executeQuery(),
                          isPGError(containsString("mismatched input 'sys'"), INTERNAL_ERROR));
         }
     }
@@ -673,7 +673,7 @@ public class PostgresITest extends SQLIntegrationTestCase {
         try (Connection conn = DriverManager.getConnection(url(RO), properties)) {
             conn.setAutoCommit(true);
             PreparedStatement stmt = conn.prepareStatement("create table test(a integer)");
-            assertThrows(() -> stmt.executeQuery(),
+            assertThrowsMatches(() -> stmt.executeQuery(),
                          isPGError(containsString("Only read operations allowed on this node"), INTERNAL_ERROR));
         }
     }
@@ -731,7 +731,7 @@ public class PostgresITest extends SQLIntegrationTestCase {
             conn.createStatement().executeUpdate("create table foo (id int) with (number_of_replicas=0)");
 
             conn.createStatement().execute("set session search_path to DEFAULT");
-            assertThrows(() -> conn.createStatement().execute("select * from foo"),
+            assertThrowsMatches(() -> conn.createStatement().execute("select * from foo"),
                          isPGError(is("Relation 'foo' unknown"), UNDEFINED_TABLE));
         }
     }
@@ -745,7 +745,7 @@ public class PostgresITest extends SQLIntegrationTestCase {
             conn.createStatement().executeUpdate("create table foo (id int) with (number_of_replicas=0)");
             conn.createStatement().executeQuery("select * from bar.foo");
 
-            assertThrows(() -> conn.createStatement().execute("select * from custom.foo"),
+            assertThrowsMatches(() -> conn.createStatement().execute("select * from custom.foo"),
                          isPGError(is("Schema 'custom' unknown"), INTERNAL_ERROR));
         }
     }

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -22,7 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -94,7 +94,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testNormalUserGrantsPrivilegeThrowsException() {
-        assertThrows(() -> executeAsNormalUser("grant DQL to " + TEST_USERNAME),
+        assertThrowsMatches(() -> executeAsNormalUser("grant DQL to " + TEST_USERNAME),
                      isSQLError(is("Missing 'AL' privilege for user 'normal'"),
                                 INTERNAL_ERROR,
                                 UNAUTHORIZED,
@@ -140,7 +140,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     @Test
     public void testGrantPrivilegeToSuperuserThrowsException() {
         String superuserName = User.CRATE_USER.name();
-        assertThrows(() -> executeAsSuperuser("grant DQL to " + superuserName),
+        assertThrowsMatches(() -> executeAsSuperuser("grant DQL to " + superuserName),
                      isSQLError(is("Cannot alter privileges for superuser '" + superuserName + "'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -149,7 +149,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testApplyPrivilegesToUnknownUserThrowsException() {
-        assertThrows(() -> executeAsSuperuser("grant DQL to unknown_user"),
+        assertThrowsMatches(() -> executeAsSuperuser("grant DQL to unknown_user"),
                      isSQLError(is("User 'unknown_user' does not exist"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -158,7 +158,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testApplyPrivilegesToMultipleUnknownUsersThrowsException() {
-        assertThrows(() -> executeAsSuperuser("grant DQL to unknown_user, also_unknown"),
+        assertThrowsMatches(() -> executeAsSuperuser("grant DQL to unknown_user, also_unknown"),
                      isSQLError(is("Users 'unknown_user, also_unknown' do not exist"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -331,7 +331,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
         executeAsSuperuser("create table doc.t1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
 
-        assertThrows(() -> execute("select * from t1", null, testUserSession()),
+        assertThrowsMatches(() -> execute("select * from t1", null, testUserSession()),
                      isSQLError(is("Schema 'doc' unknown"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -347,7 +347,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         ensureYellow();
 
         executeAsSuperuser("create view doc.v1 as select 1");
-        assertThrows(() -> execute("select * from v1", null, testUserSession()),
+        assertThrowsMatches(() -> execute("select * from v1", null, testUserSession()),
                      isSQLError(is("Schema 'doc' unknown"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -367,7 +367,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         assertThat(response.rowCount(), is(0L));
 
         executeAsSuperuser("create table doc.t1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
-        assertThrows(() -> execute("select * from t1", null, testUserSession()),
+        assertThrowsMatches(() -> execute("select * from t1", null, testUserSession()),
                      isSQLError(is("Schema 'doc' unknown"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -384,7 +384,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         executeAsSuperuser("grant dql on table t2 to "+ TEST_USERNAME);
         assertThat(response.rowCount(), is(1L));
 
-        assertThrows(() -> executeAsSuperuser("grant dql on table t1 to "+ TEST_USERNAME),
+        assertThrowsMatches(() -> executeAsSuperuser("grant dql on table t1 to "+ TEST_USERNAME),
                      isSQLError(is("Relation 't1' unknown"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -396,7 +396,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         executeAsSuperuser("alter cluster reroute retry failed");
         assertThat(response.rowCount(), is (0L));
 
-        assertThrows(() -> executeAsNormalUser("alter cluster reroute retry failed"),
+        assertThrowsMatches(() -> executeAsNormalUser("alter cluster reroute retry failed"),
                      isSQLError(containsString("User \"normal\" is not authorized to execute the statement"),
                                 INTERNAL_ERROR,
                                 UNAUTHORIZED,
@@ -412,7 +412,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         executeAsSuperuser("grant dql on schema s to " + TEST_USERNAME);
         assertThat(response.rowCount(), is(1L));
 
-        assertThrows(() ->  execute("refresh table s.t1", null, testUserSession()),
+        assertThrowsMatches(() ->  execute("refresh table s.t1", null, testUserSession()),
                      isSQLError(containsString("The relation \"s.t1\" doesn't support or allow REFRESH " +
                                                "operations, as it is currently closed."),
                                 INTERNAL_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
@@ -25,7 +25,7 @@ import io.crate.data.Paging;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -56,7 +56,7 @@ public class QueryThenFetchIntegrationTest extends SQLIntegrationTestCase {
         execute("insert into t (s) values ('foo')");
         execute("refresh table t");
 
-        assertThrows(() -> execute("select format('%d', s) from t"),
+        assertThrowsMatches(() -> execute("select format('%d', s) from t"),
                      isSQLError(containsString("d != java.lang.String"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -37,7 +37,7 @@ import org.junit.rules.TemporaryFolder;
 import javax.annotation.Nullable;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static org.hamcrest.Matchers.containsString;
@@ -121,7 +121,7 @@ public class ReadOnlyNodeIntegrationTest extends SQLIntegrationTestCase {
     }
 
     private void assertReadOnly(String stmt, Object[] args) throws Exception {
-        assertThrows(() -> execute(stmt, args),
+        assertThrowsMatches(() -> execute(stmt, args),
                      isSQLError(containsString("Only read operations allowed on this node"),
                                 INTERNAL_ERROR,
                                 FORBIDDEN,

--- a/server/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -25,7 +25,7 @@ import io.crate.protocols.postgres.PGErrorStatus;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Test;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
@@ -61,7 +61,7 @@ public class RegexpIntegrationTest extends SQLIntegrationTestCase {
             new Object[]{"+1234567890"}
         });
         refresh();
-        assertThrows(() -> execute("select * from phone where phone ~* '+1234567890'"),
+        assertThrowsMatches(() -> execute("select * from phone where phone ~* '+1234567890'"),
                      isSQLError(containsString("Dangling meta character '+' near index"),
                                 PGErrorStatus.INTERNAL_ERROR, HttpResponseStatus.BAD_REQUEST, 4000)
         );

--- a/server/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.util.HashMap;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static org.hamcrest.Matchers.is;
@@ -87,7 +87,7 @@ public class RepositoryIntegrationTest extends SQLIntegrationTestCase {
                 repoLocation
             });
         waitNoPendingTasksOnAll();
-        assertThrows(() -> execute("CREATE REPOSITORY \"myRepo\" TYPE \"fs\" with (location=?, compress=True)",
+        assertThrowsMatches(() -> execute("CREATE REPOSITORY \"myRepo\" TYPE \"fs\" with (location=?, compress=True)",
                                    new Object[]{repoLocation}),
                      isSQLError(is("Repository 'myRepo' already exists"),
                                 INTERNAL_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -22,7 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.containsString;
@@ -177,7 +177,7 @@ public class SQLTypeMappingTest extends SQLIntegrationTestCase {
     public void testInsertObjectField() throws Exception {
         setUpObjectTable();
 
-        assertThrows(() -> execute("insert into test12 (object_field['size']) values (127)"),
+        assertThrowsMatches(() -> execute("insert into test12 (object_field['size']) values (127)"),
                      isSQLError(is(
                          String.format(Locale.ENGLISH, "invalid table column reference \"object_field\"['size']",
                                        sqlExecutor.getCurrentSchema())),
@@ -191,7 +191,7 @@ public class SQLTypeMappingTest extends SQLIntegrationTestCase {
     public void testInvalidInsertIntoObject() throws Exception {
         setUpObjectTable();
 
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("insert into test12 (object_field, strict_field) values (?,?)", new Object[]{
                 Map.of("created", true, "size", 127),
                 Map.of("path", "/dev/null", "created", 0)
@@ -203,7 +203,7 @@ public class SQLTypeMappingTest extends SQLIntegrationTestCase {
     public void testInvalidWhereClause() throws Exception {
         setUpSimple();
 
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("delete from t1 where byte_field=129"),
             isSQLError(
                 containsString("Cannot cast `129` of type `integer` to type `char`"),
@@ -218,7 +218,7 @@ public class SQLTypeMappingTest extends SQLIntegrationTestCase {
     public void testInvalidWhereInWhereClause() throws Exception {
         setUpSimple();
 
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("update t1 set byte_field=0 where byte_field in (129)"),
             isSQLError(
                 containsString("Cannot cast `[129]` of type `integer_array` to type `char_array`"),
@@ -314,7 +314,7 @@ public class SQLTypeMappingTest extends SQLIntegrationTestCase {
         execute("insert into t1 values ({a='abc'})");
         waitForMappingUpdateOnAll("t1", "o.a");
 
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("insert into t1 values ({a=['123', '456']})"),
             isSQLError(
                 is("Cannot cast object element `a` with value `[123, 456]` to type `text`"),
@@ -378,7 +378,7 @@ public class SQLTypeMappingTest extends SQLIntegrationTestCase {
     public void testInsertNewColumnToStrictObject() throws Exception {
         setUpObjectTable();
 
-        assertThrows(() ->  execute("insert into test12 (strict_field) values (?)",
+        assertThrowsMatches(() ->  execute("insert into test12 (strict_field) values (?)",
                                     new Object[]{Map.of("another_new_col", "1970-01-01T00:00:00")}),
                      isSQLError(is("mapping set to strict, dynamic introduction of [another_new_col] within [strict_field] is not allowed"),
                          INTERNAL_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/ShardLimitsIT.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardLimitsIT.java
@@ -43,7 +43,7 @@ public class ShardLimitsIT extends SQLIntegrationTestCase {
     @Test
     public void test_shard_limit_is_checked_on_create_table() throws Exception {
         execute("set global \"cluster.max_shards_per_node\" = 1");
-        Asserts.assertThrows(
+        Asserts.assertThrowsMatches(
             () -> execute("create table tbl (x int) clustered into 4 shards with (number_of_replicas = 0)"),
             SQLErrorMatcher.isSQLError(
                 Matchers.containsString("this action would add [4] total shards, but this cluster currently has [0]/[2] maximum shards open;"),
@@ -64,7 +64,7 @@ public class ShardLimitsIT extends SQLIntegrationTestCase {
             with (number_of_replicas = 0)
         """);
         execute("set global \"cluster.max_shards_per_node\" = 1");
-        Asserts.assertThrows(
+        Asserts.assertThrowsMatches(
             () -> execute("insert into tbl (x, p) values (1, 1)"),
             SQLErrorMatcher.isSQLError(
                 Matchers.containsString("this action would add [4] total shards, but this cluster currently has [0]/[2] maximum shards open;"),
@@ -79,7 +79,7 @@ public class ShardLimitsIT extends SQLIntegrationTestCase {
     public void test_shard_limit_is_checked_on_alter_table() throws Exception {
         execute("set global \"cluster.max_shards_per_node\" = 1");
         execute("create table tbl (x int) clustered into 2 shards with (number_of_replicas = 0)");
-        Asserts.assertThrows(
+        Asserts.assertThrowsMatches(
             () -> execute("alter table tbl set (number_of_replicas = 1)"),
             SQLErrorMatcher.isSQLError(
                 Matchers.containsString("this action would add [2] total shards, but this cluster currently has [2]/[2] maximum shards open;"),

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.Locale;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -40,7 +40,7 @@ public class ShowIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testShowCrateSystemTable() throws Exception {
-        assertThrows(() -> execute("show create table sys.shards"),
+        assertThrowsMatches(() -> execute("show create table sys.shards"),
                      isSQLError(is("The relation \"sys.shards\" doesn't support or allow SHOW CREATE operations, as it is read-only."),
                          INTERNAL_ERROR, BAD_REQUEST, 4007));
     }
@@ -48,7 +48,7 @@ public class ShowIntegrationTest extends SQLIntegrationTestCase {
     @Test
     public void testShowCreateBlobTable() throws Exception {
         execute("create blob table table_blob");
-        assertThrows(() -> execute("show create table blob.table_blob"),
+        assertThrowsMatches(() -> execute("show create table blob.table_blob"),
                      isSQLError(is("The relation \"blob.table_blob\" doesn't support or allow SHOW CREATE operations."),
                          INTERNAL_ERROR, BAD_REQUEST, 4007));
     }
@@ -386,7 +386,7 @@ public class ShowIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testShowUnknownSetting() {
-        assertThrows(() -> execute("show foo"),
+        assertThrowsMatches(() -> execute("show foo"),
                      isSQLError(is("Unknown session setting name 'foo'."),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -61,7 +61,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
@@ -187,7 +187,7 @@ public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
     @Test
     public void testDropUnknownSnapshot() throws Exception {
         String snapshot = "unknown_snap";
-        assertThrows(() -> execute("drop snapshot " + REPOSITORY_NAME + "." + snapshot),
+        assertThrowsMatches(() -> execute("drop snapshot " + REPOSITORY_NAME + "." + snapshot),
                      isSQLError(is(String.format(Locale.ENGLISH, "Snapshot '%s.%s' unknown", REPOSITORY_NAME, snapshot)),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -198,7 +198,7 @@ public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
     public void testDropSnapshotUnknownRepository() throws Exception {
         String repository = "unknown_repo";
         String snapshot = "unknown_snap";
-        assertThrows(() -> execute("drop snapshot " + repository + "." + snapshot),
+        assertThrowsMatches(() -> execute("drop snapshot " + repository + "." + snapshot),
                      isSQLError(is(String.format(Locale.ENGLISH, "Repository '%s' unknown", repository)),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -282,7 +282,7 @@ public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
 
         execute("CREATE SNAPSHOT " + snapshotName() + " ALL WITH (wait_for_completion=true)");
         assertThat(response.rowCount(), is(1L));
-        assertThrows(() -> execute("CREATE SNAPSHOT " + snapshotName() + " ALL WITH (wait_for_completion=true)"),
+        assertThrowsMatches(() -> execute("CREATE SNAPSHOT " + snapshotName() + " ALL WITH (wait_for_completion=true)"),
                      isSQLError(containsString("Invalid snapshot name [my_snapshot], snapshot with the same name already exists"),
                                 INTERNAL_ERROR,
                                 CONFLICT,
@@ -291,7 +291,7 @@ public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testCreateSnapshotUnknownRepo() throws Exception {
-        assertThrows(() -> execute("CREATE SNAPSHOT unknown_repo.my_snapshot ALL WITH (wait_for_completion=true)"),
+        assertThrowsMatches(() -> execute("CREATE SNAPSHOT unknown_repo.my_snapshot ALL WITH (wait_for_completion=true)"),
                      isSQLError(is("Repository 'unknown_repo' unknown"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -300,7 +300,7 @@ public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void testInvalidSnapshotName() throws Exception {
-        assertThrows(() -> execute("CREATE SNAPSHOT my_repo.\"MY_UPPER_SNAPSHOT\" ALL WITH (wait_for_completion=true)"),
+        assertThrowsMatches(() -> execute("CREATE SNAPSHOT my_repo.\"MY_UPPER_SNAPSHOT\" ALL WITH (wait_for_completion=true)"),
                      isSQLError(containsString("Invalid snapshot name [MY_UPPER_SNAPSHOT], must be lowercase"),
                                 INTERNAL_ERROR,
                                 CONFLICT,
@@ -570,7 +570,7 @@ public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
         execute("CREATE SNAPSHOT " + snapshotName() + " ALL WITH (wait_for_completion=true)");
         ensureYellow();
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "RESTORE SNAPSHOT " + snapshotName() + " TABLE employees with (wait_for_completion=true)"),
                      isSQLError(is(String.format("[%s..partitioned.employees.] template not found", sqlExecutor.getCurrentSchema())),
                         INTERNAL_ERROR,
@@ -581,7 +581,7 @@ public class SnapshotRestoreIntegrationTest extends SQLIntegrationTestCase {
 
     @Test
     public void test_cannot_create_snapshot_in_read_only_repo() {
-        assertThrows(() -> execute("create snapshot my_repo_ro.s1 ALL WITH (wait_for_completion=true)"),
+        assertThrowsMatches(() -> execute("create snapshot my_repo_ro.s1 ALL WITH (wait_for_completion=true)"),
                      isSQLError(containsString("cannot create snapshot in a readonly repository"),
                                 INTERNAL_ERROR,
                                 INTERNAL_SERVER_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.hamcrest.core.Is.is;
@@ -47,7 +47,7 @@ public class StaticInformationSchemaQueryTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectSysColumnsFromInformationSchema() throws Exception {
-        assertThrows(() -> execute("select sys.nodes.id, table_name, number_of_replicas from information_schema.tables"),
+        assertThrowsMatches(() -> execute("select sys.nodes.id, table_name, number_of_replicas from information_schema.tables"),
                      isSQLError(is("Relation 'sys.nodes' unknown"),
                                 UNDEFINED_TABLE,
                                 NOT_FOUND,
@@ -207,7 +207,7 @@ public class StaticInformationSchemaQueryTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectUnknownTableFromInformationSchema() throws Exception {
-        assertThrows(() -> execute("select * from information_schema.non_existent"),
+        assertThrowsMatches(() -> execute("select * from information_schema.non_existent"),
                      isSQLError(is("Relation 'information_schema.non_existent' unknown"),
                                 UNDEFINED_TABLE,
                                 NOT_FOUND,

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -40,7 +40,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -340,7 +340,7 @@ public class SubSelectIntegrationTest extends SQLIntegrationTestCase {
         execute("insert into t1 (x) values (1), (2)");
         execute("refresh table t1");
 
-        assertThrows(() -> execute("select name from sys.cluster where 1 = (select x from t1)"),
+        assertThrowsMatches(() -> execute("select name from sys.cluster where 1 = (select x from t1)"),
                      isSQLError(containsString("Subquery returned more than 1 row"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
@@ -56,7 +56,7 @@ public class SwapTableITest extends SQLIntegrationTestCase {
             is("t2\n")
         );
 
-        assertThrows(() ->  execute("select * from t1"),
+        assertThrowsMatches(() ->  execute("select * from t1"),
                      isSQLError(containsString("Relation 't1' unknown"),
                                 UNDEFINED_TABLE,
                                 NOT_FOUND,

--- a/server/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -68,7 +68,7 @@ public class SysClusterTest extends SQLIntegrationTestCase {
 
     @Test
     public void testScalarEvaluatesInErrorOnSysCluster() throws Exception {
-        assertThrows(() -> execute("select 1/0 from sys.cluster"),
+        assertThrowsMatches(() -> execute("select 1/0 from sys.cluster"),
                      isSQLError(is("/ by zero"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
@@ -26,7 +26,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
@@ -48,7 +48,7 @@ public class SysNodesITest extends SQLIntegrationTestCase {
 
     @Test
     public void testScalarEvaluatesInErrorOnSysNodes() throws Exception {
-        assertThrows(() -> execute("select 1/0 from sys.nodes"),
+        assertThrowsMatches(() -> execute("select 1/0 from sys.nodes"),
                      isSQLError(CoreMatchers.is("/ by zero"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
@@ -32,7 +32,7 @@ import org.junit.rules.TemporaryFolder;
 import java.util.Locale;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +65,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.write\" = true)");
         ensureYellow();
 
-        assertThrows(() -> execute("insert into t1 (id) values (1)"),
+        assertThrowsMatches(() -> execute("insert into t1 (id) values (1)"),
                      isSQLError(is(String.format(Locale.ENGLISH,
                                           "The relation \"%s.t1\" doesn't support or allow INSERT operations.",
                                           sqlExecutor.getCurrentSchema())),
@@ -79,7 +79,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.write\" = true, \"blocks.read\" = true)");
         ensureYellow();
 
-        assertThrows(() -> execute("update t1 set id = 2"),
+        assertThrowsMatches(() -> execute("update t1 set id = 2"),
                      isSQLError(is(String.format(Locale.ENGLISH,
                                           "The relation \"%s.t1\" doesn't support or allow UPDATE operations.",
                                           sqlExecutor.getCurrentSchema())),
@@ -93,7 +93,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.write\" = true, \"blocks.read\" = true)");
         ensureYellow();
 
-        assertThrows(() -> execute("delete from t1"),
+        assertThrowsMatches(() -> execute("delete from t1"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or" +
                                                                  " allow DELETE operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -106,7 +106,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.metadata\" = true)");
         ensureYellow();
 
-        assertThrows(() -> execute("drop table t1"),
+        assertThrowsMatches(() -> execute("drop table t1"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or" +
                                                                  " allow DROP operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -119,7 +119,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.metadata\" = true)");
         ensureYellow();
 
-        assertThrows(() -> execute("alter table t1 add column name string"),
+        assertThrowsMatches(() -> execute("alter table t1 add column name string"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or " +
                                                                  "allow ALTER operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -132,7 +132,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.metadata\" = true)");
         ensureYellow();
 
-        assertThrows(() -> execute("alter table t1 set (number_of_replicas = 1)"),
+        assertThrowsMatches(() -> execute("alter table t1 set (number_of_replicas = 1)"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support " +
                                                                  "or allow ALTER operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -159,7 +159,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
 
         execute("insert into t1 (id) values (1)");
 
-        assertThrows(() -> execute("select * from t1"),
+        assertThrowsMatches(() -> execute("select * from t1"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or " +
                                                                  "allow READ operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -174,7 +174,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         ensureYellow();
         execute("insert into t1 (id) values (1)");
 
-        assertThrows(() -> execute("insert into t2 (id) (select id from t1)"),
+        assertThrowsMatches(() -> execute("insert into t2 (id) (select id from t1)"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or " +
                                                                  "allow READ operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -188,7 +188,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t2 (id integer) with (number_of_replicas = 0)");
         ensureYellow();
 
-        assertThrows(() -> execute("select * from t2, t1"),
+        assertThrowsMatches(() -> execute("select * from t2, t1"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support" +
                                                                  " or allow READ operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -200,7 +200,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
     public void testCopyToForbidden() throws Exception {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.read\" = true)");
 
-        assertThrows(() -> execute("copy t1 to DIRECTORY '/tmp/'"),
+        assertThrowsMatches(() -> execute("copy t1 to DIRECTORY '/tmp/'"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or " +
                                                                  "allow COPY TO operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -213,7 +213,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.write\" = true)");
         ensureYellow();
 
-        assertThrows(() -> execute("copy t1 from '/tmp'"),
+        assertThrowsMatches(() -> execute("copy t1 from '/tmp'"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support " +
                                                                  "or allow INSERT operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -228,7 +228,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("CREATE REPOSITORY repo TYPE \"fs\" with (location=?, compress=True)",
             new Object[]{TEMPORARY_FOLDER.newFolder().getAbsolutePath()});
 
-        assertThrows(() -> execute("CREATE SNAPSHOT repo.snap TABLE t1 WITH (wait_for_completion=true)"),
+        assertThrowsMatches(() -> execute("CREATE SNAPSHOT repo.snap TABLE t1 WITH (wait_for_completion=true)"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or " +
                                                                  "allow CREATE SNAPSHOT operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -243,7 +243,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("CREATE REPOSITORY repo TYPE \"fs\" with (location=?, compress=True)",
             new Object[]{TEMPORARY_FOLDER.newFolder().getAbsolutePath()});
 
-        assertThrows(() -> execute("CREATE SNAPSHOT repo.snap ALL WITH (wait_for_completion=true)"),
+        assertThrowsMatches(() -> execute("CREATE SNAPSHOT repo.snap ALL WITH (wait_for_completion=true)"),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or " +
                                                                  "allow READ operations.", sqlExecutor.getCurrentSchema())),
                          INTERNAL_ERROR,
@@ -265,7 +265,7 @@ public class TableBlocksIntegrationTest extends SQLIntegrationTestCase {
         execute("select settings['blocks']['read_only'] from information_schema.tables where table_name = 't1'");
         assertThat((Boolean) response.rows()[0][0], Is.is(true));
 
-        assertThrows(() -> execute("insert into t1 (id, name, date) values (?, ?, ?)",
+        assertThrowsMatches(() -> execute("insert into t1 (id, name, date) values (?, ?, ?)",
                                    new Object[]{1, "Ford", 13959981214861L}),
                      isSQLError(is(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or " +
                                                                  "allow INSERT operations, " + "as it is read-only.",

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -88,7 +88,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSetNonDynamicTableSetting() {
-        assertThrows(() -> execute("alter table settings_table set (\"soft_deletes.enabled\"='true')"),
+        assertThrowsMatches(() -> execute("alter table settings_table set (\"soft_deletes.enabled\"='true')"),
                      isSQLError(containsString("Can't update non dynamic settings [[index.soft_deletes.enabled]] for open indices"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -137,7 +137,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
         // One more column exceeds the limit
         var msg = String.format(Locale.ENGLISH,
             "Limit of total fields [%d] in index [%s.test] has been exceeded", totalFields + 1, sqlExecutor.getCurrentSchema());
-        assertThrows(() -> execute("alter table test add column new_column2 int"),
+        assertThrowsMatches(() -> execute("alter table test add column new_column2 int"),
                      isSQLError(is(msg), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
 
@@ -179,7 +179,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectConcreteDynamicSetting() {
-        assertThrows(() -> execute("select settings['routing']['allocation']['exclude']['foo'] from information_schema.tables " +
+        assertThrowsMatches(() -> execute("select settings['routing']['allocation']['exclude']['foo'] from information_schema.tables " +
             "where table_name = 'settings_table'"),
                      isSQLError(is("Column settings['routing']['allocation']['exclude']['foo'] unknown"),
                                 UNDEFINED_COLUMN,
@@ -197,7 +197,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSetDynamicSettingGroup() {
-        assertThrows(() ->  execute("alter table settings_table set (\"routing.allocation.exclude\" = {foo = 'bar2'})"),
+        assertThrowsMatches(() ->  execute("alter table settings_table set (\"routing.allocation.exclude\" = {foo = 'bar2'})"),
                      isSQLError(is("Cannot change a dynamic group setting, only concrete settings allowed."),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -221,7 +221,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
 
     @Test
     public void testResetDynamicSettingGroup() {
-        assertThrows(() ->  execute("alter table settings_table reset (\"routing.allocation.exclude\")"),
+        assertThrowsMatches(() ->  execute("alter table settings_table reset (\"routing.allocation.exclude\")"),
                      isSQLError(is("Cannot change a dynamic group setting, only concrete settings allowed."),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
@@ -84,7 +84,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLIntegrationTestCase
     @Test
     public void testSelectNonExistentGlobalExpression() throws Exception {
         new Setup(sqlExecutor).groupBySetup();
-        assertThrows(() -> execute("select count(race), suess.cluster.name from characters"),
+        assertThrowsMatches(() -> execute("select count(race), suess.cluster.name from characters"),
             isSQLError(is("Relation 'suess.cluster' unknown"), UNDEFINED_TABLE, NOT_FOUND, 4041));
     }
 
@@ -198,7 +198,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLIntegrationTestCase
 
     @Test
     public void selectMultiGetRequestFromNonExistentTable() throws Exception {
-        assertThrows(() -> execute("SELECT * FROM \"non_existent\" WHERE \"_id\" in (?,?)", new Object[]{"1", "2"}),
+        assertThrowsMatches(() -> execute("SELECT * FROM \"non_existent\" WHERE \"_id\" in (?,?)", new Object[]{"1", "2"}),
                      isSQLError(is("Relation 'non_existent' unknown"), UNDEFINED_TABLE, NOT_FOUND, 4041));
     }
 
@@ -436,7 +436,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLIntegrationTestCase
 
     @Test
     public void testSetStatementInvalid() throws Exception {
-        assertThrows(() -> execute("set global persistent stats.operations_log_size=-1024"),
+        assertThrowsMatches(() -> execute("set global persistent stats.operations_log_size=-1024"),
                      isSQLError(containsString("Failed to parse value [-1024] for setting [stats.operations_log_size] must be >= 0"),
                                 INTERNAL_ERROR, BAD_REQUEST, 4000));
 
@@ -524,7 +524,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLIntegrationTestCase
     @Test
     public void testAddPrimaryKeyColumnToNonEmptyTable() throws Exception {
         new Setup(sqlExecutor).groupBySetup();
-        assertThrows(() -> execute("alter table characters add newpkcol string primary key"),
+        assertThrowsMatches(() -> execute("alter table characters add newpkcol string primary key"),
                      isSQLError(is("Cannot add a primary key column to a table that isn't empty"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -555,7 +555,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLIntegrationTestCase
 
     @Test
     public void testCreateTableWithInvalidAnalyzer() throws Exception {
-        assertThrows(() -> execute("create table t (content string index using fulltext with (analyzer='foobar'))"),
+        assertThrowsMatches(() -> execute("create table t (content string index using fulltext with (analyzer='foobar'))"),
                      isSQLError(is("Failed to parse mapping: analyzer [foobar] not found for field [content]"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -107,7 +107,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
         PlanForNode plan = plan("select * from t");
         execute("drop table t");
 
-        assertThrows(() -> execute(plan).getResult(), instanceOf(IndexNotFoundException.class));
+        assertThrowsMatches(() -> execute(plan).getResult(), instanceOf(IndexNotFoundException.class));
     }
 
     @Test
@@ -819,7 +819,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
     public void selectWhereNonExistingColumnMatchFunction() throws Exception {
         nonExistingColumnSetup();
 
-        assertThrows(() -> execute("select * from quotes where match(o['something'], 'bla')"),
+        assertThrowsMatches(() -> execute("select * from quotes where match(o['something'], 'bla')"),
                      isSQLError(is("Can only use MATCH on columns of type STRING or GEO_SHAPE, not on 'undefined'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -1381,7 +1381,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
         execute("insert into t (i, l, d) values (1, 2, 90.5)");
         refresh();
 
-        assertThrows(() -> execute("select log(d, l) from t where log(d, -1) >= 0"),
+        assertThrowsMatches(() -> execute("select log(d, l) from t where log(d, -1) >= 0"),
                      isSQLError(is("log(x, b): given arguments would result in: 'NaN'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -1395,7 +1395,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
         execute("insert into t (i, l, d) values (1, 2, 90.5), (0, 4, 100)");
         execute("refresh table t");
 
-        assertThrows(() -> execute("select log(d, l) from t where log(d, -1) >= 0 group by log(d, l)"),
+        assertThrowsMatches(() -> execute("select log(d, l) from t where log(d, -1) >= 0 group by log(d, l)"),
                      isSQLError(is("log(x, b): given arguments would result in: 'NaN'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -1533,7 +1533,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
         String uniqueId = UUID.randomUUID().toString();
         String stmtStr = "select '" + uniqueId + "' from foobar";
         String stmtStrWhere = "select ''" + uniqueId + "'' from foobar";
-        assertThrows(() -> execute(stmtStr),
+        assertThrowsMatches(() -> execute(stmtStr),
                      isSQLError(containsString("Relation 'foobar' unknown"),
                                 UNDEFINED_TABLE,
                                 NOT_FOUND,
@@ -1585,7 +1585,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectWithSingleBulkArgRaisesUnsupportedError() {
-        assertThrows(() ->  execute("select * from sys.cluster", new Object[0][]),
+        assertThrowsMatches(() ->  execute("select * from sys.cluster", new Object[0][]),
                      isSQLError(is("Bulk operations for statements that return result sets is not supported"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -1594,7 +1594,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
 
     @Test
     public void testSelectWithBulkArgsRaisesUnsupportedError() {
-        assertThrows(() -> execute("select * from sys.cluster", new Object[][]{new Object[]{1}, new Object[]{2}}),
+        assertThrowsMatches(() -> execute("select * from sys.cluster", new Object[][]{new Object[]{1}, new Object[]{2}}),
                      isSQLError(is("Bulk operations for statements that return result sets is not supported"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -1659,7 +1659,7 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
         execute("insert into t1 (id) values (1)");
         refresh();
 
-        assertThrows(() -> execute("select 1/0 from t1"),
+        assertThrowsMatches(() -> execute("select 1/0 from t1"),
                      isSQLError(is("/ by zero"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -80,7 +80,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         assertEquals(2, response.rowCount());
         refresh();
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update test set message=null where id=1"),
                      isSQLError(Matchers.is("\"message\" must not be null"),
                                 INTERNAL_ERROR,
@@ -98,7 +98,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         assertEquals(1, response.rowCount());
         refresh();
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update test set stuff['level1']=null"),
                      isSQLError(Matchers.is("\"stuff['level1']\" must not be null"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
@@ -115,7 +115,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         assertEquals(1, response.rowCount());
         refresh();
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update test set stuff['level1']['level2']=null"),
                      isSQLError(Matchers.is("\"stuff['level1']['level2']\" must not be null"), INTERNAL_ERROR, BAD_REQUEST, 4000));
     }
@@ -648,7 +648,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         execute("insert into test (id, c) values (1, 1)");
         execute("refresh table test");
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update test set c = 4 where _version = 2 or _version=1"),
                      isSQLError(Matchers.is(VersioninigValidationException.VERSION_COLUMN_USAGE_MSG),
                                 INTERNAL_ERROR,
@@ -663,7 +663,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         execute("insert into test (id, c) values (1, 1)");
         execute("refresh table test");
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update test set c = 4 where _version in (1,2)"),
                      isSQLError(Matchers.is(VersioninigValidationException.VERSION_COLUMN_USAGE_MSG),
                                 INTERNAL_ERROR,
@@ -784,7 +784,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         execute("insert into computed (ts) values (1)");
         refresh();
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update computed set gen_col=1745"),
                      isSQLError(Matchers.is("Given value 1745 for generated column gen_col does not match calculation extract(YEAR FROM ts) = 1970"),
                                 INTERNAL_ERROR,
@@ -803,7 +803,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         assertEquals(1, response.rowCount());
         refresh();
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update generated_column set ts=null where id=1"),
                      isSQLError(Matchers.is("\"gen_col\" must not be null"), INTERNAL_ERROR, INTERNAL_SERVER_ERROR, 5000));
 
@@ -820,7 +820,7 @@ public class UpdateIntegrationTest extends SQLIntegrationTestCase {
         assertEquals(1, response.rowCount());
         refresh();
 
-        assertThrows(() -> execute(
+        assertThrowsMatches(() -> execute(
             "update generated_column set gen_col=null where id=1"),
                      isSQLError(Matchers.is("\"gen_col\" must not be null"),
                                 INTERNAL_ERROR,

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.CoreMatchers.is;
@@ -351,7 +351,7 @@ public class UserDefinedFunctionsIntegrationTest extends SQLIntegrationTestCase 
             " 'function foo(a) { return a; }'");
         execute("create table doc.t1 (id long, l as doc.foo(id))");
 
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("drop function doc.foo(long)"),
             isSQLError(containsString(
                     "Cannot drop function 'doc.foo(bigint)', it is still in use by 'doc.t1.l AS doc.foo(id)'"),

--- a/server/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
@@ -126,7 +126,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testAlterNonExistingUserThrowsException() throws Exception {
-        assertThrows(() -> executeAsSuperuser("alter user unknown_user set (password = 'unknown')"),
+        assertThrowsMatches(() -> executeAsSuperuser("alter user unknown_user set (password = 'unknown')"),
                      isSQLError(is("User 'unknown_user' does not exist"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -149,7 +149,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testDropUserUnAuthorized() throws Exception {
-        assertThrows(() -> executeAsNormalUser("drop user ford"),
+        assertThrowsMatches(() -> executeAsNormalUser("drop user ford"),
                      isSQLError(is("Missing 'AL' privilege for user 'normal'"),
                                 INTERNAL_ERROR,
                                 UNAUTHORIZED,
@@ -158,7 +158,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testCreateUserUnAuthorized() throws Exception {
-        assertThrows(() -> executeAsNormalUser("create user ford"),
+        assertThrowsMatches(() -> executeAsNormalUser("create user ford"),
                      isSQLError(is("Missing 'AL' privilege for user 'normal'"),
                                 INTERNAL_ERROR,
                                 UNAUTHORIZED,
@@ -167,7 +167,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testCreateNormalUserUnAuthorized() throws Exception {
-        assertThrows(() -> executeAsNormalUser("create user ford"),
+        assertThrowsMatches(() -> executeAsNormalUser("create user ford"),
                      isSQLError(is("Missing 'AL' privilege for user 'normal'"),
                                 INTERNAL_ERROR,
                                 UNAUTHORIZED,
@@ -189,7 +189,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
         executeAsSuperuser("create user ford_exists");
         assertUserIsCreated("ford_exists");
 
-        assertThrows(() -> executeAsSuperuser("create user ford_exists"),
+        assertThrowsMatches(() -> executeAsSuperuser("create user ford_exists"),
                      isSQLError(is("User 'ford_exists' already exists"),
                                 INTERNAL_ERROR,
                                 CONFLICT,
@@ -198,7 +198,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testDropNonExistingUserThrowsException() throws Exception {
-        assertThrows(() -> executeAsSuperuser("drop user not_exists"),
+        assertThrowsMatches(() -> executeAsSuperuser("drop user not_exists"),
                      isSQLError(is("User 'not_exists' does not exist"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -207,7 +207,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testDropSuperUserThrowsException() throws Exception {
-        assertThrows(() -> executeAsSuperuser("drop user crate"),
+        assertThrowsMatches(() -> executeAsSuperuser("drop user crate"),
                      isSQLError(is("Cannot drop a superuser 'crate'"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -122,7 +122,7 @@ public class VersionHandlingIntegrationTest extends SQLIntegrationTestCase {
     public void testUpdateWhereVersionWithoutPrimaryKey() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)");
         ensureYellow();
-        assertThrows(() -> execute("update test set col2 = ? where \"_version\" = ?", new Object[]{"ok now panic", 1}),
+        assertThrowsMatches(() -> execute("update test set col2 = ? where \"_version\" = ?", new Object[]{"ok now panic", 1}),
                      isSQLError(containsString(VersioninigValidationException.VERSION_COLUMN_USAGE_MSG),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
@@ -162,7 +162,7 @@ public class VersionHandlingIntegrationTest extends SQLIntegrationTestCase {
     public void testSelectWhereVersionWithoutPrimaryKey() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)");
         ensureYellow();
-        assertThrows(() -> execute("select _version from test where col2 = 'hello' and _version = 1"),
+        assertThrowsMatches(() -> execute("select _version from test where col2 = 'hello' and _version = 1"),
                      isSQLError(containsString(VersioninigValidationException.VERSION_COLUMN_USAGE_MSG),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.DUPLICATE_TABLE;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
@@ -109,7 +109,7 @@ public class ViewsITest extends SQLIntegrationTestCase {
     public void testCreateViewFailsIfViewAlreadyExists() {
         execute("create view v3 as select 1");
 
-        assertThrows(() ->  execute("create view v3 as select 1"),
+        assertThrowsMatches(() ->  execute("create view v3 as select 1"),
                      isSQLError(containsString("Relation '" + sqlExecutor.getCurrentSchema() + ".v3' already exists"),
                                 DUPLICATE_TABLE,
                                 CONFLICT,
@@ -120,7 +120,7 @@ public class ViewsITest extends SQLIntegrationTestCase {
     public void testCreateViewFailsIfNameConflictsWithTable() {
         execute("create table t1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
 
-        assertThrows(() -> execute("create view t1 as select 1"),
+        assertThrowsMatches(() -> execute("create view t1 as select 1"),
                      isSQLError(containsString("Relation '" + sqlExecutor.getCurrentSchema() + ".t1' already exists"),
                                 DUPLICATE_TABLE,
                                 CONFLICT,
@@ -131,7 +131,7 @@ public class ViewsITest extends SQLIntegrationTestCase {
     public void testCreateViewFailsIfNameConflictsWithPartitionedTable() {
         execute("create table t1 (x int) partitioned by (x) clustered into 1 shards with (number_of_replicas = 0)");
 
-        assertThrows(() -> execute("create view t1 as select 1"),
+        assertThrowsMatches(() -> execute("create view t1 as select 1"),
                      isSQLError(containsString("Relation '" + sqlExecutor.getCurrentSchema() + ".t1' already exists"),
                                 DUPLICATE_TABLE,
                                 CONFLICT,
@@ -168,7 +168,7 @@ public class ViewsITest extends SQLIntegrationTestCase {
 
     @Test
     public void testDropViewFailsIfViewIsMissing() {
-        assertThrows(() -> execute("drop view v1"),
+        assertThrowsMatches(() -> execute("drop view v1"),
                      isSQLError(containsString("Relations not found: " + sqlExecutor.getCurrentSchema() + ".v1"),
                                 INTERNAL_ERROR,
                                 NOT_FOUND,
@@ -202,7 +202,7 @@ public class ViewsITest extends SQLIntegrationTestCase {
     @Test
     public void test_creating_a_self_referencing_view_is_not_allowed() throws Exception {
         execute("create view v as select * from sys.cluster");
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("create or replace view v as select * from v"),
             isSQLError(
                 containsString("Creating a view that references itself is not allowed"),

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.TestingHelpers.isDocKey;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
@@ -102,7 +102,7 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_delete_where_id_and_seq_missing_primary_term() throws Exception {
-        assertThrows(
+        assertThrowsMatches(
             () -> e.plan("delete from users where id = 1 and _seq_no = 11"),
             VersioninigValidationException.class,
             VersioninigValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -104,7 +104,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_invalid_any_param_leads_to_clear_error_message() throws Exception {
         LogicalPlan plan = e.logicalPlan("select name = ANY(?) from sys.cluster");
-        Asserts.assertThrows(
+        Asserts.assertThrowsMatches(
             () -> {
                 LogicalPlanner.getNodeOperationTree(
                     plan,

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -84,7 +84,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
@@ -1084,7 +1084,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_select_where_id_and_seq_missing_primary_term() throws Exception {
-        assertThrows(
+        assertThrowsMatches(
             () -> e.plan("select id from users where id = 1 and _seq_no = 11"),
             VersioninigValidationException.class,
             VersioninigValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG
@@ -1093,7 +1093,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_select_where_seq_and_primary_term_missing_id() throws Exception {
-        assertThrows(
+        assertThrowsMatches(
             () -> e.plan("select id from users where _seq_no = 11 and _primary_term = 1"),
             VersioninigValidationException.class,
             VersioninigValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -58,7 +58,7 @@ import java.util.Map;
 
 import static io.crate.expression.symbol.SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES;
 import static io.crate.expression.symbol.SelectSymbol.ResultType.SINGLE_COLUMN_SINGLE_VALUE;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.isSQL;
@@ -163,7 +163,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_update_where_id_and_seq_missing_primary_term() throws Exception {
-        assertThrows(
+        assertThrowsMatches(
             () -> e.plan("update users set name = 'should not update' where id = 1 and _seq_no = 11"),
             VersioninigValidationException.class,
             VersioninigValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG

--- a/server/src/test/java/io/crate/protocols/postgres/types/DateTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/DateTypeTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import java.time.format.DateTimeParseException;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 
@@ -62,7 +62,7 @@ public class DateTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testDecodeUTF8TextWithUnexpectedFormat() {
-        assertThrows(() -> DateType.INSTANCE.decodeUTF8Text("2016.06.28".getBytes(UTF_8)),
+        assertThrowsMatches(() -> DateType.INSTANCE.decodeUTF8Text("2016.06.28".getBytes(UTF_8)),
             DateTimeParseException.class, "");
     }
 

--- a/server/src/test/java/io/crate/types/DateTypeTest.java
+++ b/server/src/test/java/io/crate/types/DateTypeTest.java
@@ -23,7 +23,7 @@ package io.crate.types;
 
 import org.junit.Test;
 
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -32,7 +32,7 @@ public class DateTypeTest {
 
     @Test
     public void testCastFromInvalidString() {
-        assertThrows(() -> DateType.INSTANCE.implicitCast("not-a-number"),
+        assertThrowsMatches(() -> DateType.INSTANCE.implicitCast("not-a-number"),
             ClassCastException.class,
             "Can't cast 'not-a-number' to date");
     }

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -63,7 +63,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.SQLTransportExecutor.REQUEST_TIMEOUT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
@@ -448,7 +448,7 @@ public class GatewayIndexStateIT extends SQLIntegrationTestCase {
         assertEquals(IndexMetadata.State.CLOSE, state.getMetadata().index(metadata.getIndex()).getState());
         assertEquals("classic", state.getMetadata().index(metadata.getIndex()).getSettings().get("archived.index.similarity.BM25.type"));
         // try to open it with the broken setting - fail again!
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("alter table test open"),
             isSQLError(is("Failed to verify index " + metadata.getIndex().getName()),
                        INTERNAL_ERROR,
@@ -519,7 +519,7 @@ public class GatewayIndexStateIT extends SQLIntegrationTestCase {
         execute("alter table test close");
 
         // try to open it with the broken setting - fail again!
-        assertThrows(
+        assertThrowsMatches(
             () -> execute("alter table test open"),
             isSQLError(is("Failed to verify index " + metadata.getIndex().getName()),
                        INTERNAL_ERROR,

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrows;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.elasticsearch.index.shard.IndexShardTestCase.flushShard;
@@ -416,7 +416,7 @@ public class IndexServiceTests extends SQLIntegrationTestCase {
     }
 
     public void testIllegalFsyncInterval() {
-        assertThrows(() -> execute("create table test(x int, data string) clustered into 1 shards with (\"translog.sync_interval\" = '0ms')"),
+        assertThrowsMatches(() -> execute("create table test(x int, data string) clustered into 1 shards with (\"translog.sync_interval\" = '0ms')"),
                      isSQLError(is("failed to parse value [0ms] for setting [index.translog.sync_interval], must be >= [100ms]"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -33,7 +33,7 @@ public class Asserts {
 
     private Asserts() {}
 
-    public static void assertThrows(Executable executable, Matcher<? super Throwable> matcher) {
+    public static void assertThrowsMatches(Executable executable, Matcher<? super Throwable> matcher) {
         try {
             executable.execute();
             Assertions.fail("Expected exception to be thrown, but nothing was thrown.");
@@ -42,7 +42,7 @@ public class Asserts {
         }
     }
 
-    public static void assertThrows(Executable executable, Class<? extends Throwable> type, String subString) {
+    public static void assertThrowsMatches(Executable executable, Class<? extends Throwable> type, String subString) {
         try {
             executable.execute();
             Assertions.fail("Expected exception to be thrown, but nothing was thrown.");


### PR DESCRIPTION

Had to rename `assertThrows` in our custom `Asserts` class because the
`Assert` base class (inherited from in `ESTestCase` / `LuceneTestCase`)
added a new `assertThrows` method that broke the method resolution.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
