### PR TITLE
Enable aggregations to be used in order-by clause

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -62,6 +62,9 @@ Deprecations
 Changes
 =======
 
+- Added support to use an aggregation in an order-by clause without having
+  them in the select list like ``select x from tbl group by x order by count(y)``
+
 - Added an empty ``pg_catalog.pg_indexes`` table for compatibility with
   PostgreSQL.
 

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -220,11 +220,16 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testSelectGroupByOrderByWithAggregateFunctionInOrderByClause() throws Exception {
+    public void testSelectGroupByOrderByWithAggregateFunctionInOrderByClauseWithoutHavingThemInTheSelectList() throws Exception {
+        QueriedSelectRelation stmt = analyze("select name, count(id) from users group by name order by count(1)");
+        assertThat(stmt.orderBy().orderBySymbols().get(0), isFunction("count"));
+    }
+
+    @Test
+    public void testSelectGroupByOrderByWithNestedAggregateFunctionInOrderByClause() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("ORDER BY function 'max(count(upper(name)))' is not allowed. " +
-                                        "Only scalar functions can be used");
-        analyze("select name, count(id) from users group by name order by max(count(upper(name)))");
+        expectedException.expectMessage("Aggregate function calls cannot be nested 'max(count(name))'.");
+        analyze("select name, count(id) from users group by name order by max(count(name))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -205,4 +205,35 @@ public class AggregateExpressionIntegrationTest extends SQLIntegrationTestCase {
                    is("a| 3\n" +
                       "b| 0\n"));
     }
+
+    @Test
+    public void test_aggregation_in_order_by_without_having_them_in_the_select_list() throws Exception {
+        execute("create table test(id integer, name varchar) clustered into 1 shards with(number_of_replicas=0)");
+        execute("insert into test(id, name) values (1, 'a'),(2, 'a'),(3, 'a'),(4, 'b'),(5, 'b'),(6, 'c')");
+        execute("refresh table test");
+
+        execute("select name from test group by name order by count(1)");
+        assertThat(printedTable(response.rows()),
+                   is("c\n" +
+                      "b\n" +
+                      "a\n"));
+
+        execute("select name from test group by name order by count(id)");
+        assertThat(printedTable(response.rows()),
+                   is("c\n" +
+                      "b\n" +
+                      "a\n"));
+
+        execute("select name from test group by name order by count(id) asc");
+        assertThat(printedTable(response.rows()),
+                   is("c\n" +
+                      "b\n" +
+                      "a\n"));
+
+        execute("select name from test group by name order by count(id) desc");
+        assertThat(printedTable(response.rows()),
+                   is("a\n" +
+                      "b\n" +
+                      "c\n"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Resolves https://github.com/crate/crate/issues/10395

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
