### PR TITLE
Avoid String → BytesRef → String roundtrip in LIKE ANY query building

### DIFF
--- a/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
@@ -21,6 +21,7 @@
 
 package io.crate.lucene;
 
+import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.Reference;
 import org.apache.lucene.search.BooleanClause;
@@ -45,7 +46,7 @@ class AnyLikeQuery extends AbstractAnyQuery {
         // col like ANY (['a', 'b']) --> or(like(col, 'a'), like(col, 'b'))
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         booleanQuery.setMinimumNumberShouldMatch(1);
-        for (Object value : toIterable(array.value())) {
+        for (Object value : AnyOperators.collectionValueToIterable(array.value())) {
             booleanQuery.add(LikeQuery.toQuery(candidate, value, context, ignoreCase), BooleanClause.Occur.SHOULD);
         }
         return booleanQuery.build();

--- a/server/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
@@ -22,6 +22,7 @@
 package io.crate.lucene;
 
 import io.crate.expression.operator.LikeOperators;
+import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.Reference;
 import org.apache.lucene.index.Term;
@@ -66,7 +67,7 @@ class AnyNotLikeQuery extends AbstractAnyQuery {
         MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
 
         BooleanQuery.Builder andLikeQueries = new BooleanQuery.Builder();
-        for (Object value : toIterable(array.value())) {
+        for (Object value : AnyOperators.collectionValueToIterable(array.value())) {
             andLikeQueries.add(
                 LikeQuery.like(candidate.valueType(), fieldType, value, ignoreCase),
                 BooleanClause.Occur.MUST);

--- a/server/src/main/java/io/crate/lucene/LikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/LikeQuery.java
@@ -32,7 +32,6 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
@@ -73,7 +72,7 @@ final class LikeQuery implements FunctionToQuery {
         if (dataType.id() == DataTypes.STRING.ID) {
             return createCaseAwareQuery(
                 fieldType.name(),
-                BytesRefs.toString(value),
+                (String) value,
                 ignoreCase);
         }
         return fieldType.termQuery(value, null);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`toIterable` implicitly converts String instances to BytesRef, that's
okay for `Eq` because there the Term requires a BytesRef instance, but
for Like we need to do some pre-processing on the pattern and require a
String.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
