### PR TITLE
Fix Sphinx extensions configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ from crate.theme.rtd.conf.crate_reference import *
 
 exclude_patterns = ['out/**', 'tmp/**', 'eggs/**', 'requirements.txt', 'README.rst']
 
-extensions = ['crate.sphinx.csv', 'sphinx_sitemap']
+extensions.append('crate.sphinx.csv')
 
 linkcheck_ignore = [
     'https://www.iso.org/obp/ui/.*'  # Breaks accessibility via JS ¯\_(ツ)_/¯


### PR DESCRIPTION
The `sphinx-docs-theme` specifies a list of default Sphinx extensions in the [src/crate/theme/rtd/conf/__init__.py][1] file.

The `conf.py` file in this Sphinx project also specified a list of Sphinx extensions. However, the way this was done meant that a direct assignment was overwriting the default value of the extensions variable (imported at the start of the file).

As a consequence, the CrateDB Reference has not yet picked up any of the following improvements:

- Intersphinx support
- PlantUML support
- Open Graph support
- [Sphinx copy button][2] support

This change replaces the direct assignment with a list append operation and removes a redundant extension (`sphinx_sitemap`) that is already present in the default list.

I have verified that as a result of this change, the Sphinx copy button correctly appears on code examples as expected ([which was previously not the case][3]).

[1]: https://github.com/crate/crate-docs-theme/blob/main/src/crate/theme/rtd/conf/__init__.py#L32
[2]: https://pypi.org/project/sphinx-copybutton/
[3]: https://github.com/crate/crate-docs-theme/issues/258#issuecomment-852080493
