### PR TITLE
Fix null cluster state handling in master node action

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause clients to receive a ``400 Bad Request``
+  error when using the HTTP interface early during node startup.
+
 - Fixed an issue that resulted in broken values when selecting multiple object
   columns with different inner types using the ``UNION`` statement.
 
@@ -76,6 +79,7 @@ Fixes
   identifiers containing white spaces to result in a validation exception
   at CrateDB ``4.6.2`` or a unusable object type column (write/reads fail)
   at CrateDB ``4.2.0`` to ``4.6.1``.
+
 - Fixed an issue from window functions, ``LEAD`` and ``LAG`` where having both
   ``IGNORE NULLS`` option together with an ``ORDER BY`` clause caused undefined
   behaviour.

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -24,7 +24,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.MasterNodeChangePredicate;
 import org.elasticsearch.cluster.NotMasterException;
@@ -102,6 +104,21 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
         new AsyncSingleAction(request, listener).start();
     }
 
+    class WaitForInitialState implements ClusterStateListener {
+
+        private final TransportMasterNodeAction<Request, Response>.AsyncSingleAction asyncSingleAction;
+
+        public WaitForInitialState(TransportMasterNodeAction<Request, Response>.AsyncSingleAction asyncSingleAction) {
+            this.asyncSingleAction = asyncSingleAction;
+        }
+
+        @Override
+        public void clusterChanged(ClusterChangedEvent event) {
+            clusterService.removeListener(this);
+            asyncSingleAction.start();
+        }
+    }
+
     class AsyncSingleAction {
 
         private final ActionListener<Response> listener;
@@ -115,6 +132,15 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
         public void start() {
             ClusterState state = clusterService.state();
+            if (state == null) {
+                WaitForInitialState waitForState = new WaitForInitialState(this);
+                clusterService.addListener(waitForState);
+                // protect against race between state null check and listener registration
+                if (clusterService.state() != null) {
+                    waitForState.clusterChanged(null);
+                }
+                return;
+            }
             this.observer = new ClusterStateObserver(state, clusterService, request.masterNodeTimeout(), logger);
             doStart(state);
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/11699

Opposed to what's stated in the issue description, this was already an
issue in 4.5.x and possibly before as well.

The `MainAndStaticFileHandler` requests some information via the
`ClusterStateAction` - this action failed with an NPE if called too
early while the node is still starting.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
