### PR TITLE
Add missing generic value streaming implementations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -138,6 +138,10 @@ Administration and Operations improvements
 Fixes
 =====
 
+- Fixed an issue that could result in a ``IOException: can not write type ...``
+  error when combining values of type ``TIMETZ``, ``NUMERIC``, ``GEO_POINT`` or
+  ``INTERVAL`` with values of type ``UNDEFINED``.
+
 - Fixed an issue that caused ``INSERT FROM VALUE`` statements to insert
   records, despite failing validation and returning an error to the client.
 

--- a/server/src/test/java/io/crate/types/UndefinedTypeTest.java
+++ b/server/src/test/java/io/crate/types/UndefinedTypeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+import io.crate.testing.DataTypeTesting;
+
+public class UndefinedTypeTest extends ESTestCase {
+
+    private void testRoundTrip(DataType<?> type) throws Exception {
+        var valueOut = DataTypeTesting.getDataGenerator(type).get();
+        var out = new BytesStreamOutput();
+
+        DataTypes.UNDEFINED.writeValueTo(out, valueOut);
+        var in = out.bytes().streamInput();
+
+        var valueIn = DataTypes.UNDEFINED.readValueFrom(in);
+        MatcherAssert.assertThat(valueIn, is(valueOut));
+    }
+
+    @Test
+    public void test_undefined_type_can_stream_big_decimal_values() throws Exception {
+        testRoundTrip(DataTypes.NUMERIC);
+    }
+
+    @Test
+    public void test_undefined_type_can_stream_timetz_values() throws Exception {
+        testRoundTrip(DataTypes.INTERVAL);
+    }
+
+    @Test
+    public void test_undefined_type_can_stream_interval_values() throws Exception {
+        testRoundTrip(DataTypes.INTERVAL);
+    }
+
+    @Test
+    public void test_undefined_type_can_stream_geo_point_values() throws Exception {
+        testRoundTrip(DataTypes.GEO_POINT);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The undefined type uses the `writeGenericValue` / `readGenericValue`
functions which couldn't stream values of type numeric, timetz,
geo_point and interval.

Fixes https://github.com/crate/crate/issues/11537

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
