### PR TITLE
implement a check for objectType compatibility for union-all stmt

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -111,3 +111,7 @@ Fixes
 
  - Fixed an issue that caused ``NullPointerException`` when inserting into
    previously altered tables that were partitioned and had generated columns.
+
+- Fixed an issue that caused ``UNION ALL`` statements to succeed or throw
+  unexpected exceptions when the ``SELECT`` results for ``UNION ALL`` included
+  object types with identically named but differently typed sub-columns.

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -331,7 +331,7 @@ public class AnalyzedColumnDefinition<T> {
                 DataType<?> dataType = definition.dataType();
                 boolean val = storageSettings.getAsBoolean(property, true);
                 if (val == false) {
-                    if (!DataTypes.isSameType(dataType, DataTypes.STRING)) {
+                    if (dataType.id() != DataTypes.STRING.id()) {
                         throw new IllegalArgumentException(
                             String.format(Locale.ENGLISH, "Invalid storage option \"columnstore\" for data type \"%s\"",
                                           dataType.getName()));

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -232,7 +232,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         for (int i = 0; i < leftOutputs.size(); i++) {
             var leftType = leftOutputs.get(i).valueType();
             var rightType = rightOutputs.get(i).valueType();
-            if (!DataTypes.isSameType(leftType, rightType)) {
+            if (!DataTypes.isCompatibleType(leftType, rightType)) {
                 throw new UnsupportedOperationException(
                     "Corresponding output columns at position: " + (i + 1) +
                     " must be compatible for all parts of a UNION");

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -101,11 +101,11 @@ public class FileCollectSource implements CollectSource {
                                                       NodeContext nodeCtx,
                                                       Symbol targetUri) {
         Object value = SymbolEvaluator.evaluate(txnCtx, nodeCtx, targetUri, Row.EMPTY, SubQueryResults.EMPTY);
-        if (DataTypes.isSameType(targetUri.valueType(), DataTypes.STRING)) {
+        if (targetUri.valueType().id() == DataTypes.STRING.id()) {
             String uri = (String) value;
             return Collections.singletonList(uri);
         } else if (DataTypes.isArray(targetUri.valueType()) &&
-                   DataTypes.isSameType(ArrayType.unnest(targetUri.valueType()), DataTypes.STRING)) {
+                   ArrayType.unnest(targetUri.valueType()).id() == DataTypes.STRING.id()) {
             //noinspection unchecked
             return (List<String>) value;
         }

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -353,7 +353,7 @@ public class ProjectionToProjectorVisitor
         StringBuilder sb = new StringBuilder(uri);
         Symbol resolvedFileName = normalizer.normalize(WriterProjection.DIRECTORY_TO_FILENAME, context.txnCtx);
         assert resolvedFileName instanceof Literal : "resolvedFileName must be a Literal, but is: " + resolvedFileName;
-        assert DataTypes.isSameType(resolvedFileName.valueType(), StringType.INSTANCE) :
+        assert resolvedFileName.valueType().id() == StringType.ID :
             "resolvedFileName.valueType() must be " + StringType.INSTANCE;
 
         String fileName = (String) ((Literal) resolvedFileName).value();

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -112,7 +112,7 @@ public class Union implements LogicalPlan {
         ResultDescription leftResultDesc = left.resultDescription();
         ResultDescription rightResultDesc = right.resultDescription();
 
-        assert DataTypes.isSameType(leftResultDesc.streamOutputs(), rightResultDesc.streamOutputs())
+        assert DataTypes.isCompatibleType(leftResultDesc.streamOutputs(), rightResultDesc.streamOutputs())
             : "Left and right must output the same types, got " +
               "lhs=" + leftResultDesc.streamOutputs() + ", rhs=" + rightResultDesc.streamOutputs();
 

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -538,33 +538,47 @@ public final class DataTypes {
     }
 
     /**
-     * Compares any two {@link DataType} by their IDs.
+     * Compares any two {@link DataType} by their IDs and names. For ObjectTypes, their inner types are compared only if the names are the same.
+     * The rest of the DataTypes are compared by their IDs.
      * The parameters of the data types, if they have any, are ignored.
      */
-    public static boolean isSameType(DataType<?> left, DataType<?> right) {
+    public static boolean isCompatibleType(DataType<?> left, DataType<?> right) {
         if (left.id() != right.id()) {
             return false;
         } else if (isArray(left)) {
-            return isSameType(
+            return isCompatibleType(
                 ((ArrayType<?>) left).innerType(),
                 ((ArrayType<?>) right).innerType());
-        } else {
-            return true;
+        } else if (left.id() == ObjectType.ID) {
+            var l = (ObjectType) left;
+            var r = (ObjectType) right;
+            for (var lEntry : l.innerTypes().entrySet()) {
+                var lInner = lEntry.getValue();
+                var rInner = r.innerTypes().get(lEntry.getKey());
+                if (rInner == null) {  // skip if the names are different
+                    continue;
+                }
+                if (!DataTypes.isCompatibleType(lInner, rInner)) {
+                    return false;
+                }
+            }
         }
+        return true;
     }
 
     /**
-     * Compares two {@link List<DataType>} by their IDs.
+     * Compares two {@link List<DataType>} by their IDs and names. For ObjectTypes, their inner types are compared only if the names are the same.
+     * The rest of the DataTypes are compared by their IDs.
      * The parameters of the data types, if they have any, are ignored.
      */
-    public static boolean isSameType(List<DataType<?>> left, List<DataType<?>> right) {
+    public static boolean isCompatibleType(List<DataType<?>> left, List<DataType<?>> right) {
         if (left.size() != right.size()) {
             return false;
         }
         assert left instanceof RandomAccess && right instanceof RandomAccess
             : "data type lists should support RandomAccess for fast lookups";
         for (int i = 0; i < left.size(); i++) {
-            if (!isSameType(left.get(i), right.get(i))) {
+            if (!isCompatibleType(left.get(i), right.get(i))) {
                 return false;
             }
         }

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -172,32 +172,32 @@ public class DataTypesTest extends ESTestCase {
 
     @Test
     public void test_is_same_type_on_primitive_types() {
-        assertThat(DataTypes.isSameType(DataTypes.STRING, DataTypes.STRING), is(true));
-        assertThat(DataTypes.isSameType(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING, DataTypes.STRING), is(true));
+        assertThat(DataTypes.isCompatibleType(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));
     }
 
     @Test
     public void test_is_same_type_on_complex_types() {
-        assertThat(DataTypes.isSameType(DataTypes.UNTYPED_OBJECT, DataTypes.BIGINT_ARRAY), is(false));
-        assertThat(DataTypes.isSameType(DataTypes.UNTYPED_OBJECT, DataTypes.GEO_POINT), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.BIGINT_ARRAY), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.GEO_POINT), is(false));
     }
 
     @Test
     public void test_is_same_type_on_primitive_and_complex_types() {
-        assertThat(DataTypes.isSameType(DataTypes.STRING_ARRAY, DataTypes.STRING), is(false));
-        assertThat(DataTypes.isSameType(DataTypes.UNTYPED_OBJECT, DataTypes.DOUBLE), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.STRING), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.DOUBLE), is(false));
     }
 
     @Test
     public void test_is_same_type_on_array_types_of_the_same_dimension() {
-        assertThat(DataTypes.isSameType(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY), is(true));
-        assertThat(DataTypes.isSameType(DataTypes.STRING_ARRAY, DataTypes.BIGINT_ARRAY), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY), is(true));
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.BIGINT_ARRAY), is(false));
     }
 
     @Test
     public void test_is_same_type_on_array_types_of_not_equal_dimension_and_same_inner_type() {
         assertThat(
-            DataTypes.isSameType(
+            DataTypes.isCompatibleType(
                 new ArrayType<>(DataTypes.STRING_ARRAY),
                 DataTypes.STRING_ARRAY),
             is(false));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
closes #11739 

As mentioned from #11739, `union-all` on object types with the same named but differently typed subcolumns should throw the exception mentioning that the objects are incompatible. But currently, it returns or throws `cannot cast...` error.


This also resolves `create table t as select obj from v1 union all select obj from v2` :
```
cr> create table v1 (obj object as (col int));                                                                                                                
cr> create table v2 (obj object as (col text));     

// without the fix
cr> create table t as select obj from v1 union all select obj from v2;                                                                                     
CREATE OK, 0 rows affected  (0.324 sec)

// with the fix
cr> create table t as select obj from v1 union all select obj from v2;                                                                                     
UnsupportedFeatureException[Corresponding output columns at position: 1 must be compatible for all parts of a UNION]
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
