### PR TITLE
Add missing gateway setting documentation and backport some deprecations

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -478,7 +478,7 @@ should be crossed out as well.
 - [ ] bc5dae2713b Fix compilation in RoutingNode
 - [ ] 90ab949415e Improve performance of shards limits decider (#53577)
 - [ ] 6cc564d677a Restore off-heap loading for term dictionary in ReadOnlyEngine (#53713)
-- [ ] e7ae9ae596e Deprecate delaying state recovery for master nodes (#53646)
+- [x] e7ae9ae596e Deprecate delaying state recovery for master nodes (#53646)
 - [ ] 71b703edd1e Rename AtomicFieldData to LeafFieldData (#53554)
 - [ ] 01d2339883d Invoke response handler on failure to send (#53631)
 - [ ] 881d0bfa8a8 Add server name to remote info API (#53634)

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -165,7 +165,9 @@ information about the currently applied cluster settings.
     | settings['discovery']['zen']                                                      | object           |
     | settings['discovery']['zen']['publish_timeout']                                   | text             |
     | settings['gateway']                                                               | object           |
+    | settings['gateway']['expected_data_nodes']                                        | integer          |
     | settings['gateway']['expected_nodes']                                             | integer          |
+    | settings['gateway']['recover_after_data_nodes']                                   | integer          |
     | settings['gateway']['recover_after_nodes']                                        | integer          |
     | settings['gateway']['recover_after_time']                                         | text             |
     | settings['indices']                                                               | object           |
@@ -757,9 +759,9 @@ Example query::
   +----+---------...-+--------------------------------------------------------------...-+
   | id | node_id     | description                                                      |
   +----+---------...-+--------------------------------------------------------------...-+
-  |  1 | ...         | The value of the cluster setting 'gateway.expected_nodes' mus... |
-  |  2 | ...         | The value of the cluster setting 'gateway.recover_after_nodes... |
-  |  3 | ...         | If any of the "expected nodes" recovery settings are set, the... |
+  |  1 | ...         | The value of the cluster setting 'gateway.expected_data_nodes... |
+  |  2 | ...         | The value of the cluster setting 'gateway.recover_after_data_... |
+  |  3 | ...         | If any of the "expected data nodes" recovery settings are set... |
   |  5 | ...         | The high disk watermark is exceeded on the node. The cluster ... |
   |  6 | ...         | The low disk watermark is exceeded on the node. The cluster w... |
   |  7 | ...         | The flood stage disk watermark is exceeded on the node. Table... |
@@ -776,9 +778,9 @@ column. By doing this, specially CrateDB's built-in Admin-UI won't complain
 anymore about failing checks.
 
 Imagine we've added a new node to our cluster, but as the
-:ref:`gateway.expected_nodes <gateway.expected_nodes>` column can only
-be set via config-file or command-line argument, the check for this setting
-will not pass on the already running nodes until the config-file or
+:ref:`gateway.expected_data_nodes <gateway.expected_data_nodes>` column can
+only be set via config-file or command-line argument, the check for this
+setting will not pass on the already running nodes until the config-file or
 command-line argument on these nodes is updated and the nodes are restarted
 (which is not what we want on a healthy well running cluster).
 
@@ -799,21 +801,35 @@ flag::
 Description of checked node settings
 ------------------------------------
 
-Recovery expected nodes
-.......................
+Recovery expected data nodes
+............................
 
-The check for the :ref:`gateway.expected_nodes <gateway.expected_nodes>`
-setting checks that the number of nodes that should be waited for the immediate
+The check for the
+:ref:`gateway.expected_data_nodes <gateway.expected_data_nodes>` setting checks
+that the number of data nodes that should be waited for the immediate
 cluster state :ref:`recovery <gloss-shard-recovery>`. This value must be equal
-to the maximum number of data and master nodes in the cluster.
+to the maximum number of data nodes in the cluster.
 
-Recovery after nodes
-....................
+.. NOTE::
 
-The check for the :ref:`gateway.recover_after_nodes
-<gateway.recover_after_nodes>` verifies that the number of started nodes before
-the cluster starts must be greater than the half of the expected number of
-nodes and equal to or less than number of nodes in the cluster.
+   For backward compatibility, setting the deprecated
+   :ref:`gateway.expected_nodes <gateway.expected_nodes>` instead is still
+   supported. It must then be equal to the maximum of data and master nodes.
+
+Recovery after data nodes
+.........................
+
+The check for the :ref:`gateway.recover_after_data_nodes
+<gateway.recover_after_data_nodes>` verifies that the number of started nodes
+before the cluster starts must be greater than the half of the expected number
+of data nodes and equal to or less than number of data nodes in the cluster.
+
+.. NOTE::
+
+   For backward compatibility, setting the deprecated
+   :ref:`gateway.recover_after_nodes <gateway.recover_after_nodes>` instead
+   is still supported. It must then be equal to less than the number data and
+   master nodes.
 
 ::
 
@@ -825,10 +841,16 @@ Here, ``R`` is the number of :ref:`recovery <gloss-shard-recovery>` nodes and
 Recovery after time
 ...................
 
-If :ref:`gateway.recover_after_nodes <gateway.recover_after_nodes>` is set,
-then :ref:`gateway.recover_after_time <gateway.recover_after_time>` must not be
-set to ``0s``, otherwise the ``gateway.recover_after_nodes`` setting wouldn't
-have any effect.
+If :ref:`gateway.recover_after_data_nodes <gateway.recover_after_data_nodes>`
+is set, then :ref:`gateway.recover_after_time <gateway.recover_after_time>`
+must not be set to ``0s``, otherwise the ``gateway.recover_after_data_nodes``
+setting wouldn't have any effect.
+
+.. NOTE::
+
+   For backward compatibility, setting the deprecated
+   :ref:`gateway.recover_after_nodes <gateway.recover_after_nodes>` instead
+   is still supported.
 
 .. _node_checks_watermark_high:
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -48,7 +48,15 @@ None
 Deprecations
 ============
 
-None
+- The :ref:`gateway.expected_nodes <gateway.expected_nodes>` cluster setting
+  has been marked as deprecated and will be removed in CrateDB 5.0.
+  The :ref:`gateway.expected_data_nodes <gateway.expected_data_nodes>` must be
+  used instead.
+
+- The :ref:`gateway.recover_after_nodes <gateway.recover_after_nodes>` cluster
+  setting has been marked as deprecated and will be removed in CrateDB 5.0.
+  The :ref:`gateway.recover_after_data_nodes <gateway.recover_after_data_nodes>`
+  must be used instead.
 
 
 Changes

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1300,6 +1300,18 @@ The following settings can be used to configure the behavior of the
   because you only want the cluster state to be recovered after all nodes are
   started.
 
+.. _gateway.expected_data_nodes:
+
+**gateway.expected_data_nodes**
+  | *Default:*   ``-1``
+  | *Runtime:*  ``no``
+
+  The setting ``gateway.expected_data_nodes`` defines the number of data nodes
+  that should be waited for until the cluster state is recovered immediately.
+  The value of the setting should be equal to the number of data nodes in the
+  cluster, because you only want the cluster state to be recovered after all
+  data nodes are started.
+
 .. _gateway.recover_after_time:
 
 **gateway.recover_after_time**
@@ -1323,6 +1335,19 @@ The following settings can be used to configure the behavior of the
   because you only want the cluster state to be recovered once all nodes are
   started. However, the value must be bigger than the half of the expected
   number of nodes in the cluster.
+
+.. _gateway.recover_after_data_nodes:
+
+**gateway.recover_after_data_nodes**
+  | *Default:*   ``-1``
+  | *Runtime:*  ``no``
+
+  The ``gateway.recover_after_data_nodes`` setting defines the number of data
+  nodes that need to be started before the cluster state recovery will start.
+  Ideally the value of the setting should be equal to the number of data nodes
+  in the cluster, because you only want the cluster state to be recovered once
+  all data nodes are started. However, the value must be bigger than the half
+  of the expected number of data nodes in the cluster.
 
 
 .. _`Active Directory application`: https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1300,6 +1300,11 @@ The following settings can be used to configure the behavior of the
   because you only want the cluster state to be recovered after all nodes are
   started.
 
+  .. CAUTION::
+
+      This setting is deprecated and will be removed in CrateDB 5.0.
+      Use `gateway.expected_data_nodes`_ instead.
+
 .. _gateway.expected_data_nodes:
 
 **gateway.expected_data_nodes**
@@ -1335,6 +1340,11 @@ The following settings can be used to configure the behavior of the
   because you only want the cluster state to be recovered once all nodes are
   started. However, the value must be bigger than the half of the expected
   number of nodes in the cluster.
+
+  .. CAUTION::
+
+      This setting is deprecated and will be removed in CrateDB 5.0.
+      Use `gateway.recover_after_data_nodes`_ instead.
 
 .. _gateway.recover_after_data_nodes:
 

--- a/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -154,8 +154,10 @@ public final class CrateSettings implements ClusterStateListener {
         DiscoverySettings.PUBLISH_TIMEOUT_SETTING,
         // GATEWAY
         GatewayService.RECOVER_AFTER_NODES_SETTING,
+        GatewayService.RECOVER_AFTER_DATA_NODES_SETTING,
         GatewayService.RECOVER_AFTER_TIME_SETTING,
         GatewayService.EXPECTED_NODES_SETTING,
+        GatewayService.EXPECTED_DATA_NODES_SETTING,
         // INDICES
         RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING,
         RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING,

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.RingBuffer;
 
 
@@ -67,6 +68,11 @@ public class DeprecationLogger {
             return size() > 128;
         }
     }));
+
+    @VisibleForTesting
+    public void resetLRU() {
+        keys.clear();
+    }
 
     /**
      * Adds a formatted warning message as a response header on the thread context, and logs a deprecation message if the associated key has

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -52,13 +52,13 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
     private static final Logger LOGGER = LogManager.getLogger(GatewayService.class);
 
     public static final Setting<Integer> EXPECTED_NODES_SETTING =
-        Setting.intSetting("gateway.expected_nodes", -1, -1, Property.NodeScope);
+        Setting.intSetting("gateway.expected_nodes", -1, -1, Property.NodeScope, Property.Deprecated);
     public static final Setting<Integer> EXPECTED_DATA_NODES_SETTING =
         Setting.intSetting("gateway.expected_data_nodes", -1, -1, Property.NodeScope);
     public static final Setting<Integer> EXPECTED_MASTER_NODES_SETTING =
-        Setting.intSetting("gateway.expected_master_nodes", -1, -1, Property.NodeScope);
+        Setting.intSetting("gateway.expected_master_nodes", -1, -1, Property.NodeScope, Property.Deprecated);
 
-    private static final TimeValue DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET = TimeValue.timeValueMinutes(5);
+    public static final TimeValue DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET = TimeValue.timeValueMinutes(5);
     public static final Setting<TimeValue> RECOVER_AFTER_TIME_SETTING =
         Setting.timeSetting(
             "gateway.recover_after_time",
@@ -74,11 +74,11 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
             Property.NodeScope
         );
     public static final Setting<Integer> RECOVER_AFTER_NODES_SETTING =
-        Setting.intSetting("gateway.recover_after_nodes", -1, -1, Property.NodeScope);
+        Setting.intSetting("gateway.recover_after_nodes", -1, -1, Property.NodeScope, Property.Deprecated);
     public static final Setting<Integer> RECOVER_AFTER_DATA_NODES_SETTING =
         Setting.intSetting("gateway.recover_after_data_nodes", -1, -1, Property.NodeScope);
     public static final Setting<Integer> RECOVER_AFTER_MASTER_NODES_SETTING =
-        Setting.intSetting("gateway.recover_after_master_nodes", 0, 0, Property.NodeScope);
+        Setting.intSetting("gateway.recover_after_master_nodes", 0, 0, Property.NodeScope, Property.Deprecated);
 
     public static final ClusterBlock STATE_NOT_RECOVERED_BLOCK = new ClusterBlock(1, "state not recovered / initialized", true, true,
         false, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);

--- a/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
@@ -23,7 +23,9 @@ package io.crate.expression.reference.sys.check.node;
 
 import io.crate.expression.reference.sys.check.SysCheck;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import io.crate.common.unit.TimeValue;
 import org.elasticsearch.gateway.GatewayService;
@@ -37,45 +39,112 @@ import static org.mockito.Mockito.when;
 
 public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
+    /**
+     * We currently test deprecated settings for BWC. Enable warnings once the deprecated gateway settings are removed.
+     */
+    @Override
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
     @Test
     public void testRecoveryExpectedNodesCheckWithDefaultSetting() {
+        ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder().build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+        when(clusterService.state().nodes().getSize()).thenReturn(1);
+
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
             new RecoveryExpectedNodesSysCheck(clusterService, Settings.EMPTY);
 
+
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
         assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
-        assertThat(recoveryExpectedNodesCheck.validate(1,
-            GatewayService.EXPECTED_NODES_SETTING.getDefault(Settings.EMPTY)), is(true));
+        assertThat(recoveryExpectedNodesCheck.isValid(), is(true));
     }
 
     @Test
     public void testRecoveryExpectedNodesCheckWithLessThanQuorum() {
+        ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder()
+            .fPut("data_node1", mock(DiscoveryNode.class))
+            .fPut("data_node2", mock(DiscoveryNode.class))
+            .build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+
+        var settings = Settings.builder()
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 1)
+            .build();
+
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
-            new RecoveryExpectedNodesSysCheck(clusterService, Settings.EMPTY);
+            new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
         assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
-        assertThat(recoveryExpectedNodesCheck.validate(2, 1), is(false));
+        assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
+    }
+
+    @Test
+    public void test_recovery_expected_nodes_check_BWC_with_deprecated_settings() {
+        ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder().build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+        when(clusterService.state().nodes().getSize()).thenReturn(2);
+
+        var settings = Settings.builder()
+            .put(GatewayService.EXPECTED_NODES_SETTING.getKey(), 1)
+            .build();
+
+        RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
+            new RecoveryExpectedNodesSysCheck(clusterService, settings);
+
+        assertThat(recoveryExpectedNodesCheck.id(), is(1));
+        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
     }
 
     @Test
     public void testRecoveryExpectedNodesCheckWithCorrectSetting() {
+        ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder()
+            .fPut("data_node1", mock(DiscoveryNode.class))
+            .fPut("data_node2", mock(DiscoveryNode.class))
+            .fPut("data_node3", mock(DiscoveryNode.class))
+            .build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+
+        var settings = Settings.builder()
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 3)
+            .build();
+
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
-            new RecoveryExpectedNodesSysCheck(clusterService, Settings.EMPTY);
+            new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
         assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
-        assertThat(recoveryExpectedNodesCheck.validate(3, 3), is(true));
+        assertThat(recoveryExpectedNodesCheck.isValid(), is(true));
     }
 
     @Test
     public void testRecoveryExpectedNodesCheckWithBiggerThanNumberOfNodes() {
+        ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder()
+            .fPut("data_node1", mock(DiscoveryNode.class))
+            .fPut("data_node2", mock(DiscoveryNode.class))
+            .fPut("data_node3", mock(DiscoveryNode.class))
+            .build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+
+        var settings = Settings.builder()
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 4)
+            .build();
+
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
-            new RecoveryExpectedNodesSysCheck(clusterService, Settings.EMPTY);
+            new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
         assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
-        assertThat(recoveryExpectedNodesCheck.validate(3, 4), is(false));
+        assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
     }
 
     @Test
@@ -85,44 +154,87 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(recoveryAfterNodesCheck.id(), is(2));
         assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
-        assertThat(recoveryAfterNodesCheck.validate(
-            GatewayService.RECOVER_AFTER_NODES_SETTING.getDefault(Settings.EMPTY),
-            GatewayService.EXPECTED_NODES_SETTING.getDefault(Settings.EMPTY)
-        ), is(true));
+        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
     }
 
     @Test
     public void testRecoveryAfterNodesCheckWithLessThanQuorum() {
         ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder()
+            .fPut("data_node1", mock(DiscoveryNode.class))
+            .fPut("data_node2", mock(DiscoveryNode.class))
+            .build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+
+        var settings = Settings.builder()
+            .put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 1)
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 2)
+            .build();
 
         RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
-            new RecoveryAfterNodesSysCheck(clusterService, Settings.EMPTY);
-
-        when(clusterService.localNode().getId()).thenReturn("node");
-        when(clusterService.state().nodes().getSize()).thenReturn(8);
+            new RecoveryAfterNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryAfterNodesCheck.id(), is(2));
         assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
-        assertThat(recoveryAfterNodesCheck.validate(4, 8), is(false));
+        assertThat(recoveryAfterNodesCheck.isValid(), is(false));
+    }
+
+    @Test
+    public void test_recovery_after_nodes_check_BWC_with_deprecated_setting() {
+        ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder().build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+        when(clusterService.state().nodes().getSize()).thenReturn(8);
+
+        var settings = Settings.builder()
+            .put(GatewayService.RECOVER_AFTER_NODES_SETTING.getKey(), 4)
+            .put(GatewayService.EXPECTED_NODES_SETTING.getKey(), 8)
+            .build();
+
+        RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
+            new RecoveryAfterNodesSysCheck(clusterService, settings);
+
+        assertThat(recoveryAfterNodesCheck.id(), is(2));
+        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryAfterNodesCheck.isValid(), is(false));
     }
 
     @Test
     public void testRecoveryAfterNodesCheckWithCorrectSetting() {
         ClusterService clusterService = mock(ClusterService.class, Answers.RETURNS_DEEP_STUBS);
+        var dataNodes = ImmutableOpenMap.<String, DiscoveryNode>builder()
+            .fPut("data_node1", mock(DiscoveryNode.class))
+            .fPut("data_node2", mock(DiscoveryNode.class))
+            .build();
+        when(clusterService.state().nodes().getDataNodes()).thenReturn(dataNodes);
+
+        var settings = Settings.builder()
+            .put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2)
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 2)
+            .build();
 
         RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
-            new RecoveryAfterNodesSysCheck(clusterService, Settings.EMPTY);
-
-        when(clusterService.localNode().getId()).thenReturn("node");
-        when(clusterService.state().nodes().getSize()).thenReturn(8);
+            new RecoveryAfterNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryAfterNodesCheck.id(), is(2));
         assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
-        assertThat(recoveryAfterNodesCheck.validate(8, 8), is(true));
+        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
     }
 
     @Test
     public void testRecoveryAfterTimeCheckWithCorrectSetting() {
+        Settings settings = Settings.builder()
+            .put(GatewayService.RECOVER_AFTER_TIME_SETTING.getKey(), TimeValue.timeValueMillis(4).toString())
+            .put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 3)
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 3)
+            .build();
+
+        RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(settings);
+        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
+    }
+
+    @Test
+    public void test_recovery_after_time_check_BWC_with_deprecated_correct_setting() {
         Settings settings = Settings.builder()
             .put(GatewayService.RECOVER_AFTER_TIME_SETTING.getKey(), TimeValue.timeValueMillis(4).toString())
             .put(GatewayService.RECOVER_AFTER_NODES_SETTING.getKey(), 3)
@@ -139,19 +251,15 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(recoveryAfterNodesCheck.id(), is(3));
         assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryAfterNodesCheck.validate(
-            GatewayService.RECOVER_AFTER_TIME_SETTING.getDefault(Settings.EMPTY),
-            GatewayService.RECOVER_AFTER_NODES_SETTING.getDefault(Settings.EMPTY),
-            GatewayService.EXPECTED_NODES_SETTING.getDefault(Settings.EMPTY)
-        ), is(true));
+        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
     }
 
     @Test
     public void testRecoveryAfterTimeCheckWithWrongSetting() {
         Settings settings = Settings.builder()
             .put(GatewayService.RECOVER_AFTER_TIME_SETTING.getKey(), TimeValue.timeValueMillis(0).toString())
-            .put(GatewayService.RECOVER_AFTER_NODES_SETTING.getKey(), 3)
-            .put(GatewayService.EXPECTED_NODES_SETTING.getKey(), 3)
+            .put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 3)
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 3)
             .build();
 
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(settings);

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -531,7 +531,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(856, response.rowCount());
+        assertEquals(858, response.rowCount());
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -145,7 +145,9 @@ public class SysClusterSettingsTest extends SQLIntegrationTestCase {
     public void testStaticGatewayDefaultSettings() {
         execute("select settings from sys.cluster");
         assertSettingsDefault(GatewayService.EXPECTED_NODES_SETTING);
+        assertSettingsDefault(GatewayService.EXPECTED_DATA_NODES_SETTING);
         assertSettingsDefault(GatewayService.RECOVER_AFTER_NODES_SETTING);
+        assertSettingsDefault(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING);
         assertSettingsValue(
             GatewayService.RECOVER_AFTER_TIME_SETTING.getKey(),
             GatewayService.RECOVER_AFTER_TIME_SETTING.getDefaultRaw(Settings.EMPTY));

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsUtil.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.common.settings;
+
+
+public class SettingsUtil {
+
+    public static void resetDeprecationLogger() {
+        Settings.DeprecationLoggerHolder.deprecationLogger.resetLRU();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsUtil;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.common.unit.TimeValue;
+
+public class GatewayServiceTests extends ESTestCase {
+
+    private GatewayService createService(final Settings.Builder settings) {
+        final ClusterService clusterService = new ClusterService(Settings.builder().put("cluster.name", "GatewayServiceTests").build(),
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                null);
+        return new GatewayService(settings.build(), null, clusterService, null, null, null);
+    }
+
+    @Before
+    public void setup() {
+        SettingsUtil.resetDeprecationLogger();
+    }
+
+    public void testDefaultRecoverAfterTime() {
+        // check that the default is not set
+        GatewayService service = createService(Settings.builder());
+        assertNull(service.recoverAfterTime());
+
+        // ensure default is set when setting expected_data_nodes
+        service = createService(Settings.builder().put("gateway.expected_data_nodes", 1));
+        assertThat(service.recoverAfterTime(), Matchers.equalTo(GatewayService.DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET));
+
+        // ensure settings override default
+        final TimeValue timeValue = TimeValue.timeValueHours(3);
+        // ensure default is set when setting expected_nodes
+        service = createService(Settings.builder().put("gateway.recover_after_time",
+            timeValue.toString()));
+        assertThat(service.recoverAfterTime().millis(), Matchers.equalTo(timeValue.millis()));
+    }
+
+    @Test
+    public void testDeprecatedSettings() {
+        GatewayService service = createService(Settings.builder());
+
+        service = createService(Settings.builder().put("gateway.expected_nodes", 1));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {GatewayService.EXPECTED_NODES_SETTING });
+
+        service = createService(Settings.builder().put("gateway.expected_master_nodes", 1));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {GatewayService.EXPECTED_MASTER_NODES_SETTING });
+
+        service = createService(Settings.builder().put("gateway.recover_after_nodes", 1));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {GatewayService.RECOVER_AFTER_NODES_SETTING });
+
+        service = createService(Settings.builder().put("gateway.recover_after_master_nodes", 1));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] {GatewayService.RECOVER_AFTER_MASTER_NODES_SETTING });
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add the missing documentation of the `gateway.expected_data_nodes` setting and backport some gateway setting deprecations while also document the new deprecations.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
