### PR TITLE
Fix disk threshold setting monkey patching in blackbox setup

### DIFF
--- a/blackbox/build.gradle
+++ b/blackbox/build.gradle
@@ -53,7 +53,7 @@ task unpackDistTar(dependsOn: [project(':app').installDist, deleteCrateDist]) {
 def ignoreDiskThreshold() {
     def file = new File("$projectDir/tmp/crate/config/crate.yml")
     file.write(file.text.replaceAll(
-        '# cluster.routing.allocation.disk.threshold_enabled: true',
+        '#cluster.routing.allocation.disk.threshold_enabled: true',
         'cluster.routing.allocation.disk.threshold_enabled: false')
     )
 }

--- a/blackbox/test_decommission.py
+++ b/blackbox/test_decommission.py
@@ -29,7 +29,7 @@ from cr8.run_crate import CrateNode
 from crate.client.http import Client
 from crate.client.exceptions import ProgrammingError, ConnectionError
 from testutils.paths import crate_path
-from testutils.ports import bind_range, bind_port
+from testutils.ports import bind_range
 
 
 def decommission(client, node):


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The entry in the `crate.yml` is

    #cluster.routing.allocation.disk.threshold_enabled: true

The replacement didn't work - leading to tests getting stuck if a
Jenkins slave is low on disk and the tests depend on relocation working.
(Like the decommission tests do)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
