### PR TITLE
Update Lucene to 8.9.0

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -22,7 +22,7 @@ jacksonasl=1.9.13
 crate_admin_ui = 1.19.0
 jdbc=42.2.18
 
-lucene=8.8.2
+lucene=8.9.0
 
 # ES Azure
 azure_storage=8.6.6

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -121,7 +121,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_4_6_0 = new Version(7_06_00_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
     public static final Version V_4_6_1 = new Version(7_06_01_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
 
-    public static final Version V_4_7_0 = new Version(7_07_00_99, true, org.apache.lucene.util.Version.LUCENE_8_8_2);
+    public static final Version V_4_7_0 = new Version(7_07_00_99, true, org.apache.lucene.util.Version.LUCENE_8_9_0);
 
     public static final Version CURRENT = V_4_7_0;
 

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -64,7 +64,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
         final Directory directory = commit.getDirectory();
         final List<IndexCommit> indexCommits = DirectoryReader.listCommits(directory);
         final IndexCommit indexCommit = indexCommits.get(indexCommits.size() - 1);
-        return new DirectoryReader(directory, new LeafReader[0]) {
+        return new DirectoryReader(directory, new LeafReader[0], null) {
             @Override
             protected DirectoryReader doOpenIfChanged() throws IOException {
                 return null;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://lucene.apache.org/core/8_9_0/changes/Changes.html

This update was previously reverted due to a performance regression.
(https://github.com/crate/crate/pull/11526)

We changed DocValuesFormat on fields to `BEST_SPEED` to prevent the
performance regression (at the cost of increased disk space
requirements).
(https://github.com/crate/crate/pull/11658)

Benchmarks which previously showed a ~80% slow-down are now looking
good:

     Results (server side duration in ms)
    V1: 4.7.0-4d1a9894c2ad8b058f47b27db02f044ef63236a1
    V2: 4.7.0-a9118156c6780243514e4089b9f238580f347bba

    Q: select hyperloglog_distinct("cCode") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      419.403 ±  166.596 |    372.875 |    389.166 |    396.250 |   1554.924 |
    |   V2    |      426.001 ±  126.988 |    386.096 |    401.648 |    410.437 |   1291.026 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               +   1.56%                           +   3.16%
    There is a 17.58% probability that the observed difference is not random, and the best estimate of that difference is 1.56%
    The test has no statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |    3     7.36    11.41 |    0     0.00     0.00 |     4295       70 |     0.00          0
     V2 |    1     4.85     4.85 |    0     0.00     0.00 |     4295      765 |     0.00          0



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
