### PR TITLE
Raise invalid-column error if sub-column is defined containing spaces

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,10 @@ Changes
 Fixes
 =====
 
+- Fixed a validation issue resulting in an unusable broken table when a
+  sub-column identifier of an object type column contains invalid whitespace
+  characters.
+
 - Fixed an issue that could cause queries on ``sys.snapshots`` to fail with an
   error if a repository is in the cluster state that cannot be accessed - for
   example due to invalid credentials.

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -211,8 +211,15 @@ public class ColumnIdent implements Comparable<ColumnIdent> {
      * @param columnName column name to check for validity
      */
     public static void validateObjectKey(String columnName) {
+        validateSpaceInObjectKey(columnName);
         validateDotInColumnName(columnName);
         validateSubscriptPatternInColumnName(columnName);
+    }
+
+    public static void validateSpaceInObjectKey(String columnName) {
+        if (columnName.indexOf(' ') != -1) {
+            throw new InvalidColumnNameException(columnName, "contains an invalid space character");
+        }
     }
 
     /**

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -72,6 +72,7 @@ import java.util.Map;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
+import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.hamcrest.Matchers.hasItem;
@@ -1445,5 +1446,14 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         assertThat(mapToSortedString(stmt.mappingProperties()), Matchers.startsWith(
             "user_name={default_expr=CURRENT_USER, position=1, type=keyword}"
         ));
+    }
+
+    @Test
+    public void test_ensure_object_key_validation_on_table_creation() {
+        assertThrowsMatches(
+            () -> analyze("create table tbl (o object as (\"col 1\" int))"),
+            InvalidColumnNameException.class,
+            "contains an invalid space character"
+        );
     }
 }

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitorTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitorTest.java
@@ -97,6 +97,11 @@ public class ExpressionToColumnIdentVisitorTest extends ESTestCase {
     }
 
     @Test
+    public void testConvertWithUnsupportedWithspaceInSubscript() throws Exception {
+        assertInvalidColumnNameExceptionOnConvert("a['col 1']", "contains an invalid space character");
+    }
+
+    @Test
     public void testConvertWithUnsupportedArithmetic() throws Exception {
         assertExceptionOnUnsupportedConvert("1+1");
     }

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
@@ -261,7 +261,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
                 "(number_of_replicas = 1, \"routing.allocation.exclude._name\" = '" + internalCluster().getMasterName()
                 + "', \"write.wait_for_active_shards\" = 1)");
         ensureGreen();
-        execute("insert into t values (?, ?)", new Object[]{1, Map.of("first field", "first value")});
+        execute("insert into t values (?, ?)", new Object[]{1, Map.of("first_field", "first value")});
 
         ServiceDisruptionScheme disruption = new BlockMasterServiceOnMaster(random());
         setDisruptionScheme(disruption);
@@ -271,9 +271,9 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         try {
             execute("insert into t values (?, ?), (?, ?), (?, ?)",
                     new Object[]{
-                        2, Map.of("2nd field", "2nd value"),
-                        3, Map.of("3rd field", "3rd value"),
-                        4, Map.of("4th field", "4th value"),
+                        2, Map.of("2nd_field", "2nd value"),
+                        3, Map.of("3rd_field", "3rd value"),
+                        4, Map.of("4th_field", "4th value"),
                     });
         } catch (Exception e) {
             // failure is acceptable


### PR DESCRIPTION
A sub-column must not contain white spaces as this results in an unusable
broken table.

Fixes #11678.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
