### PR TITLE
Add settings for node limits

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -111,6 +111,9 @@ Changes
 Fixes
 =====
 
+- Added various :ref:`node limit <node_limits>` settings to control the
+  concurrency of operations like ``INSERT INTO FROM QUERY``.
+
 - Fixed an issue that caused ``ALTER TABLE <tbl> ADD COLUMN <columName> INDEX
   USING FULLTEXT`` statements to ignore the ``INDEX USING FULLTEXT`` part.
 

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1268,6 +1268,56 @@ settings.
   Size of the queue for pending requests. A value of ``-1`` sets it to
   unbounded.
 
+.. _node_limits:
+
+Node limits
+-----------
+
+Node limits control how much resources operations like ``INSERT INTO FROM
+QUERY`` or ``COPY`` can use.
+
+The values here serve as a starting point for an algorithm that dynamically
+adapts the effective concurrency limit based on the round-trip time of
+requests. Whenever one of these settings is updated, the previously calculated
+effective concurrency is reset.
+
+Changing settings will only effect new operations, already running operations
+will continue with the previous settings.
+
+
+.. _node_limits.initial_concurrency:
+
+**node_limits.initial_concurrency**
+  | *Default:* ``50``
+  | *Runtime:* ``yes``
+
+The initial number of concurrent operations allowed per target node.
+
+.. _node_limits.min_concurrency:
+
+**node_limits.min_concurrency**
+  | *Default:* ``1``
+  | *Runtime:* ``yes``
+
+The minimum number of concurrent operations allowed per target node.
+
+.. _node_limits.max_concurrency:
+
+**node_limits.max_concurrency**
+  | *Default:* ``2000``
+  | *Runtime:* ``yes``
+
+The maximum number of concurrent operations allowed per target node.
+
+.. _node_limits.queue_size:
+
+**node_limits.queue_size**
+  | *Default:* ``200``
+  | *Runtime:* ``yes``
+
+How many operations are allowed to queue up.
+
+
 Metadata
 --------
 

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -92,6 +92,8 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportSettings;
 
+import io.crate.execution.jobs.NodeLimits;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -413,5 +415,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
         TransportAddVotingConfigExclusionsAction.MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING,
         ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING,
         ClusterBootstrapService.UNCONFIGURED_BOOTSTRAP_TIMEOUT_SETTING,
-        LagDetector.CLUSTER_FOLLOWER_LAG_TIMEOUT_SETTING);
+        LagDetector.CLUSTER_FOLLOWER_LAG_TIMEOUT_SETTING,
+        NodeLimits.INITIAL_CONCURRENCY,
+        NodeLimits.MIN_CONCURRENCY,
+        NodeLimits.MAX_CONCURRENCY,
+        NodeLimits.QUEUE_SIZE
+    );
 }

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -21,6 +21,26 @@
 
 package io.crate.execution.engine.indexing;
 
+import static io.crate.data.SentinelRow.SENTINEL;
+import static io.crate.testing.TestingHelpers.isRow;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Test;
+
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
@@ -47,24 +67,6 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
-import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static io.crate.data.SentinelRow.SENTINEL;
-import static io.crate.testing.TestingHelpers.isRow;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
 public class IndexWriterProjectorTest extends SQLIntegrationTestCase {
 
@@ -85,7 +87,7 @@ public class IndexWriterProjectorTest extends SQLIntegrationTestCase {
         ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class);
         IndexWriterProjector writerProjector = new IndexWriterProjector(
             clusterService(),
-            new NodeLimits(),
+            new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoopCircuitBreaker("dummy"),
             RamAccounting.NO_ACCOUNTING,
             threadPool.scheduler(),

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -21,6 +21,28 @@
 
 package io.crate.execution.engine.indexing;
 
+import static io.crate.data.SentinelRow.SENTINEL;
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
@@ -41,26 +63,6 @@ import io.crate.metadata.Schemas;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.settings.Settings;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
-import static io.crate.testing.TestingHelpers.createNodeContext;
-import static io.crate.data.SentinelRow.SENTINEL;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
 public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTest {
 
@@ -98,7 +100,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
         TransportCreatePartitionsAction transportCreatePartitionsAction = mock(TransportCreatePartitionsAction.class);
         IndexWriterProjector indexWriter = new IndexWriterProjector(
             clusterService,
-            new NodeLimits(),
+            new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoopCircuitBreaker("dummy"),
             RamAccounting.NO_ACCOUNTING,
             scheduler,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -21,6 +21,29 @@
 
 package io.crate.execution.engine.pipeline;
 
+import static io.crate.data.SentinelRow.SENTINEL;
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
@@ -49,26 +72,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Answers;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-
-import static io.crate.testing.TestingHelpers.createNodeContext;
-import static io.crate.data.SentinelRow.SENTINEL;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
 public class ProjectingRowConsumerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -84,7 +87,7 @@ public class ProjectingRowConsumerTest extends CrateDummyClusterServiceUnitTest 
         memoryManager = new OnHeapMemoryManager(usedBytes -> {});
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
-            new NodeLimits(),
+            new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoneCircuitBreakerService(),
             nodeCtx,
             THREAD_POOL,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -21,6 +21,29 @@
 
 package io.crate.execution.engine.pipeline;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static io.crate.data.SentinelRow.SENTINEL;
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static io.crate.testing.TestingHelpers.isRow;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.MockitoAnnotations;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Bucket;
@@ -60,27 +83,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Answers;
-import org.mockito.MockitoAnnotations;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
-import static io.crate.data.SentinelRow.SENTINEL;
-import static io.crate.testing.TestingHelpers.createNodeContext;
-import static io.crate.testing.TestingHelpers.isRow;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
 
 public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUnitTest {
 
@@ -97,7 +99,7 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         MockitoAnnotations.initMocks(this);
         visitor = new ProjectionToProjectorVisitor(
             clusterService,
-            new NodeLimits(),
+            new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoneCircuitBreakerService(),
             nodeCtx,
             THREAD_POOL,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
@@ -38,6 +38,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -67,7 +68,7 @@ public class ProjectorsTest extends CrateDummyClusterServiceUnitTest {
         memoryManager = new OnHeapMemoryManager(bytes -> {});
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
-            new NodeLimits(),
+            new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoneCircuitBreakerService(),
             nodeCtx,
             THREAD_POOL,

--- a/server/src/test/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
@@ -34,6 +34,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
@@ -63,7 +65,7 @@ public class NodeDisconnectJobMonitorServiceTest extends CrateDummyClusterServic
 
         NodeDisconnectJobMonitorService monitorService = new NodeDisconnectJobMonitorService(
             tasksService,
-            new NodeLimits(),
+            new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             mock(TransportService.class),
             mock(TransportKillJobsNodeAction.class));
 
@@ -107,7 +109,7 @@ public class NodeDisconnectJobMonitorServiceTest extends CrateDummyClusterServic
         };
         NodeDisconnectJobMonitorService monitorService = new NodeDisconnectJobMonitorService(
             tasksService,
-            new NodeLimits(),
+            new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             mock(TransportService.class),
             killAction);
 

--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
@@ -330,6 +330,20 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
         });
     }
 
+    @After
+    public void ensure_one_node_limit_instance_per_node() throws Exception {
+        Iterable<NodeLimits> nodeLimitsInstances = internalCluster().getInstances(NodeLimits.class);
+        int numInstances = 0;
+        for (var nodeLimits : nodeLimitsInstances) {
+            numInstances++;
+        }
+        assertThat(
+            "There must only be as many NodeLimits instances as there are nodes in the cluster",
+            numInstances,
+            is(internalCluster().numNodes())
+        );
+    }
+
     public void waitUntilShardOperationsFinished() throws Exception {
         assertBusy(() -> {
             Iterable<IndicesService> indexServices = internalCluster().getInstances(IndicesService.class);

--- a/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2220,4 +2220,8 @@ public final class InternalTestCluster extends TestCluster {
             }
         }
     }
+
+    public int numNodes() {
+        return nodes.size();
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Allows users to tweak how aggressive INSERT-INTO-FROM-QUERY and COPY operations are.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
