### PR TITLE
Add float4 and float8 aliases for real/double

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,8 @@ None
 Changes
 =======
 
+- Added ``float4`` type as alias to ``real`` and ``float8`` type as alias to
+  ``double precision``
 - Added the :ref:`JSON type <data-type-json>`.
 - Added the :ref:`date_bin <date-bin>` scalar function that truncates timestamp
   into specified interval aligned with specified origin.

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -1728,6 +1728,10 @@ See the table below for a full list of aliases:
 +-------------+--------------------------+
 | float       | real                     |
 +-------------+--------------------------+
+| float4      | real                     |
++-------------+--------------------------+
+| float8      | double precision         |
++-------------+--------------------------+
 | double      | double precision         |
 +-------------+--------------------------+
 | timestamp   | timestamp with time zone |

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -393,6 +393,8 @@ public final class DataTypes {
         entry("byte", BYTE),
         entry("short", SHORT),
         entry("float", FLOAT),
+        entry("float4", FLOAT),
+        entry("float8", DOUBLE),
         entry("double", DOUBLE),
         entry("string", STRING),
         entry("varchar", STRING),

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -161,6 +161,16 @@ public class DataTypesTest extends ESTestCase {
     }
 
     @Test
+    public void testFloat4IsAliasedToReal() {
+        assertThat(DataTypes.ofName("float4"), is(DataTypes.FLOAT));
+    }
+
+    @Test
+    public void testFloat8IsAliasedToDouble() {
+        assertThat(DataTypes.ofName("float8"), is(DataTypes.DOUBLE));
+    }
+
+    @Test
     public void test_is_same_type_on_primitive_types() {
         assertThat(DataTypes.isSameType(DataTypes.STRING, DataTypes.STRING), is(true));
         assertThat(DataTypes.isSameType(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add `float4` type alias for `real` and `float8` alias for `double`

I'm unsure if [SQL compatibility data types](https://github.com/crate/crate/blob/master/docs/appendices/compatibility.rst#data-types) needs to be updated as well or not 🤷 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
