### PR TITLE
Use correct authMethod name in log message

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -138,3 +138,7 @@ Fixes
 - Fixed an issue that caused ``UNION ALL`` statements to succeed or throw
   unexpected exceptions when the ``SELECT`` results for ``UNION ALL`` included
   object types with identically named but differently typed sub-columns.
+
+- Fixed an issue that caused showing an incorrect log message in case of an
+  authentication failure. "Password authentication" used to be shown instead
+  of the actual authentication method name.

--- a/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
+++ b/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
@@ -118,8 +118,8 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
                 ctx.fireChannelRead(request);
             } catch (Exception e) {
                 if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info("Password authentication failed for user={} from connection={}",
-                                username, connectionProperties.address());
+                    LOGGER.info("{} authentication failed for user={} from connection={}",
+                                authMethod.name(), username, connectionProperties.address());
                 }
                 sendUnauthorized(ctx.channel(), e.getMessage());
             }


### PR DESCRIPTION
`HttpAuthUpstreamHandler` shows "Password authentication failed" in logs which might be confusing since actual authMethod might be different.

Exception message dynamically gets `authMethod.name` as shown in [test](https://github.com/crate/crate/blob/388807579829bcdb2051532fe751f1ed574a7748/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java#L162)

For example, user doesn't have password entry in HBA but sees a message `Password authentication failed`: https://github.com/crate/crate/issues/11760#issuecomment-928168168


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
