### PR TITLE
Allow users with DDL permission to execute OPTIMIZE TABLE

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -55,6 +55,9 @@ Deprecations
 Changes
 =======
 
+- Changed the privileges model to allow users with ``DDL`` privileges on a
+  table to use the :ref:`OPTIMIZE TABLE <sql-optimize>` statement.
+
 - Added the :ref:`bit(n) <data-type-bit>` data type.
 
 - Added support for encrypting node-to-node communication.

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -52,6 +52,7 @@ import io.crate.analyze.AnalyzedDropUser;
 import io.crate.analyze.AnalyzedDropView;
 import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.AnalyzedKill;
+import io.crate.analyze.AnalyzedOptimizeTable;
 import io.crate.analyze.AnalyzedPrivileges;
 import io.crate.analyze.AnalyzedRefreshTable;
 import io.crate.analyze.AnalyzedResetStatement;
@@ -687,6 +688,20 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         public Void visitSetTransaction(AnalyzedSetTransaction setTransaction, User context) {
+            return null;
+        }
+
+        @Override
+        public Void visitOptimizeTableStatement(AnalyzedOptimizeTable optimizeTable, User user) {
+            for (TableInfo table : optimizeTable.tables().values()) {
+                Privileges.ensureUserHasPrivilege(
+                    Privilege.Type.DDL,
+                    Privilege.Clazz.TABLE,
+                    table.ident().toString(),
+                    user,
+                    defaultSchema
+                );
+            }
             return null;
         }
     }

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -191,14 +191,6 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testOptimizeNotAllowedAsNormalUser() throws Exception {
-        expectedException.expect(UnauthorizedException.class);
-        expectedException.expectMessage("User \"normal\" is not authorized to execute the statement. " +
-                                        "Superuser permissions are required");
-        analyze("optimize table users");
-    }
-
-    @Test
     public void test_set_global_statements_can_be_executed_with_al_cluster_privileges() throws Exception {
         analyze("set global stats.enabled = true");
         assertAskedForCluster(Privilege.Type.AL);
@@ -572,5 +564,11 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         analyze("create table target_schema.target_table as (select * from sys.cluster)");
         assertAskedForSchema(Privilege.Type.DDL, "target_schema");
         assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
+    }
+
+    @Test
+    public void test_optimize_table_is_allowed_with_ddl_privileges_on_table() {
+        analyze("optimize table users");
+        assertAskedForTable(Privilege.Type.DDL, "doc.users");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/11473


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
