### PR TITLE
Enable best speed compression for doc values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
@@ -64,7 +64,7 @@ public class PerFieldMappingPostingFormatCodec extends Lucene87Codec {
 
     @Override
     public DocValuesFormat getDocValuesFormatForField(String field) {
-        return new Lucene80DocValuesFormat(Lucene80DocValuesFormat.Mode.BEST_COMPRESSION);
+        return new Lucene80DocValuesFormat(Lucene80DocValuesFormat.Mode.BEST_SPEED);
     }
 
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`BEST_COMPRESSION` was enabled for doc values. Switching it to `BEST_SPEED` seems to not have massive impact on Lucene 8.8.2.

```
V1: 4.6.0-573bd2feb9052f9a83c01bd36cfb3c7485d0e9d3
V2: 4.6.0-2f50a01b4011df01b8162425c500c234a2120291

Q: select hyperloglog_distinct("cCode") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      435.727 ±  286.346 |    360.052 |    398.781 |    402.522 |   2415.015 |
|   V2    |      380.811 ±  241.370 |    316.669 |    348.036 |    350.276 |   2049.792 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  13.45%                           -  13.59%
There is a 69.77% probability that the observed difference is not random, and the best estimate of that difference is 13.45%
The test has no statistical significance

Q: select hyperloglog_distinct("visitDate") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       72.094 ±   83.647 |     58.270 |     59.755 |     60.984 |    651.541 |
|   V2    |       62.516 ±   63.652 |     51.382 |     53.389 |     54.052 |    503.479 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  14.23%                           -  11.25%
There is a 47.92% probability that the observed difference is not random, and the best estimate of that difference is 14.23%
The test has no statistical significance
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
