### PR TITLE
Add more Snapshot tests back to test suite

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -628,6 +628,7 @@ should be crossed out as well.
 - [x] 38f02217f00 Omit writing index metadata for non-replicated closed indices on data-only node (#47285)
 - [x] 4f52ebd32eb Better logging for TLS message on non-secure transport channel (#45835)
 - [x] 5ba4f5fb3c9 Use dynamic port ranges for ExternalTestCluster (#45601)
+- [x] 722ab70cc96 Make BlobStoreRepository Validation Read master.dat (#45546)
 - [x] 29235a637f7 Wait for events in waitForRelocation (#45074)
 - [x] 42a331c59ba Remove Unused Features Field on StreamOutput (#44667)
 - [x] f20414dd7d9 Optimize some StreamOutput Operations (#44660)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -631,6 +631,7 @@ should be crossed out as well.
 - [x] 29235a637f7 Wait for events in waitForRelocation (#45074)
 - [x] 42a331c59ba Remove Unused Features Field on StreamOutput (#44667)
 - [x] f20414dd7d9 Optimize some StreamOutput Operations (#44660)
+- [x] 4b8fd4e76f1 Remove blobExists Method from BlobContainer (#44472)
 - [x] f00b658130d Remove RemoteClusterConnection.ConnectedNodes (#44235)
 - [x] 433b3458522 Fix port range allocation with large worker IDs (#44213)
 - [x] c40b77b771b Simplify port usage in transport tests (#44157)

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -50,8 +50,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
         this.keyPath = path.buildAsString();
     }
 
-    @Override
-    public boolean blobExists(String blobName) {
+    private boolean blobExists(String blobName) {
         logger.trace("blobExists({})", blobName);
         try {
             return blobStore.blobExists(buildKey(blobName));

--- a/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -59,15 +59,6 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public boolean blobExists(String blobName) {
-        try {
-            return store.execute(fileContext -> fileContext.util().exists(new Path(path, blobName)));
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    @Override
     public void deleteBlob(String blobName) throws IOException {
         try {
             if (store.execute(fileContext -> fileContext.delete(new Path(path, blobName), true)) == false) {

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobMetadata;
 import org.elasticsearch.common.blobstore.BlobPath;
-import org.elasticsearch.common.blobstore.BlobStoreException;
 import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetadata;
 import io.crate.common.collections.Tuple;
@@ -81,15 +80,6 @@ class S3BlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public boolean blobExists(String blobName) {
-        try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-            return clientReference.client().doesObjectExist(blobStore.bucket(), buildKey(blobName));
-        } catch (final Exception e) {
-            throw new BlobStoreException("Failed to check if blob [" + blobName + "] exists", e);
-        }
-    }
-
-    @Override
     public InputStream readBlob(String blobName) throws IOException {
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
             final S3Object s3Object = clientReference.client().getObject(blobStore.bucket(), buildKey(blobName));
@@ -118,9 +108,6 @@ class S3BlobContainer extends AbstractBlobContainer {
 
     @Override
     public void deleteBlob(String blobName) throws IOException {
-        if (blobExists(blobName) == false) {
-            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
-        }
         deleteBlobIgnoringIfNotExists(blobName);
     }
 

--- a/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -101,14 +101,6 @@ public class URLBlobContainer extends AbstractBlobContainer {
         throw new UnsupportedOperationException("URL repository is read only");
     }
 
-    /**
-     * This operation is not supported by URLBlobContainer
-     */
-    @Override
-    public boolean blobExists(String blobName) {
-        throw new UnsupportedOperationException("URL repository doesn't support this operation");
-    }
-
     @Override
     public InputStream readBlob(String name) throws IOException {
         try {

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -39,15 +39,6 @@ public interface BlobContainer {
     BlobPath path();
 
     /**
-     * Tests whether a blob with the given blob name exists in the container.
-     *
-     * @param   blobName
-     *          The name of the blob whose existence is to be determined.
-     * @return  {@code true} if a blob exists in the {@link BlobContainer} with the given name, and {@code false} otherwise.
-     */
-    boolean blobExists(String blobName);
-
-    /**
      * Creates a new {@link InputStream} for the given blob name.
      *
      * @param   blobName

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -129,11 +129,6 @@ public class FsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public boolean blobExists(String blobName) {
-        return Files.exists(path.resolve(blobName));
-    }
-
-    @Override
     public InputStream readBlob(String name) throws IOException {
         final Path resolvedPath = path.resolve(name);
         try {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1715,7 +1715,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
         } else {
             BlobContainer testBlobContainer = blobStore().blobContainer(basePath().add(testBlobPrefix(seed)));
-            if (testBlobContainer.blobExists("master.dat")) {
+            try (InputStream ignored = testBlobContainer.readBlob("master.dat")) {
                 try {
                     BytesArray bytes = new BytesArray(seed);
                     try (InputStream stream = bytes.streamInput()) {
@@ -1725,10 +1725,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     throw new RepositoryVerificationException(metadata.name(), "store location [" + blobStore() +
                                                                                "] is not accessible on the node [" + localNode + "]", exp);
                 }
-            } else {
-                throw new RepositoryVerificationException(metadata.name(), "a file written by master to the store [" + blobStore() + "] cannot be accessed on the node [" + localNode + "]. "
-                                                                           + "This might indicate that the store [" + blobStore() + "] is not shared between this node and the master node or "
-                                                                           + "that permissions on the store don't allow reading files written by the master node");
+            } catch (NoSuchFileException e) {
+                throw new RepositoryVerificationException(metadata.name(), "a file written by master to the store [" + blobStore() +
+                    "] cannot be accessed on the node [" + localNode + "]. " +
+                    "This might indicate that the store [" + blobStore() + "] is not shared between this node and the master node or " +
+                    "that permissions on the store don't allow reading files written by the master node", e);
+            } catch (IOException e) {
+                throw new RepositoryVerificationException(metadata.name(), "Failed to verify repository", e);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1709,7 +1709,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         if (isReadOnly()) {
             try {
                 latestIndexBlobId();
-            } catch (IOException e) {
+            } catch (Exception e) {
                 throw new RepositoryVerificationException(metadata.name(), "path " + basePath() +
                                                                            " is not accessible on node " + localNode, e);
             }
@@ -1720,7 +1720,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 try (InputStream stream = bytes.streamInput()) {
                     testBlobContainer.writeBlob("data-" + localNode.getId() + ".dat", stream, bytes.length(), true);
                 }
-            } catch (IOException exp) {
+            } catch (Exception exp) {
                 throw new RepositoryVerificationException(metadata.name(), "store location [" + blobStore() +
                     "] is not accessible on the node [" + localNode + "]", exp);
             }
@@ -1735,7 +1735,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     "] cannot be accessed on the node [" + localNode + "]. " +
                     "This might indicate that the store [" + blobStore() + "] is not shared between this node and the master node or " +
                     "that permissions on the store don't allow reading files written by the master node", e);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 throw new RepositoryVerificationException(metadata.name(), "Failed to verify repository", e);
             }
         }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1715,15 +1715,20 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
         } else {
             BlobContainer testBlobContainer = blobStore().blobContainer(basePath().add(testBlobPrefix(seed)));
-            try (InputStream ignored = testBlobContainer.readBlob("master.dat")) {
-                try {
-                    BytesArray bytes = new BytesArray(seed);
-                    try (InputStream stream = bytes.streamInput()) {
-                        testBlobContainer.writeBlob("data-" + localNode.getId() + ".dat", stream, bytes.length(), true);
-                    }
-                } catch (IOException exp) {
-                    throw new RepositoryVerificationException(metadata.name(), "store location [" + blobStore() +
-                                                                               "] is not accessible on the node [" + localNode + "]", exp);
+            try {
+                BytesArray bytes = new BytesArray(seed);
+                try (InputStream stream = bytes.streamInput()) {
+                    testBlobContainer.writeBlob("data-" + localNode.getId() + ".dat", stream, bytes.length(), true);
+                }
+            } catch (IOException exp) {
+                throw new RepositoryVerificationException(metadata.name(), "store location [" + blobStore() +
+                    "] is not accessible on the node [" + localNode + "]", exp);
+            }
+            try (InputStream masterDat = testBlobContainer.readBlob("master.dat")) {
+                final String seedRead = Streams.readFully(masterDat).utf8ToString();
+                if (seedRead.equals(seed) == false) {
+                    throw new RepositoryVerificationException(metadata.name(), "Seed read from master.dat was [" + seedRead +
+                        "] but expected seed [" + seed + "]");
                 }
             } catch (NoSuchFileException e) {
                 throw new RepositoryVerificationException(metadata.name(), "a file written by master to the store [" + blobStore() +

--- a/server/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.testing.UseJdbc;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.snapshots.mockstore.MockRepository;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Tests for snapshot/restore that require at least 2 threads available
+ * in the thread pool (for example, tests that use the mock repository that
+ * block on master).
+ */
+@UseJdbc(0)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+            .put("thread_pool.snapshot.core", 2)
+            .put("thread_pool.snapshot.max", 2)
+            .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(MockRepository.Plugin.class);
+        return plugins;
+    }
+
+    public void testConcurrentSnapshotDeletionsNotAllowed() throws Exception {
+        logger.info("--> creating repository");
+
+        assertAcked(client().admin().cluster().preparePutRepository("repo").setType("mock").setSettings(
+            Settings.builder()
+                .put("location", randomRepoPath())
+                .put("random", randomAlphaOfLength(10))
+                .put("wait_after_unblock", 200)).get());
+
+        logger.info("--> snapshot twice");
+        execute("create table doc.test1 (x integer) clustered into 1 shards with (number_of_replicas=0)");
+        for (int i = 0; i < 10; i++) {
+            execute("insert into doc.test1 values(?)", new Object[]{i});
+        }
+        refresh();
+        execute("create snapshot repo.snapshot1 all WITH (wait_for_completion=true)");
+
+        execute("create table doc.test2(x integer) clustered into 1 shards with (number_of_replicas=0)");
+
+        for (int i = 0; i < 10; i++) {
+            execute("insert into doc.test2 values(?)", new Object[]{i});
+        }
+        refresh();
+        execute("create snapshot repo.snapshot2 all WITH (wait_for_completion=true)");
+
+        String blockedNode = internalCluster().getMasterName();
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository("repo")).blockOnDataFiles(true);
+        logger.info("--> start deletion of second snapshot");
+        ActionFuture<AcknowledgedResponse> future =
+            client().admin().cluster().prepareDeleteSnapshot("repo", "snapshot2").execute();
+        logger.info("--> waiting for block to kick in on node [{}]", blockedNode);
+        waitForBlock(blockedNode, "repo", TimeValue.timeValueSeconds(10));
+
+        logger.info("--> try deleting the first snapshot, should fail because there is already a deletion is in progress");
+        try {
+            execute("drop snapshot repo.snapshot1");
+            fail("should not be able to delete snapshots concurrently");
+        } catch (ConcurrentSnapshotExecutionException e) {
+            assertThat(e.getMessage(), containsString("cannot delete - another snapshot is currently being deleted"));
+        }
+
+        logger.info("--> unblocking blocked node [{}]", blockedNode);
+        unblockNode("repo", blockedNode);
+
+        logger.info("--> wait until second snapshot deletion is finished");
+        assertAcked(future.actionGet());
+
+        logger.info("--> try delete first snapshot again, which should now work");
+        execute("drop snapshot repo.snapshot1");
+        assertTrue(client().admin().cluster().prepareGetSnapshots("repo").setSnapshots("_all").get().getSnapshots().isEmpty());
+    }
+
+    public void testSnapshottingWithInProgressDeletionNotAllowed() throws Exception {
+        logger.info("--> creating repository");
+        assertAcked(client().admin().cluster().preparePutRepository("repo").setType("mock").setSettings(
+            Settings.builder()
+                .put("location", randomRepoPath())
+                .put("random", randomAlphaOfLength(10))
+                .put("wait_after_unblock", 200)).get());
+
+        logger.info("--> snapshot");
+        execute("create table doc.test1 (x integer) clustered into 1 shards with (number_of_replicas=0)");
+
+        for (int i = 0; i < 10; i++) {
+            execute("insert into doc.test1 values(?)", new Object[]{i});
+        }
+        refresh();
+        execute("create snapshot repo.snapshot1 all WITH (wait_for_completion=true)");
+
+        String blockedNode = internalCluster().getMasterName();
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository("repo")).blockOnDataFiles(true);
+        logger.info("--> start deletion of snapshot");
+        ActionFuture<AcknowledgedResponse> future = client().admin().cluster().prepareDeleteSnapshot("repo", "snapshot1").execute();
+        logger.info("--> waiting for block to kick in on node [{}]", blockedNode);
+        waitForBlock(blockedNode, "repo", TimeValue.timeValueSeconds(10));
+
+        logger.info("--> try creating a second snapshot, should fail because the deletion is in progress");
+        try {
+            execute("create snapshot repo.snapshot2 all WITH (wait_for_completion=true)");
+            fail("should not be able to create a snapshot while another is being deleted");
+        } catch (ConcurrentSnapshotExecutionException e) {
+            assertThat(e.getMessage(), containsString("cannot snapshot while a snapshot deletion is in-progress"));
+        }
+
+        logger.info("--> unblocking blocked node [{}]", blockedNode);
+        unblockNode("repo", blockedNode);
+
+        logger.info("--> wait until snapshot deletion is finished");
+        assertAcked(future.actionGet());
+
+        logger.info("--> creating second snapshot, which should now work");
+        execute("create snapshot repo.snapshot2 all WITH (wait_for_completion=true)");
+        assertEquals(1, client().admin().cluster().prepareGetSnapshots("repo").setSnapshots("_all").get().getSnapshots().size());
+    }
+
+    public void testRestoreWithInProgressDeletionsNotAllowed() throws Exception {
+        logger.info("--> creating repository");
+        assertAcked(client().admin().cluster().preparePutRepository("repo").setType("mock").setSettings(
+            Settings.builder()
+                .put("location", randomRepoPath())
+                .put("random", randomAlphaOfLength(10))
+                .put("wait_after_unblock", 200)).get());
+
+        logger.info("--> snapshot");
+        execute("create table doc.test1 (x integer) clustered into 1 shards with (number_of_replicas=0)");
+
+        for (int i = 0; i < 10; i++) {
+            execute("insert into doc.test1 values(?)", new Object[]{i});
+        }
+        refresh();
+        execute("create snapshot repo.snapshot1 all WITH (wait_for_completion=true)");
+        execute("create table doc.test2 (x integer) clustered into 1 shards with (number_of_replicas=0)");
+
+        for (int i = 0; i < 10; i++) {
+            execute("insert into doc.test2 values(?)", new Object[]{i});
+        }
+        refresh();
+        execute("create snapshot repo.snapshot2 all WITH (wait_for_completion=true)");
+        execute("alter table doc.test1 close");
+        execute("alter table doc.test2 close");
+
+        String blockedNode = internalCluster().getMasterName();
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository("repo")).blockOnDataFiles(true);
+        logger.info("--> start deletion of snapshot");
+        ActionFuture<AcknowledgedResponse> future = client().admin().cluster().prepareDeleteSnapshot("repo", "snapshot2").execute();
+        logger.info("--> waiting for block to kick in on node [{}]", blockedNode);
+        waitForBlock(blockedNode, "repo", TimeValue.timeValueSeconds(10));
+
+        logger.info("--> try restoring the other snapshot, should fail because the deletion is in progress");
+        try {
+            execute("restore snapshot repo.snapshot1 all");
+            fail("should not be able to restore a snapshot while another is being deleted");
+        } catch (ConcurrentSnapshotExecutionException e) {
+            assertThat(e.getMessage(), containsString("cannot restore a snapshot while a snapshot deletion is in-progress"));
+        }
+
+        logger.info("--> unblocking blocked node [{}]", blockedNode);
+        unblockNode("repo", blockedNode);
+
+        logger.info("--> wait until snapshot deletion is finished");
+        assertAcked(future.actionGet());
+
+        logger.info("--> restoring snapshot, which should now work");
+        execute("restore snapshot repo.snapshot1 all");
+        assertEquals(1, client().admin().cluster().prepareGetSnapshots("repo").setSnapshots("_all").get().getSnapshots().size());
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/repositories/ESBlobStoreTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/repositories/ESBlobStoreTestCase.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -48,11 +49,8 @@ public abstract class ESBlobStoreTestCase extends ESTestCase {
             assertArrayEquals(readBlobFully(containerFoo, "test", data1.length), data1);
             assertArrayEquals(readBlobFully(containerBar, "test", data2.length), data2);
 
-            assertTrue(containerFoo.blobExists("test"));
-            assertTrue(containerBar.blobExists("test"));
-            store.delete(new BlobPath());
-            assertFalse(containerFoo.blobExists("test"));
-            assertFalse(containerBar.blobExists("test"));
+            assertTrue(BlobStoreTestUtil.blobExists(containerFoo, "test"));
+            assertTrue(BlobStoreTestUtil.blobExists(containerBar, "test"));
         }
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -41,11 +41,6 @@ public class BlobContainerWrapper implements BlobContainer {
     }
 
     @Override
-    public boolean blobExists(String blobName) {
-        return false;
-    }
-
-    @Override
     public InputStream readBlob(String name) throws IOException {
         return delegate.readBlob(name);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes the `BlobStoreRepository.verify` method and enables the `MinThreadsSnapshotRestoreIT` to pass and also adds `SnapshotShardsServiceIT`.

Based on the state of:
https://github.com/elastic/elasticsearch/commit/8402ad95f2be603b7d939085723243750356f951


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
