### PR TITLE
Fix COPY FROM CSV import into partitioned tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -61,4 +61,6 @@ None
 Fixes
 =====
 
-None
+- Fixed an issue that caused a class cast error when trying to import records
+  from a ``CSV`` file into a partitioned table using the ``COPY FROM``
+  statement.

--- a/server/src/main/java/io/crate/expression/reference/file/ColumnExtractingLineExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/ColumnExtractingLineExpression.java
@@ -23,19 +23,22 @@ package io.crate.expression.reference.file;
 
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 import io.crate.metadata.ColumnIdent;
+import io.crate.types.DataType;
 
 public class ColumnExtractingLineExpression extends LineCollectorExpression<Object> {
 
     private final ColumnIdent columnIdent;
+    private final DataType<?> type;
     private LineContext context;
 
-    public ColumnExtractingLineExpression(ColumnIdent columnIdent) {
+    public ColumnExtractingLineExpression(ColumnIdent columnIdent, DataType<?> type) {
         this.columnIdent = columnIdent;
+        this.type = type;
     }
 
     @Override
     public Object value() {
-        return context.get(columnIdent);
+        return type.implicitCast(context.get(columnIdent));
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/reference/file/FileLineReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/file/FileLineReferenceResolver.java
@@ -43,11 +43,11 @@ public final class FileLineReferenceResolver {
     private FileLineReferenceResolver() {
     }
 
-    public static LineCollectorExpression<?> getImplementation(Reference refInfo) {
-        ColumnIdent columnIdent = refInfo.column();
+    public static LineCollectorExpression<?> getImplementation(Reference ref) {
+        ColumnIdent columnIdent = ref.column();
         Supplier<LineCollectorExpression<?>> supplier = EXPRESSION_BUILDER.get(columnIdent.name());
         if (supplier == null) {
-            return new ColumnExtractingLineExpression(columnIdent);
+            return new ColumnExtractingLineExpression(columnIdent, ref.valueType());
         }
         return supplier.get();
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Values in a CSV are read as text - if any of the target columns required
a different type it resulted in a class-cast exception.

Fixes https://github.com/crate/crate/issues/11563

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
