### PR TITLE
handle NPE thrown from TransportSchemaUpdateAction.mergeIntoSource

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -97,3 +97,6 @@ Fixes
 - Fixed an issue that caused ``INSERT INTO`` statements to fail on partitioned
   tables where the partitioned column is generated and the column and value are
   provided in the statement.
+
+ - Fixed an issue that caused ``NullPointerException`` when inserting into
+   previously altered tables that were partitioned and had generated columns.

--- a/server/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
@@ -67,6 +67,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static org.elasticsearch.index.mapper.MapperService.parseMapping;
@@ -226,9 +227,11 @@ public class TransportSchemaUpdateAction extends TransportMasterNodeAction<Schem
                     //noinspection unchecked
                     mergeIntoSource((Map) sourceValue, (Map) updateValue, Lists2.concat(path, key));
                 } else {
-                    if (updateAllowed(key, sourceValue, updateValue)) {
+                    if (sourceValue == null) {  // mainly to handle BWC. Ideally there should not be null-valued entries.
                         source.put(key, updateValue);
-                    } else if (!isUpdateIgnored(path) && !sourceValue.equals(updateValue)) {
+                    } else if (updateAllowed(key, sourceValue, updateValue)) {
+                        source.put(key, updateValue);
+                    } else if (!isUpdateIgnored(path) && !Objects.equals(sourceValue, updateValue)) {
                         String fqKey = String.join(".", path) + '.' + key;
                         throw new IllegalArgumentException(
                             "Can't overwrite " + fqKey + "=" + sourceValue + " with " + updateValue);

--- a/server/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
@@ -29,6 +29,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.node.ddl.AlterTableAddColumnPlan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
@@ -99,6 +100,14 @@ public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUni
     public void testDynamicTrueCanBeChangedFromBooleanToStringValue() {
         HashMap<String, Object> source = new HashMap<>();
         source.put("dynamic", true);
+        TransportSchemaUpdateAction.mergeIntoSource(source, singletonMap("dynamic", "true"));
+        assertThat(source.get("dynamic"), Matchers.is("true"));
+    }
+
+    @Test
+    public void testMergeIntoSourceWithNullValuedSource() {
+        HashMap<String, Object> source = new HashMap<>();
+        source.put("dynamic", null);
         TransportSchemaUpdateAction.mergeIntoSource(source, singletonMap("dynamic", "true"));
         assertThat(source.get("dynamic"), Matchers.is("true"));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
closes #11722

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
