### PR TITLE
Docs: Add VIEW to ON clause for GRANT/REVOKE

### DIFF
--- a/docs/sql/statements/grant.rst
+++ b/docs/sql/statements/grant.rst
@@ -17,7 +17,7 @@ Synopsis
 .. code-block:: psql
 
   GRANT { { DQL | DML | DDL | AL [,...] } | ALL [ PRIVILEGES ] }
-  [ON {SCHEMA | TABLE} identifier [, ...]]
+  [ON {SCHEMA | TABLE | VIEW} identifier [, ...]]
   TO user_name [, ...];
 
 Description
@@ -26,8 +26,8 @@ Description
 ``GRANT`` is a management statement to grant one or many privileges
 on the whole cluster or on a specific object to one or many existing users.
 
-``ON {SCHEMA | TABLE}`` is optional, if not specified the privilege will be
-granted on the ``CLUSTER`` level.
+``ON {SCHEMA | TABLE | VIEW}`` is optional, if not specified the privilege will
+be granted on the ``CLUSTER`` level.
 
 For usage of the ``GRANT`` statement see :ref:`administration-privileges`.
 
@@ -37,8 +37,8 @@ Parameters
 :identifier:
   The identifier of the corresponding object.
 
-  If ``TABLE`` is specified the ``identifier`` should include the
-  table's full qualified name. Otherwise the table will be looked up in
+  If ``TABLE`` or ``VIEW`` is specified the ``identifier`` should include the
+  object's full qualified name. Otherwise it will be looked up in
   the current schema.
 
 :user_name:

--- a/docs/sql/statements/revoke.rst
+++ b/docs/sql/statements/revoke.rst
@@ -18,7 +18,7 @@ Synopsis
 .. code-block:: psql
 
   REVOKE { { DQL | DML | DDL | AL [,...] } | ALL [ PRIVILEGES ] }
-  [ON {SCHEMA | TABLE} identifier [, ...]]
+  [ON {SCHEMA | TABLE | VIEW} identifier [, ...]]
   FROM user_name [, ...];
 
 Description
@@ -27,8 +27,8 @@ Description
 ``REVOKE`` is a management statement to revoke previously granted privileges
 on a specific object from one or many existing users.
 
-``ON {SCHEMA | TABLE}`` is optional, if not specified the privilege will be
-revoked on the ``CLUSTER`` level.
+``ON {SCHEMA | TABLE | VIEW}`` is optional, if not specified the privilege will
+be revoked on the ``CLUSTER`` level.
 
 For usage of the ``REVOKE`` statement see :ref:`administration-privileges`.
 
@@ -38,8 +38,8 @@ Parameters
 :identifier:
   The identifier of the corresponding object.
 
-  If ``TABLE`` is specified the ``identifier`` should include the
-  table's full qualified name. Otherwise the table will be looked up in
+  If ``TABLE`` or ``VIEW`` is specified the ``identifier`` should include the
+  object's full qualified name. Otherwise it will be looked up in
   the current schema.
 
 :user_name:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The documentation for `GRANT`/`REVOKE` currently doesn't state that `ON VIEW` is part of the SQL grammar.

Although in a quick test, I found no practical difference between using `ON VIEW` vs. `ON TABLE` with a view, both seemed to have the same effect. 

## Checklist

 - [X] Added an entry in `CHANGES.txt` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
