### PR TITLE
Fix NPE in NodeStatsContextFieldResolverTest

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -419,7 +419,10 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return builder;
     }
 
-    private static Map<String, DiscoveryNodeRole> roleNameToPossibleRoles;
+    // This is initialized to the proper value via #setPossibleRoles in the Node constructor.
+    // It is set here to a non-null default value to avoid NPEs if DiscoveryNode is used in unit tests
+    private static Map<String, DiscoveryNodeRole> roleNameToPossibleRoles = DiscoveryNodeRole.BUILT_IN_ROLES.stream()
+        .collect(Collectors.toUnmodifiableMap(DiscoveryNodeRole::roleName, Function.identity()));
 
     public static void setPossibleRoles(final Set<DiscoveryNodeRole> possibleRoles) {
         final Map<String, DiscoveryNodeRole> roleNameToPossibleRoles =


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This ensures `roleNameToPossibleRoles` is initialized in unit tests
without having to call `setPossibleRoles` manually.

In production code the `Node` constructor always calls
`setPossibleRoles`.

`NodeStatsContextFieldResolverTest` failed when running individually,
but not if another test case already initialized `Node`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
