### PR TITLE
Resolves #5463

### DIFF
--- a/docs/general/builtins/comparison-operators.rst
+++ b/docs/general/builtins/comparison-operators.rst
@@ -68,6 +68,26 @@ When comparing dates, `ISO date formats`_ can be used::
     +--------------+----------+
     SELECT 2 rows in set (... sec)
 
+For integer :ref:`data types <data-types>`, in addition to basic operators,
+the following operators can be used:
+
+========  ==========================
+Operator  Description
+========  ==========================
+``&``     Bitwise AND
+========  ==========================
+
+Bitwise AND example::
+
+    cr> select * from bitwise where type_value & 3;
+    +-------------+------------+
+    | type_name   | type_value |
+    +-------------+------------+
+    | MSG_ERROR   |          1 |
+    | MSG_WARNING |          2 |
+    +-------------+------------+
+    SELECT 2 rows in set (0.003 sec)
+
 .. TIP::
 
     Comparison operators are commonly used to filter rows (e.g., in the

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -343,7 +343,7 @@ subscriptSafe
     ;
 
 cmpOp
-    : EQ | NEQ | LT | LTE | GT | GTE | LLT | REGEX_MATCH | REGEX_NO_MATCH | REGEX_MATCH_CI | REGEX_NO_MATCH_CI
+    : EQ | NEQ | LT | LTE | GT | GTE | LLT | BITWISE_AND | REGEX_MATCH | REGEX_NO_MATCH | REGEX_MATCH_CI | REGEX_NO_MATCH_CI
     ;
 
 setCmpQuantifier
@@ -968,6 +968,7 @@ LTE : '<=';
 GT  : '>';
 GTE : '>=';
 LLT  : '<<';
+BITWISE_AND: '&';
 REGEX_MATCH: '~';
 REGEX_NO_MATCH: '!~';
 REGEX_MATCH_CI: '~*';

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -2063,6 +2063,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
                 return ComparisonExpression.Type.GREATER_THAN_OR_EQUAL;
             case SqlBaseLexer.LLT:
                 return ComparisonExpression.Type.CONTAINED_WITHIN;
+            case SqlBaseLexer.BITWISE_AND:
+                return ComparisonExpression.Type.BITWISE_AND;
             case SqlBaseLexer.REGEX_MATCH:
                 return ComparisonExpression.Type.REGEX_MATCH;
             case SqlBaseLexer.REGEX_NO_MATCH:

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ComparisonExpression.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ComparisonExpression.java
@@ -35,6 +35,7 @@ public class ComparisonExpression extends Expression {
         GREATER_THAN(">"),
         GREATER_THAN_OR_EQUAL(">="),
         CONTAINED_WITHIN("<<"),
+        BITWISE_AND("&"),
         IS_DISTINCT_FROM("IS DISTINCT FROM"),
         REGEX_MATCH("~"),
         REGEX_NO_MATCH("!~"),

--- a/server/src/main/java/io/crate/expression/operator/BitwiseAndOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/BitwiseAndOperator.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.operator;
+
+import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public final class BitwiseAndOperator extends Operator<Object> {
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    public static final String NAME = "op_&";
+
+    public BitwiseAndOperator(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    public static void register(OperatorModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                Operator.RETURN_TYPE.getTypeSignature()
+            ), BitwiseAndOperator::new
+        );
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.LONG.getTypeSignature(),
+                DataTypes.LONG.getTypeSignature(),
+                Operator.RETURN_TYPE.getTypeSignature()
+            ), BitwiseAndOperator::new
+        );
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.SHORT.getTypeSignature(),
+                DataTypes.SHORT.getTypeSignature(),
+                Operator.RETURN_TYPE.getTypeSignature()
+            ), BitwiseAndOperator::new
+        );
+    }
+
+    @Override
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
+        assert args != null : "args must not be null";
+        assert args.length == 2 : "number of args must be 2";
+        assert args[0] != null && args[1] != null : "1st and 2nd argument must not be null";
+
+        Object left = args[0].value();
+        Object right = args[1].value();
+        if (left == null || right == null) {
+            return null;
+        }
+
+        assert (left.getClass().equals(right.getClass())) : "left and right must have the same type for comparison";
+
+        long leftValue, rightValue;
+        if (left instanceof Long) {
+            leftValue = (Long) left;
+            rightValue = (Long) right;
+        } else if (left instanceof Integer) {
+            leftValue = ((Integer) left).longValue();
+            rightValue = ((Integer) right).longValue();
+        } else if (left instanceof Short) {
+            leftValue = ((Short) left).longValue();
+            rightValue = ((Short) right).longValue();
+        } else {
+            return null;
+        }
+
+        return (leftValue & rightValue) == leftValue;
+    }
+}

--- a/server/src/test/java/io/crate/expression/operator/BitwiseAndOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/BitwiseAndOperatorTest.java
@@ -21,28 +21,27 @@
 
 package io.crate.expression.operator;
 
-import io.crate.expression.AbstractFunctionModule;
-import io.crate.expression.operator.any.AnyOperators;
-import io.crate.metadata.FunctionImplementation;
+import io.crate.expression.scalar.ScalarTestCase;
+import org.junit.Test;
 
-public class OperatorModule extends AbstractFunctionModule<FunctionImplementation> {
+import static io.crate.testing.SymbolMatchers.isFunction;
+import static io.crate.testing.SymbolMatchers.isLiteral;
 
-    @Override
-    public void configureFunctions() {
-        AndOperator.register(this);
-        OrOperator.register(this);
-        EqOperator.register(this);
-        CIDROperator.register(this);
-        LtOperator.register(this);
-        LteOperator.register(this);
-        GtOperator.register(this);
-        GteOperator.register(this);
-        BitwiseAndOperator.register(this);
-        RegexpMatchOperator.register(this);
-        RegexpMatchCaseInsensitiveOperator.register(this);
+public class BitwiseAndOperatorTest extends ScalarTestCase {
 
-        AnyOperators.register(this);
-        AllOperator.register(this);
-        LikeOperators.register(this);
+    @Test
+    public void testBitwiseAnd() {
+        assertNormalize("id & 8", isFunction("op_&"));
+        assertNormalize("4 & 20", isLiteral(true));
+        assertNormalize("16 & 20", isLiteral(true));
+        assertNormalize("1 & 20", isLiteral(false));
+        assertNormalize("2 & 20", isLiteral(false));
+        assertNormalize("1 & 3", isLiteral(true));
+        assertNormalize("2 & 3", isLiteral(true));
+        assertNormalize("4 & 3", isLiteral(false));
+        assertNormalize("16 & 3", isLiteral(false));
+        assertEvaluate("null & null", null);
+        assertEvaluate("20 & null", null);
+        assertEvaluate("null & 3", null);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This patch implements bitwise AND operator for integer types. Other types, like implemented in MySQL for example, see https://dev.mysql.com/doc/refman/8.0/en/bit-functions.html, are out of scope for this patch but perhaps can be added later as required.

## Checklist

 - [ N] Added an entry in `CHANGES.txt` for user facing changes
 - [ Y] Updated documentation & `sql_features` table for user facing changes
 - [ Y] Touched code is covered by tests
 - [ Y] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ Y] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
