### PR TITLE
Use KahanSummation for AverageAggregation

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -82,14 +82,28 @@ public class AverageAggregationTest extends AggregationTestCase {
 
     @Test
     public void testDouble() throws Exception {
-        Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.7d}, {0.3d}});
-        assertEquals(0.5d, result);
+        Object[][] data = new Object[100][];
+        for (int i = 0; i < 100; i++) {
+                data[i] = new Object[]{10000.1d};
+        }
+
+        // AverageAggregation returns double
+        double result = (double) executeAggregation(DataTypes.DOUBLE, data);
+
+        assertEquals(10000.1d, result, 0d);
     }
 
     @Test
     public void testFloat() throws Exception {
-        Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.7f}, {0.3f}});
-        assertEquals(0.5d, result);
+        Object[][] data = new Object[100][];
+        for (int i = 0; i < 100; i++) {
+            data[i] = new Object[]{10000.1f};
+        }
+
+        //AverageAggregation returns double
+        double result = (double) executeAggregation(DataTypes.FLOAT, data);
+
+        assertEquals(10000.1f, result, 0f);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
@@ -42,6 +42,6 @@ public class KahanSummationForDoubleTest extends AggregationTestCase {
         }
 
         // The same operations using '+' returns 1.9999999999999998
-        assertEquals(total, 2.0d, 0.0d);
+        assertEquals(2.0d, total, 0.0d);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
@@ -42,6 +42,6 @@ public class KahanSummationForFloatTest extends AggregationTestCase {
         }
 
         // The same operations using '+' returns 2.0000002
-        assertEquals(total, 2.0f, 0.0f);
+        assertEquals(2.0f, total, 0.0f);
     }
 }


### PR DESCRIPTION
Improved precision for average aggregation for floats and doubles.


`create table nums (value double precision);`

`insert into nums (value) (select * from unnest([10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1,10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1, 10000.1]));`

`select avg(value) avg from nums; `

Before:

```
cr> select avg(value) avg from nums;                                                                                                                                                                                    
+--------------------+
|                avg |
+--------------------+
| 10000.100000000002 |
+--------------------+
SELECT 1 row in set (0.003 sec)
```

After

```
 select avg(value) avg from nums;                                                                                                                                                                                                   
+---------+
|     avg |
+---------+
| 10000.1 |
+---------+
SELECT 1 row in set (0.035 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
