### PR TITLE
Assign highest precedence to target type in INSERT FROM VALUES statements

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,15 @@ None
 Changes
 =======
 
+- Changed the type precedence rules for ``INSERT FROM VALUES`` statements. The
+  target column types now take higher precedence to avoid errors in statements
+  like ``INSERT INTO tbl (text_column) VALUES ('a'), (3)``. Here ``3``
+  (``INTEGER``) used to take precedence, leading to a cast error because ``a``
+  cannot be converted to an ``INTEGER``.
+
+  This doesn't change the behavior of standalone ``VALUES`` statements.
+  ``VALUES ('a'), (3)`` as a standalone statement will still fail.
+
 - Added a new ``table_partitions`` column to the :ref:`sys.snapshots
   <sys-snapshots>` table.
 

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -698,8 +698,10 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         for (int c = 0; c < numColumns; c++) {
             ArrayList<Symbol> columnValues = new ArrayList<>();
             DataType<?> targetType;
+            boolean usePrecedence = true;
             if (parentOutputColumns.size() > c) {
                 targetType = parentOutputColumns.get(c).valueType();
+                usePrecedence = false;
             } else {
                 targetType = DataTypes.UNDEFINED;
             }
@@ -721,7 +723,9 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                         "The types of the columns within VALUES lists must match. " +
                         "Found `" + targetType + "` and `" + cellType + "` at position: " + c);
                 }
-                if (cellType.precedes(targetType)) {
+                if (usePrecedence && cellType.precedes(targetType)) {
+                    targetType = cellType;
+                } else if (targetType == DataTypes.UNDEFINED) {
                     targetType = cellType;
                 }
             }

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -462,4 +462,12 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         e.analyze("insert into doc.nested_clustered (obj) values ({id=4, name='George'})");
     }
 
+    @Test
+    public void test_insert_from_values_with_mixed_type_used_target_column_type() throws Exception {
+        AnalyzedInsertStatement stmt = e.analyze("insert into users (id, name) values (1, '1'), (2, 2)");
+        assertThat(stmt.subQueryRelation().outputs(), contains(
+            isReference("col1", DataTypes.LONG),
+            isReference("col2", DataTypes.STRING)
+        ));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/11519

@seut gave the hint that we can use the target column information.

I first wasn't sure if this is a good idea because it makes `VALUES ('a'), (3)`
used standalone behave differently than when used within the `INSERT`
statement, but PostgreSQL also behaves that way:

    > VALUES ('a'), (3);
    ERROR:  22P02: invalid input syntax for type integer: "a"

    > INSERT INTO tbl (name) VALUES ('a'), (3);
    Time: 2.978 ms


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
