### PR TITLE
Change field DocValuesFormat to BEST_SPEED

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
@@ -25,7 +25,6 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene80.Lucene80DocValuesFormat;
 import org.apache.lucene.codecs.lucene87.Lucene87Codec;
-import org.apache.lucene.codecs.lucene87.Lucene87StoredFieldsFormat.Mode;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
@@ -64,7 +63,7 @@ public class PerFieldMappingPostingFormatCodec extends Lucene87Codec {
 
     @Override
     public DocValuesFormat getDocValuesFormatForField(String field) {
-        return new Lucene80DocValuesFormat(Lucene80DocValuesFormat.Mode.BEST_COMPRESSION);
+        return new Lucene80DocValuesFormat(Lucene80DocValuesFormat.Mode.BEST_SPEED);
     }
 
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will increase disk usage by ~3-4% (based on a rough test) but is
required to upgrade to Lucene 8.9 without major performance regressions.
See https://github.com/crate/crate/pull/11526 for more information.

    uservisits, 3_856_836 records

    Best compression:

        Segment Info:           58.34 KB
        Fields:                 21.01 KB
        Field Index:            23.19 KB
        Field Data:            750.63 MB
        Term Dictionary:       252.42 MB
        Term Index:              2.35 MB
        Frequencies:            76.11 MB
        Positions:              14.13 MB
        Payloads:                0.00 Bytes
        Norms:                   5.58 MB
                                 1.63 KB
        Per-Document Values:   272.56 MB
                                25.97 KB

    Best speed:

        Segment Info:           58.50 KB
        Fields:                 24.51 KB
        Field Index:            24.31 KB
        Field Data:            775.02 MB
        Term Dictionary:       262.31 MB
        Term Index:              2.46 MB
        Frequencies:            78.68 MB
        Positions:              14.84 MB
        Payloads:                0.00 Bytes
        Norms:                   5.77 MB
                                 1.90 KB
        Per-Document Values:   282.98 MB
                                30.30 KB

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
