### PR TITLE
Documentation: Satisfy link checker (backport to 4.6)

### DIFF
--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -7,7 +7,7 @@ Altering tables
 .. NOTE::
 
    ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported.
-   See :ref:`crate_standard_sql`.
+   See :ref:`appendix-compatibility`.
 
 .. rubric:: Table of contents
 

--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -7,8 +7,8 @@ Creating tables
 Tables are the basic building blocks of a relational database. A table can hold
 multiple rows (i.e., records), with each row having multiple columns and each
 column holding a single data element (i.e., value). You can :ref:`query <dql>`
-tables to :ref:`insert data <inserting_data>`, :ref:`select <sql_dql_queries>`
-(i.e., retrieve) data, and :ref:`delete data <dml_deleting_data>`.
+tables to :ref:`insert data <dml-inserting-data>`, :ref:`select <sql_dql_queries>`
+(i.e., retrieve) data, and :ref:`delete data <dml-deleting-data>`.
 
 .. rubric:: Table of contents
 
@@ -228,7 +228,7 @@ of functionality that CrateDB supports. For example:
 
   By partitioning a table, you can segment some :ref:`SQL statements
   <gloss-statement>` (e.g., those used for :ref:`table optimization
-  <optimize>`, :ref:`import and export <importing_data>`, and :ref:`backup and
+  <optimize>`, :ref:`import and export <dml-importing-data>`, and :ref:`backup and
   restore <snapshot-restore>`) by constraining them to one or more partitions.
 
   .. SEEALSO::

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -634,7 +634,7 @@ Arrays
 CrateDB supports :ref:`arrays <data-type-array>`. It is possible to select and
 query array elements.
 
-For example, you might :ref:`insert <inserting_data>` an array like so::
+For example, you might :ref:`insert <dml-inserting-data>` an array like so::
 
     cr> insert into locations (id, name, position, kind, landmarks)
     ... values (14, 'Frogstar', 4, 'Star System',

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -341,7 +341,7 @@ execution engine address different requirements (see :ref:`Clustering
 The listed features below cover the main differences in implementation and
 dialect between CrateDB and PostgreSQL. A detailed comparison between CrateDB's
 SQL dialect and standard SQL is defined in
-:ref:`crate_standard_sql`.
+:ref:`appendix-compatibility`.
 
 ``COPY``
 --------

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -11,7 +11,7 @@ from a file into a table.
 
 .. SEEALSO::
 
-    :ref:`Data manipulation: Import and export <importing_data>`
+    :ref:`Data manipulation: Import and export <dml-import-export>`
 
     :ref:`SQL syntax: COPY TO <sql-copy-to>`
 
@@ -84,7 +84,7 @@ Example CSV data::
     1,"Don't panic"
     2,"Ford, you're turning into a penguin. Stop it."
 
-See also: :ref:`importing_data`.
+See also: :ref:`dml-importing-data`.
 
 
 .. _sql-copy-from-type-checks:

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -11,7 +11,7 @@ data to a file.
 
 .. SEEALSO::
 
-    :ref:`Data manipulation: Import and export <importing_data>`
+    :ref:`Data manipulation: Import and export <dml-import-export>`
 
     :ref:`SQL syntax: COPY FROM <sql-copy-from>`
 


### PR DESCRIPTION
Hi there,

this patch fixes some broken link references within the documentation. It is a manual backport of #11606 for the 4.6 release branch. It will supersede the automatically created #11611.

With kind regards,
Andreas.
