### PR TITLE
Fix ClassCastException on `byte_col = 123` queries

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -167,7 +167,7 @@ public final class EqOperator extends Operator<Object> {
             return new TermQuery(new Term(column, Uid.encodeId((String) value)));
         }
         return switch (type.id()) {
-            case ByteType.ID, ShortType.ID, IntegerType.ID -> IntPoint.newExactQuery(column, (int) value);
+            case ByteType.ID, ShortType.ID, IntegerType.ID -> IntPoint.newExactQuery(column, ((Number) value).intValue());
             case LongType.ID -> LongPoint.newExactQuery(column, (long) value);
             case FloatType.ID -> FloatPoint.newExactQuery(column, (float) value);
             case DoubleType.ID -> DoublePoint.newExactQuery(column, (double) value);

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -553,6 +553,12 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_eq_on_byte_column() throws Exception {
+        Query query = convert("byte_col = 127");
+        assertThat(query.toString(), is("byte_col:[127 TO 127]"));
+    }
+
+    @Test
     public void test_range_query_on_bit_type_is_not_supported() throws Exception {
         assertThrows(UnsupportedOperationException.class, () -> convert("bits > B'01'"));
     }

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -67,7 +67,8 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
             " ts timestamp with time zone," +
             " addr ip," +
             " vchar_name varchar(40)," +
-            " bits bit(8)" +
+            " bits bit(8)," +
+            " byte_col byte " +
             ")"
         );
         queryTester = builder.build();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes a regression in master introduced with https://github.com/crate/crate/pull/11669
Discovered via the rnd-query tests of https://github.com/crate/crate-benchmarks

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
