### PR TITLE
Fix type<->signature conversion to handle sub-columns with spaces

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,4 +69,7 @@ Changes
 Fixes
 =====
 
-None
+- Fixed an issue which caused object data types definitions with sub-column
+  identifiers containing white spaces to result in a validation exception
+  at CrateDB ``4.6.2`` or a unusable object type column (write/reads fail)
+  at CrateDB ``4.2.0`` to ``4.6.1``.

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -211,15 +211,8 @@ public class ColumnIdent implements Comparable<ColumnIdent> {
      * @param columnName column name to check for validity
      */
     public static void validateObjectKey(String columnName) {
-        validateSpaceInObjectKey(columnName);
         validateDotInColumnName(columnName);
         validateSubscriptPatternInColumnName(columnName);
-    }
-
-    public static void validateSpaceInObjectKey(String columnName) {
-        if (columnName.indexOf(' ') != -1) {
-            throw new InvalidColumnNameException(columnName, "contains an invalid space character");
-        }
     }
 
     /**

--- a/server/src/main/java/io/crate/types/ParameterTypeSignature.java
+++ b/server/src/main/java/io/crate/types/ParameterTypeSignature.java
@@ -58,6 +58,7 @@ public final class ParameterTypeSignature extends TypeSignature {
 
     @Override
     public String toString() {
-        return parameterName + " " + super.toString();
+        // Quote name as it may be a sub-column ident which is allowed to contain white spaces
+        return "\"" + parameterName + "\" " + super.toString();
     }
 }

--- a/server/src/main/java/io/crate/types/TypeSignature.java
+++ b/server/src/main/java/io/crate/types/TypeSignature.java
@@ -104,10 +104,22 @@ public class TypeSignature implements Writeable {
 
     private static TypeSignature of(String signature, List<TypeSignature> parameters) {
         if (isNamedTypeSignature(signature)) {
-            int split = signature.indexOf(" ");
+            String parameterName;
+            int splitStart;
+            if (signature.charAt(0) == '"') {
+                int closingIdx = signature.lastIndexOf('"');
+                if (closingIdx == -1) {
+                    throw new IllegalArgumentException(format(Locale.ENGLISH, "Bad type signature: '%s'", signature));
+                }
+                parameterName = signature.substring(1, closingIdx);
+                splitStart = signature.indexOf(' ', closingIdx);
+            } else {
+                splitStart = signature.indexOf(' ');
+                parameterName = signature.substring(0, splitStart);
+            }
             return new ParameterTypeSignature(
-                signature.substring(0, split),
-                new TypeSignature(signature.substring(split + 1), parameters));
+                parameterName,
+                new TypeSignature(signature.substring(splitStart + 1), parameters));
         } else {
             return new TypeSignature(signature, parameters);
         }
@@ -116,7 +128,7 @@ public class TypeSignature implements Writeable {
 
     private static boolean isNamedTypeSignature(String signature) {
         return !DataTypes.PRIMITIVE_TYPE_NAMES_WITH_SPACES.contains(signature)
-               && signature.contains(" ");
+               && (signature.charAt(0) == '"' || signature.contains(" "));
     }
 
     private static TypeSignature parseTypeSignatureParameter(String signature, int begin, int end) {

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1447,13 +1447,4 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "user_name={default_expr=CURRENT_USER, position=1, type=keyword}"
         ));
     }
-
-    @Test
-    public void test_ensure_object_key_validation_on_table_creation() {
-        assertThrowsMatches(
-            () -> analyze("create table tbl (o object as (\"col 1\" int))"),
-            InvalidColumnNameException.class,
-            "contains an invalid space character"
-        );
-    }
 }

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitorTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitorTest.java
@@ -97,11 +97,6 @@ public class ExpressionToColumnIdentVisitorTest extends ESTestCase {
     }
 
     @Test
-    public void testConvertWithUnsupportedWithspaceInSubscript() throws Exception {
-        assertInvalidColumnNameExceptionOnConvert("a['col 1']", "contains an invalid space character");
-    }
-
-    @Test
     public void testConvertWithUnsupportedArithmetic() throws Exception {
         assertExceptionOnUnsupportedConvert("1+1");
     }

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
@@ -261,7 +261,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
                 "(number_of_replicas = 1, \"routing.allocation.exclude._name\" = '" + internalCluster().getMasterName()
                 + "', \"write.wait_for_active_shards\" = 1)");
         ensureGreen();
-        execute("insert into t values (?, ?)", new Object[]{1, Map.of("first_field", "first value")});
+        execute("insert into t values (?, ?)", new Object[]{1, Map.of("first field", "first value")});
 
         ServiceDisruptionScheme disruption = new BlockMasterServiceOnMaster(random());
         setDisruptionScheme(disruption);
@@ -271,9 +271,9 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         try {
             execute("insert into t values (?, ?), (?, ?), (?, ?)",
                     new Object[]{
-                        2, Map.of("2nd_field", "2nd value"),
-                        3, Map.of("3rd_field", "3rd value"),
-                        4, Map.of("4th_field", "4th value"),
+                        2, Map.of("2nd field", "2nd value"),
+                        3, Map.of("3rd field", "3rd value"),
+                        4, Map.of("4th field", "4th value"),
                     });
         } catch (Exception e) {
             // failure is acceptable

--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -180,7 +180,7 @@ public class ObjectTypeTest extends ESTestCase {
     @Test
     public void test_object_type_to_signature_to_object_type_round_trip() {
         var objectType = ObjectType.builder()
-            .setInnerType("inner", DataTypes.STRING)
+            .setInnerType("inner field", DataTypes.STRING)
             .build();
         assertThat(objectType.getTypeSignature().createType(), is(objectType));
     }

--- a/server/src/test/java/io/crate/types/TypeSignatureTest.java
+++ b/server/src/test/java/io/crate/types/TypeSignatureTest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static io.crate.common.collections.Lists2.getOnlyElement;
 import static io.crate.types.TypeSignature.parseTypeSignature;
@@ -160,7 +161,7 @@ public class TypeSignatureTest extends ESTestCase {
         var objectType = ObjectType.builder()
             .setInnerType("name", StringType.of(1))
             .build();
-        assertThat(objectType.getTypeSignature().toString(), is("object(text,name text(1))"));
+        assertThat(objectType.getTypeSignature().toString(), is("object(text,\"name\" text(1))"));
     }
 
     @Test
@@ -187,5 +188,17 @@ public class TypeSignatureTest extends ESTestCase {
             signature.getParameters(),
             contains(new IntegerLiteralTypeSignature(1), new IntegerLiteralTypeSignature(2)));
         assertThat(signature.createType(), is(NumericType.of(1, 2)));
+    }
+
+    @Test
+    public void test_create_and_parse_object_type_containing_parameter_name_with_spaces_and_quotes() {
+        var type = ObjectType.builder()
+            .setInnerType("first\" field", DataTypes.STRING)
+            .build();
+        var signature = type.getTypeSignature();
+        assertThat(signature.toString(), is("object(text,\"first\" field\" text)"));
+        var parsedSignature = parseTypeSignature(signature.toString());
+        assertThat(parsedSignature, is(signature));
+        assertThat(parsedSignature.createType(), is(type));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix the data type signature parsing and creation logic to correctly
handle white spaces inside object/row inner column names.

Revert https://github.com/crate/crate/commit/dafdc8d3559
which added validation to prevent white spaces in such cases.
We always allowed it and broke it by mistake with the type signature
registry/logic introduced in CrateDB 4.2.0 (commits 507cf5d7320 and 0d5adc08af6).

Relates #11678.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
