### PR TITLE
Don't mark NOW() as deterministic

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -118,6 +118,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused the ``NOW()`` function to get normalized to a
+  literal value when used as part of a generated column or ``DEFAULT``
+  expression in a ``CREATE TABLE`` statement.
+
 - Fixed a HBA SSL configuration parsing issue. The ``on`` value for the ``ssl``
   configuration option was not recognized and got interpreted as 'true'.
 

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -41,7 +41,7 @@ public final class NowFunction extends Scalar<Long, Object> {
             Signature.scalar(
                 NAME,
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ),
+            ).withFeatures(Scalar.NO_FEATURES),
             NowFunction::new
         );
     }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1430,4 +1430,12 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "xs={length=1, position=1, type=bit}"
         ));
     }
+
+    @Test
+    public void test_now_function_is_not_normalized_to_literal_in_create_table() throws Exception {
+        BoundCreateTable stmt = analyze("create table tbl (ts timestamp with time zone default now())");
+        assertThat(mapToSortedString(stmt.mappingProperties()), Matchers.startsWith(
+            "ts={default_expr=now()"
+        ));
+    }
 }


### PR DESCRIPTION
## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
