### PR TITLE
bug: when both ignore-nulls option and order-by (window order clause) are specified

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -73,3 +73,6 @@ Fixes
   identifiers containing white spaces to result in a validation exception
   at CrateDB ``4.6.2`` or a unusable object type column (write/reads fail)
   at CrateDB ``4.2.0`` to ``4.6.1``.
+- Fixed an issue from window functions, ``LEAD`` and ``LAG`` where having both
+  ``IGNORE NULLS`` option together with an ``ORDER BY`` clause caused undefined
+  behaviour.

--- a/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
@@ -83,9 +83,9 @@ public class OffsetValueFunctions implements WindowFunction {
         }
         /* from cached index, search from left to right for a non-null element.
            for 'lag', cache index will never go past idxInPartition(current index).
-           for 'lead', cache index may reach upperBoundExclusive. */
-        for (int i = cachedNonNullIndex + 1; i <= currentFrame.upperBoundExclusive(); i++) {
-            if (i == currentFrame.upperBoundExclusive()) {
+           for 'lead', cache index may reach partitionEnd. */
+        for (int i = cachedNonNullIndex + 1; i <= currentFrame.partitionEnd(); i++) {
+            if (i == currentFrame.partitionEnd()) {
                 cachedNonNullIndex = null;
                 break;
             }
@@ -132,10 +132,10 @@ public class OffsetValueFunctions implements WindowFunction {
         }
     }
 
-    private Object getValueAtTargetIndex(Integer targetIndex,
-                                                WindowFrameState currentFrame,
-                                                List<? extends CollectExpression<Row, ?>> expressions,
-                                                Input[] args) {
+    private Object getValueAtTargetIndex(@Nullable Integer targetIndex,
+                                         WindowFrameState currentFrame,
+                                         List<? extends CollectExpression<Row, ?>> expressions,
+                                         Input[] args) {
         if (targetIndex == null) {
             throw new IndexOutOfBoundsException();
         }

--- a/server/src/main/java/io/crate/execution/engine/window/WindowFrameState.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowFrameState.java
@@ -49,6 +49,10 @@ public final class WindowFrameState {
         return upperBoundExclusive;
     }
 
+    public int partitionEnd() {
+        return partitionEnd;
+    }
+
     public Iterable<Object[]> getRows() {
         return rows;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
bug fix, fixes #11645

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
