### PR TITLE
fixed description of scalar function array_avg

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -105,7 +105,7 @@ New Scalars
   that returns the sum of all elements in an array.
 
 - Added the :ref:`array_avg <scalar-array-avg>` scalar function that returns
-  the sum of all elements in an array.
+  the average of all elements in an array.
 
 
 Administration and Operations improvements


### PR DESCRIPTION
description of the change should have said average is returned

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [X] Added an entry in `CHANGES.txt` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
