### PR TITLE
Do not require privileges on SYS schema for show transaction_isolation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,6 +67,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused the ``SHOW TRANSACTION_ISOLATION`` statement to
+  require privileges for the ``sys`` schema.
+
 - Fixed an issue in the execution plan generation for ``SELECT COUNT(*) FROM
   ...`` statements with predicates like ``'a' in ANY(varchar_array_column)``.
   Such predicates resulted in a cast on the column (``'a' in

--- a/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -69,7 +69,7 @@ class ShowStatementAnalyzer {
          * Rewrite
          *     SHOW TRANSACTION ISOLATION LEVEL
          * To
-         *      select 'read uncommitted' from sys.cluster
+         *      select 'read uncommitted'
          *
          * In order to return a single row with 'read uncommitted`.
          *
@@ -79,14 +79,14 @@ class ShowStatementAnalyzer {
          *
          * See https://www.postgresql.org/docs/9.5/static/transaction-iso.html
          */
-        return (Query) SqlParser.createStatement("select 'read uncommitted' as transaction_isolation from sys.cluster");
+        return (Query) SqlParser.createStatement("select 'read uncommitted' as transaction_isolation");
     }
 
     AnalyzedStatement analyzeShowTransaction(Analysis analysis) {
         return unboundAnalyze(rewriteShowTransaction(), analysis);
     }
 
-    public AnalyzedStatement analyzeShowCreateTable(Table table, Analysis analysis) {
+    public AnalyzedStatement analyzeShowCreateTable(Table<?> table, Analysis analysis) {
         DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
             table.getName(),
             Operation.SHOW_CREATE,

--- a/server/src/test/java/io/crate/analyze/ShowStatementsAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ShowStatementsAnalyzerTest.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.metadata.sys.SysClusterTableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -34,6 +35,7 @@ import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 
@@ -189,11 +191,11 @@ public class ShowStatementsAnalyzerTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void testRewriteOfTransactionIsolation() {
         QueriedSelectRelation stmt = analyze("show transaction isolation level");
-        assertThat(stmt.from(), contains(isSystemTable(SysClusterTableInfo.IDENT)));
+        assertThat(stmt.from(), contains(instanceOf(TableFunctionRelation.class)));
         assertThat(stmt.outputs(), contains(isAlias("transaction_isolation", isLiteral("read uncommitted"))));
 
         stmt = analyze("show transaction_isolation");
-        assertThat(stmt.from(), contains(isSystemTable(SysClusterTableInfo.IDENT)));
+        assertThat(stmt.from(), contains(instanceOf(TableFunctionRelation.class)));
         assertThat(stmt.outputs(), contains(isAlias("transaction_isolation", isLiteral("read uncommitted"))));
     }
 }

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -43,6 +43,7 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -609,5 +610,11 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_optimize_table_is_allowed_with_ddl_privileges_on_table() {
         analyze("optimize table users");
         assertAskedForTable(Privilege.Type.DDL, "doc.users");
+    }
+
+    @Test
+    public void test_show_transaction_isolation_does_not_require_privileges() throws Exception {
+        analyze("show transaction_isolation");
+        assertThat(validationCallArguments, Matchers.empty());
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11638


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
