### PR TITLE
Fix ssl=on parsing/mapping issue.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -112,4 +112,6 @@ Changes
 Fixes
 =====
 
-None
+- Fixed a HBA SSL configuration parsing issue. The ``on`` value for the ``ssl``
+  configuration option was not recognized and got interpreted as 'true'.
+

--- a/server/src/test/resources/org/elasticsearch/node/config/crate.yml
+++ b/server/src/test/resources/org/elasticsearch/node/config/crate.yml
@@ -2,3 +2,14 @@ cluster.name: testCluster
 stats.enabled: false
 psql.enabled: false
 path.logs: /some/path
+
+#this entry is needed for test cert_method_resolved_when_ssl_on_and_keystore_configured
+auth.host_based.enabled: true
+auth:
+  host_based:
+    config:
+      0:
+        protocol: transport
+        ssl: on
+        method: cert
+


### PR DESCRIPTION
Fixes [11489](https://github.com/crate/crate/issues/11489). 

- Use only one Enum for SSL mode throughout the codebase
- Compare enum values instead of Strings to avoid ["true" and "on" comparison ](https://github.com/crate/crate/blob/388807579829bcdb2051532fe751f1ed574a7748/server/src/main/java/io/crate/auth/HostBasedAuthentication.java#L205)  


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
