### PR TITLE
Fix job_id column expression in sys operations_log

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -138,6 +138,10 @@ Administration and Operations improvements
 Fixes
 =====
 
+- Fixed a regression that caused the ``job_id`` column within the
+  ``sys.operations_log`` table to return the ``id`` values instead of the
+  ``job_id`` values.
+
 - Fixed an issue that could result in a ``IOException: can not write type ...``
   error when combining values of type ``TIMETZ``, ``NUMERIC``, ``GEO_POINT`` or
   ``INTERVAL`` with values of type ``UNDEFINED``.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11536


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
