### PR TITLE
Revert to Lucene 8.8.2

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -22,7 +22,7 @@ jacksonasl=1.9.13
 crate_admin_ui = 1.18.0
 jdbc=42.2.18
 
-lucene=8.9.0
+lucene=8.8.2
 
 # ES Azure
 azure_storage=8.6.6

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -116,7 +116,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_4_5_2 = new Version(7_05_02_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final Version V_4_5_3 = new Version(7_05_03_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
 
-    public static final Version V_4_6_0 = new Version(7_06_00_99, true, org.apache.lucene.util.Version.LUCENE_8_9_0);
+    public static final Version V_4_6_0 = new Version(7_06_00_99, true, org.apache.lucene.util.Version.LUCENE_8_8_2);
 
     public static final Version CURRENT = V_4_6_0;
 

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -64,7 +64,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
         final Directory directory = commit.getDirectory();
         final List<IndexCommit> indexCommits = DirectoryReader.listCommits(directory);
         final IndexCommit indexCommit = indexCommits.get(indexCommits.size() - 1);
-        return new DirectoryReader(directory, new LeafReader[0], null) {
+        return new DirectoryReader(directory, new LeafReader[0]) {
             @Override
             protected DirectoryReader doOpenIfChanged() throws IOException {
                 return null;


### PR DESCRIPTION
Lucene 8.9.0 caused a performance regression on the benchmark
    `select hyperloglog_distinct("cCode") from uservisits` causing
    the doc values decompression running much slower introduced by the
    change https://issues.apache.org/jira/browse/LUCENE-9663. We
    should therefore release 4.6 with Lucene 8.8.2 and investigate
    further on the regression.

    V1: 4.6.0-b227e962b16a58e5900e5c770777e432ec66cae9
    V2: 4.6.0-600c7c866f49825f762b4376aa1059600ecaef7c
    Q: select hyperloglog_distinct("cCode") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      403.000 ±  103.730 |    355.374 |    389.946 |    392.092 |   1118.239 |
    |   V2    |      989.173 ±  129.581 |    941.106 |    966.361 |    977.820 |   1881.523 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               +  84.21%                           +  85.00%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 84.21%
    The test has statistical significance

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
