### PR TITLE
Always prefer doc-values for ORDER BY operations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -61,6 +61,11 @@ None
 Fixes
 =====
 
+- Fixed an issue that could lead to ``NULL`` values getting returned when using
+  a ``_doc['columnName']`` expression in the ``ORDER BY`` clause.
+  Prior to 4.6.0 this also affected ``INSERT INTO`` statements on top level
+  columns.
+
 - Fixed an issue that caused a class cast error when trying to import records
   from a ``CSV`` file into a partitioned table using the ``COPY FROM``
   statement.

--- a/server/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -48,6 +48,7 @@ import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.FieldTypeLookup;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
@@ -116,27 +117,34 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
      * the implementation is similar to how ES 2.4 SortParseElement worked
      */
     @Override
-    public SortField visitReference(final Reference symbol, final SortSymbolContext context) {
+    public SortField visitReference(Reference ref, final SortSymbolContext context) {
         // can't use the SortField(fieldName, type) constructor
         // because values are saved using docValues and therefore they're indexed in lucene as binary and not
         // with the reference valueType.
         // this is why we use a custom comparator source with the same logic as ES
 
-        ColumnIdent columnIdent = symbol.column();
+
+        // Always prefer doc-values. Should be faster for sorting and otherwise we'd
+        // default to the `NullFieldComparatorSource` - leading to `null` values.
+        if (ref.column().isChildOf(DocSysColumns.DOC)) {
+            ref = (Reference) DocReferences.inverseSourceLookup(ref);
+        }
+
+        ColumnIdent columnIdent = ref.column();
         if (DocSysColumns.SCORE.equals(columnIdent)) {
             return !context.reverseFlag ? SORT_SCORE_REVERSE : SORT_SCORE;
         }
         if (DocSysColumns.RAW.equals(columnIdent) || DocSysColumns.ID.equals(columnIdent)) {
-            return customSortField(DocSysColumns.nameForLucene(columnIdent), symbol, context);
+            return customSortField(DocSysColumns.nameForLucene(columnIdent), ref, context);
         }
-        if (symbol.isColumnStoreDisabled()) {
-            return customSortField(symbol.toString(), symbol, context);
+        if (ref.isColumnStoreDisabled()) {
+            return customSortField(ref.toString(), ref, context);
         }
 
         MappedFieldType fieldType = fieldTypeLookup.get(columnIdent.fqn());
         if (fieldType == null) {
             FieldComparatorSource fieldComparatorSource = new NullFieldComparatorSource(NullSentinelValues.nullSentinelForScoreDoc(
-                symbol.valueType(),
+                ref.valueType(),
                 context.reverseFlag,
                 context.nullFirst
             ));
@@ -144,11 +152,11 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
                 columnIdent.fqn(),
                 fieldComparatorSource,
                 context.reverseFlag);
-        } else if (symbol.valueType().equals(DataTypes.IP) || symbol.valueType().id() == BitStringType.ID) {
-            return customSortField(symbol.toString(), symbol, context);
+        } else if (ref.valueType().equals(DataTypes.IP) || ref.valueType().id() == BitStringType.ID) {
+            return customSortField(ref.toString(), ref, context);
         } else {
             return mappedSortField(
-                symbol,
+                ref,
                 fieldType,
                 context.reverseFlag,
                 NullValueOrder.fromFlag(context.nullFirst)

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1995,4 +1995,18 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
             "[B'010', B'110']\n"
         ));
     }
+
+    @Test
+    public void test_can_select_and_order_by_doc_expression() throws Exception {
+        execute("create table tbl (x int)");
+        execute("insert into tbl (x) values (1), (2), (3)");
+        execute("refresh table tbl");
+        execute("select _doc['x'] from tbl order by 1");
+        assertThat(printedTable(response.rows()), is(
+            "1\n" +
+            "2\n" +
+            "3\n"
+        ));
+
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11568

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
