### PR TITLE
allow querying objects' non-existing subcolumns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -76,7 +76,9 @@ Changes
 
 - Added a new ``table_partitions`` column to the :ref:`sys.snapshots
   <sys-snapshots>` table.
-
+- Added ``error_on_unknown_object_key`` session setting. This will either allow
+  or suppress an error when unknown object keys are queried from dynamic
+  objects.
 - Added ``float4`` type as alias to ``real`` and ``float8`` type as alias to
   ``double precision``
 

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -74,6 +74,16 @@ Supported session settings
   :ref:`evaluated <gloss-evaluation>` using the ``HashJoin`` implementation
   instead of the ``Nested-Loops`` implementation.
 
+.. _conf-session-error_on_unknown_object_key:
+
+**error_on_unknown_object_key**
+  | *Default:* ``true``
+  | *Modifiable:* ``yes``
+
+  This setting controls the behaviour of querying unknown object keys to
+  dynamic objects. CrateDB will throw an error by default if any of the queried
+  object keys are unknown or will return a null if the setting is set to false.
+
   .. NOTE::
 
      It is not always possible or efficient to use the ``HashJoin``

--- a/server/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/server/src/main/java/io/crate/action/sql/SessionContext.java
@@ -39,6 +39,7 @@ public class SessionContext {
 
     private SearchPath searchPath;
     private boolean hashJoinEnabled = true;
+    private boolean errorOnUnknownObjectKey = true;
     private Set<Class<? extends Rule<?>>> excludedOptimizerRules;
 
     /**
@@ -82,8 +83,16 @@ public class SessionContext {
         return hashJoinEnabled;
     }
 
+    public boolean errorOnUnknownObjectKey() {
+        return errorOnUnknownObjectKey;
+    }
+
     public void setHashJoinEnabled(boolean hashJoinEnabled) {
         this.hashJoinEnabled = hashJoinEnabled;
+    }
+
+    public void setErrorOnUnknownObjectKey(boolean errorOnUnknownObjectKey) {
+        this.errorOnUnknownObjectKey = errorOnUnknownObjectKey;
     }
 
     public User authenticatedUser() {

--- a/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -79,7 +79,7 @@ class AlterTableAddColumnAnalyzer {
             txnCtx, nodeCtx, paramTypeHints, referenceResolver, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         AddColumnDefinition<Expression> tableElement = alterTable.tableElement();
         // convert and validate the column name
@@ -142,11 +142,14 @@ class AlterTableAddColumnAnalyzer {
         }
 
         @Override
-        public Reference resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
+        public Reference resolveField(QualifiedName qualifiedName,
+                                      @Nullable List<String> path,
+                                      Operation operation,
+                                      boolean errorOnUnknownObjectKey) {
             try {
                 // SQL Semantics: CHECK expressions cannot refer to other
                 // columns to not invalidate existing data inadvertently.
-                Reference ref = referenceResolver.resolveField(qualifiedName, path, operation);
+                Reference ref = referenceResolver.resolveField(qualifiedName, path, operation, errorOnUnknownObjectKey);
                 throw new IllegalArgumentException(String.format(
                     Locale.ENGLISH,
                     "CHECK expressions defined in this context cannot refer to other columns: %s",

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -58,7 +58,7 @@ class AlterTableAnalyzer {
                                CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         AlterTable<Symbol> alterTable = node.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
 
@@ -78,7 +78,7 @@ class AlterTableAnalyzer {
 
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         AlterTable<Symbol> alterTable = node.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
 
@@ -119,7 +119,7 @@ class AlterTableAnalyzer {
                                                CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsStrings = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         Table<Symbol> table = node.table().map(x -> exprAnalyzerWithFieldsAsStrings.convert(x, exprCtx));
         RelationName relationName;

--- a/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -100,7 +100,7 @@ public class AlterTableRerouteAnalyzer {
                         ParamTypeHints paramTypeHints) {
             this.tableInfo = tableInfo;
             this.partitionProperties = partitionProperties;
-            this.exprCtx = new ExpressionAnalysisContext();
+            this.exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
             this.exprAnalyzer = new ExpressionAnalyzer(
                 txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
             this.exprAnalyzerWithFields = new ExpressionAnalyzer(

--- a/server/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -66,7 +67,7 @@ public class AnalyzedCopyFromReturnSummary extends AnalyzedCopyFrom implements A
     }
 
     @Override
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         throw new UnsupportedOperationException("Cannot use getField on " + getClass().getSimpleName());
     }
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -64,7 +65,7 @@ public class AnalyzedShowCreateTable implements AnalyzedStatement, AnalyzedRelat
     }
 
     @Override
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         throw new UnsupportedOperationException("Cannot use getField on " + getClass().getSimpleName());
     }
 

--- a/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -62,7 +62,7 @@ class CopyAnalyzer {
             txnCtx.sessionContext().sessionUser(),
             txnCtx.sessionContext().searchPath());
 
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
@@ -116,7 +116,7 @@ class CopyAnalyzer {
             null,
             tableRelation);
 
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
         var expressionAnalyzer = new ExpressionAnalyzer(
             txnCtx,
             nodeCtx,

--- a/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -74,7 +74,7 @@ class CreateAnalyzerStatementAnalyzer {
             this.charFilters = new HashMap<>();
             this.tokenFilters = new HashMap<>();
 
-            this.exprContext = new ExpressionAnalysisContext();
+            this.exprContext = new ExpressionAnalysisContext(transactionContext.sessionContext());
             this.exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
                 transactionContext,
                 nodeCtx,

--- a/server/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
@@ -48,7 +48,7 @@ public class CreateBlobTableAnalyzer {
                                            CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         CreateBlobTable<Symbol> createBlobTable = node.map(x -> exprAnalyzerWithoutFields.convert(x, exprCtx));
 

--- a/server/src/main/java/io/crate/analyze/CreateFunctionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateFunctionAnalyzer.java
@@ -49,7 +49,7 @@ public class CreateFunctionAnalyzer {
                                           SearchPath searchPath) {
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         CreateFunction<Symbol> createFunction = node.map(x -> exprAnalyzerWithoutFields.convert(x, exprCtx));
 

--- a/server/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
@@ -53,7 +53,7 @@ class CreateRepositoryAnalyzer {
 
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
         GenericProperties<Symbol> genericProperties = createRepository.properties()
             .map(p -> exprAnalyzerWithFieldsAsString.convert(p, exprCtx));
 

--- a/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -65,7 +65,7 @@ class CreateSnapshotAnalyzer {
         String snapshotName = createSnapshot.name().getSuffix();
         Snapshot snapshot = new Snapshot(repositoryName, new SnapshotId(snapshotName, UUID.randomUUID().toString()));
 
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(

--- a/server/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -63,7 +63,7 @@ public final class CreateTableStatementAnalyzer {
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
         Function<Expression, Symbol> exprMapper = y -> exprAnalyzerWithFieldsAsString.convert(y, exprCtx);
 
         // 1st phase, map and analyze everything EXCEPT:

--- a/server/src/main/java/io/crate/analyze/DecommissionNodeAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DecommissionNodeAnalyzer.java
@@ -49,7 +49,7 @@ public class DecommissionNodeAnalyzer {
             null);
 
         Symbol nodeIdOrName = expressionAnalyzer
-            .convert(decommissionNode.nodeIdOrName(), new ExpressionAnalysisContext());
+            .convert(decommissionNode.nodeIdOrName(), new ExpressionAnalysisContext(txnCtx.sessionContext()));
         return new AnalyzedDecommissionNode(nodeIdOrName);
     }
 }

--- a/server/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -72,12 +72,11 @@ final class DeleteAnalyzer {
             new FullQualifiedNameFieldProvider(
                 relationCtx.sources(),
                 relationCtx.parentSources(),
-                txnContext.sessionContext().searchPath().currentSchema()
-            ),
+                txnContext.sessionContext().searchPath().currentSchema()),
             new SubqueryAnalyzer(relationAnalyzer, new StatementAnalysisContext(typeHints, Operation.READ, txnContext))
         );
         Symbol query = Objects.requireNonNullElse(
-            expressionAnalyzer.generateQuerySymbol(delete.getWhere(), new ExpressionAnalysisContext()),
+            expressionAnalyzer.generateQuerySymbol(delete.getWhere(), new ExpressionAnalysisContext(txnContext.sessionContext())),
             Literal.BOOLEAN_TRUE
         );
         query = maybeAliasedStatement.maybeMapFields(query);

--- a/server/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
+++ b/server/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -75,7 +76,7 @@ public class ExplainAnalyzedStatement implements AnalyzedStatement, AnalyzedRela
     }
 
     @Override
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         throw new UnsupportedOperationException("Cannot use getField on " + getClass().getSimpleName());
     }
 

--- a/server/src/main/java/io/crate/analyze/KillAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/KillAnalyzer.java
@@ -47,7 +47,7 @@ public class KillAnalyzer {
                 txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
             jobId = exprAnalyzerWithoutFields.convert(
                 killStatement.jobId(),
-                new ExpressionAnalysisContext());
+                new ExpressionAnalysisContext(txnCtx.sessionContext()));
         } else {
             jobId = null;
         }

--- a/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -52,7 +52,7 @@ public class OptimizeTableAnalyzer {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
 
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
         OptimizeStatement<Symbol> analyzedStatement =
             statement.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
 

--- a/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -82,7 +82,7 @@ public class QueriedSelectRelation implements AnalyzedRelation {
         return from;
     }
 
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         Symbol match = null;
         for (Symbol output : outputs()) {
             ColumnIdent outputName = Symbols.pathFromSymbol(output);
@@ -97,7 +97,7 @@ public class QueriedSelectRelation implements AnalyzedRelation {
             // SELECT obj['x'] FROM (select...)
             // This is to optimize `obj['x']` to a reference with path instead of building a subscript function.
             for (AnalyzedRelation analyzedRelation : from) {
-                Symbol field = analyzedRelation.getField(column, operation);
+                Symbol field = analyzedRelation.getField(column, operation, errorOnUnknownObjectKey);
                 if (field != null) {
                     if (match != null) {
                         throw new AmbiguousColumnException(column, field);

--- a/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -51,7 +51,7 @@ class RefreshTableAnalyzer {
                                         CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.FIELDS_AS_LITERAL, null);
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         HashMap<Table<Symbol>, DocTableInfo> analyzedTables = new HashMap<>();
         for (var table : refreshStatement.tables()) {

--- a/server/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
@@ -50,7 +50,7 @@ public class ResetStatementAnalyzer {
             null
         );
 
-        var statement = node.map(x -> exprAnalyzer.convert(x, new ExpressionAnalysisContext()));
+        var statement = node.map(x -> exprAnalyzer.convert(x, new ExpressionAnalysisContext(txnCtx.sessionContext())));
         return new AnalyzedResetStatement(new HashSet<>(statement.columns()));
     }
 }

--- a/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
@@ -74,7 +74,7 @@ class RestoreSnapshotAnalyzer {
         var snapshotName = nameParts.get(1);
         repositoryService.failIfRepositoryDoesNotExist(repositoryName);
 
-        var exprCtx = new ExpressionAnalysisContext();
+        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
             txnCtx,
             nodeCtx,

--- a/server/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -49,7 +49,7 @@ class SetStatementAnalyzer {
             FieldProvider.FIELDS_AS_LITERAL,
             null
         );
-        SetStatement<Symbol> statement = node.map(x -> exprAnalyzer.convert(x, new ExpressionAnalysisContext()));
+        SetStatement<Symbol> statement = node.map(x -> exprAnalyzer.convert(x, new ExpressionAnalysisContext(txnCtx.sessionContext())));
 
         if (node.scope() == SetStatement.Scope.LICENSE) {
             if (node.assignments().size() != AnalyzedSetLicenseStatement.LICENSE_TOKEN_NUM) {

--- a/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
@@ -64,7 +64,7 @@ public final class SwapTableAnalyzer {
         } else {
             ExpressionAnalyzer exprAnalyzer = new ExpressionAnalyzer(
                 txnCtx, nodeCtx, typeHints, FieldProvider.UNSUPPORTED, null);
-            dropSource = exprAnalyzer.convert(dropSourceExpr, new ExpressionAnalysisContext());
+            dropSource = exprAnalyzer.convert(dropSourceExpr, new ExpressionAnalysisContext(txnCtx.sessionContext()));
         }
         SearchPath searchPath = txnCtx.sessionContext().searchPath();
         User user = txnCtx.sessionContext().sessionUser();

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -116,7 +116,7 @@ public final class UpdateAnalyzer {
             ),
             subqueryAnalyzer
         );
-        ExpressionAnalysisContext exprCtx = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         Map<Reference, Symbol> assignmentByTargetCol = getAssignments(
             update.assignments(), typeHints, txnCtx, table, normalizer, subqueryAnalyzer, sourceExprAnalyzer, exprCtx);

--- a/server/src/main/java/io/crate/analyze/UserAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UserAnalyzer.java
@@ -59,7 +59,7 @@ public class UserAnalyzer {
     private GenericProperties<Symbol> mappedProperties(GenericProperties<Expression> properties,
                                                        ParamTypeHints paramTypeHints,
                                                        CoordinatorTxnCtx txnContext) {
-        ExpressionAnalysisContext exprContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext exprContext = new ExpressionAnalysisContext(txnContext.sessionContext());
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             txnContext,
             nodeCtx,

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze.expressions;
 
+import io.crate.action.sql.SessionContext;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.Expression;
@@ -40,8 +41,13 @@ public class ExpressionAnalysisContext {
 
     private boolean hasAggregates;
     private boolean allowEagerNormalize = true;
+    private final boolean errorOnUnknownObjectKey;
 
     private Map<String, Window> windows = Map.of();
+
+    public ExpressionAnalysisContext(SessionContext sessionContext) {
+        this.errorOnUnknownObjectKey = sessionContext.errorOnUnknownObjectKey();
+    }
 
     void indicateAggregates() {
         hasAggregates = true;
@@ -65,6 +71,10 @@ public class ExpressionAnalysisContext {
 
     public Map<String, Window> windows() {
         return windows;
+    }
+
+    public boolean errorOnUnknownObjectKey() {
+        return errorOnUnknownObjectKey;
     }
 
     /**

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -156,7 +156,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.UndefinedType;
 
-
 /**
  * <p>This Analyzer can be used to convert Expression from the SQL AST into symbols.</p>
  * <p>
@@ -669,13 +668,16 @@ public class ExpressionAnalyzer {
 
                 Symbol name;
                 try {
-                    name = fieldProvider.resolveField(qualifiedName, parts, operation);
+                    name = fieldProvider.resolveField(qualifiedName, parts, operation, context.errorOnUnknownObjectKey());
                 } catch (ColumnUnknownException e) {
                     if (operation != Operation.READ) {
                         throw e;
                     }
                     try {
-                        Symbol base = fieldProvider.resolveField(qualifiedName, List.of(), operation);
+                        Symbol base = fieldProvider.resolveField(qualifiedName,
+                                                                 List.of(),
+                                                                 operation,
+                                                                 context.errorOnUnknownObjectKey());
                         if (base instanceof Reference) {
                             throw e;
                         }
@@ -840,9 +842,9 @@ public class ExpressionAnalyzer {
             if (base instanceof QualifiedNameReference) {
                 QualifiedName name = ((QualifiedNameReference) base).getName();
                 try {
-                    return fieldProvider.resolveField(name, path, operation);
+                    return fieldProvider.resolveField(name, path, operation, context.errorOnUnknownObjectKey());
                 } catch (ColumnUnknownException e) {
-                    var baseSymbol = fieldProvider.resolveField(name, List.of(), operation);
+                    var baseSymbol = fieldProvider.resolveField(name,List.of(), operation, context.errorOnUnknownObjectKey());
                     var subscriptFunction = SubscriptFunctions.tryCreateSubscript(baseSymbol, path);
                     if (subscriptFunction == null) {
                         throw e;
@@ -878,7 +880,7 @@ public class ExpressionAnalyzer {
                 return visitSubscriptExpression(subscript, context);
             }
 
-            return fieldProvider.resolveField(node.getName(), null, operation);
+            return fieldProvider.resolveField(node.getName(), null, operation, context.errorOnUnknownObjectKey());
         }
 
         @Override

--- a/server/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
+++ b/server/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
@@ -59,7 +59,10 @@ public class TableReferenceResolver implements FieldProvider<Reference> {
     }
 
     @Override
-    public Reference resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
+    public Reference resolveField(QualifiedName qualifiedName,
+                                  @Nullable List<String> path,
+                                  Operation operation,
+                                  boolean errorOnUnknownObjectKey) {
         ColumnIdent columnIdent = columnIdent(qualifiedName, path);
         for (Reference reference : tableReferences) {
             if (reference.column().equals(columnIdent)) {

--- a/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -130,7 +130,7 @@ public final class ValueNormalizer {
                 }
                 DynamicReference dynamicReference = null;
                 if (tableInfo instanceof DocTableInfo) {
-                    dynamicReference = ((DocTableInfo) tableInfo).getDynamic(nestedIdent, true);
+                    dynamicReference = ((DocTableInfo) tableInfo).getDynamic(nestedIdent, true, true);
                 }
                 if (dynamicReference == null) {
                     throw new ColumnUnknownException(nestedIdent.sqlFqn(), tableInfo.ident());

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -21,10 +21,12 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
@@ -85,7 +87,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
     }
 
     @Override
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         if (operation != Operation.READ) {
             throw new UnsupportedOperationException(operation + " is not supported on " + alias);
         }
@@ -109,9 +111,9 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
                 childColumnName = new ColumnIdent(childColumnName.name(), column.path());
             }
         }
-        Symbol field = relation.getField(childColumnName, operation);
-        if (field == null) {
-            return null;
+        Symbol field = relation.getField(childColumnName, operation, errorOnUnknownObjectKey);
+        if (field == null || field instanceof VoidReference) {
+            return field;
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field.valueType());
 

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
@@ -23,6 +23,8 @@ package io.crate.analyze.relations;
 
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
+import io.crate.exceptions.AmbiguousColumnException;
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
@@ -63,10 +65,20 @@ public interface AnalyzedRelation extends AnalyzedStatement {
      *  <ul>
      *  <li>They can support implicit column creation. In that case a `DynamicReference` is returned.</li>
      *  <li>They can return `Reference` symbols for subscripts; In that case on the `topLevel` part of the column appears in the `output`</li>
+     *  </ul>
      * </p>
      */
     @Nullable
-    Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException;
+    Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException;
+
+    /**
+     * Like {@link #getField(ColumnIdent, Operation, boolean)}
+     * This version sets `errorOnUnknownObjectKey` to true and is for cases where the `ColumnIdent` is derived from a `Symbol` that was previously already analyzed and retrieved via `getField`.
+     **/
+    @Nullable
+    default Symbol getField(ColumnIdent column, Operation operation) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
+        return getField(column, operation, true);
+    }
 
     RelationName relationName();
 

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -21,10 +21,12 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
@@ -85,10 +87,10 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
     }
 
     @Override
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
-        Symbol field = relation.getField(column, operation);
-        if (field == null) {
-            return null;
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
+        Symbol field = relation.getField(column, operation, errorOnUnknownObjectKey);
+        if (field == null || field instanceof VoidReference) {
+            return field;
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(name, column, field.valueType());
         int i = outputSymbols.indexOf(scopedSymbol);

--- a/server/src/main/java/io/crate/analyze/relations/ExcludedFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/ExcludedFieldProvider.java
@@ -48,13 +48,16 @@ public class ExcludedFieldProvider implements FieldProvider<Symbol> {
     }
 
     @Override
-    public Symbol resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
+    public Symbol resolveField(QualifiedName qualifiedName,
+                               @Nullable List<String> path,
+                               Operation operation,
+                               boolean errorOnUnknownObjectKey) {
         List<String> parts = qualifiedName.getParts();
         if (parts.size() == 2 && parts.get(0).equals("excluded")) {
             String colName = parts.get(1);
-            Symbol symbol = fieldProvider.resolveField(new QualifiedName(colName), path, operation);
+            Symbol symbol = fieldProvider.resolveField(new QualifiedName(colName), path, operation, errorOnUnknownObjectKey);
             return valuesResolver.allocateAndResolve(symbol);
         }
-        return fieldProvider.resolveField(qualifiedName, path, operation);
+        return fieldProvider.resolveField(qualifiedName, path, operation, errorOnUnknownObjectKey);
     }
 }

--- a/server/src/main/java/io/crate/analyze/relations/FieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/FieldProvider.java
@@ -32,13 +32,16 @@ import java.util.List;
 
 public interface FieldProvider<T extends Symbol> {
 
-    T resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation);
+    T resolveField(QualifiedName qualifiedName,
+                   @Nullable List<String> path,
+                   Operation operation,
+                   boolean errorOnUnknownObjectKey);
 
-    FieldProvider<?> UNSUPPORTED = (qualifiedName, path, operation) -> {
+    FieldProvider<?> UNSUPPORTED = (qualifiedName, path, operation, errorOnUnknownObjectKey) -> {
         throw new UnsupportedOperationException(
             "Columns cannot be used in this context. " +
             "Maybe you wanted to use a string literal which requires single quotes: '" + qualifiedName + "'");
     };
 
-    FieldProvider<Literal<?>> FIELDS_AS_LITERAL = ((qualifiedName, path, operation) -> Literal.of(new ColumnIdent(qualifiedName.toString(), path).fqn()));
+    FieldProvider<Literal<?>> FIELDS_AS_LITERAL = ((qualifiedName, path, operation, errorOnUnknownObjectKey) -> Literal.of(new ColumnIdent(qualifiedName.toString(), path).fqn()));
 }

--- a/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -45,7 +45,10 @@ public class NameFieldProvider implements FieldProvider<Symbol> {
     }
 
     @Override
-    public Symbol resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
+    public Symbol resolveField(QualifiedName qualifiedName,
+                               @Nullable List<String> path,
+                               Operation operation,
+                               boolean errorOnUnknownObjectKey) {
         List<String> parts = qualifiedName.getParts();
         ColumnIdent columnIdent = new ColumnIdent(parts.get(parts.size() - 1), path);
         if (parts.size() != 1) {
@@ -54,7 +57,7 @@ public class NameFieldProvider implements FieldProvider<Symbol> {
                 "A column must not have a schema or a table here.", qualifiedName));
         }
 
-        Symbol field = relation.getField(columnIdent, operation);
+        Symbol field = relation.getField(columnIdent, operation, errorOnUnknownObjectKey);
         if (field == null) {
             throw new ColumnUnknownException(columnIdent.sqlFqn(), relation.relationName());
         }

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.action.sql.SessionContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
@@ -47,10 +48,11 @@ public class RelationAnalysisContext {
     private List<JoinPair> joinPairs;
 
     RelationAnalysisContext(boolean aliasedRelation,
-                            ParentRelations parents) {
+                            ParentRelations parents,
+                            SessionContext sessionContext) {
         this.aliasedRelation = aliasedRelation;
         this.parents = parents;
-        this.expressionAnalysisContext = new ExpressionAnalysisContext();
+        this.expressionAnalysisContext = new ExpressionAnalysisContext(sessionContext);
     }
 
     boolean isAliasedRelation() {

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -675,7 +675,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             FieldProvider.UNSUPPORTED,
             new SubqueryAnalyzer(this, context)
         );
-        var expressionAnalysisContext = new ExpressionAnalysisContext();
+        var expressionAnalysisContext = new ExpressionAnalysisContext(context.sessionContext());
         // prevent normalization of the values array, otherwise the value literals are converted to an array literal
         // and a special per-value-literal casting logic won't be executed (e.g. FloatLiteral.cast())
         expressionAnalysisContext.allowEagerNormalize(false);

--- a/server/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -75,7 +75,7 @@ public class StatementAnalysisContext {
             parentRelations = parentCtx.parentSources().newLevel(parentCtx.sources());
         }
         RelationAnalysisContext currentRelationContext =
-            new RelationAnalysisContext(aliasedRelation, parentRelations);
+            new RelationAnalysisContext(aliasedRelation, parentRelations, sessionContext());
         lastRelationContextQueue.add(currentRelationContext);
         return currentRelationContext;
     }

--- a/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.exceptions.AmbiguousColumnException;
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.scalar.SubscriptFunctions;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.ScopedSymbol;
@@ -83,7 +85,7 @@ public class TableFunctionRelation implements AnalyzedRelation, FieldResolver {
     }
 
     @Override
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException {
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         for (Symbol output : outputs) {
             ColumnIdent outputColumn = Symbols.pathFromSymbol(output);
             if (column.equals(outputColumn)) {
@@ -124,7 +126,7 @@ public class TableFunctionRelation implements AnalyzedRelation, FieldResolver {
     @Nullable
     @Override
     public Symbol resolveField(ScopedSymbol field) {
-        return getField(field.column(), Operation.READ);
+        return getField(field.column(), Operation.READ, true);
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/relations/TableRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableRelation.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -41,7 +42,7 @@ public class TableRelation extends AbstractTableRelation<TableInfo> {
     }
 
     @Override
-    public Reference getField(ColumnIdent column, Operation operation) throws ColumnUnknownException {
+    public Reference getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         switch (operation) {
             case READ:
             case UPDATE:

--- a/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze.relations;
 
+import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -70,7 +71,7 @@ public class UnionSelect implements AnalyzedRelation {
     }
 
     @Override
-    public Symbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
+    public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         for (var output : outputs) {
             if (output.column().equals(column)) {
                 return output;

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -88,7 +88,8 @@ final class UpdateSourceGen {
         for (String updateColumn : updateColumns) {
             ColumnIdent column = ColumnIdent.fromPath(updateColumn);
             Reference ref = table.getReference(column);
-            this.updateColumns.add(ref == null ? table.getDynamic(column, true) : ref);
+            this.updateColumns.add(
+                ref == null ? table.getDynamic(column, true, txnCtx.sessionSettings().errorOnUnknownObjectKey()) : ref);
         }
         if (table.generatedColumns().isEmpty()) {
             generatedColumns = GeneratedColumns.empty();

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -212,7 +212,8 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
 
     private Symbol asSymbol(String expression) {
         try {
-            return expressionAnalyzer.convert(SqlParser.createExpression(expression), new ExpressionAnalysisContext());
+            return expressionAnalyzer.convert(SqlParser.createExpression(expression),
+                                              new ExpressionAnalysisContext(systemTransactionCtx.sessionContext()));
         } catch (Throwable t) {
             throw new IllegalArgumentException("Invalid filter expression: " + expression + ": " + t.getMessage(), t);
         }

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -134,7 +134,7 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
             if (mapValue == null) {
                 return null;
             }
-            mapValue = SubscriptFunction.lookupByName(mapValue, args[i].value());
+            mapValue = SubscriptFunction.lookupByName(mapValue, args[i].value(), txnCtx.sessionSettings().errorOnUnknownObjectKey());
         }
         return mapValue;
     }

--- a/server/src/main/java/io/crate/expression/symbol/SymbolType.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolType.java
@@ -57,7 +57,8 @@ public enum SymbolType {
     ALIAS(AliasSymbol::new),
     FETCH_STUB(in -> {
         throw new UnsupportedEncodingException("FetchStub is not streamable");
-    });
+    }),
+    VOID_REFERENCE(VoidReference::new);
 
     public static final List<SymbolType> VALUES = List.of(values());
 

--- a/server/src/main/java/io/crate/expression/symbol/VoidReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/VoidReference.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.symbol;
+
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.sql.tree.ColumnPolicy;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * A reference to a column which does not exist. This is primarily used for object columns where lookups like `some_column['nested_column']` are allowed if the session `error_on_unknown_object_key` setting is set to false.
+ **/
+public class VoidReference extends DynamicReference {
+
+    public VoidReference(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public VoidReference(ReferenceIdent ident,
+                         RowGranularity granularity,
+                         int position) {
+        super(ident, granularity, position);
+    }
+
+    public VoidReference(ReferenceIdent ident,
+                         RowGranularity granularity,
+                         ColumnPolicy columnPolicy,
+                         int position) {
+        super(ident, granularity, columnPolicy, position);
+    }
+
+    @Override
+    public SymbolType symbolType() {
+        return SymbolType.VOID_REFERENCE;
+    }
+}

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -301,14 +301,15 @@ public class UserDefinedFunctionService {
             ).build();
 
             TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(tableInfo.columns(), tableInfo.ident());
+            CoordinatorTxnCtx coordinatorTxnCtx = CoordinatorTxnCtx.systemTransactionContext();
             ExpressionAnalyzer exprAnalyzer = new ExpressionAnalyzer(
-                CoordinatorTxnCtx.systemTransactionContext(), nodeCtxWithRemovedFunction, ParamTypeHints.EMPTY, tableReferenceResolver, null);
+                coordinatorTxnCtx, nodeCtxWithRemovedFunction, ParamTypeHints.EMPTY, tableReferenceResolver, null);
             for (var ref : tableInfo.columns()) {
                 if (ref instanceof GeneratedReference) {
                     var genRef = (GeneratedReference) ref;
                     Expression expression = SqlParser.createExpression(genRef.formattedGeneratedExpression());
                     try {
-                        exprAnalyzer.convert(expression, new ExpressionAnalysisContext());
+                        exprAnalyzer.convert(expression, new ExpressionAnalysisContext(coordinatorTxnCtx.sessionContext()));
                     } catch (UnsupportedOperationException e) {
                         throw new IllegalArgumentException(
                             "Cannot drop function '" + functionName + "', it is still in use by '" +

--- a/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
+++ b/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
@@ -63,7 +63,8 @@ public final class CoordinatorTxnCtx implements TransactionContext {
         return new SessionSettings(sessionContext.sessionUser().name(),
                                    sessionContext.searchPath(),
                                    sessionContext.isHashJoinEnabled(),
-                                   sessionContext.excludedOptimizerRules());
+                                   sessionContext.excludedOptimizerRules(),
+                                   sessionContext.errorOnUnknownObjectKey());
     }
 
     public SessionContext sessionContext() {

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -263,7 +263,9 @@ public class DocIndexMetadata {
         Symbol defaultExpression = null;
         if (formattedDefaultExpression != null) {
             Expression expression = SqlParser.createExpression(formattedDefaultExpression);
-            defaultExpression = expressionAnalyzer.convert(expression, new ExpressionAnalysisContext());
+            defaultExpression = this.expressionAnalyzer.convert(
+                expression,
+                new ExpressionAnalysisContext(CoordinatorTxnCtx.systemTransactionContext().sessionContext()));
         }
         return new Reference(
             refIdent(column),
@@ -617,9 +619,10 @@ public class DocIndexMetadata {
 
         Collection<Reference> references = this.references.values();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references, ident);
+        CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         ExpressionAnalyzer exprAnalyzer = new ExpressionAnalyzer(
-            CoordinatorTxnCtx.systemTransactionContext(), nodeCtx, ParamTypeHints.EMPTY, tableReferenceResolver, null);
-        ExpressionAnalysisContext analysisCtx = new ExpressionAnalysisContext();
+            txnCtx, nodeCtx, ParamTypeHints.EMPTY, tableReferenceResolver, null);
+        ExpressionAnalysisContext analysisCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
 
         ArrayList<CheckConstraint<Symbol>> checkConstraintsBuilder = null;
         Map<String, Object> metaMap = Maps.get(mappingMap, "_meta");

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -45,6 +45,7 @@ public class SessionSettingRegistry {
     static final String MAX_INDEX_KEYS = "max_index_keys";
     private static final String SERVER_VERSION_NUM = "server_version_num";
     private static final String SERVER_VERSION = "server_version";
+    static final String ERROR_ON_UNKNOWN_OBJECT_KEY = "error_on_unknown_object_key";
     private final Map<String, SessionSetting<?>> settings;
 
     @Inject
@@ -113,7 +114,22 @@ public class SessionSettingRegistry {
                      "Reports the emulated PostgreSQL version number",
                      DataTypes.STRING
                  )
-            );
+            )
+            .put(ERROR_ON_UNKNOWN_OBJECT_KEY,
+                 new SessionSetting<>(
+                     ERROR_ON_UNKNOWN_OBJECT_KEY,
+                     objects -> {
+                         if (objects.length != 1) {
+                             throw new IllegalArgumentException(ERROR_ON_UNKNOWN_OBJECT_KEY + " should have only one argument.");
+                         }
+                     },
+                     objects -> DataTypes.BOOLEAN.implicitCast(objects[0]),
+                     SessionContext::setErrorOnUnknownObjectKey,
+                     s -> Boolean.toString(s.errorOnUnknownObjectKey()),
+                     () -> String.valueOf(true),
+                     "Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.",
+                     DataTypes.BOOLEAN));
+
         for (var providers : sessionSettingProviders) {
             for (var setting : providers.sessionSettings()) {
                 builder.put(setting.name(), setting);

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -88,7 +88,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws Exception {
         paramTypeHints = ParamTypeHints.EMPTY;
-        context = new ExpressionAnalysisContext();
+        context = new ExpressionAnalysisContext(SessionContext.systemSessionContext());
         executor = SQLExecutor.builder(clusterService)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
@@ -134,7 +134,9 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             coordinatorTxnCtx,
             expressions.nodeCtx,
             paramTypeHints,
-            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, sessionContext.searchPath().currentSchema()),
+            new FullQualifiedNameFieldProvider(sources,
+                                               ParentRelations.NO_PARENTS,
+                                               sessionContext.searchPath().currentSchema()),
             null
         );
         Function andFunction = (Function) expressionAnalyzer.convert(
@@ -173,28 +175,29 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNonDeterministicFunctionsAlwaysNew() throws Exception {
-        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext();
+        CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext(txnCtx.sessionContext());
         String functionName = CoalesceFunction.NAME;
         Symbol fn1 = ExpressionAnalyzer.allocateFunction(
             functionName,
             List.of(Literal.BOOLEAN_FALSE),
             null,
             localContext,
-            CoordinatorTxnCtx.systemTransactionContext(),
+            txnCtx,
             expressions.nodeCtx);
             Symbol fn2 = ExpressionAnalyzer.allocateFunction(
             functionName,
             List.of(Literal.BOOLEAN_FALSE),
             null,
             localContext,
-            CoordinatorTxnCtx.systemTransactionContext(),
+            txnCtx,
             expressions.nodeCtx);
         Symbol fn3 = ExpressionAnalyzer.allocateFunction(
             functionName,
             List.of(Literal.BOOLEAN_TRUE),
             null,
             localContext,
-            CoordinatorTxnCtx.systemTransactionContext(),
+            txnCtx,
             expressions.nodeCtx);
 
         // different instances

--- a/server/src/test/java/io/crate/analyze/relations/ExcludedFieldProviderTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/ExcludedFieldProviderTest.java
@@ -37,13 +37,15 @@ import static org.junit.Assert.assertThat;
 
 public class ExcludedFieldProviderTest {
 
+    private static final boolean DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY = true;
+
     @Test
     public void testResolveFieldsAndValues() {
         QualifiedName normalField1 = QualifiedName.of("field1");
         QualifiedName normalField2 = QualifiedName.of("normal", "field2");
         QualifiedName excludedName = QualifiedName.of("excluded", "field3");
 
-        FieldProvider<?> fieldProvider = (qualifiedName, path, operation) ->
+        FieldProvider<?> fieldProvider = (qualifiedName, path, operation, errorOnUnknownObjectKey) ->
             new ScopedSymbol(
                 new RelationName("doc", "dummy"),
                 new ColumnIdent(qualifiedName.toString()),
@@ -56,15 +58,15 @@ public class ExcludedFieldProviderTest {
         ExcludedFieldProvider excludedFieldProvider = new ExcludedFieldProvider(fieldProvider, valuesResolver);
 
         assertThat(
-            excludedFieldProvider.resolveField(normalField1, null, Operation.READ),
+            excludedFieldProvider.resolveField(normalField1, null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY),
             isField(normalField1.toString()));
 
         assertThat(
-            excludedFieldProvider.resolveField(normalField2, null, Operation.READ),
+            excludedFieldProvider.resolveField(normalField2, null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY),
             isField(normalField2.toString()));
 
         assertThat(
-            excludedFieldProvider.resolveField(excludedName, null, Operation.READ),
+            excludedFieldProvider.resolveField(excludedName, null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY),
             isLiteral(42));
     }
 

--- a/server/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
@@ -45,6 +45,8 @@ public class FieldProviderTest extends ESTestCase {
 
     private Map<QualifiedName, AnalyzedRelation> dummySources = Map.of(new QualifiedName("dummy"), dummyRelation);
 
+    private boolean DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY = true;
+
     private static QualifiedName newQN(String dottedName) {
         return new QualifiedName(Arrays.asList(dottedName.split("\\.")));
     }
@@ -67,7 +69,7 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expectMessage("Table with more than 2 QualifiedName parts is not supported. Only <schema>.<tableName> works.");
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("too.many.parts"), relation));
-        resolver.resolveField(newQN("name"), null, Operation.READ);
+        resolver.resolveField(newQN("name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -75,7 +77,7 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'invalid.table' unknown");
         FieldProvider<Symbol> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(newQN("invalid.table.name"), null, Operation.READ);
+        resolver.resolveField(newQN("invalid.table.name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -83,7 +85,7 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'dummy.invalid' unknown");
         FieldProvider<Symbol> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(newQN("dummy.invalid.name"), null, Operation.READ);
+        resolver.resolveField(newQN("dummy.invalid.name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -92,14 +94,14 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expectMessage("Relation 'sys.nodes' unknown");
         FieldProvider<Symbol> resolver = newFQFieldProvider(dummySources);
 
-        resolver.resolveField(newQN("sys.nodes.name"), null, Operation.READ);
+        resolver.resolveField(newQN("sys.nodes.name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
     public void testRegularColumnUnknown() throws Exception {
         expectedException.expect(ColumnUnknownException.class);
         FieldProvider<Symbol> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(newQN("age"), null, Operation.READ);
+        resolver.resolveField(newQN("age"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -108,7 +110,7 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expectMessage("Column age unknown");
         AnalyzedRelation barT = new DummyRelation("name");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("bar.t"), barT));
-        resolver.resolveField(newQN("t.age"), null, Operation.READ);
+        resolver.resolveField(newQN("t.age"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -123,13 +125,13 @@ public class FieldProviderTest extends ESTestCase {
             newQN("foo.t"), fooT,
             newQN("foo.a"), fooA,
             newQN("custom.t"), customT));
-        Symbol field = resolver.resolveField(newQN("foo.t.name"), null, Operation.READ);
+        Symbol field = resolver.resolveField(newQN("foo.t.name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("name", fooT.relationName()));
 
-        Symbol tags = resolver.resolveField(newQN("tags"), null, Operation.READ);
+        Symbol tags = resolver.resolveField(newQN("tags"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(tags, isField("tags", customT.relationName()));
 
-        field = resolver.resolveField(newQN("a.name"), null, Operation.READ);
+        field = resolver.resolveField(newQN("a.name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("name", fooA.relationName()));
     }
 
@@ -139,7 +141,7 @@ public class FieldProviderTest extends ESTestCase {
         AnalyzedRelation relation = new DummyRelation(new RelationName("doc", "t"), "name");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(
             new QualifiedName(Arrays.asList("t")), relation));
-        Symbol field = resolver.resolveField(newQN("t.name"), null, Operation.READ);
+        Symbol field = resolver.resolveField(newQN("t.name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("name", relation.relationName()));
     }
 
@@ -148,7 +150,7 @@ public class FieldProviderTest extends ESTestCase {
         // select name from t
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("doc.t"), relation));
-        Symbol field = resolver.resolveField(newQN("name"), null, Operation.READ);
+        Symbol field = resolver.resolveField(newQN("name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("name", relation.relationName()));
     }
 
@@ -158,7 +160,7 @@ public class FieldProviderTest extends ESTestCase {
 
         AnalyzedRelation relation = new DummyRelation(new RelationName("doc", "t"), "name");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("doc.t"), relation));
-        Symbol field = resolver.resolveField(newQN("doc.t.name"), null, Operation.INSERT);
+        Symbol field = resolver.resolveField(newQN("doc.t.name"), null, Operation.INSERT, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("name", relation.relationName()));
     }
 
@@ -166,7 +168,7 @@ public class FieldProviderTest extends ESTestCase {
     public void testTooManyParts() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         FieldProvider<Symbol> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b", "c", "d")), null, Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b", "c", "d")), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -174,7 +176,7 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Column reference \"a.b\" has too many parts. A column must not have a schema or a table here.");
         FieldProvider<Symbol> resolver = new NameFieldProvider(dummyRelation);
-        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b")), null, Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b")), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -188,7 +190,7 @@ public class FieldProviderTest extends ESTestCase {
                 new QualifiedName(Arrays.asList("custom", "t")), new DummyRelation("name"),
                 new QualifiedName(Arrays.asList("doc", "t")), new DummyRelation("name"))
         );
-        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), null, Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -199,7 +201,7 @@ public class FieldProviderTest extends ESTestCase {
                 new QualifiedName(Arrays.asList("custom", "t")), new DummyRelation("address"),
                 new QualifiedName(Arrays.asList("doc", "t")), new DummyRelation("name"))
         );
-        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), null, Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -207,7 +209,7 @@ public class FieldProviderTest extends ESTestCase {
         // select name from doc.t
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Symbol> resolver = new NameFieldProvider(relation);
-        Symbol field = resolver.resolveField(new QualifiedName(Arrays.asList("name")), null, Operation.READ);
+        Symbol field = resolver.resolveField(new QualifiedName(Arrays.asList("name")), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("name", relation.relationName()));
     }
 
@@ -217,7 +219,7 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expectMessage("Column unknown unknown");
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("doc.t"), relation));
-        resolver.resolveField(new QualifiedName(Arrays.asList("unknown")), null, Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("unknown")), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -225,7 +227,7 @@ public class FieldProviderTest extends ESTestCase {
         AnalyzedRelation barT = new DummyRelation(new RelationName("Foo", "Bar"), "\"Name\"");
 
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("\"Foo\".\"Bar\""), barT));
-        Symbol field = resolver.resolveField(newQN("\"Foo\".\"Bar\".\"Name\""), null, Operation.READ);
+        Symbol field = resolver.resolveField(newQN("\"Foo\".\"Bar\".\"Name\""), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("\"Name\"", barT.relationName()));
     }
 
@@ -235,7 +237,7 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expectMessage("Column name unknown");
         AnalyzedRelation barT = new DummyRelation("\"Name\"");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("bar"), barT));
-        resolver.resolveField(newQN("bar.name"), null, Operation.READ);
+        resolver.resolveField(newQN("bar.name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 
     @Test
@@ -243,7 +245,7 @@ public class FieldProviderTest extends ESTestCase {
         AnalyzedRelation barT = new DummyRelation(new RelationName("doc", "Bar"), "name");
 
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("\"Bar\""), barT));
-        Symbol field = resolver.resolveField(newQN("\"Bar\".name"), null, Operation.READ);
+        Symbol field = resolver.resolveField(newQN("\"Bar\".name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
         assertThat(field, isField("name", barT.relationName()));
     }
 
@@ -253,6 +255,6 @@ public class FieldProviderTest extends ESTestCase {
         expectedException.expectMessage("Relation 'doc.\"Bar\"' unknown");
         AnalyzedRelation barT = new DummyRelation("name");
         FieldProvider<Symbol> resolver = newFQFieldProvider(Map.of(newQN("bar"), barT));
-        resolver.resolveField(newQN("\"Bar\".name"), null, Operation.READ);
+        resolver.resolveField(newQN("\"Bar\".name"), null, Operation.READ, DEFAULT_ERROR_ON_UNKNOWN_OBJECT_KEY);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -21,9 +21,11 @@
 
 package io.crate.expression.scalar;
 
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
+import io.crate.testing.Asserts;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -73,5 +75,17 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
         assertNormalize("subscript(['Youri', 'Ruben'], 'foo')", isLiteral("Ruben"));
+    }
+
+    @Test
+    public void testLookupByNameWithUnknownName() throws Exception {
+        sqlExpressions.setErrorOnUnknownObjectKey(true);
+        Asserts.assertThrowsMatches(
+            () -> assertEvaluate("{}['y']", null),
+            ColumnUnknownException.class,
+            "The object `{}` does not contain the key `y`"
+        );
+        sqlExpressions.setErrorOnUnknownObjectKey(false);
+        assertEvaluate("{}['y']", null);
     }
 }

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -29,6 +29,7 @@ import io.crate.expression.symbol.FetchReference;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
@@ -175,6 +176,15 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDynamicReference() throws Exception {
         Reference r = new DynamicReference(
+            new ReferenceIdent(new RelationName("schema", "table"), new ColumnIdent("column", Arrays.asList("path", "nested"))),
+            RowGranularity.DOC,
+            0);
+        assertPrint(r, "schema.\"table\".\"column\"['path']['nested']");
+    }
+
+    @Test
+    public void testVoidReference() throws Exception {
+        Reference r = new VoidReference(
             new ReferenceIdent(new RelationName("schema", "table"), new ColumnIdent("column", Arrays.asList("path", "nested"))),
             RowGranularity.DOC,
             0);

--- a/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractTableFunctionsTest extends ESTestCase {
 
         DocTableRelation relation = mock(DocTableRelation.class);
         RelationName relationName = new RelationName(null, "t");
-        when(relation.getField(any(ColumnIdent.class), any(Operation.class)))
+        when(relation.getField(any(ColumnIdent.class), any(Operation.class), any(Boolean.class)))
             .thenReturn(new Reference(
                 new ReferenceIdent(relationName, "name"),
                 RowGranularity.NODE,

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -107,6 +107,7 @@ public class PgCatalogITest extends SQLIntegrationTestCase {
         execute("select name, setting, short_desc, min_val, max_val from pg_catalog.pg_settings");
         assertThat(printedTable(response.rows()), is(
             "enable_hashjoin| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL\n" +
+            "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.| NULL| NULL\n" +
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL\n" +
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL\n" +
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL\n" +

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -399,6 +399,7 @@ public class ShowIntegrationTest extends SQLIntegrationTestCase {
         execute("show all");
         assertThat(printedTable(response.rows()), is(
             "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.\n" +
+            "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.\n" +
             "max_index_keys| 32| Shows the maximum number of index keys.\n" +
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.\n" +
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.\n" +

--- a/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -66,6 +66,12 @@ public class SessionSettingRegistryTest {
         assertBooleanNonEmptySetting(sessionContext::isHashJoinEnabled, setting, true);
     }
 
+    @Test
+    public void testSettingErrorOnUnknownObjectKey() {
+        SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.ERROR_ON_UNKNOWN_OBJECT_KEY);
+        assertBooleanNonEmptySetting(sessionContext::errorOnUnknownObjectKey, setting, true);
+    }
+
     private void assertBooleanNonEmptySetting(Supplier<Boolean> contextBooleanSupplier,
                                               SessionSetting<?> sessionSetting,
                                               boolean defaultValue) {

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -103,7 +103,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         var relation = new DocTableRelation(tableInfo);
         var alias = new AliasedAnalyzedRelation(relation, new RelationName(null, "t1"));
         var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
-        Symbol t1X = alias.getField(x.column(), Operation.READ);
+        Symbol t1X = alias.getField(x.column(), Operation.READ, true);
         assertThat(t1X, Matchers.notNullValue());
         var rename = new Rename(List.of(t1X), alias.relationName(), alias, collect);
 

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
@@ -64,7 +64,8 @@ public class OptimizerRuleSessionSettingProviderTest {
         var mergefilterSettings = new SessionSettings("user",
                                                       SearchPath.createSearchPathFrom("dummySchema"),
                                                       true,
-                                                      Set.of(MergeFilters.class));
+                                                      Set.of(MergeFilters.class),
+                                                      true);
 
         assertThat(sessionSetting.getValue(mergefilterSettings), is("false"));
 

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
@@ -40,7 +40,8 @@ public class OptimizerTest {
         SessionSettings sessionSettings = new SessionSettings("User",
                                                               SearchPath.pathWithPGCatalogAndDoc(),
                                                               true,
-                                                              Set.of(MergeFilters.class));
+                                                              Set.of(MergeFilters.class),
+                                                              true);
 
         List<Rule<?>> rules = Optimizer.removeExcludedRules(List.of(new MergeFilters()),
                                                             sessionSettings.excludedOptimizerRules());

--- a/server/src/testFixtures/java/io/crate/testing/DummyRelation.java
+++ b/server/src/testFixtures/java/io/crate/testing/DummyRelation.java
@@ -23,6 +23,8 @@ package io.crate.testing;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.exceptions.AmbiguousColumnException;
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -62,7 +64,7 @@ public class DummyRelation implements AnalyzedRelation {
     }
 
     @Override
-    public ScopedSymbol getField(ColumnIdent column, Operation operation) throws UnsupportedOperationException {
+    public ScopedSymbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         if (columnReferences.contains(column)) {
             return new ScopedSymbol(name, column, DataTypes.STRING);
         }

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -742,8 +742,9 @@ public class SQLExecutor {
                 new StatementAnalysisContext(ParamTypeHints.EMPTY, Operation.READ, coordinatorTxnCtx)
             )
         );
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(coordinatorTxnCtx.sessionContext());
         return expressionAnalyzer.convert(
-            SqlParser.createExpression(expression), new ExpressionAnalysisContext());
+            SqlParser.createExpression(expression), expressionAnalysisContext);
     }
 
     public <T> T plan(String statement, UUID jobId, int fetchSize) {

--- a/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
+++ b/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
@@ -88,7 +88,7 @@ public class SqlExpressions {
             )
         );
         normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.DOC, null, fieldResolver);
-        expressionAnalysisCtx = new ExpressionAnalysisContext();
+        expressionAnalysisCtx = new ExpressionAnalysisContext(coordinatorTxnCtx.sessionContext());
     }
 
     public Symbol asSymbol(String expression) {
@@ -109,5 +109,9 @@ public class SqlExpressions {
 
     public void setSearchPath(String... schemas) {
         this.coordinatorTxnCtx.sessionContext().setSearchPath(schemas);
+    }
+
+    public void setErrorOnUnknownObjectKey(boolean errorOnUnknownObjectKey) {
+        this.coordinatorTxnCtx.sessionContext().setErrorOnUnknownObjectKey(errorOnUnknownObjectKey);
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SymbolMatchers.java
+++ b/server/src/testFixtures/java/io/crate/testing/SymbolMatchers.java
@@ -32,6 +32,7 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -152,6 +153,13 @@ public class SymbolMatchers {
             return allOf(Matchers.instanceOf(Reference.class), fm);
         }
         return allOf(Matchers.instanceOf(Reference.class), hasDataType(dataType), fm);
+    }
+
+    public static Matcher<Symbol> isVoidReference(String expectedName) {
+        return allOf(
+            Matchers.instanceOf(VoidReference.class),
+            isReference(expectedName)
+        );
     }
 
     @SafeVarargs


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Since CrateDB supports dynamic objects, it would be useful in certain scenarios to support querying unknown object keys.
There are 3 related issues (#6553, #9383 and #11575) which should be handled by this PR.

After discussing the suggested options such as a table option, ? operator as in Postgres, and more, it has been decided to go with an additional [session setting](https://crate.io/docs/crate/reference/en/4.6/config/session.html) to control the behaviour.

```
ex)
cr> create table tbl (obj object);                                                                                                                            
CREATE OK, 1 row affected  (0.563 sec)

cr> select obj['unknown'] from tbl;                                                                                                                           
ColumnUnknownException[Column obj['unknown'] unknown]

cr> set error_on_unknown_object_key = false;                                                                                                                  
SET OK, 0 rows affected  (0.001 sec)

cr> select obj['unknown'] from tbl;                                                                                                                           
+----------------+
| obj['unknown'] |  ----> selected name is preserved (but not always)
+----------------+
+----------------+
SELECT 0 rows in set (0.051 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
