### PR TITLE
Expose new node limit settings for use with SET GLOBAL

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -196,6 +196,11 @@ information about the currently applied cluster settings.
     | settings['memory']                                                                | object           |
     | settings['memory']['allocation']                                                  | object           |
     | settings['memory']['allocation']['type']                                          | text             |
+    | settings['node_limits']                                                           | object           |
+    | settings['node_limits']['initial_concurrency']                                    | integer          |
+    | settings['node_limits']['max_concurrency']                                        | integer          |
+    | settings['node_limits']['min_concurrency']                                        | integer          |
+    | settings['node_limits']['queue_size']                                             | integer          |
     | settings['stats']                                                                 | object           |
     | settings['stats']['breaker']                                                      | object           |
     | settings['stats']['breaker']['log']                                               | object           |

--- a/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
+++ b/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
@@ -83,7 +83,7 @@ public class NodeLimits {
 
 
     /**
-     * Retrieve the current CurrencyLimit for a node.
+     * Retrieve the current ConcurrencyLimit for a node.
      *
      * <p>
      * Instances may change if the settings are updated.

--- a/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -24,6 +24,7 @@ package io.crate.metadata.settings;
 import io.crate.cluster.gracefulstop.DecommissioningService;
 import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
+import io.crate.execution.jobs.NodeLimits;
 import io.crate.memory.MemoryManagerFactory;
 import io.crate.statistics.TableStatsService;
 import io.crate.types.DataTypes;
@@ -170,7 +171,12 @@ public final class CrateSettings implements ClusterStateListener {
         HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING,
         HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING,
         HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING,
-        ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE
+        ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE,
+
+        NodeLimits.INITIAL_CONCURRENCY,
+        NodeLimits.QUEUE_SIZE,
+        NodeLimits.MIN_CONCURRENCY,
+        NodeLimits.MAX_CONCURRENCY
     );
 
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -531,7 +531,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(858, response.rowCount());
+        assertEquals(863, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/11759

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
