### PR TITLE
Reduce node_limits.initial_concurrency from 50 to 5

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -111,6 +111,13 @@ Changes
 Fixes
 =====
 
+- Reduced the default :ref:`initial concurrency limit
+  <node_limits.initial_concurrency>` for operations like ``INSERT INTO FROM
+  QUERY`` from 50 to 5. This is closer to the behavior before 4.6.0. If the
+  nodes have spare capacity for a higher concurrency the effective concurrency
+  limit will grow dynamically over time, but it will start out lower to avoid
+  overloading a cluster with an initial spike of internal requests.
+
 - Added various :ref:`node limit <node_limits>` settings to control the
   concurrency of operations like ``INSERT INTO FROM QUERY``.
 

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1288,7 +1288,7 @@ will continue with the previous settings.
 .. _node_limits.initial_concurrency:
 
 **node_limits.initial_concurrency**
-  | *Default:* ``50``
+  | *Default:* ``5``
   | *Runtime:* ``yes``
 
 The initial number of concurrent operations allowed per target node.

--- a/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
+++ b/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
@@ -44,7 +44,7 @@ public class NodeLimits {
     private final Map<String, ConcurrencyLimit> limitsPerNode = new ConcurrentHashMap<>();
     private final ClusterSettings clusterSettings;
 
-    public static final Setting<Integer> INITIAL_CONCURRENCY = Setting.intSetting("node_limits.initial_concurrency", 50, Property.NodeScope, Property.Dynamic);
+    public static final Setting<Integer> INITIAL_CONCURRENCY = Setting.intSetting("node_limits.initial_concurrency", 5, Property.NodeScope, Property.Dynamic);
     public static final Setting<Integer> MIN_CONCURRENCY = Setting.intSetting("node_limits.min_concurrency", 1, Property.NodeScope, Property.Dynamic);
     public static final Setting<Integer> MAX_CONCURRENCY = Setting.intSetting("node_limits.max_concurrency", 2000, Property.NodeScope, Property.Dynamic);
     public static final Setting<Integer> QUEUE_SIZE = Setting.intSetting("node_limits.queue_size", 200, Property.NodeScope, Property.Dynamic);

--- a/server/src/test/java/io/crate/execution/jobs/NodeLimitsTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/NodeLimitsTest.java
@@ -62,7 +62,7 @@ public class NodeLimitsTest extends ESTestCase {
         );
         ConcurrencyLimit updatedLimit = nodeLimits.get("n1");
         assertThat(limit, not(sameInstance(updatedLimit)));
-        assertThat(limit.getLimit(), is(50));
+        assertThat(limit.getLimit(), is(5));
         assertThat(updatedLimit.getLimit(), is(10));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See changes for reason.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
