### PR TITLE
Fix cross join + order by alias + limit 

### DIFF
--- a/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
@@ -43,6 +43,15 @@ public class SymbolVisitors {
         return false;
     }
 
+    public static boolean any(Predicate<? super Symbol> predicate, Iterable<? extends Symbol> symbols) {
+        for (Symbol symbol: symbols) {
+            if (any(predicate, symbol)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean any(Predicate<? super Symbol> symbolPredicate, Symbol symbol) {
         return symbol.accept(ANY_VISITOR, symbolPredicate);
     }

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -378,7 +378,7 @@ public class Collect implements LogicalPlan {
             } else if (!SymbolVisitors.any(Symbols.IS_COLUMN, output)) {
                 newOutputs.add(output);
                 replacedOutputs.put(output, output);
-            } else if (SymbolVisitors.any(usedColumns::contains, output)) {
+            } else if (SymbolVisitors.any(output::equals, usedColumns)) {
                 newOutputs.add(output);
                 replacedOutputs.put(output, output);
             } else {

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -184,6 +184,19 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
     }
 
     @Test
+    public void test_cross_join_with_order_by_alias_and_order() throws Exception {
+        execute("create table t1 (price int)");
+        execute("create table t2 (price int)");
+        ensureYellow();
+        execute("insert into t1 (price) values (1)");
+        execute("insert into t2 (price) values (2)");
+        execute("refresh table t1, t2");
+
+        execute("select t1.price as total_price from t1 cross join t2 order by total_price limit 10");
+        assertThat(printedTable(response.rows()), is("1\n"));
+    }
+
+    @Test
     public void testOrderByWithMixedRelationOrder() throws Exception {
         execute("create table t1 (price float)");
         execute("create table t2 (price float, name string)");


### PR DESCRIPTION
Fixes [#78](https://github.com/crate/crate-alerts/issues/78)

There was a regression in master after  https://github.com/crate/crate/commit/c3a01ea41fc27109f75acf9241437271e5b57b6d 

Query `select articles.name as article from articles, colors order by article limit 10000` from `joins.toml` spec file fails with the error message:

```
SQLParseException[Couldn't create execution plan from logical plan because of: 
Cannot ORDER BY `name`, the column does not appear in the outputs of the underlying relation:
Eval[name AS article]
  └ Fetch[name, name AS article]
    └ Limit[10000::bigint;0]
      └ NestedLoopJoin[CROSS]
        ├ OrderBy[name AS article ASC]
        │  └ Collect[doc.articles | [_fetchid] | true]
        └ Collect[doc.colors | [] | true]] occurred using: 
{"stmt": "select articles.name as article from articles, colors order by article limit 10000"}
```

This PR has only a test case for a previously failing join. It doesn't have a non-join test as I couldn't reproduce alias_in_used_but_ref_in_ouput case without join

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
