### PR TITLE
Fix null cluster state handling in master node action

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,9 @@ None
 Fixes
 =====
 
+- Fixed an issue that could cause clients to receive a ``400 Bad Request``
+  error when using the HTTP interface early during node startup.
+
 - Fixed an issue that resulted in broken values when selecting multiple object
   columns with different inner types using the ``UNION`` statement.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The mergify backport job failed. This is a BP of https://github.com/crate/crate/pull/11702

Fixes https://github.com/crate/crate/issues/11699

Opposed to what's stated in the issue description, this was already an
issue in 4.5.x and possibly before as well.

The `MainAndStaticFileHandler` requests some information via the
`ClusterStateAction` - this action failed with an NPE if called too
early while the node is still starting.

(cherry picked from commit 35aa4a2ca200324fdc4a43eeca222af5cf347f2d)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
