### PR TITLE
Add limit pushdown rules to fix perf regression

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -90,6 +90,9 @@ Changes
 Fixes
 =====
 
+- Fixed a performance regression introduced in 4.2 which caused queries with a
+  ``LIMIT`` on top of views or virtual tables with an ``ORDER BY`` to be slow.
+
 - Fixed an issue in the ``Query View`` function of the administration console.
   It generated queries with extra quotes around identifiers.
 

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -91,6 +91,8 @@ import io.crate.planner.optimizer.rule.MoveFilterBeneathProjectSet;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathRename;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathUnion;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathWindowAgg;
+import io.crate.planner.optimizer.rule.MoveLimitBeneathEval;
+import io.crate.planner.optimizer.rule.MoveLimitBeneathRename;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathRename;
@@ -134,6 +136,8 @@ public class LogicalPlanner {
                 new MoveFilterBeneathUnion(),
                 new MoveFilterBeneathGroupBy(),
                 new MoveFilterBeneathWindowAgg(),
+                new MoveLimitBeneathRename(),
+                new MoveLimitBeneathEval(),
                 new MergeFilterAndCollect(),
                 new RewriteFilterOnOuterJoinToInnerJoin(),
                 new MoveOrderBeneathUnion(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MoveLimitBeneathEval implements Rule<Limit> {
+
+    private final Capture<Eval> evalCapture;
+    private final Pattern<Limit> pattern;
+
+    public MoveLimitBeneathEval() {
+        this.evalCapture = new Capture<>();
+        this.pattern = typeOf(Limit.class)
+            .with(source(), typeOf(Eval.class).capturedAs(evalCapture));
+    }
+
+    @Override
+    public Pattern<Limit> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Limit limit,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx) {
+        Eval eval = captures.get(evalCapture);
+        return transpose(limit, eval);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Rename;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MoveLimitBeneathRename implements Rule<Limit> {
+
+    private final Capture<Rename> renameCapture;
+    private final Pattern<Limit> pattern;
+
+    public MoveLimitBeneathRename() {
+        this.renameCapture = new Capture<>();
+        this.pattern = typeOf(Limit.class)
+            .with(source(), typeOf(Rename.class).capturedAs(renameCapture));
+    }
+
+    @Override
+    public Pattern<Limit> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Limit limit,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx) {
+        Rename rename = captures.get(renameCapture);
+        return transpose(limit, rename);
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -76,9 +76,9 @@ public class SubSelectIntegrationTest extends SQLIntegrationTestCase {
         execute("refresh table doc.tbl");
         execute("explain select i, name from (select ord as i, name from doc.tbl order by name) as t order by i desc limit 20");
         assertThat(printedTable(response.rows()), is(
-            "Fetch[i, name]\n" +
-            "  └ Limit[20::bigint;0]\n" +
-            "    └ Rename[t._fetchid, i] AS t\n" +
+            "Rename[i, name] AS t\n" +
+            "  └ Fetch[ord AS i, name]\n" +
+            "    └ Limit[20::bigint;0]\n" +
             "      └ OrderBy[ord AS i DESC]\n" +
             "        └ Collect[doc.tbl | [_fetchid, ord AS i] | true]\n"
         ));

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -148,8 +148,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                 "   select a, x from t1 order by a limit 3) tt " +
                                 "order by x desc limit 1");
         assertThat(plan, isPlan(
-            "Limit[1::bigint;0]\n" +
-            "  └ Rename[a, x] AS tt\n" +
+            "Rename[a, x] AS tt\n" +
+            "  └ Limit[1::bigint;0]\n" +
             "    └ OrderBy[x DESC]\n" +
             "      └ Fetch[a, x]\n" +
             "        └ Limit[3::bigint;0]\n" +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

With https://github.com/crate/crate/pull/9669 and
https://github.com/crate/crate/pull/9765 we switched to a rule based
fetch optimization. This change unfortunately caused a performance
regression for cases where a subquery uses an ORDER BY and a parent
query uses a LIMIT. Due to the distance between the LIMIT and ORDER BY
operators caused by RENAME/EVAL, the LIMIT operation got applied late,
resulting in an unlimited ORDER BY.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
