### PR TITLE
Support fetch on joins with only one side propagation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -90,6 +90,10 @@ Changes
 Fixes
 =====
 
+- Fixed a performance regression introduced in 4.2 which could cause queries
+  including joins, virtual tables and ``LIMIT`` operators to run slower than
+  before.
+
 - Fixed an issue that caused ``INSERT INTO`` statements to fail on partitioned
   tables where the partitioned column is generated and the column and value are
   provided in the statement.

--- a/server/src/main/java/io/crate/execution/dsl/phases/FetchPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/FetchPhase.java
@@ -178,4 +178,13 @@ public class FetchPhase implements ExecutionPhase {
     public int hashCode() {
         return Objects.hash(bases, tableIndices, fetchRefs, executionPhaseId, executionNodes);
     }
+
+    @Override
+    public String toString() {
+        return "FetchPhase{bases=" + bases
+            + ", executionNodes=" + executionNodes
+            + ", executionPhaseId=" + executionPhaseId
+            + ", fetchRefs=" + fetchRefs
+            + ", tableIndices=" + tableIndices + "}";
+    }
 }

--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -21,6 +21,13 @@
 
 package io.crate.planner;
 
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.ShardRouting;
+
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
 import io.crate.data.Row;
@@ -29,11 +36,6 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.table.TableInfo;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.routing.ShardRouting;
-
-import javax.annotation.Nullable;
-import java.util.UUID;
 
 public class PlannerContext {
 
@@ -136,5 +138,9 @@ public class PlannerContext {
 
     public ClusterState clusterState() {
         return clusterState;
+    }
+
+    public void newReaderAllocations() {
+        routingBuilder.newAllocations();
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/server/src/main/java/io/crate/planner/operators/Fetch.java
@@ -117,7 +117,8 @@ public final class Fetch extends ForwardingLogicalPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
-        ExecutionPlan executionPlan = Merge.ensureOnHandler(
+        plannerContext.newReaderAllocations();
+        var executionPlan = Merge.ensureOnHandler(
             source.build(
                 plannerContext,
                 hints,
@@ -131,8 +132,8 @@ public final class Fetch extends ForwardingLogicalPlan {
             ),
             plannerContext
         );
-        Function<Symbol, Symbol> paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
         ReaderAllocations readerAllocations = plannerContext.buildReaderAllocations();
+        Function<Symbol, Symbol> paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
         FetchPhase fetchPhase = new FetchPhase(
             plannerContext.nextExecutionPhaseId(),
             readerAllocations.nodeReaders().keySet(),

--- a/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
+++ b/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
@@ -67,11 +67,13 @@ public class RoutingBuilderTest extends CrateDummyClusterServiceUnitTest {
                 EqOperator.RETURN_TYPE
             ));
 
+        routingBuilder.newAllocations();
+
         routingBuilder.allocateRouting(tableInfo, WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, null);
         routingBuilder.allocateRouting(tableInfo, whereClause, RoutingProvider.ShardSelection.ANY, null);
 
         // 2 routing allocations with different where clause must result in 2 allocated routings
-        List<Routing> tableRoutings = routingBuilder.routingListByTable.get(relationName);
+        List<Routing> tableRoutings = routingBuilder.routingListByTableStack.pop().get(relationName);
         assertThat(tableRoutings.size(), is(2));
 
         // The routings are the same because the RoutingProvider enforces this - this test doesn't reflect that fact
@@ -84,9 +86,11 @@ public class RoutingBuilderTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testBuildReaderAllocations() {
         RoutingBuilder routingBuilder = new RoutingBuilder(clusterService.state(), routingProvider);
+        routingBuilder.newAllocations();
         routingBuilder.allocateRouting(tableInfo, WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, null);
 
         ReaderAllocations readerAllocations = routingBuilder.buildReaderAllocations();
+        routingBuilder.newAllocations();
 
         assertThat(readerAllocations.indices().size(), is(1));
         assertThat(readerAllocations.indices().get(0), is(relationName.indexNameOrAlias()));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This should fix a performance regression introduced in 4.2


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
