### PR TITLE
Automatically create the GH release on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+---
+name: Create Github release on tag
+on:
+  create
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release
+        if: github.event.create.ref_type == 'tag'
+        run: |
+          (
+          cat <<EOF
+          Release notes:
+
+          - https://crate.io/docs/crate/reference/en/latest/appendices/release-notes/${VERSION}.html
+
+          Download on:
+
+          - https://crate.io/download
+          EOF
+          ) > notes.md
+          gh release create $VERSION --title $VERSION --prerelease -F notes.md
+        env:
+          VERSION: ${{ github.event.create.ref }}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To automate one more step during the release process


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
