### PR TITLE
Fix for issue #10963

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3383,6 +3383,32 @@ Example::
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-pg_encoding_to_char:
+
+``pg_encoding_to_char()``
+---------------------
+
+The function ``pg_encoding_to_char`` is implemented to improve compatibility with
+clients that use the PostgreSQL wire protocol. CrateDB only supports charset ``UTF8``
+so the function will always return ``UTF8``.
+
+Returns: ``text``
+
+Synopsis::
+
+   pg_encoding_to_char(encoding int)
+
+Example::
+
+    cr> select pg_encoding_to_char(1) AS encoding;
+    +----------+
+    | encoding |
+    +----------+
+    | UTF8     |
+    +----------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-pg_get_userbyid:
 
 ``pg_get_userbyid()``

--- a/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
@@ -35,7 +35,7 @@ import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInn
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
-class ArrayToStringFunction extends Scalar<String, Object> {
+public class ArrayToStringFunction extends Scalar<String, Object> {
 
     private static final String NAME = "array_to_string";
 
@@ -64,7 +64,7 @@ class ArrayToStringFunction extends Scalar<String, Object> {
     private final Signature signature;
     private final Signature boundSignature;
 
-    private ArrayToStringFunction(Signature signature, Signature boundSignature) {
+    protected ArrayToStringFunction(Signature signature, Signature boundSignature) {
         this.signature = signature;
         this.boundSignature = boundSignature;
         ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), NAME);

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -53,10 +53,7 @@ import io.crate.expression.scalar.geo.DistanceFunction;
 import io.crate.expression.scalar.geo.GeoHashFunction;
 import io.crate.expression.scalar.geo.IntersectsFunction;
 import io.crate.expression.scalar.geo.WithinFunction;
-import io.crate.expression.scalar.postgres.CurrentSettingFunction;
-import io.crate.expression.scalar.postgres.PgBackendPidFunction;
-import io.crate.expression.scalar.postgres.PgGetUserByIdFunction;
-import io.crate.expression.scalar.postgres.PgPostmasterStartTime;
+import io.crate.expression.scalar.postgres.*;
 import io.crate.expression.scalar.regex.RegexpReplaceFunction;
 import io.crate.expression.scalar.string.AsciiFunction;
 import io.crate.expression.scalar.string.ChrFunction;
@@ -194,6 +191,8 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         CurrentSettingFunction.register(this, getProvider(SessionSettingRegistry.class));
 
         PgBackendPidFunction.register(this);
+        PgEncodingToChar.register(this);
+        PgArrayToString.register(this);
         PgGetUserByIdFunction.register(this);
         PgTypeofFunction.register(this);
         CurrentDatabaseFunction.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgArrayToString.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgArrayToString.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.postgres;
+
+import io.crate.expression.scalar.ArrayToStringFunction;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.types.DataTypes;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
+public class PgArrayToString extends ArrayToStringFunction {
+    public static final String NAME = "array_to_string";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+
+    public static void register(ScalarFunctionModule module) {
+
+        module.register(
+            Signature.scalar(
+                FQN,
+                parseTypeSignature("array(E)"),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ).withTypeVariableConstraints(typeVariable("E")),
+            PgArrayToString::new
+        );
+        module.register(
+            Signature.scalar(
+                FQN,
+                parseTypeSignature("array(E)"),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ).withTypeVariableConstraints(typeVariable("E")),
+            PgArrayToString::new
+        );
+    }
+
+    public PgArrayToString(Signature signature, Signature boundSignature) {
+        super(signature, boundSignature);
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToChar.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToChar.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.postgres;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.types.DataTypes;
+
+import static io.crate.metadata.functions.Signature.scalar;
+
+public class PgEncodingToChar extends Scalar<String, Integer> {
+    public static final String NAME = "pg_encoding_to_char";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            scalar(
+                FQN,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ).withFeatures(NO_FEATURES),
+            PgEncodingToChar::new
+        );
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    public PgEncodingToChar(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @SafeVarargs
+    @Override
+    public final String evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Integer>... args) {
+        return "UTF8";
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgArrayToStringTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgArrayToStringTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.postgres;
+
+import io.crate.expression.scalar.ArrayToStringFunction;
+import io.crate.expression.scalar.ScalarTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+public class PgArrayToStringTest extends ScalarTestCase {
+    @Test
+    public void testPgArrayToStringWithFQNFunctionName() throws Exception {
+        assertEvaluate("pg_catalog.array_to_string([1, 2, 3], ', ')", "1, 2, 3");
+    }
+
+    @Test
+    public void testPgArrayToString() throws Exception {
+        // PgArrayToString must be a subclass of ArrayToStringFunction.
+        // It may only have a constructor and a static register method
+
+        Assert.assertTrue(PgArrayToString.class.getSuperclass() == ArrayToStringFunction.class);
+
+        Constructor<?>[] constructors = PgArrayToString.class.getConstructors();
+        Assert.assertTrue(constructors.length == 1);
+
+        Method[] methods = PgArrayToString.class.getMethods();
+        for(Method method: methods) {
+            Class<?> declaringClass = method.getDeclaringClass();
+            Assert.assertTrue ((declaringClass != PgArrayToString.class) ||
+                (declaringClass == PgArrayToString.class && method.getName() == "register"));
+        }
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgEncodingToCharTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgEncodingToCharTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.postgres;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isFunction;
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class PgEncodingToCharTest extends ScalarTestCase {
+    @Test
+    public void testPgEncodingToChar() throws Exception {
+        assertEvaluate("pg_encoding_to_char(1)", "UTF8");
+        assertNormalize("pg_encoding_to_char(1)", isLiteral("UTF8"));
+    }
+
+    @Test
+    public void testPgEncodingToCharWithFQNFunctionName() throws Exception {
+        assertEvaluate("pg_catalog.pg_encoding_to_char(1)", "UTF8");
+    }
+}


### PR DESCRIPTION
* Added scalar method pg_catalog.pg_encoding_to_char
* Added scalar method pg_catalog.array_to_string (subclass of ArrayToStringFunction)
Test: pg_encoding_to_char should always return UTF8, pg_catalog.array_to_string should not override anything from ArrayToStringFunction
Doc: Description of pg_encoding_to_char added to scalar-functions.rst

## Summary of the changes / Why this improves CrateDB
This is a fix for issue [#10963](https://github.com/crate/crate/issues/10963)

## Questions:
- Is UTF8 correct as a return value for pg_encoding_to_char or should it be UTF-8 or something else?
- Do we have to check the input parameter in pg_encoding_to_char since it will not care about that.
- Is there any better way to register the already existing array_to_string under pg_catalog. or is it fine like it is implemented in PgArrayToString.java (subclassed from ArrayToStringFunction)?

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
