### PR TITLE
Add a missing backtick to cross-reference

### DIFF
--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -95,7 +95,7 @@ Collecting stats
   | *Default:* ``true`` (Include everything)
   | *Runtime:* ``yes``
 
-  An :ref:expression <gloss-expression>` to determine if a job should be
+  An :ref:`expression <gloss-expression>` to determine if a job should be
   recorded into ``sys.jobs_log``.  The expression must :ref:`evaluate
   <gloss-evaluation>` to a boolean. If it evaluates to ``true`` the statement
   will show up in ``sys.jobs_log`` until it's evicted due to one of the other


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Just a small documentation fix for a currently broken reference in the documentation.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
