### PR TITLE
Fix dual-dual and dual-on probe flow.

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/netty4/DualProbeAwareHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/DualProbeAwareHandler.java
@@ -40,15 +40,17 @@ import io.netty.handler.ssl.SslHandler;
  *
  * https://github.com/opendistro-for-elasticsearch/security/blob/main/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/DualModeSSLHandler.java
  **/
-public final class DualModeSSLHandler extends ByteToMessageDecoder {
+public final class DualProbeAwareHandler extends ByteToMessageDecoder {
 
-    public static final String NAME = "dual_mode_handler";
+    public static final String NAME = "dual_probe_aware_handler";
     private final SslContextProvider sslContextProvider;
     private final Logger logger;
+    private final boolean plainSupported;
 
-    public DualModeSSLHandler(Logger logger, SslContextProvider sslContextProvider) {
+    public DualProbeAwareHandler(Logger logger, SslContextProvider sslContextProvider, boolean plainSupported) {
         this.logger = logger;
         this.sslContextProvider = sslContextProvider;
+        this.plainSupported = plainSupported;
     }
 
     @Override
@@ -59,6 +61,7 @@ public final class DualModeSSLHandler extends ByteToMessageDecoder {
         }
         int offset = in.readerIndex();
         if (in.getCharSequence(offset, 6, StandardCharsets.UTF_8).equals(ConnectionTest.DUAL_MODE_CLIENT_HELLO_MSG)) {
+            in.readerIndex(in.readerIndex() + 6);
             logger.debug("Received DualSSL Client Hello message");
             ByteBuf responseBuffer = ctx.alloc().buffer(6);
             responseBuffer.writeCharSequence(ConnectionTest.DUAL_MODE_SERVER_HELLO_MSG, StandardCharsets.UTF_8);
@@ -66,16 +69,22 @@ public final class DualModeSSLHandler extends ByteToMessageDecoder {
             return;
         }
 
-        boolean tls = ConnectionTest.isTLS(in);
-        if (tls) {
+        boolean isEncrypted = SslHandler.isEncrypted(in);
+        if (isEncrypted) {
             logger.debug("Identified request as SSL request");
             SslContext sslContext = sslContextProvider.getServerContext(Protocol.TRANSPORT);
             SslHandler sslHandler = sslContext.newHandler(ctx.alloc());
-            ctx.pipeline().replace(NAME, "ssl_handler", sslHandler);
+            ctx.pipeline().addAfter(NAME, "ssl_server", sslHandler);
+            ctx.pipeline().remove(this);
             logger.debug("Replaced DualModeSSLHandler with SSLHandler");
-        } else {
+        } else if (plainSupported) {
             logger.debug("Identified request as non SSL request, running without SSL dual mode is enabled");
             ctx.pipeline().remove(this);
+        } else {
+            // Data is not encrypted but node supports only SSL/TLS.
+            // Discard everything and close the connection.
+            in.clear();
+            ctx.close();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -321,6 +321,9 @@ public class Netty4Transport extends TcpTransport {
                 case DUAL: {
                     switch (probeResult) {
                         case SSL_AVAILABLE:
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("SSL Dual mode enabled, target node use SSL {}", node.getHostName());
+                            }
                             SslContext sslContext = sslContextProvider.clientContext();
                             SslHandler sslHandler = sslContext.newHandler(ch.alloc());
                             sslHandler.engine().setUseClientMode(true);

--- a/server/src/test/java/io/crate/integrationtests/SSLDualModeTransportITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SSLDualModeTransportITest.java
@@ -40,7 +40,7 @@ import io.crate.protocols.ssl.ConnectionTest.ProbeResult;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.protocols.ssl.SslSettings;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 2, supportsDedicatedMasters = false, numClientNodes = 0)
+@ESIntegTestCase.ClusterScope(numDataNodes = 3, supportsDedicatedMasters = false, numClientNodes = 0)
 public class SSLDualModeTransportITest extends SQLIntegrationTestCase {
 
     private static Path keyStoreFile;
@@ -67,7 +67,10 @@ public class SSLDualModeTransportITest extends SQLIntegrationTestCase {
             .put(super.nodeSettings(nodeOrdinal))
             .put(sslSettings);
 
-        if (nodeOrdinal > 0) {
+        if (nodeOrdinal == 1) {
+            builder.put(SslSettings.SSL_TRANSPORT_MODE.getKey(), "off");
+        }
+        if (nodeOrdinal == 2) {
             builder.put(SslSettings.SSL_TRANSPORT_MODE.getKey(), "off");
         }
         return builder.build();
@@ -75,8 +78,11 @@ public class SSLDualModeTransportITest extends SQLIntegrationTestCase {
 
     @Test
     public void test_dual_mode_on_first_node_allows_cluster_to_form_if_other_nodes_have_no_ssl() throws Exception {
+        // This test covers all kinds of client-server pairs where SSL must not be used.
+        // 1 dual node, 2 ssl-off node setup covers dual->off, off->dual, off->off connections.
+        // Pairs which must be connected by SSL are tested in SSLTransportITest
         execute("select count(*) from sys.nodes");
-        assertThat(response.rows()[0][0], is(2L));
+        assertThat(response.rows()[0][0], is(3L));
 
         SslContextProvider sslContextProvider = new SslContextProvider(sslSettings);
         SSLContext sslContext = sslContextProvider.jdkSSLContext();
@@ -93,6 +99,15 @@ public class SSLDualModeTransportITest extends SQLIntegrationTestCase {
         String nodeName2 = nodeNames[1];
         {
             var transport = internalCluster().getInstance(Transport.class, nodeName2);
+            var publishAddress = transport.boundAddress().publishAddress();
+            var address = publishAddress.address();
+            ProbeResult probeResult = ConnectionTest.probeSSL(sslContext, address);
+            assertThat(probeResult, is(ProbeResult.SSL_MISSING));
+        }
+
+        String nodeName3 = nodeNames[2];
+        {
+            var transport = internalCluster().getInstance(Transport.class, nodeName3);
             var publishAddress = transport.boundAddress().publishAddress();
             var address = publishAddress.address();
             ProbeResult probeResult = ConnectionTest.probeSSL(sslContext, address);

--- a/server/src/test/java/io/crate/integrationtests/SSLTransportITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SSLTransportITest.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import javax.net.ssl.SSLContext;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.Transport;
 import org.junit.BeforeClass;
@@ -39,7 +40,7 @@ import io.crate.protocols.ssl.ConnectionTest.ProbeResult;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.protocols.ssl.SslSettings;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 2, supportsDedicatedMasters = false, numClientNodes = 0)
+@ESIntegTestCase.ClusterScope(numDataNodes = 4, supportsDedicatedMasters = false, numClientNodes = 0)
 public class SSLTransportITest extends SQLIntegrationTestCase {
 
     private static Path keyStoreFile;
@@ -62,7 +63,7 @@ public class SSLTransportITest extends SQLIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
+        Builder builder = Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put("auth.host_based.enabled", true)
             .put("auth.host_based.config.a.method", "cert")
@@ -72,14 +73,28 @@ public class SSLTransportITest extends SQLIntegrationTestCase {
             .put("auth.host_based.config.c.protocol", "http")
             .put("auth.host_based.config.d.method", "trust")
             .put("auth.host_based.config.d.protocol", "pg")
-            .put(sslSettings)
-            .build();
+            .put(sslSettings);
+
+        if (nodeOrdinal == 1) {
+            builder.put(SslSettings.SSL_TRANSPORT_MODE.getKey(), "on");
+        }
+        if (nodeOrdinal == 2) {
+            builder.put(SslSettings.SSL_TRANSPORT_MODE.getKey(), "dual");
+        }
+        if (nodeOrdinal == 3) {
+            builder.put(SslSettings.SSL_TRANSPORT_MODE.getKey(), "dual");
+        }
+        return builder.build();
     }
 
     @Test
     public void test_nodes_connect_with_ssl() throws Exception {
+        // This test covers all kinds of client-server pairs where SSL must be used.
+        // 2 dual nodes, 2 ssl-on nodes setup covers dual->on, dual->dual, on->dual, on->on connections.
+        // Pairs which must be connected without SSL are tested
+        // in SSLDualModeTransportITest
         execute("select count(*) from sys.nodes");
-        assertThat(response.rows()[0][0], is(2L));
+        assertThat(response.rows()[0][0], is(4L));
 
         SslContextProvider sslContextProvider = new SslContextProvider(sslSettings);
         SSLContext sslContext = sslContextProvider.jdkSSLContext();


### PR DESCRIPTION
Changes:

1. Have only one outermost try-with-resources in probeDualMode. 
2. Remove `isTLS`  as it's same code as Netty's `SSLHander.isEncrypted`
3. Probe dual mode in constructor like opendistro does (but only for dual mode)
4. server with ssl=on must handle SSL from the beginning as it's subject to probe and will just fail with NonSslRecordException - adapted DualModeHandler to be aware of serverMode(dual or on) and aware of plaintext probe message
5. added tests to cover all valid 7 cases out of 9 (excluding off-on and on-off)
6. We need to `setUseClientMode(true)` for `SslHandler` as by default it's false


## Checklist

 - [] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
