### PR TITLE
Prefer doc-values in INSERT FROM query with GROUP BY operations

### DIFF
--- a/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -21,16 +21,14 @@
 
 package io.crate.analyze;
 
-import io.crate.action.sql.SessionContext;
-import io.crate.data.Row;
-import io.crate.planner.ExecutionPlan;
-import io.crate.planner.Plan;
-import io.crate.planner.PlannerContext;
-import io.crate.planner.operators.LogicalPlan;
-import io.crate.planner.operators.SubQueryResults;
-import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.Statement;
-import io.crate.testing.SQLExecutor;
+import static io.crate.testing.DiscoveryNodes.newNode;
+import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -49,12 +47,16 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-
-import static io.crate.testing.DiscoveryNodes.newNode;
-import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+import io.crate.action.sql.SessionContext;
+import io.crate.data.Row;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.Plan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Statement;
+import io.crate.testing.SQLExecutor;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -111,7 +113,7 @@ public class PreExecutionBenchmark {
     @Benchmark
     public ExecutionPlan measurePlanSimpleSelect() {
         return ((LogicalPlan) e.planner.plan(analyzedStatement, e.getPlannerContext(ClusterState.EMPTY_STATE)))
-            .build(plannerContext, null, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
+            .build(plannerContext, Set.of(), null, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
     }
 
     @Benchmark

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -55,6 +55,9 @@ Deprecations
 Changes
 =======
 
+- Improved the performance of ``INSERT FROM query`` statements where the
+  ``query`` contains a ``GROUP BY`` clause.
+
 - Changed the privileges model to allow users with ``DDL`` privileges on a
   table to use the :ref:`OPTIMIZE TABLE <sql-optimize>` statement.
 

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -22,6 +22,14 @@
 package io.crate.planner.consumer;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+
 import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.dsl.projection.ColumnIndexWriterProjection;
@@ -35,16 +43,8 @@ import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.operators.Insert;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanner;
-import io.crate.planner.operators.PlanHint;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.settings.Settings;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
 
 
 public final class InsertFromSubQueryPlanner {
@@ -102,7 +102,7 @@ public final class InsertFromSubQueryPlanner {
             statement.subQueryRelation(),
             plannerContext,
             subqueryPlanner,
-            EnumSet.of(PlanHint.PREFER_SOURCE_LOOKUP, PlanHint.AVOID_TOP_LEVEL_FETCH)
+            true
         );
         EvalProjection castOutputs = createCastProjection(statement.columns(), plannedSubQuery.outputs());
         return new Insert(plannedSubQuery, indexWriterProjection, castOutputs);

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -21,6 +21,14 @@
 
 package io.crate.planner.operators;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
@@ -44,12 +52,6 @@ import io.crate.planner.node.dql.CountPlan;
 import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 /**
  * An optimized version for "select count(*) from t where ..."
  */
@@ -69,6 +71,7 @@ public class Count implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -21,6 +21,15 @@
 
 package io.crate.planner.operators;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
@@ -35,14 +44,6 @@ import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
 import io.crate.statistics.TableStats;
-
-import javax.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.function.Function;
 
 
 /**
@@ -70,6 +71,7 @@ public final class Eval extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -78,7 +80,7 @@ public final class Eval extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan executionPlan = source.build(
-            plannerContext, projectionBuilder, limit, offset, null, pageSizeHint, params, subQueryResults);
+            plannerContext, planHints, projectionBuilder, limit, offset, null, pageSizeHint, params, subQueryResults);
         if (outputs.equals(source.outputs())) {
             return executionPlan;
         }

--- a/server/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/server/src/main/java/io/crate/planner/operators/Fetch.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -108,6 +109,7 @@ public final class Fetch extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -118,6 +120,7 @@ public final class Fetch extends ForwardingLogicalPlan {
         ExecutionPlan executionPlan = Merge.ensureOnHandler(
             source.build(
                 plannerContext,
+                hints,
                 projectionBuilder,
                 limit,
                 offset,

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public final class Filter extends ForwardingLogicalPlan {
 
@@ -71,6 +72,7 @@ public final class Filter extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -79,7 +81,7 @@ public final class Filter extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan executionPlan = source.build(
-            plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+            plannerContext, planHints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
         Symbol boundQuery = SubQueryAndParamBinder.convert(query, params, subQueryResults);
         FilterProjection filterProjection = ProjectionBuilder.filterProjection(source.outputs(), boundQuery);
         if (executionPlan.resultDescription().executesOnShard()) {

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -61,6 +61,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -91,6 +92,7 @@ public class Get implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limitHint,
                                int offsetHint,

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class HashAggregate extends ForwardingLogicalPlan {
 
@@ -62,6 +63,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -70,7 +72,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan executionPlan = source.build(
-            plannerContext, projectionBuilder, LogicalPlanner.NO_LIMIT, 0, null, null, params, subQueryResults);
+            plannerContext, planHints, projectionBuilder, LogicalPlanner.NO_LIMIT, 0, null, null, params, subQueryResults);
 
         AggregationOutputValidator.validateOutputs(aggregates);
         var paramBinder = new SubQueryAndParamBinder(params, subQueryResults);

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -111,6 +112,7 @@ public class HashJoin implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -119,9 +121,9 @@ public class HashJoin implements LogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan leftExecutionPlan = lhs.build(
-            plannerContext, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
         ExecutionPlan rightExecutionPlan = rhs.build(
-            plannerContext, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
 
         LogicalPlan leftLogicalPlan = lhs;
         LogicalPlan rightLogicalPlan = rhs;

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -21,6 +21,15 @@
 
 package io.crate.planner.operators;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.common.collections.Lists2;
@@ -36,12 +45,6 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
-
-import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 public class Insert implements LogicalPlan {
 
@@ -59,6 +62,7 @@ public class Insert implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -67,7 +71,16 @@ public class Insert implements LogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan sourcePlan = source.build(
-            plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+            plannerContext,
+            EnumSet.of(PlanHint.PREFER_SOURCE_LOOKUP),
+            projectionBuilder,
+            limit,
+            offset,
+            order,
+            pageSizeHint,
+            params,
+            subQueryResults
+        );
         if (applyCasts != null) {
             sourcePlan.addProjection(applyCasts);
         }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -792,6 +792,7 @@ public class InsertFromValues implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -21,6 +21,16 @@
 
 package io.crate.planner.operators;
 
+import static io.crate.analyze.SymbolEvaluator.evaluate;
+import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
@@ -38,14 +48,6 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.ResultDescription;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import static io.crate.analyze.SymbolEvaluator.evaluate;
-import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
 public class Limit extends ForwardingLogicalPlan {
 
@@ -79,6 +81,7 @@ public class Limit extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limitHint,
                                int offsetHint,
@@ -104,7 +107,7 @@ public class Limit extends ForwardingLogicalPlan {
             0);
 
         ExecutionPlan executionPlan = source.build(
-            plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+            plannerContext, planHints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
         List<DataType<?>> sourceTypes = Symbols.typeView(source.outputs());
         ResultDescription resultDescription = executionPlan.resultDescription();
         if (resultDescription.hasRemainingLimitOrOffset()

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -91,6 +91,7 @@ public interface LogicalPlan extends Plan {
      * operators implementation. Operator may choose to make use of this information, but can also ignore it.
      */
     ExecutionPlan build(PlannerContext plannerContext,
+                        Set<PlanHint> planHints,
                         ProjectionBuilder projectionBuilder,
                         int limit,
                         int offset,

--- a/server/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/server/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This is the {@link LogicalPlan} equivalent of the {@link MultiPhasePlan} plan.
@@ -66,6 +67,7 @@ public class MultiPhase extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -74,7 +76,7 @@ public class MultiPhase extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         return source.build(
-            plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+            plannerContext, planHints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -138,6 +138,7 @@ public class NestedLoopJoin implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -158,9 +159,9 @@ public class NestedLoopJoin implements LogicalPlan {
             : null;
 
         ExecutionPlan left = lhs.build(
-            plannerContext, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
         ExecutionPlan right = rhs.build(
-            plannerContext, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
 
         PositionalOrderBy orderByFromLeft = left.resultDescription().orderBy();
         boolean hasDocTables = baseTables.stream().anyMatch(r -> r instanceof DocTableRelation);

--- a/server/src/main/java/io/crate/planner/operators/Order.java
+++ b/server/src/main/java/io/crate/planner/operators/Order.java
@@ -45,6 +45,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -117,6 +118,7 @@ public class Order extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -125,7 +127,7 @@ public class Order extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan plan = source.build(
-            plannerContext, projectionBuilder, limit, offset, orderBy, pageSizeHint, params, subQueryResults);
+            plannerContext, planHints, projectionBuilder, limit, offset, orderBy, pageSizeHint, params, subQueryResults);
         if (plan.resultDescription().orderBy() != null) {
             // Collect applied ORDER BY eagerly to produce a optimized execution plan;
             if (source instanceof Collect) {

--- a/server/src/main/java/io/crate/planner/operators/PlanHint.java
+++ b/server/src/main/java/io/crate/planner/operators/PlanHint.java
@@ -23,5 +23,4 @@ package io.crate.planner.operators;
 
 public enum PlanHint {
     PREFER_SOURCE_LOOKUP,
-    AVOID_TOP_LEVEL_FETCH;
 }

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ProjectSet extends ForwardingLogicalPlan {
@@ -105,6 +106,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -114,6 +116,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
                                SubQueryResults subQueryResults) {
         ExecutionPlan sourcePlan = source.build(
             plannerContext,
+            planHints,
             projectionBuilder,
             limit,
             offset,

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -183,6 +183,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -190,7 +191,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
-        return source.build(plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+        return source.build(plannerContext, hints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -21,6 +21,11 @@
 
 package io.crate.planner.operators;
 
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
@@ -28,9 +33,6 @@ import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * An operator with the primary purpose to ensure that the result is on the handler and no longer distributed.
@@ -43,6 +45,7 @@ public class RootRelationBoundary extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -52,6 +55,7 @@ public class RootRelationBoundary extends ForwardingLogicalPlan {
                                SubQueryResults subQueryResults) {
         return Merge.ensureOnHandler(source.build(
             plannerContext,
+            hints,
             projectionBuilder,
             LogicalPlanner.NO_LIMIT,
             0,

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 public final class TableFunction implements LogicalPlan {
@@ -70,6 +71,7 @@ public final class TableFunction implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,

--- a/server/src/main/java/io/crate/planner/operators/TopNDistinct.java
+++ b/server/src/main/java/io/crate/planner/operators/TopNDistinct.java
@@ -26,6 +26,7 @@ import static io.crate.analyze.SymbolEvaluator.evaluate;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
@@ -75,6 +76,7 @@ public final class TopNDistinct extends ForwardingLogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limitHint,
                                int offsetHint,
@@ -84,6 +86,7 @@ public final class TopNDistinct extends ForwardingLogicalPlan {
                                SubQueryResults subQueryResults) {
         var executionPlan = source.build(
             plannerContext,
+            planHints,
             projectionBuilder,
             TopN.NO_LIMIT,
             TopN.NO_OFFSET,

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.crate.planner.operators.Limit.limitAndOffset;
 
@@ -77,6 +78,7 @@ public class Union implements LogicalPlan {
 
     @Override
     public ExecutionPlan build(PlannerContext plannerContext,
+                               Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
                                int offset,
@@ -90,9 +92,9 @@ public class Union implements LogicalPlan {
             : null;
 
         ExecutionPlan left = lhs.build(
-            plannerContext, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
+            plannerContext, hints, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
         ExecutionPlan right = rhs.build(
-            plannerContext, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
+            plannerContext, hints, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
 
         if (left.resultDescription().hasRemainingLimitOrOffset()) {
             left = Merge.ensureOnHandler(left, plannerContext);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -64,7 +64,6 @@ public class MergeFilterAndCollect implements Rule<Filter> {
         Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(
-            collect.preferSourceLookup(),
             collect.relation(),
             collect.outputs(),
             newWhere,

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -153,12 +153,11 @@ public final class CopyToPlan implements Plan {
             new DocTableRelation(boundedCopyTo.table()),
             boundedCopyTo.outputs(),
             boundedCopyTo.whereClause(),
-            Set.of(),
             tableStats,
             context.params()
         );
         LogicalPlan source = optimizeCollect(context, tableStats, collect);
-        ExecutionPlan executionPlan = source.build(context, projectionBuilder, 0, 0, null, null, params, SubQueryResults.EMPTY);
+        ExecutionPlan executionPlan = source.build(context, Set.of(), projectionBuilder, 0, 0, null, null, params, SubQueryResults.EMPTY);
         executionPlan.addProjection(projection);
 
         return Merge.ensureOnHandler(

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -47,7 +47,6 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -73,7 +72,6 @@ import org.locationtech.spatial4j.shape.Point;
 
 import io.crate.common.collections.Lists2;
 import io.crate.exceptions.SQLExceptions;
-import io.crate.sql.tree.BitString;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -49,6 +49,7 @@ import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.operators.InsertFromValues;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.SymbolMatchers;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.Randomness;
 import org.hamcrest.Matchers;
@@ -467,5 +468,14 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
             )
         );
         assertThat(projections.get(0).requiredGranularity(), is(RowGranularity.SHARD));
+    }
+
+    @Test
+    public void test_insert_from_group_by_uses_doc_values() throws Exception {
+        Merge merge = e.plan("insert into users (id) (select id from users group by 1)");
+        Collect collect = (Collect) merge.subPlan();
+        assertThat(collect.collectPhase().toCollect(), contains(
+            SymbolMatchers.isReference("id")
+        ));
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -58,7 +58,6 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
             new DocTableRelation(e.resolveTableInfo("t")),
             List.of(x, e.asSymbol("y")),
             WhereClause.MATCH_ALL,
-            Set.of(),
             tableStats,
             Row.EMPTY
         );
@@ -82,8 +81,17 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan operator = logicalPlanner.plan(analyzedRelation, plannerCtx);
-        ExecutionPlan build = operator.build(plannerCtx, projectionBuilder, -1, 0, null,
-                                             null, Row.EMPTY, SubQueryResults.EMPTY);
+        ExecutionPlan build = operator.build(
+            plannerCtx,
+            Set.of(),
+            projectionBuilder,
+            -1,
+            0,
+            null,
+            null,
+            Row.EMPTY,
+            SubQueryResults.EMPTY
+        );
         assertThat((((RoutedCollectPhase) ((io.crate.planner.node.dql.Collect) build).collectPhase())).orderBy(), is(nullValue()));
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -63,7 +63,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(false, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         var eval = new Eval(
             collect,
             List.of(
@@ -102,7 +102,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         Reference x = (Reference) e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
         var alias = new AliasedAnalyzedRelation(relation, new RelationName(null, "t1"));
-        var collect = new Collect(false, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         Symbol t1X = alias.getField(x.column(), Operation.READ);
         assertThat(t1X, Matchers.notNullValue());
         var rename = new Rename(List.of(t1X), alias.relationName(), alias, collect);
@@ -143,7 +143,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = new AliasSymbol("x_alias", e.asSymbol("x"));
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(false, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         var eval = new Eval(
             collect,
             List.of(x)

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -105,13 +105,13 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.from(),
             mss.where(),
             mss.joinPairs(),
-            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, Set.of()),
+            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, true),
             txnCtx.sessionContext().isHashJoinEnabled()
         );
     }
 
     private Join buildJoin(LogicalPlan operator) {
-        return (Join) operator.build(plannerCtx, projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
+        return (Join) operator.build(plannerCtx, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
     }
 
     private Join plan(QueriedSelectRelation mss, TableStats tableStats) {
@@ -195,11 +195,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.from(),
             mss.where(),
             mss.joinPairs(),
-            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, Set.of()),
+            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, false),
             false
         );
         Join nl = (Join) operator.build(
-            context, projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
+            context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
 
         assertThat(((Collect) nl.left()).collectPhase().toCollect(), isSQL("doc.users.id"));
         assertThat(nl.resultDescription().orderBy(), notNullValue());
@@ -223,7 +223,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = logicalPlanner.plan(e.analyze("select users.id from users, locations " +
                                                          "where users.id = locations.id order by users.id"), context);
         Merge merge = (Merge) plan.build(
-            context, projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
+            context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
         Join nl = (Join) merge.subPlan();
 
         assertThat(nl.resultDescription().orderBy(), notNullValue());
@@ -414,7 +414,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan operator = logicalPlanner.plan(mss, plannerCtx);
-        ExecutionPlan build = operator.build(plannerCtx, projectionBuilder, -1, 0, null,
+        ExecutionPlan build = operator.build(plannerCtx, Set.of(), projectionBuilder, -1, 0, null,
             null, Row.EMPTY, SubQueryResults.EMPTY);
 
         assertThat((((NestedLoopPhase) ((Join) build).joinPhase())).blockNestedLoop, is(false));

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -59,7 +59,6 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
                     ((AbstractTableRelation<?>) queriedDocTable.from().get(0)),
                     queriedDocTable.outputs(),
                     new WhereClause(queriedDocTable.where()),
-                    Set.of(),
                     new TableStats(),
                     null
                 ),
@@ -76,6 +75,7 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
         PlannerContext ctx = e.getPlannerContext(clusterService.state());
         Merge merge = (Merge) plan.build(
             ctx,
+            Set.of(),
             new ProjectionBuilder(e.nodeCtx),
             TopN.NO_LIMIT,
             0,

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -58,7 +58,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testMergeFiltersMatchesOnAFilterWithAnotherFilterAsChild() {
-        Collect source = new Collect(false, tr1, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
+        Collect source = new Collect(tr1, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
         Filter sourceFilter = new Filter(source, e.asSymbol("x > 10"));
         Filter parentFilter = new Filter(sourceFilter, e.asSymbol("y > 10"));
 

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -21,6 +21,17 @@
 
 package io.crate.planner.optimizer.symbol;
 
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.AbstractTableRelation;
@@ -45,15 +56,6 @@ import io.crate.sql.tree.ComparisonExpression;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import static java.util.Collections.emptyMap;
-import static org.hamcrest.Matchers.is;
 
 public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest {
 
@@ -89,7 +91,6 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
 
     private void assertCollectQuery(String query, String expected) {
         var collect = new Collect(
-            false,
             tr1,
             Collections.emptyList(),
             new WhereClause(e.asSymbol(query)),
@@ -98,6 +99,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
         );
         var plan = (io.crate.planner.node.dql.Collect) collect.build(
             plannerContext,
+            Set.of(),
             new ProjectionBuilder(e.nodeCtx),
             TopN.NO_LIMIT,
             0,

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -770,6 +770,7 @@ public class SQLExecutor {
         if (plan instanceof LogicalPlan) {
             return (T) ((LogicalPlan) plan).build(
                 plannerContext,
+                Set.of(),
                 new ProjectionBuilder(nodeCtx),
                 TopN.NO_LIMIT,
                 0,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


The insert-from-query planner set a `PREFER_SOURCE_LOOKUP` hint. Using a
source lookup is okay for operations that can work in a
iterative/streaming model, but it is not ideal for pipeline breaker
operations.

In the case of GROUP BY it also prevents the optimizations from kicking
in, as those are all based on doc-values.

This moves the `planHints` parameter to the `LogicalPlan.build`  method. That allows individual operators to manipulate the hints.

This reduces the duration of a query like the following from ~120sec to
~0.7sec on a simple test on my machine:

    INSERT INTO readings_last (device_id, last_record)
        SELECT device_id, MAX(ts)
        FROM readings
        GROUP BY 1
        ON CONFLICT (device_id) DO UPDATE SET last_record = excluded.last_record;
    INSERT OK, 3000 rows affected  (0.671 sec)

Closes https://github.com/crate/crate/issues/11495



Question:

- Should this be treated as hotfix or change?


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
