### PR TITLE
add object_details to information_schema.columns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -86,6 +86,9 @@ Changes
 
 - Added support of ``numeric`` type to the ``avg`` aggregation function.
 
+- Added `object_details` to the `information_schema.columns` table including the
+  top level column for objects, path information and leaf name
+
 
 Fixes
 =====

--- a/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.STRING_ARRAY;
 import static io.crate.types.DataTypes.TIMESTAMP;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 
@@ -113,6 +114,11 @@ public class InformationColumnsTableInfo {
             .add("udt_name", STRING, ignored -> null)
             .add("check_references", STRING, ignored -> null)
             .add("check_action", INTEGER, ignored -> null)
+            .startObject("object_details")
+                .add("name", STRING , r -> r.info.column().name())
+                .add("leaf", STRING , r -> r.info.column().leafName())
+                .add("path", STRING_ARRAY, r -> r.info.column().path())
+            .endObject()
             .setPrimaryKeys(
                 new ColumnIdent("table_catalog"),
                 new ColumnIdent("table_name"),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Added `object_details` to the `information_schema.columns` table including the
  top level column for objects, path information and leaf name

closes #11738

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
