### PR TITLE
Don't optimize away casts for LIKE on non-string columns

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
@@ -21,6 +21,16 @@
 
 package io.crate.planner.optimizer.symbol;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.common.collections.Lists2;
 import io.crate.exceptions.ConversionException;
@@ -32,20 +42,12 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.planner.optimizer.symbol.rule.MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators;
-import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastInsideOperators;
 import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference;
 import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference;
 import io.crate.planner.optimizer.symbol.rule.MoveSubscriptOnReferenceCastToLiteralCastInsideOperators;
 import io.crate.planner.optimizer.symbol.rule.SimplifyEqualsOperationOnIdenticalReferences;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.List;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.crate.planner.optimizer.symbol.rule.SwapCastsInComparisonOperators;
+import io.crate.planner.optimizer.symbol.rule.SwapCastsInLikeOperators;
 
 public class Optimizer {
 
@@ -55,7 +57,8 @@ public class Optimizer {
             plannerContext.nodeContext(),
             () -> plannerContext.clusterState().nodes().getMinNodeVersion(),
             List.of(
-                MoveReferenceCastToLiteralCastInsideOperators::new,
+                SwapCastsInComparisonOperators::new,
+                SwapCastsInLikeOperators::new,
                 MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference::new,
                 MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference::new,
                 MoveSubscriptOnReferenceCastToLiteralCastInsideOperators::new,

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.symbol.rule;
+
+import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.crate.expression.scalar.cast.CastFunctionResolver;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.NodeContext;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.DataType;
+
+
+public class SwapCastsInComparisonOperators implements Rule<Function> {
+
+    private final Capture<Function> castCapture;
+    private final Pattern<Function> pattern;
+
+    public SwapCastsInComparisonOperators(FunctionSymbolResolver functionResolver) {
+        this.castCapture = new Capture<>();
+        this.pattern = typeOf(Function.class)
+            .with(f -> COMPARISON_OPERATORS.contains(f.name()))
+            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+                .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
+                .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
+            );
+    }
+
+    @Override
+    public Pattern<Function> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Symbol apply(Function operator,
+                        Captures captures,
+                        NodeContext nodeCtx,
+                        Symbol parentNode) {
+        var literal = operator.arguments().get(1);
+        var castFunction = captures.get(castCapture);
+        var reference = castFunction.arguments().get(0);
+        DataType<?> targetType = reference.valueType();
+        Symbol castedLiteral = literal.cast(targetType, CastFunctionResolver.getCastMode(castFunction.name()));
+        // Can't use functionResolver here because it would attempt to re-resolve the function
+        // and re-add casts if there is a text/varchar(n) missmatch.
+        return new Function(operator.signature(), List.of(reference, castedLiteral), operator.valueType());
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
@@ -21,49 +21,42 @@
 
 package io.crate.planner.optimizer.symbol.rule;
 
-import io.crate.common.collections.Lists2;
+import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
 import io.crate.planner.optimizer.symbol.Rule;
-import io.crate.types.DataType;
+import io.crate.types.StringType;
 
-import java.util.List;
-import java.util.Optional;
+public class SwapCastsInLikeOperators implements Rule<Function> {
 
-import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
-import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-
-
-public class MoveReferenceCastToLiteralCastInsideOperators implements Rule<Function> {
-
-    private static List<String> MATCHING_OPERATORS = Lists2.concat(
-        COMPARISON_OPERATORS,
-        List.of(
-            LikeOperators.OP_LIKE,
-            LikeOperators.OP_ILIKE
-        )
-    );
+    private final Set<String> LIKE_OPERATORS = Set.of(LikeOperators.OP_LIKE, LikeOperators.OP_ILIKE);
 
     private final Capture<Function> castCapture;
     private final Pattern<Function> pattern;
 
-    public MoveReferenceCastToLiteralCastInsideOperators(FunctionSymbolResolver functionResolver) {
+    public SwapCastsInLikeOperators(FunctionSymbolResolver functionResolver) {
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
-            .with(f -> MATCHING_OPERATORS.contains(f.name()))
+            .with(f -> LIKE_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
-                .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
+                .with(f -> f.arguments().get(0) instanceof Reference ref && ref.valueType().id() == StringType.ID)
             );
     }
 
@@ -73,17 +66,11 @@ public class MoveReferenceCastToLiteralCastInsideOperators implements Rule<Funct
     }
 
     @Override
-    public Symbol apply(Function operator,
-                        Captures captures,
-                        NodeContext nodeCtx,
-                        Symbol parentNode) {
-        var literal = operator.arguments().get(1);
+    public Symbol apply(Function likeFunction, Captures captures, NodeContext nodeCtx, Symbol parentNode) {
+        var literal = likeFunction.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);
-        DataType<?> targetType = reference.valueType();
-        Symbol castedLiteral = literal.cast(targetType, CastFunctionResolver.getCastMode(castFunction.name()));
-        // Can't use functionResolver here because it would attempt to re-resolve the function.
-        // LIKE is only registered for (text, text), and if the `reference` here has varchar(n) it would again wrap the arguments in casts.
-        return new Function(operator.signature(), List.of(reference, castedLiteral), operator.valueType());
+        Symbol castedLiteral = literal.cast(StringType.INSTANCE, CastFunctionResolver.getCastMode(castFunction.name()));
+        return new Function(likeFunction.signature(), List.of(reference, castedLiteral), likeFunction.valueType());
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/OptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/OptimizerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.symbol;
+
+
+import org.junit.Test;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.SymbolMatchers;
+
+public class OptimizerTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_like_on_numeric_columns_keeps_cast_around_reference() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int)")
+            .build();
+        Symbol symbol = Optimizer.optimizeCasts(e.asSymbol("x like 10"), e.getPlannerContext(clusterService.state()));
+        assertThat(symbol, SymbolMatchers.isFunction(
+            "op_like",
+            SymbolMatchers.isFunction("_cast"),
+            SymbolMatchers.isLiteral("10")
+        ));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `LIKE` operator is only registered for `(string, string)`
signatures. We must keep casts for operations like `x = '10'` where `x`
is a numeric column to ensure the type system checks out.

Scalars need to be able to assume that they are only called with values
matching their type signature.


(So far this wasn't an issue because the LikeQuery implementation in the
LuceneQueryBuilder is lenient, but when moving to the Scalar.toQuery variant
this popped up)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
