### PR TITLE
Adjust test_jmx for updated sjk.jar output

### DIFF
--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -100,7 +100,9 @@ class JmxClient:
         if stderr.startswith(restart_msg):
             stderr = stderr[len(restart_msg):]
         # Bean name is printed in the first line. Remove it
-        return (stdout[len(bean) + 1:], stderr)
+        stdout = stdout[len(bean) + 1:]
+        stdout = stdout.replace(attribute, '').strip()
+        return (stdout, stderr)
 
 
 class JmxIntegrationTest(unittest.TestCase):
@@ -196,18 +198,17 @@ class JmxIntegrationTest(unittest.TestCase):
         jmx_client = JmxClient(JMX_PORT)
         stdout, stderr = jmx_client.query_jmx(
             'io.crate.monitoring:type=ThreadPools', 'Search')
-        self.assertEqual(
-            '\n'.join((line.strip() for line in stdout.split('\n'))),
-            '''\
-active:          0
-completed:       1
-largestPoolSize: 1
-name:            search
-poolSize:        1
-queueSize:       0
-rejected:        0
-
-''')
+        lines = [line.strip() for line in stdout.split('\n')]
+        expected = [
+            'active:          0',
+            'completed:       1',
+            'largestPoolSize: 1',
+            'name:            search',
+            'poolSize:        1',
+            'queueSize:       0',
+            'rejected:        0',
+        ]
+        self.assertSequenceEqual(expected, lines)
         self.assertEqual(stderr, '')
 
     def test_parent_breaker(self):


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

New versions of sjk.jar produce slightly different output.

This change makes the tests pass with the new version and should also
work with the older versions.

If not, we'll have to clear the cached version on the Jenkins slaves and
locally.

Fixes:

```
File "/var/lib/jenkins/workspace/CrateDB/crate_on_pr/blackbox/test_jmx.py", line 184, in test_mbean_cluster_state_version

    self.assertGreater(int(stdout), 0)

ValueError: invalid literal for int() with base 10: '    ClusterStateVersion 4\n\n'
```



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
