### PR TITLE
Fix restoring of concrete custom metadata only

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,6 +67,10 @@ Changes
 Fixes
 =====
 
+- Fixed a regression introduced in CrateDB `4.6.0` that broke the functionality
+  of restoring only concrete custom metadata like ``USERS``, ``PRIVILEGES``,
+  ``VIEWS`` and ``UDFS``.
+
 - Fixed an issue that caused the ``SHOW TRANSACTION_ISOLATION`` statement to
   require privileges for the ``sys`` schema.
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -403,20 +403,20 @@ public class RestoreService implements ClusterStateApplier {
 
                             clusterSettings.validateUpdate(settings);
                             mdBuilder.persistentSettings(settings);
+                        }
 
-                            if (request.includeCustomMetadata() && metadata.customs() != null) {
-                                // CrateDB patch to only restore defined custom metadata types
-                                List<String> customMetadataTypes = Arrays.asList(request.customMetadataTypes());
-                                boolean includeAll = customMetadataTypes.size() == 0;
+                        if (request.includeCustomMetadata() && metadata.customs() != null) {
+                            // CrateDB patch to only restore defined custom metadata types
+                            List<String> customMetadataTypes = Arrays.asList(request.customMetadataTypes());
+                            boolean includeAll = customMetadataTypes.size() == 0;
 
-                                for (ObjectObjectCursor<String, Metadata.Custom> cursor : metadata.customs()) {
-                                    if (!RepositoriesMetadata.TYPE.equals(cursor.key)) {
-                                        // Don't restore repositories while we are working with them
-                                        // TODO: Should we restore them at the end?
+                            for (ObjectObjectCursor<String, Metadata.Custom> cursor : metadata.customs()) {
+                                if (!RepositoriesMetadata.TYPE.equals(cursor.key)) {
+                                    // Don't restore repositories while we are working with them
+                                    // TODO: Should we restore them at the end?
 
-                                        if (includeAll || customMetadataTypes.contains(cursor.key)) {
-                                            mdBuilder.putCustom(cursor.key, cursor.value);
-                                        }
+                                    if (includeAll || customMetadataTypes.contains(cursor.key)) {
+                                        mdBuilder.putCustom(cursor.key, cursor.value);
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes a regression introduced by
https://github.com/crate/crate/commit/25b6d5e01aef108fe840d3f09f9584ea83c14a4a

Fixes #11671

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
