### PR TITLE
Add a config for codespell

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = crate


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Codespell (https://github.com/codespell-project/codespell) can be useful
to spot typo's in comments, but in the CrateDB code base it is noisy
without configuration because it thinks `crate` is a typo for `create`.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
