### PR TITLE
Revert "Update gradle to 7.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,5 +278,5 @@ idea {
 }
 
 wrapper {
-    gradleVersion = '7.1'
+    gradleVersion = '7.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This reverts commit 1cde22fca73fe0534d9461ab84f7e8a56070d064.

Breaks buildship/eclipse support.
See https://github.com/eclipse/buildship/issues/1091


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
