### PR TITLE
Optimize enum streaming

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnPolicy.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnPolicy.java
@@ -21,12 +21,16 @@
 
 package io.crate.sql.tree;
 
+import java.util.List;
 import java.util.Locale;
+
 
 public enum ColumnPolicy {
     DYNAMIC,
     STRICT,
     IGNORED;
+
+    public static final List<ColumnPolicy> VALUES = List.of(values());
 
     public String lowerCaseName() {
         return name().toLowerCase(Locale.ENGLISH);
@@ -48,4 +52,5 @@ public enum ColumnPolicy {
                     "Invalid column policy: " + value + " use one of [dynamic, strict, ignored]");
         }
     }
+
 }

--- a/server/src/main/java/io/crate/metadata/RowGranularity.java
+++ b/server/src/main/java/io/crate/metadata/RowGranularity.java
@@ -21,10 +21,11 @@
 
 package io.crate.metadata;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
 
 /**
  * granularity of references
@@ -42,8 +43,10 @@ public enum RowGranularity {
     SHARD,
     DOC;
 
+    private static final List<RowGranularity> VALUES = List.of(values());
+
     public static RowGranularity fromStream(StreamInput in) throws IOException {
-        return RowGranularity.values()[in.readVInt()];
+        return VALUES.get(in.readVInt());
     }
 
     public static void toStream(RowGranularity granularity, StreamOutput out) throws IOException {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Calling `<Enum>.values()` when a value is streamed has an overhead
because it allocates a new array each time.

See https://github.com/crate/crate/commit/98f4998fa4b9e9397facda73286c5a97f481e191

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
