### PR TITLE
Fix aggregation on primary key lookup regression

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -109,4 +109,10 @@ Changes
 Fixes
 =====
 
-None
+- Fixed a regression introduced in 4.5.2 which caused aggregations on virtual
+  tables using a primary key lookup to fail. An example::
+
+    SELECT count(*) FROM (
+      SELECT * FROM users WHERE id = ? AND (addr is NULL)
+    ) AS u;
+        

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -40,6 +40,7 @@ import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.ExecutionPlan;
@@ -176,10 +177,11 @@ public class Get implements LogicalPlan {
         if (requiresAdditionalFilteringOnNonDocKeyColumns.get()) {
             toCollect = List.copyOf(toCollectSet);
             var filterProjection = ProjectionBuilder.filterProjection(toCollect, boundQuery);
+            filterProjection.requiredGranularity(RowGranularity.SHARD);
             projections.add(filterProjection);
 
             // reduce outputs which have been added for the filter projection
-            var evalProjection = new EvalProjection(InputColumn.mapToInputColumns(boundOutputs));
+            var evalProjection = new EvalProjection(InputColumn.mapToInputColumns(boundOutputs), RowGranularity.SHARD);
             projections.add(evalProjection);
         }
 

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -114,6 +114,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_4_5_0 = new Version(7_05_00_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final Version V_4_5_1 = new Version(7_05_01_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final Version V_4_5_2 = new Version(7_05_02_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
+    public static final Version V_4_5_3 = new Version(7_05_03_99, true, org.apache.lucene.util.Version.LUCENE_8_7_0);
 
     public static final Version V_4_6_0 = new Version(7_06_00_99, true, org.apache.lucene.util.Version.LUCENE_8_8_2);
 

--- a/server/src/test/java/io/crate/execution/dsl/projection/EvalProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/EvalProjectionTest.java
@@ -1,0 +1,28 @@
+
+package io.crate.execution.dsl.projection;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.List;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.RowGranularity;
+
+public class EvalProjectionTest extends ESTestCase {
+
+    @Test
+    public void test_granularity_property_is_serialized() throws Exception {
+        var projection = new EvalProjection(List.of(Literal.of(10)), RowGranularity.SHARD);
+        var out = new BytesStreamOutput();
+        projection.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        var inProjection  = new EvalProjection(in);
+        assertThat(projection.requiredGranularity(), is(inProjection.requiredGranularity()));
+        assertThat(projection.outputs(), is(inProjection.outputs()));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

ccca7a9a908b3aebe6a949e35bd688633d04ea9a introduced a regression because
the filter and eval projections ran on cluster level, this messed up the
projection ordering.

Instead of `filter -> eval -> aggregation` the projections got applied
as `aggregation -> filter -> eval`.

Fixes https://github.com/crate/crate/issues/11493


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
