### PR TITLE
Fix unreleased changelog

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,18 +56,27 @@ Changes
 
 - Added ``float4`` type as alias to ``real`` and ``float8`` type as alias to
   ``double precision``
+
 - Added the :ref:`JSON type <data-type-json>`.
+
 - Added the :ref:`date_bin <date-bin>` scalar function that truncates timestamp
   into specified interval aligned with specified origin.
+
 - Introduced ``RESPECT NULLS`` and ``IGNORE NULLS`` flags to window function
   calls. The following window functions can now utilize the flags: ``LEAD``,
   ``LAG``, ``NTH_VALUE``, ``FIRST_VALUE``, and ``LAST_VALUE``.
+
 - Added the :ref:`scalar-area` scalar function that calculates the area for a
   ``GEO_SHAPE``.
+
 - Added support of ``numeric`` type to the ``avg`` aggregation function.
+
 
 Fixes
 =====
+
+- Fixed an issue in the ``Query View`` function of the administration console.
+  It generated queries with extra quotes around identifiers.
 
 - Fixed an issue that could cause clients to receive a ``400 Bad Request``
   error when using the HTTP interface early during node startup.
@@ -79,7 +88,3 @@ Fixes
   identifiers containing white spaces to result in a validation exception
   at CrateDB ``4.6.2`` or a unusable object type column (write/reads fail)
   at CrateDB ``4.2.0`` to ``4.6.1``.
-
-- Fixed an issue from window functions, ``LEAD`` and ``LAG`` where having both
-  ``IGNORE NULLS`` option together with an ``ORDER BY`` clause caused undefined
-  behaviour.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- We don't need to add a fixes entry for unreleased features (IGNORE
  NULLS)

- Administration console fixes should also get mentioned

- All release notes up to now used empty lines between the bullet
  points

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
