### PR TITLE
Implement area function for geo_shape types

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,8 @@ Changes
 - Introduced ``RESPECT NULLS`` and ``IGNORE NULLS`` flags to window function
   calls. The following window functions can now utilize the flags: ``LEAD``,
   ``LAG``, ``NTH_VALUE``, ``FIRST_VALUE``, and ``LAST_VALUE``.
+- Added the :ref:`scalar-area` scalar function that calculates the area for a
+  ``GEO_SHAPE``.
 
 
 Fixes

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1650,6 +1650,34 @@ Example::
     SELECT 1 row in set (... sec)
 
 
+
+.. _scalar-area:
+
+``area(geo_shape)``
+----------------------
+
+Returns: ``double precision``
+
+The ``area`` function calculates the  area of the input shape in
+square-degrees. The calculation will use geospatial awareness (AKA `geodetic`_)
+instead of `Euclidean geometry`_. The input has to be a column of type
+:ref:`geo_shape_data_type`, a valid `WKT`_ string or `GeoJSON`_.
+See :ref:`geo_shape_data_type` for more information.
+
+Below you can find an example.
+
+Example::
+
+    cr> select
+    ...     round(area('POLYGON ((5 5, 10 5, 10 10, 5 10, 5 5))')) as "area";
+    +------+
+    | area |
+    +------+
+    |   25 |
+    +------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-math:
 
 Mathematical functions
@@ -3680,7 +3708,10 @@ Example::
 .. _3-valued logic: https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)
 .. _available time zones: https://www.joda.org/joda-time/timezones.html
 .. _CrateDB PDO: https://crate.io/docs/pdo/en/latest/connect.html
+.. _Euclidean geometry: https://en.wikipedia.org/wiki/Euclidean_geometry
 .. _formatter: https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html
+.. _geodetic: https://en.wikipedia.org/wiki/Geodesy
+.. _GeoJSON: https://geojson.org/
 .. _Haversine formula: https://en.wikipedia.org/wiki/Haversine_formula
 .. _Java DateTimeFormatter: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 .. _Java DecimalFormat: https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html
@@ -3688,3 +3719,4 @@ Example::
 .. _Joda-Time: https://www.joda.org/joda-time/
 .. _Lucene Regular Expressions: https://lucene.apache.org/core/4_9_0/core/org/apache/lucene/util/automaton/RegExp.html
 .. _MySQL date_format: https://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format
+.. _WKT: https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -48,6 +48,7 @@ import io.crate.expression.scalar.conditional.IfFunction;
 import io.crate.expression.scalar.conditional.LeastFunction;
 import io.crate.expression.scalar.conditional.NullIfFunction;
 import io.crate.expression.scalar.formatting.ToCharFunction;
+import io.crate.expression.scalar.geo.AreaFunction;
 import io.crate.expression.scalar.geo.CoordinateFunction;
 import io.crate.expression.scalar.geo.DistanceFunction;
 import io.crate.expression.scalar.geo.GeoHashFunction;
@@ -112,6 +113,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         IntersectsFunction.register(this);
         CoordinateFunction.register(this);
         GeoHashFunction.register(this);
+        AreaFunction.register(this);
 
         SubscriptFunction.register(this);
         SubscriptObjectFunction.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.geo;
+
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.scalar.UnaryScalar;
+import io.crate.geo.GeoJSONUtils;
+import io.crate.types.DataTypes;
+import io.crate.types.GeoShapeType;
+import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
+
+import java.util.Map;
+
+import static io.crate.metadata.functions.Signature.scalar;
+
+/**
+ * This class implements the area(geoShape) function on columns of GEO_SHAPE type.
+ * Usage example:
+ * <pre>
+ *    SELECT area(shape)
+ *    FROM table
+ *    ORDER BY area(shape)
+ * </pre>
+ */
+public final class AreaFunction {
+
+    public static final String FUNCTION_NAME = "area";
+
+    /**
+     * Registers the area function in the {@link ScalarFunctionModule}.
+     * It takes as input a GEO_SHAPE and produces a double value
+     * designated as the area of the shape.
+     *
+     * @param module the {@link ScalarFunctionModule}
+     */
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            scalar(
+                FUNCTION_NAME,
+                DataTypes.GEO_SHAPE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature()
+            ),
+            (signature, boundSignature) ->
+                new UnaryScalar<>(
+                    signature,
+                    boundSignature,
+                    DataTypes.GEO_SHAPE,
+                    AreaFunction::getArea
+                )
+        );
+    }
+
+    protected static Double getArea(Object value) {
+
+        Map<String, Object> shapeAsMap = GeoShapeType.INSTANCE.sanitizeValue(value);
+        Shape shape = GeoJSONUtils.map2Shape(shapeAsMap);
+
+        return shape.getArea(JtsSpatialContext.GEO);
+    }
+}
+

--- a/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.geo;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+import io.crate.geo.GeoJSONUtils;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+import org.locationtech.spatial4j.shape.Shape;
+
+import java.util.Map;
+
+import static io.crate.expression.scalar.geo.AreaFunction.getArea;
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+/**
+ * Tests for {@link AreaFunction}.
+ */
+public class AreaFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void testEvaluateWithRectangularGeoShapeLiteral() throws Exception {
+        assertEvaluate("area(geoShape)", 20.996801695711337,
+                       Literal.of(DataTypes.GEO_SHAPE,
+                                  DataTypes.GEO_SHAPE.implicitCast("POLYGON ((-2 -1, -2 2, 5 2, 5 -1, -2 -1))")));
+    }
+
+    @Test
+    public void testWithMapShape() throws Exception {
+
+        String wkt = "POLYGON ((-2 -1, -2 2, 5 2, 5 -1, -2 -1))";
+        Shape shape = GeoJSONUtils.wkt2Shape(wkt);
+        Map<String, Object> map = GeoJSONUtils.shape2Map(shape);
+
+        assertEquals(20.996801695711337, getArea(map), 0);
+    }
+
+    @Test
+    public void testEvaluateRoundWithRectangularGeoShapeLiteral() throws Exception {
+        assertEvaluate("round(area(geoShape))", 21L,
+                       Literal.of(DataTypes.GEO_SHAPE,
+                                  DataTypes.GEO_SHAPE.implicitCast("POLYGON ((-2 -1, -2 2, 5 2, 5 -1, -2 -1))")));
+    }
+
+    @Test
+    public void testWithNullValue() throws Exception {
+        assertEvaluate("area(geoShape)", null,
+                       Literal.of(DataTypes.GEO_SHAPE, null));
+    }
+
+    @Test
+    public void testNormalizeWithStringTypes() throws Exception {
+        assertNormalize("area('POLYGON ((5 5, 10 5, 10 10, 5 10, 5 5))')", isLiteral(24.7782574034212), false);
+    }
+
+    @Test
+    public void testWithTooManyArguments() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+            "Unknown function: area(doc.users.geoshape, 'foo'), no overload found for matching argument types: (geo_shape, text). Possible candidates: area(geo_shape):double precision");
+        assertNormalize("area(geoShape, 'foo')", null);
+    }
+
+    @Test
+    public void testResolveWithInvalidType() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+            "Unknown function: area(1), no overload found for matching argument types: (integer). Possible candidates: area(geo_shape):double precision");
+        assertEvaluate("area(1)", null);
+    }
+
+    @Test
+    public void testWithInvalidStringReferences() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Cannot cast `'POLYGON (foo)'` of type `text` to type `geo_shape`");
+        assertEvaluate("area('POLYGON (foo)')", null);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Added area function for geo_shape types. It computes the area of a shape, in square-degrees.
Can be used to approximate sizes of shapes.

Fixes #9231

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
