### PR TITLE
Documentation: Satisfy link checker

### DIFF
--- a/docs/appendices/compliance.rst
+++ b/docs/appendices/compliance.rst
@@ -18,7 +18,7 @@ CrateDB supports, along with implementation notes and any associated caveats.
 
 .. SEEALSO::
 
-    :ref:`SQL compatibility <crate_standard_sql>`
+    :ref:`SQL compatibility <appendix-compatibility>`
 
 .. csv-filter::
    :header: ID,Package,#,Description,Supported,Verified,Comments

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -19,7 +19,7 @@ Released on 2019/06/25.
     When restarting, CrateDB will migrate indexes to a newer format. Depending
     on the amount of data, this may delay node start-up time.
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading.
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading.
 
 .. WARNING::
 
@@ -184,7 +184,7 @@ Removed Settings
   ``concurrent_streams`` as it is no longer supported.
 
 - The ``zen1`` related discovery settings mentioned in
-  :ref:`discovery-changes`.
+  :ref:`v4.0.0-discovery-changes`.
 
 
 .. _v4.0.0-breaking-sys:

--- a/docs/appendices/release-notes/4.0.1.rst
+++ b/docs/appendices/release-notes/4.0.1.rst
@@ -8,7 +8,7 @@ Released on 2019/07/08.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading.
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading.
     Before upgrading to 4.0.1 you should be running a CrateDB cluster that is
     at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.10.rst
+++ b/docs/appendices/release-notes/4.0.10.rst
@@ -8,7 +8,7 @@ Released on 2019/12/10.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.  Before upgrading to 4.0.10 you should be running a
     CrateDB cluster that is at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.11.rst
+++ b/docs/appendices/release-notes/4.0.11.rst
@@ -8,7 +8,7 @@ Released on 2020/01/15.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.
     Before upgrading to 4.0.11 you should be running a CrateDB cluster that is
     at least on 3.0.7.

--- a/docs/appendices/release-notes/4.0.12.rst
+++ b/docs/appendices/release-notes/4.0.12.rst
@@ -8,7 +8,7 @@ Released on 2020-01-30.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.
     Before upgrading to 4.0.12 you should be running a CrateDB cluster that is
     at least on 3.0.7.

--- a/docs/appendices/release-notes/4.0.2.rst
+++ b/docs/appendices/release-notes/4.0.2.rst
@@ -8,7 +8,7 @@ Released on 2019/07/12.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading.
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading.
     Before upgrading to 4.0.2 you should be running a CrateDB cluster that is
     at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.3.rst
+++ b/docs/appendices/release-notes/4.0.3.rst
@@ -8,7 +8,7 @@ Released on 2019/08/06.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading.
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading.
     Before upgrading to 4.0.3 you should be running a CrateDB cluster that is
     at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.4.rst
+++ b/docs/appendices/release-notes/4.0.4.rst
@@ -8,7 +8,7 @@ Released on 2019/08/21.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.  Before upgrading to 4.0.4 you should be running a
     CrateDB cluster that is at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.5.rst
+++ b/docs/appendices/release-notes/4.0.5.rst
@@ -8,7 +8,7 @@ Released on 2019/09/19.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.  Before upgrading to 4.0.5 you should be running a
     CrateDB cluster that is at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.6.rst
+++ b/docs/appendices/release-notes/4.0.6.rst
@@ -8,7 +8,7 @@ Released on 2019/10/03.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.  Before upgrading to 4.0.6 you should be running a
     CrateDB cluster that is at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.7.rst
+++ b/docs/appendices/release-notes/4.0.7.rst
@@ -8,7 +8,7 @@ Released on 2019/10/24.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.  Before upgrading to 4.0.7 you should be running a
     CrateDB cluster that is at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.8.rst
+++ b/docs/appendices/release-notes/4.0.8.rst
@@ -8,7 +8,7 @@ Released on 2019/11/07.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.  Before upgrading to 4.0.8 you should be running a
     CrateDB cluster that is at least on 3.0.7.
 

--- a/docs/appendices/release-notes/4.0.9.rst
+++ b/docs/appendices/release-notes/4.0.9.rst
@@ -8,7 +8,7 @@ Released on 2019/11/25.
 
 .. NOTE::
 
-    Please consult the :ref:`version_4.0.0_upgrade_notes` before upgrading from
+    Please consult the :ref:`v4.0.0-upgrade-notes` before upgrading from
     CrateDB 3.x or earlier.  Before upgrading to 4.0.9 you should be running a
     CrateDB cluster that is at least on 3.0.7.
 

--- a/docs/concepts/joins.rst
+++ b/docs/concepts/joins.rst
@@ -101,9 +101,9 @@ Join algorithms
 
 CrateDB supports (a) CROSS JOIN, (b) INNER JOIN, (c) EQUI JOIN, (d) LEFT JOIN,
 (e) RIGHT JOIN and (f) FULL JOIN. All of these join types are executed using
-the :ref:`nested loop join algorithm <joins_nested_loop>` except for the
-:ref:`Equi Joins <joins_equi_join>` which are executed using the :ref:`hash
-join algorithm <joins_hash_join>`. Special optimizations, according to the
+the :ref:`nested loop join algorithm <join-algos-nested-loop>` except for the
+:ref:`Equi Joins <join-types-equi>` which are executed using the :ref:`hash
+join algorithm <join-algos-hash>`. Special optimizations, according to the
 specific use cases, are applied to improve execution performance.
 
 
@@ -180,7 +180,7 @@ Hash join
 ---------
 
 The Hash Join algorithm is used to execute certains types of joins in a more
-perfomant way than :ref:`Nested Loop <joins_nested_loop>`.
+perfomant way than :ref:`Nested Loop <join-algos-nested-loop>`.
 
 
 .. _join-algos-hash-basic:
@@ -270,7 +270,7 @@ of nodes in the cluster, is applied and the resulting number defines the node
 to which this row should be sent. As a result each node of the cluster receives
 a subset of the whole data set which is ensured (by the hashing and modulo) to
 contain all candidate matching rows. Each node in turn performs a :ref:`block
-hash join <joins_block_hash_join>` on this subset and sends its result tuples
+hash join <join-algos-hash-block>` on this subset and sends its result tuples
 to the handler node (where the client issued the query). Finally, the handler
 node receives those intermediate results, merges them and applies any pending
 ``ORDER BY``, ``LIMIT`` and ``OFFSET`` and sends the final result to the
@@ -299,7 +299,7 @@ Query then fetch
 ----------------
 
 Join operations on large relation can be extremely slow especially if the join
-is executed with a :ref:`Nested Loop <joins_nested_loop>`. - which means that
+is executed with a :ref:`Nested Loop <join-algos-nested-loop>`. - which means that
 the runtime complexity grows quadratically (O(n*m)). Specifically for
 :ref:`cross joins <cross-joins>` this results in large amounts of data sent
 over the network and loaded into memory at the handler node. CrateDB reduces

--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -7,7 +7,7 @@ Altering tables
 .. NOTE::
 
    ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported.
-   See :ref:`crate_standard_sql`.
+   See :ref:`appendix-compatibility`.
 
 .. rubric:: Table of contents
 

--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -7,8 +7,8 @@ Creating tables
 Tables are the basic building blocks of a relational database. A table can hold
 multiple rows (i.e., records), with each row having multiple columns and each
 column holding a single data element (i.e., value). You can :ref:`query <dql>`
-tables to :ref:`insert data <inserting_data>`, :ref:`select <sql_dql_queries>`
-(i.e., retrieve) data, and :ref:`delete data <dml_deleting_data>`.
+tables to :ref:`insert data <dml-inserting-data>`, :ref:`select <sql_dql_queries>`
+(i.e., retrieve) data, and :ref:`delete data <dml-deleting-data>`.
 
 .. rubric:: Table of contents
 
@@ -228,7 +228,7 @@ of functionality that CrateDB supports. For example:
 
   By partitioning a table, you can segment some :ref:`SQL statements
   <gloss-statement>` (e.g., those used for :ref:`table optimization
-  <optimize>`, :ref:`import and export <importing_data>`, and :ref:`backup and
+  <optimize>`, :ref:`import and export <dml-importing-data>`, and :ref:`backup and
   restore <snapshot-restore>`) by constraining them to one or more partitions.
 
   .. SEEALSO::

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -634,7 +634,7 @@ Arrays
 CrateDB supports :ref:`arrays <data-type-array>`. It is possible to select and
 query array elements.
 
-For example, you might :ref:`insert <inserting_data>` an array like so::
+For example, you might :ref:`insert <dml-inserting-data>` an array like so::
 
     cr> insert into locations (id, name, position, kind, landmarks)
     ... values (14, 'Frogstar', 4, 'Star System',

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -341,7 +341,7 @@ execution engine address different requirements (see :ref:`Clustering
 The listed features below cover the main differences in implementation and
 dialect between CrateDB and PostgreSQL. A detailed comparison between CrateDB's
 SQL dialect and standard SQL is defined in
-:ref:`crate_standard_sql`.
+:ref:`appendix-compatibility`.
 
 ``COPY``
 --------

--- a/docs/sql/index.rst
+++ b/docs/sql/index.rst
@@ -4,7 +4,7 @@
 SQL syntax
 ==========
 
-You can use :ref:`Structured Query Language <crate_standard_sql>` (SQL) to
+You can use :ref:`Structured Query Language <appendix-compatibility>` (SQL) to
 query your data.
 
 This section of the documentation provides a complete SQL syntax

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -11,7 +11,7 @@ from a file into a table.
 
 .. SEEALSO::
 
-    :ref:`Data manipulation: Import and export <importing_data>`
+    :ref:`Data manipulation: Import and export <dml-import-export>`
 
     :ref:`SQL syntax: COPY TO <sql-copy-to>`
 
@@ -84,7 +84,7 @@ Example CSV data::
     1,"Don't panic"
     2,"Ford, you're turning into a penguin. Stop it."
 
-See also: :ref:`importing_data`.
+See also: :ref:`dml-importing-data`.
 
 
 .. _sql-copy-from-type-checks:

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -11,7 +11,7 @@ data to a file.
 
 .. SEEALSO::
 
-    :ref:`Data manipulation: Import and export <importing_data>`
+    :ref:`Data manipulation: Import and export <dml-import-export>`
 
     :ref:`SQL syntax: COPY FROM <sql-copy-from>`
 

--- a/docs/sql/statements/start-transaction.rst
+++ b/docs/sql/statements/start-transaction.rst
@@ -11,7 +11,7 @@ CrateDB accepts the ``START TRANSACTION`` statement for compatibility with the
 not support transactions and will silently ignore this statement.
 .. SEEALSO::
 
-    :ref:`Appendix: SQL compatibility <crate_standard_sql>`
+    :ref:`Appendix: SQL compatibility <appendix-compatibility>`
 
 .. rubric:: Table of contents
 


### PR DESCRIPTION
Hi there,

apparently, some links/anchors have diverged, making the link checker croak. I observed this when running CI tasks on #11220. This patch accounts for that and updates the documentation to use the corresponding new link references.

With kind regards,
Andreas.
