### PR TITLE
Minor docs improvements 

### DIFF
--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -4,9 +4,15 @@
 SQL compatibility
 =================
 
-CrateDB aims to provide a `SQL implementation`_ that is familiar to anyone who
-has used databases that provide a standards-compliant SQL language. However,
-you should be aware of some unique characteristics in CrateDB's SQL dialect.
+CrateDB provides a :ref:`standards-based <sql_supported_features>` SQL
+implementation similar to many other SQL databases. In particular, CrateDB aims
+for compatibility with :ref:`PostgreSQL <postgres_wire_protocol>`. However,
+CrateDB's SQL dialect does have some unique characteristics, documented on this
+page.
+
+.. SEEALSO::
+
+    :ref:`SQL: Syntax reference <sql>`
 
 .. rubric:: Table of contents
 

--- a/docs/appendices/compliance.rst
+++ b/docs/appendices/compliance.rst
@@ -1,18 +1,24 @@
 .. highlight:: psql
+
 .. _sql_supported_features:
 
 =======================
 SQL standard compliance
 =======================
 
-This section provides a list of features that CrateDB supports and to what
-extent it conforms to the current SQL standard `ISO/IEC 9075`_ "Database
-Language SQL".
+This page documents the standard SQL (`ISO/IEC 9075`_) features that
+CrateDB supports, along with implementation notes and any associated caveats.
 
-This list is approximate and features that are listed as supported might be
-nonconforming in their implementation. However, the main reference
-documentation of CrateDB always contains the most accurate information about
-what CrateDB supports, what they are and how to use them.
+.. CAUTION::
+
+    This list is approximate and features that are listed as supported might be
+    nonconforming in their implementation. However, the main reference
+    documentation always contains the most accurate information about
+    the features CrateDB supports and how to use them.
+
+.. SEEALSO::
+
+    :ref:`SQL compatibility <crate_standard_sql>`
 
 .. csv-filter::
    :header: ID,Package,#,Description,Supported,Verified,Comments

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -41,13 +41,13 @@ Released on 2019/06/25.
    :local:
 
 
-.. _version_4.0.0_upgrade_notes:
+.. _v4.0.0-upgrade-notes:
 
 Upgrade Notes
 =============
 
 
-.. _discovery-changes:
+.. _v4.0.0-discovery-changes:
 
 Discovery Changes
 -----------------
@@ -109,9 +109,13 @@ Due to this some discovery settings are added, renamed and removed.
    or CMD arguments upfront.
 
 
+.. _v4.0.0-breaking:
+
 Breaking Changes
 ================
 
+
+.. _v4.0.0-breaking-general:
 
 General
 -------
@@ -153,6 +157,8 @@ General
 - Dropped support for Java versions < 11
 
 
+.. _v4.0.0-breaking-rm-settings:
+
 Removed Settings
 ----------------
 
@@ -180,6 +186,8 @@ Removed Settings
 - The ``zen1`` related discovery settings mentioned in
   :ref:`discovery-changes`.
 
+
+.. _v4.0.0-breaking-sys:
 
 System table changes
 --------------------
@@ -226,6 +234,8 @@ System table changes
   ``STRING`` with value ``NEVER`` or ``ALWAYS`` for SQL standard compatibility.
 
 
+.. _v4.0.0-breaking-rm-function:
+
 Removed Functionality
 ---------------------
 
@@ -258,6 +268,8 @@ Removed Functionality
   without clean shutdown.
 
 
+.. _v4.0.0-deprecations:
+
 Deprecations
 ============
 
@@ -278,9 +290,13 @@ Deprecations
 - Marked LowerCase tokenizer as deprecated.
 
 
+.. _v4.0.0-changes:
+
 Changes
 =======
 
+
+.. _v4.0.0-changes-compat:
 
 SQL Standard and PostgreSQL compatibility improvements
 ------------------------------------------------------
@@ -350,6 +366,8 @@ SQL Standard and PostgreSQL compatibility improvements
   string if it is needed.
 
 
+.. _v4.0.0-changes-users-acl:
+
 Users and Access Control
 ------------------------
 
@@ -365,6 +383,8 @@ Users and Access Control
   :ref:`administration-privileges`.
 
 
+.. _v4.0.0-changes-snapshots:
+
 Repositories and Snapshots
 --------------------------
 
@@ -376,6 +396,8 @@ Repositories and Snapshots
 
 - Improved resiliency of the :ref:`sql-create-snapshot` operation.
 
+
+.. _v4.0.0-changes-perf-resiliency:
 
 Performance and resiliency improvements
 ---------------------------------------
@@ -408,6 +430,8 @@ Performance and resiliency improvements
 - Added a new optimization that allows to run predicates on top of views or
   sub-queries more efficiently in some cases.
 
+
+.. _v4.0.0_changes-others:
 
 Others
 ------

--- a/docs/concepts/joins.rst
+++ b/docs/concepts/joins.rst
@@ -20,8 +20,10 @@ to work with huge datasets.
    :local:
 
 
-Types of join
-=============
+.. _join-types:
+
+Join types
+==========
 
 A join is a relational operation that merges two data sets based on certain
 properties. :ref:`joins_figure_1` (Inspired by `this article`_) shows which
@@ -38,6 +40,8 @@ elements appear in which join.
    join, and cross join of a set L and R.
 
 
+.. _join-types-cross:
+
 Cross join
 ----------
 
@@ -47,6 +51,8 @@ consists of all possible permutations of each tuple of the relation *L* with
 every tuple of the relation *R*.
 
 
+.. _join-types-inner:
+
 Inner join
 ----------
 
@@ -54,7 +60,7 @@ An :ref:`inner join <inner-joins>` is a join of two or more relations that
 returns only tuples that satisfy the join condition.
 
 
-.. _joins_equi_join:
+.. _join-types-equi:
 
 Equi Join
 .........
@@ -64,6 +70,8 @@ uses equality comparisons in the join condition. The equi join of the relation
 *L* and *R* combines tuple *l* of relation *L* with a tuple *r* of the relation
 *R* if the join attributes of both tuples are identical.
 
+
+.. _join-types-outer:
 
 Outer join
 ----------
@@ -86,8 +94,10 @@ An outer join has following types:
     tuples produced by left and right outer joins.
 
 
-Joins in CrateDB
-================
+.. _join-algos:
+
+Join algorithms
+===============
 
 CrateDB supports (a) CROSS JOIN, (b) INNER JOIN, (c) EQUI JOIN, (d) LEFT JOIN,
 (e) RIGHT JOIN and (f) FULL JOIN. All of these join types are executed using
@@ -97,7 +107,7 @@ join algorithm <joins_hash_join>`. Special optimizations, according to the
 specific use cases, are applied to improve execution performance.
 
 
-.. _joins_nested_loop:
+.. _join-algos-nested-loop:
 
 Nested loop join
 ----------------
@@ -116,6 +126,8 @@ are concatenated and added into the returned virtual relation::
 *Listing 1. Nested loop join algorithm.*
 
 
+.. _join-algos-nested-loop-prim:
+
 Primitive nested loop
 .....................
 
@@ -128,7 +140,7 @@ of collecting data from shards the rows can be the result of a previous join or
 :ref:`table function <table-functions>`.
 
 
-.. _joins_distributed_nested_loop:
+.. _join-algos-nested-loop-dist:
 
 Distributed nested loop
 .......................
@@ -150,10 +162,6 @@ return the results to the requesting client (see :ref:`joins_figure_2`).
    Nodes that are holding the smaller shards broadcast the data to the
    processing nodes which then return the results to the requesting node.
 
-
-Pre-ordering and limits optimization
-''''''''''''''''''''''''''''''''''''
-
 Queries can be optimized if they contain (a) ORDER BY, (b) LIMIT, or (c) if
 INNER/EQUI JOIN. In any of these cases, the nested loop can be terminated
 earlier:
@@ -166,7 +174,7 @@ Consequently, the number of rows is significantly reduced allowing the
 operation to complete much faster.
 
 
-.. _joins_hash_join:
+.. _join-algos-hash:
 
 Hash join
 ---------
@@ -174,6 +182,8 @@ Hash join
 The Hash Join algorithm is used to execute certains types of joins in a more
 perfomant way than :ref:`Nested Loop <joins_nested_loop>`.
 
+
+.. _join-algos-hash-basic:
 
 Basic algorithm
 ...............
@@ -200,7 +210,7 @@ left and right relation is returned.
    Basic hash join algorithm
 
 
-.. _joins_block_hash_join:
+.. _join-algos-hash-block:
 
 Block hash join
 ...............
@@ -228,6 +238,8 @@ iterate over the rows of the right table multiple times, and it is the default
 algorithm used for Hash Join execution by CrateDB.
 
 
+.. _join-algos-hash-block-switch:
+
 Switch tables optimization
 ''''''''''''''''''''''''''
 
@@ -237,6 +249,8 @@ two relations participating in the join. Therefore, if originally the right
 relation is larger than the left the query planner performs a switch to take
 advantage of this detail and execute the hash join with better performance.
 
+
+.. _join-algos-hash-dist:
 
 Distributed block hash join
 ...........................
@@ -273,12 +287,16 @@ for joins on complex subqueries that contain ``LIMIT`` and/or ``OFFSET``.
    Distributed hash join algorithm
 
 
-Optimizations
--------------
+.. _join-optim:
 
+Join optimizations
+==================
+
+
+.. _join-optim-optim-query-fetch:
 
 Query then fetch
-................
+----------------
 
 Join operations on large relation can be extremely slow especially if the join
 is executed with a :ref:`Nested Loop <joins_nested_loop>`. - which means that
@@ -291,8 +309,10 @@ required document IDs. Next, as soon as the final data set is ready, CrateDB
 fetches the selected fields and returns the data to the client.
 
 
+.. _join-optim-optim-push-down:
+
 Push-down query optimization
-.............................
+----------------------------
 
 Complex queries such as Listing 2 require the planner to decide when to filter,
 sort, and merge in order to efficiently execute the plan. In this case, the
@@ -326,8 +346,8 @@ optimized.*
    before joining.
 
 
-.. _this article: https://www.codeproject.com/Articles/33052/Visual-Representation-of-SQL-Joins
+.. _hash table: https://en.wikipedia.org/wiki/Hash_table
+.. _here: http://www.dcs.ed.ac.uk/home/tz/phd/thesis.pdf
 .. _information_schema: https://crate.io/docs/reference/sql/information_schema.html
 .. _system tables: https://crate.io/docs/reference/sql/system.html
-.. _here: http://www.dcs.ed.ac.uk/home/tz/phd/thesis.pdf
-.. _hash table: https://en.wikipedia.org/wiki/Hash_table
+.. _this article: https://www.codeproject.com/Articles/33052/Visual-Representation-of-SQL-Joins

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -1,27 +1,25 @@
-.. _protocols:
+.. _interfaces:
 
 =================
 Client interfaces
 =================
 
-There are two ways for clients to talk to CrateDB. This section of the documentation covers both from a
-client implementation perspective.
-
-.. SEEALSO::
-
-   `Connecting to CrateDB`_ — Includes an introduction to the web admin
-   UI, the CrateDB shell, and the CrateDB HTTP endpoint
-
-   `Client Libraries`_ — Officially supported clients and community supported
-   clients
-
-.. _Connecting to CrateDB: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
-.. _Client Libraries: https://crate.io/docs/crate/clients-tools/en/latest/
-
-.. rubric:: Table of contents
+CrateDB has two primary client interfaces:
 
 .. toctree::
     :maxdepth: 1
 
     http
     postgres
+
+.. SEEALSO::
+
+   `Connecting to CrateDB`_ — Includes an introduction to the web admin UI, the
+   CrateDB shell, and the CrateDB HTTP endpoint
+
+   `Client Libraries`_ — Officially supported clients and community supported
+   clients
+
+
+.. _Connecting to CrateDB: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
+.. _Client Libraries: https://crate.io/docs/crate/clients-tools/en/latest/

--- a/docs/sql/index.rst
+++ b/docs/sql/index.rst
@@ -1,19 +1,30 @@
+.. _sql:
+
 ==========
 SQL syntax
 ==========
 
-CrateDB uses `SQL`_ to query documents.
+You can use :ref:`Structured Query Language <crate_standard_sql>` (SQL) to
+query your data.
 
-This section of the documentation provides a full SQL syntax reference.
+This section of the documentation provides a complete SQL syntax
+reference for CrateDB.
 
 .. NOTE::
 
-   If you’re just getting started with a particular part of CrateDB, we
-   recommend you consult the appropriate top-level section of the
-   documentation. The SQL syntax reference assumes a basic familiarity with the
-   relevant parts of CrateDB.
+   For introductions to CrateDB functionality, we recommend you consult the
+   appropriate top-level section of the documentation. The SQL syntax reference
+   assumes a basic familiarity with the relevant parts of CrateDB.
 
-.. _`SQL`: https://en.wikipedia.org/wiki/Sql
+.. SEEALSO::
+
+    :ref:`General use: Data definition <ddl>`
+
+    :ref:`General use: Data manipulation <dml>`
+
+    :ref:`General use: Querying <dql>`
+
+    :ref:`General use: Built-in functions and operators <builtins>`
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Specifically:

- For `docs/appendices/compatibility.rst`:

  - Improve the intro description and add a SEEALSO block to improve cross-referencing  and discoverability.

- For `docs/appendices/compliance.rst`:

  - Improve the intro description and add a CAUTION block advising readers to consult the full SQL reference for more info.

  - Add a SEEALSO to `compatibility.rst` to improve cross-referencing and discoverability.

- For `docs/appendices/release-notes/4.0.0.rst`

  - Added RST labels to all headers. This has been done in preparation for the changes coming in #11558 which need to link to a specific section of this doc.

- For `docs/concepts/joins.rst`

  - Added RST labels to all headers. This has been done in preparation for the changes coming in #11558 which need to link to a specific section of this doc.

  - The headers themselves have been tidied up a little, and in one case, an unnecessary header was removed.

  - Link references at the end of the doc have been sorted alphabetically case-insensitive, as is standard.

- For `docs/interfaces/index.rst`:

  - Improved the intro by moving the TOC to the top. I think this improved the navigability of the page. Because the TOC is now worked into the normal prose, there is no need for the typical "Table of contents" rubric.

  - Fixed some hard-wrapping.

- For `docs/sql/index.rst`:

  - Improved intro by expanding the text.

  - Improved the tone and style of the NOTE block.

  - Added a SEEALSO block to improve cross-referencing and discoverability.

  - Removed an unnecessary link definition.

