### PR TITLE
Type references in docValueAggregator as Reference

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -24,9 +24,9 @@ package io.crate.execution.engine.aggregation;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.DataType;
 import org.elasticsearch.Version;
@@ -118,7 +118,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     }
 
     @Nullable
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -21,6 +21,21 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
@@ -30,7 +45,6 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Reference;
@@ -47,19 +61,6 @@ import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
-import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.Version;
-import org.elasticsearch.index.fielddata.FieldData;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.function.Function;
 
 public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
@@ -138,7 +139,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -21,6 +21,20 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.collections.Lists2;
@@ -29,7 +43,6 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Reference;
@@ -44,18 +57,6 @@ import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
-import org.apache.lucene.util.NumericUtils;
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
 
 public class AverageAggregation extends AggregationFunction<AverageAggregation.AverageState, Double> {
 
@@ -280,7 +281,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -21,6 +21,19 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.MutableLong;
@@ -54,17 +67,6 @@ import io.crate.types.ObjectType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-
-import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class CountAggregation extends AggregationFunction<MutableLong, Long> {
 
@@ -279,7 +281,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        java.util.function.Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -21,7 +21,24 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ComparisonChain;
+
+import org.apache.commons.math3.util.FastMath;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.collections.Lists2;
@@ -30,7 +47,6 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Reference;
@@ -46,20 +62,6 @@ import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
-import org.apache.commons.math3.util.FastMath;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
 
 public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanAggregation.GeometricMeanState, Double> {
 
@@ -297,7 +299,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -27,14 +27,6 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import io.crate.common.MutableFloat;
-import io.crate.common.collections.Lists2;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Reference;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.types.ByteType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -47,12 +39,19 @@ import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.common.MutableDouble;
+import io.crate.common.MutableFloat;
 import io.crate.common.MutableLong;
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -219,7 +218,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
 
         @Nullable
         @Override
-        public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+        public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                            Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                            DocTableInfo table,
                                                            List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -27,14 +27,6 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import io.crate.common.MutableFloat;
-import io.crate.common.collections.Lists2;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Reference;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.types.ByteType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -47,12 +39,19 @@ import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import io.crate.breaker.SizeEstimatorFactory;
 import io.crate.common.MutableDouble;
+import io.crate.common.MutableFloat;
 import io.crate.common.MutableLong;
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -255,7 +254,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
 
         @Nullable
         @Override
-        public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+        public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                            Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                            DocTableInfo table,
                                                            List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -21,6 +21,21 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
@@ -28,7 +43,6 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Reference;
@@ -43,19 +57,6 @@ import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.NumericType;
 import io.crate.types.ShortType;
-import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.function.Function;
 
 public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDecimal> {
 
@@ -175,7 +176,7 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -21,6 +21,19 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.collections.Lists2;
@@ -30,7 +43,6 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.execution.engine.aggregation.statistics.StandardDeviation;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Reference;
@@ -46,17 +58,6 @@ import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.function.Function;
 
 public class StandardDeviationAggregation extends AggregationFunction<StandardDeviation, Double> {
 
@@ -218,7 +219,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -21,6 +21,22 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.common.MutableDouble;
 import io.crate.common.MutableFloat;
@@ -31,7 +47,6 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionImplementation;
@@ -46,20 +61,6 @@ import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
-import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
 
 public class SumAggregation<T extends Number> extends AggregationFunction<T, T> {
 
@@ -188,7 +189,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -21,6 +21,19 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
 import io.crate.Streamer;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.collections.Lists2;
@@ -30,7 +43,6 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
 import io.crate.execution.engine.aggregation.statistics.Variance;
 import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Reference;
@@ -46,17 +58,6 @@ import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.mapper.MappedFieldType;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.function.Function;
 
 public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
@@ -220,7 +221,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
     @Nullable
     @Override
-    public DocValueAggregator<?> getDocValueAggregator(List<Symbol> aggregationReferences,
+    public DocValueAggregator<?> getDocValueAggregator(List<Reference> aggregationReferences,
                                                        Function<List<String>, List<MappedFieldType>> getMappedFieldTypes,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -151,7 +151,7 @@ public class DocValuesAggregates {
                 return null;
             }
 
-            var aggregationReferences = new ArrayList<Symbol>(aggregation.inputs().size());
+            var aggregationReferences = new ArrayList<Reference>(aggregation.inputs().size());
             var literals = new ArrayList<Literal<?>>();
             for (var input : aggregation.inputs()) {
                 if (input instanceof Literal<?> literal) {
@@ -197,13 +197,13 @@ public class DocValuesAggregates {
         return aggregator;
     }
 
-    private static class AggregationInputToReferenceResolver extends SymbolVisitor<List<Symbol>, Symbol> {
+    private static class AggregationInputToReferenceResolver extends SymbolVisitor<List<Symbol>, Reference> {
 
         public static final AggregationInputToReferenceResolver INSTANCE =
             new AggregationInputToReferenceResolver();
 
         @Override
-        public Symbol visitFunction(io.crate.expression.symbol.Function function, List<Symbol> toCollect) {
+        public Reference visitFunction(io.crate.expression.symbol.Function function, List<Symbol> toCollect) {
             if (function.name().equals(ExplicitCastFunction.NAME)) {
                 var arg = function.arguments().get(0);
                 // Currently, it is the concrete case for the ::numeric explicit cast only.
@@ -217,12 +217,12 @@ public class DocValuesAggregates {
         }
 
         @Override
-        public Symbol visitReference(Reference reference, List<Symbol> context) {
+        public Reference visitReference(Reference reference, List<Symbol> context) {
             return reference;
         }
 
         @Override
-        public Symbol visitInputColumn(InputColumn inputColumn, List<Symbol> toCollect) {
+        public Reference visitInputColumn(InputColumn inputColumn, List<Symbol> toCollect) {
             Symbol collectSymbol = toCollect.get(inputColumn.index());
             if (collectSymbol == null) {
                 return null;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -21,33 +21,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import io.crate.common.MutableLong;
-import io.crate.common.collections.Lists2;
-import io.crate.execution.engine.aggregation.AggregationFunction;
-import io.crate.execution.engine.aggregation.impl.templates.BinaryDocValueAggregator;
-import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.SearchPath;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.operation.aggregation.AggregationTestCase;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.Map;
-
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.instanceOf;
@@ -58,6 +31,33 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import io.crate.common.MutableLong;
+import io.crate.common.collections.Lists2;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.impl.templates.BinaryDocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.operation.aggregation.AggregationTestCase;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 
 public class CountAggregationTest extends AggregationTestCase {
@@ -73,7 +73,7 @@ public class CountAggregationTest extends AggregationTestCase {
         );
     }
 
-    private void assertHasDocValueAggregator(List<Symbol> aggregationReferences,
+    private void assertHasDocValueAggregator(List<Reference> aggregationReferences,
                                              DocTableInfo sourceTable,
                                              Class<?> expectedAggregatorClass) {
         var aggregationFunction = (AggregationFunction<?, ?>) nodeCtx.functions().get(

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -584,8 +584,8 @@ public abstract class AggregationTestCase extends ESTestCase {
         );
     }
 
-    public static List<Symbol> toReference(List<DataType<?>> dataTypes) {
-        var references = new ArrayList<Symbol>(dataTypes.size());
+    public static List<Reference> toReference(List<DataType<?>> dataTypes) {
+        var references = new ArrayList<Reference>(dataTypes.size());
         for (int i = 0; i < dataTypes.size(); i++) {
             references.add(
                 new Reference(


### PR DESCRIPTION
We expect `Reference` instances, so we should type them as `Reference`,
not as `Symbol`.
