### PR TITLE
Abort insert operation on validation errors

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -118,6 +118,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused ``INSERT FROM VALUE`` statements to insert
+  records, despite failing validation and returning an error to the client.
+
 - Fixed an issue that caused the ``NOW()`` and ``CURRENT_USER`` functions to
   get normalized to a literal value when used as part of a generated column or
   ``DEFAULT`` expression in a ``CREATE TABLE`` statement.

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -267,6 +267,7 @@ public class InsertFromValues implements LogicalPlan {
                     validatorsCache);
             } catch (Throwable t) {
                 consumer.accept(null, t);
+                return;
             }
         }
         validatorsCache.clear();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`INSERT FROM VALUES` returned an error to the user if validation
failed, but didn't stop processing records.

Fixes https://github.com/crate/crate/issues/11517

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
