### PR TITLE
Replace like pattern match flags / ignoreCase with enum

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -22,6 +22,7 @@
 package io.crate.expression.operator;
 
 import io.crate.data.Input;
+import io.crate.expression.operator.LikeOperators.CaseSensitivity;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -35,17 +36,17 @@ public class LikeOperator extends Operator<String> {
 
     private final Signature signature;
     private final Signature boundSignature;
-    private final TriPredicate<String, String, Integer> matcher;
-    private final int patternMatchingFlags;
+    private final TriPredicate<String, String, CaseSensitivity> matcher;
+    private final CaseSensitivity caseSensitivity;
 
     public LikeOperator(Signature signature,
-                         Signature boundSignature,
-                         TriPredicate<String, String, Integer> matcher,
-                         int patternMatchingFlags) {
+                        Signature boundSignature,
+                        TriPredicate<String, String, CaseSensitivity> matcher,
+                        CaseSensitivity caseSensitivity) {
         this.signature = signature;
         this.boundSignature = boundSignature;
         this.matcher = matcher;
-        this.patternMatchingFlags = patternMatchingFlags;
+        this.caseSensitivity = caseSensitivity;
     }
 
     @Override
@@ -66,7 +67,7 @@ public class LikeOperator extends Operator<String> {
             if (value == null) {
                 return this;
             }
-            return new CompiledLike(signature, boundSignature, (String) value, patternMatchingFlags);
+            return new CompiledLike(signature, boundSignature, (String) value, caseSensitivity);
         }
         return super.compile(arguments);
     }
@@ -81,7 +82,7 @@ public class LikeOperator extends Operator<String> {
         if (expression == null || pattern == null) {
             return null;
         }
-        return matcher.test(expression, pattern, patternMatchingFlags);
+        return matcher.test(expression, pattern, caseSensitivity);
     }
 
     private static class CompiledLike extends Scalar<Boolean, String> {
@@ -89,10 +90,10 @@ public class LikeOperator extends Operator<String> {
         private final Signature boundSignature;
         private final Pattern pattern;
 
-        CompiledLike(Signature signature, Signature boundSignature, String pattern, int patternMatchingFlags) {
+        CompiledLike(Signature signature, Signature boundSignature, String pattern, CaseSensitivity caseSensitivity) {
             this.signature = signature;
             this.boundSignature = boundSignature;
-            this.pattern = LikeOperators.makePattern(pattern, patternMatchingFlags);
+            this.pattern = LikeOperators.makePattern(pattern, caseSensitivity);
         }
 
         @Override

--- a/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -24,6 +24,7 @@ package io.crate.expression.operator.any;
 import io.crate.data.Input;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.TriPredicate;
+import io.crate.expression.operator.LikeOperators.CaseSensitivity;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -37,17 +38,17 @@ public class AnyLikeOperator extends Operator<Object> {
 
     private final Signature signature;
     private final Signature boundSignature;
-    private final TriPredicate<String, String, Integer> matcher;
-    private final int patternMatchingFlags;
+    private final TriPredicate<String, String, CaseSensitivity> matcher;
+    private final CaseSensitivity caseSensitivity;
 
     public AnyLikeOperator(Signature signature,
                            Signature boundSignature,
-                           TriPredicate<String, String, Integer> matcher,
-                           int patternMatchingFlags) {
+                           TriPredicate<String, String, CaseSensitivity> matcher,
+                           CaseSensitivity caseSensitivity) {
         this.signature = signature;
         this.boundSignature = boundSignature;
         this.matcher = matcher;
-        this.patternMatchingFlags = patternMatchingFlags;
+        this.caseSensitivity = caseSensitivity;
         DataType<?> innerType = ((ArrayType<?>) boundSignature.getArgumentDataTypes().get(1)).innerType();
         if (innerType.id() == ObjectType.ID) {
             throw new IllegalArgumentException("ANY on object arrays is not supported");
@@ -74,7 +75,7 @@ public class AnyLikeOperator extends Operator<Object> {
             }
             assert elem instanceof String : "elem must be a String";
             String elemValue = (String) elem;
-            if (matcher.test(elemValue, pattern, patternMatchingFlags)) {
+            if (matcher.test(elemValue, pattern, caseSensitivity)) {
                 return true;
             }
         }

--- a/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
+++ b/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
@@ -23,6 +23,7 @@ package io.crate.lucene;
 
 import com.google.common.collect.Iterables;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.expression.operator.LikeOperators.CaseSensitivity;
 import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -37,14 +38,14 @@ import java.io.IOException;
 
 abstract class AbstractAnyQuery implements FunctionToQuery {
 
-    protected boolean ignoreCase;
+    protected final CaseSensitivity caseSensitivity;
 
     AbstractAnyQuery() {
-        this(false);
+        this(CaseSensitivity.SENSITIVE);
     }
 
-    AbstractAnyQuery(boolean ignoreCase) {
-        this.ignoreCase = ignoreCase;
+    AbstractAnyQuery(CaseSensitivity caseSensitivity) {
+        this.caseSensitivity = caseSensitivity;
     }
 
     @Override

--- a/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
@@ -21,24 +21,26 @@
 
 package io.crate.lucene;
 
-import io.crate.expression.operator.any.AnyOperators;
-import io.crate.expression.symbol.Literal;
-import io.crate.metadata.Reference;
+import java.io.IOException;
+
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 
-import java.io.IOException;
+import io.crate.expression.operator.LikeOperators.CaseSensitivity;
+import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
 
 class AnyLikeQuery extends AbstractAnyQuery {
 
-    AnyLikeQuery(boolean ignoreCase) {
-        super(ignoreCase);
+    AnyLikeQuery(CaseSensitivity caseSensitivity) {
+        super(caseSensitivity);
     }
 
     @Override
     protected Query literalMatchesAnyArrayRef(Literal candidate, Reference array, LuceneQueryBuilder.Context context) throws IOException {
-        return LikeQuery.toQuery(array, candidate.value(), context, ignoreCase);
+        return LikeQuery.toQuery(array, candidate.value(), context, caseSensitivity);
     }
 
     @Override
@@ -47,7 +49,7 @@ class AnyLikeQuery extends AbstractAnyQuery {
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         booleanQuery.setMinimumNumberShouldMatch(1);
         for (Object value : AnyOperators.collectionValueToIterable(array.value())) {
-            booleanQuery.add(LikeQuery.toQuery(candidate, value, context, ignoreCase), BooleanClause.Occur.SHOULD);
+            booleanQuery.add(LikeQuery.toQuery(candidate, value, context, caseSensitivity), BooleanClause.Occur.SHOULD);
         }
         return booleanQuery.build();
     }

--- a/server/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
@@ -21,10 +21,9 @@
 
 package io.crate.lucene;
 
-import io.crate.expression.operator.LikeOperators;
-import io.crate.expression.operator.any.AnyOperators;
-import io.crate.expression.symbol.Literal;
-import io.crate.metadata.Reference;
+import java.io.IOException;
+import java.util.Locale;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -34,8 +33,11 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.RegexpFlag;
 
-import java.io.IOException;
-import java.util.Locale;
+import io.crate.expression.operator.LikeOperators;
+import io.crate.expression.operator.LikeOperators.CaseSensitivity;
+import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
 
 class AnyNotLikeQuery extends AbstractAnyQuery {
 
@@ -43,8 +45,8 @@ class AnyNotLikeQuery extends AbstractAnyQuery {
         return String.format(Locale.ENGLISH, "~(%s)", wildCard);
     }
 
-    AnyNotLikeQuery(boolean ignoreCase) {
-        super(ignoreCase);
+    AnyNotLikeQuery(CaseSensitivity caseSensitivity) {
+        super(caseSensitivity);
     }
 
     @Override
@@ -69,7 +71,7 @@ class AnyNotLikeQuery extends AbstractAnyQuery {
         BooleanQuery.Builder andLikeQueries = new BooleanQuery.Builder();
         for (Object value : AnyOperators.collectionValueToIterable(array.value())) {
             andLikeQueries.add(
-                LikeQuery.like(candidate.valueType(), fieldType, value, ignoreCase),
+                LikeQuery.like(candidate.valueType(), fieldType, value, caseSensitivity),
                 BooleanClause.Occur.MUST);
         }
         return Queries.not(andLikeQueries.build());

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -66,6 +66,7 @@ import io.crate.expression.operator.LteOperator;
 import io.crate.expression.operator.OrOperator;
 import io.crate.expression.operator.RegexpMatchCaseInsensitiveOperator;
 import io.crate.expression.operator.RegexpMatchOperator;
+import io.crate.expression.operator.LikeOperators.CaseSensitivity;
 import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.predicate.IsNullPredicate;
 import io.crate.expression.predicate.MatchPredicate;
@@ -295,8 +296,8 @@ public class LuceneQueryBuilder {
             entry(GteOperator.NAME, GTE_QUERY),
             entry(GtOperator.NAME, GT_QUERY),
             entry(CIDROperator.CONTAINED_WITHIN, LLT_QUERY),
-            entry(LikeOperators.OP_LIKE, new LikeQuery(false)),
-            entry(LikeOperators.OP_ILIKE, new LikeQuery(true)),
+            entry(LikeOperators.OP_LIKE, new LikeQuery(CaseSensitivity.SENSITIVE)),
+            entry(LikeOperators.OP_ILIKE, new LikeQuery(CaseSensitivity.INSENSITIVE)),
             entry(NotPredicate.NAME, new NotQuery(this)),
             entry(Ignore3vlFunction.NAME, new Ignore3vlQuery()),
             entry(IsNullPredicate.NAME, new IsNullQuery()),
@@ -307,10 +308,10 @@ public class LuceneQueryBuilder {
             entry(AnyOperators.Type.LTE.opName(), new AnyRangeQuery("gte", "lte")),
             entry(AnyOperators.Type.GTE.opName(), new AnyRangeQuery("lte", "gte")),
             entry(AnyOperators.Type.GT.opName(), new AnyRangeQuery("lt", "gt")),
-            entry(LikeOperators.ANY_LIKE, new AnyLikeQuery(false)),
-            entry(LikeOperators.ANY_NOT_LIKE, new AnyNotLikeQuery(false)),
-            entry(LikeOperators.ANY_ILIKE, new AnyLikeQuery(true)),
-            entry(LikeOperators.ANY_NOT_ILIKE, new AnyNotLikeQuery(true)),
+            entry(LikeOperators.ANY_LIKE, new AnyLikeQuery(CaseSensitivity.SENSITIVE)),
+            entry(LikeOperators.ANY_NOT_LIKE, new AnyNotLikeQuery(CaseSensitivity.SENSITIVE)),
+            entry(LikeOperators.ANY_ILIKE, new AnyLikeQuery(CaseSensitivity.INSENSITIVE)),
+            entry(LikeOperators.ANY_NOT_ILIKE, new AnyNotLikeQuery(CaseSensitivity.INSENSITIVE)),
             entry(RegexpMatchOperator.NAME, new RegexpMatchQuery()),
             entry(RegexpMatchCaseInsensitiveOperator.NAME, new RegexMatchQueryCaseInsensitive())
         );

--- a/server/src/main/java/io/crate/lucene/RegexMatchQueryCaseInsensitive.java
+++ b/server/src/main/java/io/crate/lucene/RegexMatchQueryCaseInsensitive.java
@@ -21,11 +21,13 @@
 
 package io.crate.lucene;
 
-import io.crate.expression.symbol.Function;
-import io.crate.lucene.match.CrateRegexCapabilities;
-import io.crate.lucene.match.CrateRegexQuery;
+import java.util.regex.Pattern;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+
+import io.crate.expression.symbol.Function;
+import io.crate.lucene.match.CrateRegexQuery;
 
 
 class RegexMatchQueryCaseInsensitive implements FunctionToQuery {
@@ -39,10 +41,10 @@ class RegexMatchQueryCaseInsensitive implements FunctionToQuery {
         String fieldName = refAndLiteral.reference().column().fqn();
         Object value = refAndLiteral.literal().value();
 
-        if (value instanceof String) {
+        if (value instanceof String str) {
             return new CrateRegexQuery(
-                new Term(fieldName, (String) value),
-                CrateRegexCapabilities.FLAG_CASE_INSENSITIVE | CrateRegexCapabilities.FLAG_UNICODE_CASE);
+                new Term(fieldName, str), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE
+            );
         }
         throw new IllegalArgumentException("Can only use ~* with patterns of type string");
     }

--- a/server/src/main/java/io/crate/lucene/match/CrateRegexCapabilities.java
+++ b/server/src/main/java/io/crate/lucene/match/CrateRegexCapabilities.java
@@ -32,9 +32,6 @@ import java.util.regex.Pattern;
  */
 public final class CrateRegexCapabilities {
 
-    public static final int FLAG_UNICODE_CASE = Pattern.UNICODE_CASE;
-    public static final int FLAG_CASE_INSENSITIVE = Pattern.CASE_INSENSITIVE;
-
     static JavaUtilRegexMatcher compile(String regex, int flags) {
         return new CrateRegexCapabilities.JavaUtilRegexMatcher(regex, flags);
     }

--- a/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -21,12 +21,13 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.TestingHelpers;
+import static org.hamcrest.Matchers.is;
+
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.is;
+import io.crate.testing.TestingHelpers;
 
 public class AnyIntegrationTest extends SQLIntegrationTestCase {
 

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -28,7 +28,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
 import org.junit.Test;
 
-import static io.crate.lucene.LikeQuery.convertSqlLikeToLuceneWildcard;
+import static io.crate.expression.operator.LikeOperators.convertSqlLikeToLuceneWildcard;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is partly related to https://github.com/crate/crate/pull/11669
(Preparing the LikeOperator to implement the query extension)

Partly because I found the flags a bit confusing. The ones defined in
`CrateRegexCapabilities` were just redirects and different from the ones
defined in `LikeOperators` but had the same name.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
