### PR TITLE
Add "triage" labels to issue templates for bug- and performance-reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,6 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way you think it should
+labels: triage
 body:
   - type: input
     id: cratedb_version

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -1,5 +1,6 @@
 name: 🐢 Slow Performance
 description: Report a performance issue
+labels: triage
 body:
   - type: input
     id: cratedb_version


### PR DESCRIPTION
Hi there,

@proddata reported that some issue templates were lacking the "triage" labels. Currently, only the "feature request" template has it. I don't know whether this was intended or not.

With kind regards,
Andreas.
