### PR TITLE
Optimize count on bitstring columns

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -40,6 +40,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.BitStringType;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -264,6 +265,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                 );
             case IpType.ID:
             case StringType.ID:
+            case BitStringType.ID:
                 return new BinaryDocValueAggregator<>(
                     fieldTypes.get(0).name(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
@@ -38,6 +38,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.query.QueryShardContext;
 
 import io.crate.sql.tree.BitString;
@@ -162,10 +163,10 @@ public class BitStringFieldMapper extends FieldMapper {
     @Override
     protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
         XContentParser parser = context.parser();
-        byte[] bytes = parser.binaryValue();
-        if (bytes == null) {
+        if (parser.currentToken() == Token.VALUE_NULL) {
             return;
         }
+        byte[] bytes = parser.binaryValue();
         BytesRef binaryValue = new BytesRef(bytes);
         if (fieldType().isSearchable()) {
             fields.add(new Field(fieldType().name(), binaryValue, fieldType));

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -36,6 +36,8 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.operation.aggregation.AggregationTestCase;
+import io.crate.sql.tree.BitString;
+import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
@@ -363,6 +365,18 @@ public class CountAggregationTest extends AggregationTestCase {
     @Test
     public void test_count_with_ip_argument() throws Exception {
         assertThat(executeAggregation(DataTypes.IP, new Object[][]{{"127.0.0.1"}}), is(1L));
+    }
+
+    @Test
+    public void test_count_with_bitstring_argument() throws Exception {
+        BitStringType bitStringType = new BitStringType(4);
+        Object[][] rows = new Object[][] {
+            { BitString.ofRawBits("0100") },
+            { null },
+            { BitString.ofRawBits("0110") },
+        };
+        assertThat(executeAggregation(bitStringType, rows), is(2L));
+        assertHasDocValueAggregator("count", List.of(bitStringType));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We can re-use the same `DocValueAggregator` implementation that we use
for Ip/StringType, because all types use `SortedBinaryDocValues` under the hood.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
