### PR TITLE
Add table_partitions column to sys.snapshots

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1907,6 +1907,11 @@ repositories (see :ref:`snapshot-restore`).
 |                      | names of all tables within the   |                              |
 |                      | snapshot.                        |                              |
 +----------------------+----------------------------------+------------------------------+
+| ``table_partitions`` | Contains the table schema, table | ``ARRAY(OBJECT)``            |
+|                      | name and partition values of     |                              |
+|                      | partitioned tables within the    |                              |
+|                      | snapshot.                        |                              |
++----------------------+----------------------------------+------------------------------+
 | ``started``          | The point in time when the       | ``TIMESTAMP WITH TIME ZONE`` |
 |                      | creation of the snapshot         |                              |
 |                      | started. Changes made after      |                              |

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,9 @@ None
 Changes
 =======
 
+- Added a new ``table_partitions`` column to the :ref:`sys.snapshots
+  <sys-snapshots>` table.
+
 - Added ``float4`` type as alias to ``real`` and ``float8`` type as alias to
   ``double precision``
 - Added the :ref:`JSON type <data-type-json>`.

--- a/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
@@ -24,6 +24,8 @@ package io.crate.expression.reference.sys.snapshot;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.crate.metadata.IndexParts;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 
 public class SysSnapshot {
@@ -93,5 +95,15 @@ public class SysSnapshot {
             .map(RelationName::fqnFromIndexName)
             .distinct()
             .collect(Collectors.toList());
+    }
+
+    public List<PartitionName> tablePartitions() {
+        return concreteIndices.stream()
+            .map(IndexParts::new)
+            .filter(IndexParts::isPartitioned)
+            .map(indexParts -> new PartitionName(
+                new RelationName(indexParts.getSchema(), indexParts.getTable()),
+                indexParts.getPartitionIdent()))
+            .toList();
     }
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
@@ -24,6 +24,7 @@ package io.crate.metadata.sys;
 import io.crate.action.sql.SessionContext;
 import io.crate.expression.reference.sys.snapshot.SysSnapshot;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -46,6 +47,11 @@ public class SysSnapshotsTableInfo {
             .add("repository", STRING, SysSnapshot::repository)
             .add("concrete_indices", STRING_ARRAY, SysSnapshot::concreteIndices)
             .add("tables", STRING_ARRAY, SysSnapshot::tables)
+            .startObjectArray("table_partitions", SysSnapshot::tablePartitions)
+                .add("table_schema", STRING, x -> x.relationName().schema())
+                .add("table_name", STRING, x -> x.relationName().name())
+                .add("values", STRING_ARRAY, PartitionName::values)
+            .endObjectArray()
             .add("started", TIMESTAMPZ, SysSnapshot::started)
             .add("finished", TIMESTAMPZ, SysSnapshot::finished)
             .add("version", STRING, SysSnapshot::version)

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -530,7 +530,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(847, response.rowCount());
+        assertEquals(851, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`table_partitions` is an object array where the object has:

    table_schema :: text
    table_name :: text
    values :: text[]

The partition column names are not provided because the information is
not available without loading the snapshots.

The values are represented as string because we don't have heterogeneous
arrays.

Closes https://github.com/crate/crate/issues/11700

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
