### PR TITLE
WIP: Add benchmarks for indexing without source parsing

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/indexing/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/indexing/IndexingBenchmark.java
@@ -52,6 +52,7 @@ import org.elasticsearch.index.mapper.SeqNoFieldMapper.SequenceIDFields;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -100,11 +101,10 @@ public class IndexingBenchmark {
             .put("path.home", tempDir.toAbsolutePath().toString())
             .build();
         Environment environment = new Environment(settings, tempDir);
+        List<Class<? extends Plugin>> plugins = List.of(Netty4Plugin.class);
         node = new Node(
             environment,
-            List.of(
-                Netty4Plugin.class
-            ),
+            plugins,
             true
         );
         node.start();
@@ -131,13 +131,9 @@ public class IndexingBenchmark {
         );
         doc = new Document();
         var intValueIndexer = new IntValueIndexer("id");
-        for (var field : intValueIndexer.indexValue(10)) {
-            doc.add(field);
-        }
+        intValueIndexer.indexValue(10, doc::add);
         var stringIndexer = new StringValueIndexer("name");
-        for (var field : stringIndexer.indexValue("Arthur")) {
-            doc.add(field);
-        }
+        stringIndexer.indexValue("Arthur", doc::add);
     }
 
     @Benchmark

--- a/benchmarks/src/main/java/io/crate/execution/engine/indexing/IndexingBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/indexing/IndexingBenchmark.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.indexing;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.Mapping;
+import org.elasticsearch.index.mapper.ParseContext.Document;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SeqNoFieldMapper.SequenceIDFields;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.crate.Streamer;
+import io.crate.action.sql.BaseResultReceiver;
+import io.crate.action.sql.SQLOperations;
+import io.crate.data.Row;
+import io.crate.execution.dml.upsert.InsertSourceGen;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.doc.DocTableInfo;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Fork(value = 2)
+@Measurement(iterations = 4)
+public class IndexingBenchmark {
+
+    private Node node;
+    private SQLOperations sqlOperations;
+    private ClusterService clusterService;
+    private NodeContext nodeCtx;
+    private Schemas schemas;
+    private DocumentMapper documentMapper;
+    private Document doc;
+    private IndexWriter indexWriter;
+
+    @Setup
+    public void createEnv() throws Exception {
+        Path tempDir = Files.createTempDirectory("");
+        Settings settings = Settings.builder()
+            .put("path.home", tempDir.toAbsolutePath().toString())
+            .build();
+        Environment environment = new Environment(settings, tempDir);
+        node = new Node(
+            environment,
+            List.of(
+                Netty4Plugin.class
+            ),
+            true
+        );
+        node.start();
+        Injector injector = node.injector();
+        sqlOperations = injector.getInstance(SQLOperations.class);
+        clusterService = injector.getInstance(ClusterService.class);
+        nodeCtx = injector.getInstance(NodeContext.class);
+        schemas = injector.getInstance(Schemas.class);
+        IndicesService indices = injector.getInstance(IndicesService.class);
+
+        String statement = "create table doc.users (id int primary key, name string)";
+        var resultReceiver = new BaseResultReceiver();
+        sqlOperations.newSystemSession()
+            .quickExec(statement, resultReceiver, Row.EMPTY);
+        resultReceiver.completionFuture().get(5, TimeUnit.SECONDS);
+
+        IndexMetadata index = clusterService.state().getMetadata().index("users");
+        IndexService indexService = indices.indexService(index.getIndex());
+        documentMapper = indexService.mapperService().documentMapper();
+
+        indexWriter = new IndexWriter(
+            new ByteBuffersDirectory(),
+            new IndexWriterConfig(new StandardAnalyzer())
+        );
+        doc = new Document();
+        var intValueIndexer = new IntValueIndexer("id");
+        for (var field : intValueIndexer.indexValue(10)) {
+            doc.add(field);
+        }
+        var stringIndexer = new StringValueIndexer("name");
+        for (var field : stringIndexer.indexValue("Arthur")) {
+            doc.add(field);
+        }
+    }
+
+    @Benchmark
+    public long measure_index_writer_add_document() throws Exception {
+        return indexWriter.addDocument(doc);
+    }
+
+    @Benchmark
+    public long measure_index_writer_add_document_and_commit() throws Exception {
+        indexWriter.addDocument(doc);
+        return indexWriter.commit();
+    }
+
+    @Benchmark
+    public ParsedDocument measure_indexing_using_source_generation_and_doc_mapper_parse() throws Exception {
+        DocTableInfo table = schemas.getTableInfo(new RelationName("doc", "users"));
+        InsertSourceGen sourceGen = InsertSourceGen.of(
+            CoordinatorTxnCtx.systemTransactionContext(),
+            nodeCtx,
+            table,
+            "users",
+            false,
+            List.copyOf(table.columns())
+        );
+        Object[] values = new Object[] { 10, "Arthur" };
+        Map<String, Object> source = sourceGen.generateSourceAndCheckConstraints(values, List.of());
+        BytesReference rawSource = BytesReference.bytes(XContentFactory.jsonBuilder().map(source));
+        SourceToParse sourceToParse = new SourceToParse(
+            "users",
+            "10",
+            rawSource,
+            XContentType.JSON
+        );
+        return documentMapper.parse(sourceToParse);
+    }
+
+    @Benchmark
+    public Document measure_indexing_using__indexers() throws Exception {
+        DocTableInfo table = schemas.getTableInfo(new RelationName("doc", "users"));
+        Object[] values = new Object[] { 10, "Arthur" };
+        Indexer indexer = new Indexer(table.columns());
+        return indexer.createDoc(values);
+    }
+
+    @Benchmark
+    public ParsedDocument measure_indexing_using__indexers_creating_parsed_doc() throws Exception {
+        DocTableInfo table = schemas.getTableInfo(new RelationName("doc", "users"));
+        Object[] values = new Object[] { 10, "Arthur" };
+        Indexer indexer = new Indexer(table.columns());
+        Document doc = indexer.createDoc(values);
+        InsertSourceGen sourceGen = InsertSourceGen.of(
+            CoordinatorTxnCtx.systemTransactionContext(),
+            nodeCtx,
+            table,
+            "users",
+            false,
+            List.copyOf(table.columns())
+        );
+        BytesReference source = sourceGen.generateSourceAndCheckConstraintsAsBytesReference(values);
+        Field version = new NumericDocValuesField("_version", -1L);
+        return new ParsedDocument(
+            version,
+            SequenceIDFields.emptySeqID(),
+            "10",
+            List.of(doc),
+            source,
+            (Mapping) null
+        );
+    }
+
+    @Benchmark
+    public ParsedDocument measure_indexing_using_indexers_creating_parsed_doc_with_binary_source() throws Exception {
+        DocTableInfo table = schemas.getTableInfo(new RelationName("doc", "users"));
+        Object[] values = new Object[] { 10, "Arthur" };
+        Indexer indexer = new Indexer(table.columns());
+        Document doc = indexer.createDoc(values);
+        Iterator<Reference> it = table.columns().iterator();
+        var out = new BytesStreamOutput();
+        for (int i = 0; i < values.length; i++) {
+            var value = values[i];
+            Reference columnRef = it.next();
+            Streamer<?> streamer = columnRef.valueType().streamer();
+            ((Streamer) streamer).writeValueTo(out, value);
+        }
+        Field version = new NumericDocValuesField("_version", -1L);
+        return new ParsedDocument(
+            version,
+            SequenceIDFields.emptySeqID(),
+            "10",
+            List.of(doc),
+            out.bytes(),
+            (Mapping) null
+        );
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/indexing/Indexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/Indexer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.crate.execution.engine.indexing;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.lucene.document.Field;
+import org.elasticsearch.index.mapper.ParseContext.Document;
+
+import io.crate.common.collections.Lists2;
+import io.crate.metadata.Reference;
+
+public class Indexer {
+
+    private final List<ValueIndexer<?>> indexers;
+
+    public Indexer(Collection<? extends Reference> columns) {
+        this.indexers = Lists2.map(
+            columns,
+            x -> x.valueType().valueIndexer(x.column().fqn()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public Document createDoc(Object[] values) {
+        var doc = new Document();
+        for (int i = 0; i < values.length; i++) {
+            var indexer = (ValueIndexer<Object>) indexers.get(i);
+            List<Field> indexValue = indexer.indexValue(values[i]);
+            for (Field field : indexValue) {
+                doc.add(field);
+            }
+        }
+        return doc;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/indexing/Indexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/Indexer.java
@@ -21,6 +21,7 @@ package io.crate.execution.engine.indexing;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.lucene.document.Field;
 import org.elasticsearch.index.mapper.ParseContext.Document;
@@ -41,12 +42,10 @@ public class Indexer {
     @SuppressWarnings("unchecked")
     public Document createDoc(Object[] values) {
         var doc = new Document();
+        Consumer<? super Field> addField = doc::add;
         for (int i = 0; i < values.length; i++) {
             var indexer = (ValueIndexer<Object>) indexers.get(i);
-            List<Field> indexValue = indexer.indexValue(values[i]);
-            for (Field field : indexValue) {
-                doc.add(field);
-            }
+            indexer.indexValue(values[i], addField);
         }
         return doc;
     }

--- a/server/src/main/java/io/crate/execution/engine/indexing/IntValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IntValueIndexer.java
@@ -19,8 +19,7 @@
 
 package io.crate.execution.engine.indexing;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntPoint;
@@ -36,12 +35,10 @@ public class IntValueIndexer implements ValueIndexer<Integer> {
     }
 
     @Override
-    public List<Field> indexValue(Integer value) {
-        ArrayList<Field> fields = new ArrayList<>(3);
+    public void indexValue(Integer value, Consumer<? super Field> consumer) {
         int intValue = value.intValue();
-        fields.add(new IntPoint(name, intValue));
-        fields.add(new StoredField(name, intValue));
-        fields.add(new SortedNumericDocValuesField(name, intValue));
-        return fields;
+        consumer.accept(new IntPoint(name, intValue));
+        consumer.accept(new StoredField(name, intValue));
+        consumer.accept(new SortedNumericDocValuesField(name, intValue));
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/indexing/IntValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IntValueIndexer.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.crate.execution.engine.indexing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+
+public class IntValueIndexer implements ValueIndexer<Integer> {
+
+    private final String name;
+
+    public IntValueIndexer(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public List<Field> indexValue(Integer value) {
+        ArrayList<Field> fields = new ArrayList<>(3);
+        int intValue = value.intValue();
+        fields.add(new IntPoint(name, intValue));
+        fields.add(new StoredField(name, intValue));
+        fields.add(new SortedNumericDocValuesField(name, intValue));
+        return fields;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/indexing/StringValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/StringValueIndexer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.crate.execution.engine.indexing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+
+public class StringValueIndexer implements ValueIndexer<String> {
+
+    private final String name;
+
+    public StringValueIndexer(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public List<Field> indexValue(String value) {
+        ArrayList<Field> fields = new ArrayList<>();
+        final BytesRef binaryValue = new BytesRef(value);
+        fields.add(new Field(name, binaryValue, KeywordFieldMapper.Defaults.FIELD_TYPE));
+        fields.add(new SortedDocValuesField(name, binaryValue));
+        return fields;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/indexing/StringValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/StringValueIndexer.java
@@ -19,8 +19,7 @@
 
 package io.crate.execution.engine.indexing;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedDocValuesField;
@@ -36,11 +35,9 @@ public class StringValueIndexer implements ValueIndexer<String> {
     }
 
     @Override
-    public List<Field> indexValue(String value) {
-        ArrayList<Field> fields = new ArrayList<>();
+    public void indexValue(String value, Consumer<? super Field> consumer) {
         final BytesRef binaryValue = new BytesRef(value);
-        fields.add(new Field(name, binaryValue, KeywordFieldMapper.Defaults.FIELD_TYPE));
-        fields.add(new SortedDocValuesField(name, binaryValue));
-        return fields;
+        consumer.accept(new Field(name, binaryValue, KeywordFieldMapper.Defaults.FIELD_TYPE));
+        consumer.accept(new SortedDocValuesField(name, binaryValue));
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/indexing/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ValueIndexer.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.crate.execution.engine.indexing;
+
+import java.util.List;
+
+import org.apache.lucene.document.Field;
+
+public interface ValueIndexer<T> {
+
+    List<Field> indexValue(T value);
+}

--- a/server/src/main/java/io/crate/execution/engine/indexing/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ValueIndexer.java
@@ -19,11 +19,11 @@
 
 package io.crate.execution.engine.indexing;
 
-import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.lucene.document.Field;
 
 public interface ValueIndexer<T> {
 
-    List<Field> indexValue(T value);
+    void indexValue(T value, Consumer<? super Field> consumer);
 }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -222,6 +222,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
         return null;
     }
 
+    // TODO: Integrate into StorageSupport?
     @Nullable
     public ValueIndexer<? super T> valueIndexer(String columnName) {
         return null;

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import io.crate.Streamer;
+import io.crate.execution.engine.indexing.ValueIndexer;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
@@ -218,6 +219,11 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      **/
     @Nullable
     public StorageSupport<? super T> storageSupport() {
+        return null;
+    }
+
+    @Nullable
+    public ValueIndexer<? super T> valueIndexer(String columnName) {
         return null;
     }
 

--- a/server/src/main/java/io/crate/types/IntegerType.java
+++ b/server/src/main/java/io/crate/types/IntegerType.java
@@ -22,6 +22,9 @@
 package io.crate.types;
 
 import io.crate.Streamer;
+import io.crate.execution.engine.indexing.IntValueIndexer;
+import io.crate.execution.engine.indexing.ValueIndexer;
+
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -128,5 +131,9 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
     @Override
     public StorageSupport<Number> storageSupport() {
         return STORAGE;
+    }
+
+    public ValueIndexer<Integer> valueIndexer(String columnName) {
+        return new IntValueIndexer(columnName);
     }
 }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -48,6 +48,18 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import io.crate.Streamer;
 import io.crate.common.unit.TimeValue;
+import static io.crate.common.StringUtils.isBlank;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import io.crate.Streamer;
+import io.crate.common.unit.TimeValue;
+import io.crate.execution.engine.indexing.StringValueIndexer;
+import io.crate.execution.engine.indexing.ValueIndexer;
 import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
@@ -327,5 +339,9 @@ public class StringType extends DataType<String> implements Streamer<String> {
     @Override
     public StorageSupport<String> storageSupport() {
         return STORAGE;
+    }
+
+    public ValueIndexer<String> valueIndexer(String columnName) {
+        return new StringValueIndexer(columnName);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

WIP

```
Benchmark                                                                                 Mode  Cnt       Score       Error  Units
IndexingBenchmark.measure_index_writer_add_document                                       avgt    8     768.747 ±    68.979  ns/op
IndexingBenchmark.measure_index_writer_add_document_and_commit                            avgt    8  531742.933 ± 35483.113  ns/op
IndexingBenchmark.measure_indexing_using__indexers                                        avgt    8     222.214 ±     9.275  ns/op
IndexingBenchmark.measure_indexing_using__indexers_creating_parsed_doc                    avgt    8     786.163 ±     9.300  ns/op
IndexingBenchmark.measure_indexing_using_indexers_creating_parsed_doc_with_binary_source  avgt    8     433.967 ±     2.865  ns/op
IndexingBenchmark.measure_indexing_using_source_generation_and_doc_mapper_parse           avgt    8    1422.076 ±     4.219  ns/op
```

After fixups:

```
IndexingBenchmark.measure_index_writer_add_document                                       avgt    8     729.249 ±   15.982  ns/op
IndexingBenchmark.measure_index_writer_add_document_and_commit                            avgt    8  545175.833 ± 4377.561  ns/op
IndexingBenchmark.measure_indexing_using__indexers                                        avgt    8     189.094 ±    2.461  ns/op
IndexingBenchmark.measure_indexing_using__indexers_creating_parsed_doc                    avgt    8     779.236 ±   23.476  ns/op
IndexingBenchmark.measure_indexing_using_indexers_creating_parsed_doc_with_binary_source  avgt    8     403.882 ±   11.974  ns/op
IndexingBenchmark.measure_indexing_using_source_generation_and_doc_mapper_parse           avgt    8    1435.205 ±   24.132  ns/op
```

This is still not really a fair apples to apples comparison, as the indexer does less work (e.g. no dynamic mapping detection)
400 to 550ns improvement might be reasonable. On a bulk-insert of 10k that would end up saving 5.0ms. Compared to current timings without this change this would amount to about a 3% of overall insert performance. (Potentially bigger with larger payloads)


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
