### PR TITLE
bp: Better logging for TLS message on non-secure transport channel

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -626,6 +626,7 @@ should be crossed out as well.
 - [x] 8360248a43a Always use last properly persisted metadata as previous state (#47779)
 - [x] e244d65869c Fix Snapshot Corruption in Edge Case (#47552)
 - [x] 38f02217f00 Omit writing index metadata for non-replicated closed indices on data-only node (#47285)
+- [x] 4f52ebd32eb Better logging for TLS message on non-secure transport channel (#45835)
 - [x] 5ba4f5fb3c9 Use dynamic port ranges for ExternalTestCluster (#45601)
 - [x] 29235a637f7 Wait for events in waitForRelocation (#45074)
 - [x] 42a331c59ba Remove Unused Features Field on StreamOutput (#44667)


### PR DESCRIPTION
[elastic/elasticsearch@4f52ebd32eb](https://github.com/elastic/elasticsearch/commit/4f52ebd32eb58526b4c8022f8863210bf88fc9be)

Related to node 2 node encryption - when SSL-enabled node connects to SSL-off node it's better to have clear message about the problem.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
