### PR TITLE
Improve internal dynamic batch sizing mechanism

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -111,6 +111,11 @@ Changes
 Fixes
 =====
 
+- Improved the internal dynamic batching mechanism for operations like ``INSERT
+  INTO FROM QUERY`` and ``COPY FROM``. It should more aggressively throttle
+  these operations in case of memory pressure, reducing the chance of them
+  failing with a ``CircuitBreakingException``.
+
 - Reduced the default :ref:`initial concurrency limit
   <overload_protection.dml.initial_concurrency>` for operations like ``INSERT
   INTO FROM QUERY`` from 50 to 5. This is closer to the behavior before 4.6.0.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Calculating the allowed bytes per requests once up-front is not good
enough. We need to check the circuit breaker repeatedly to reduce the
chance of the circuit breaker tripping.

This fixes a `CircuitBreakerException` which reproduced reliably using
the following schema:

    CREATE TABLE "nyc_taxi" (
        "congestion_surcharge" real,
        "dolocationid" integer,
        "extra" real,
        "fare_amount" real,
        "improvement_surcharge" real,
        "mta_tax" real,
        "passenger_count" integer,
        "payment_type" integer,
        "pickup_datetime" timestamp with time zone,
        "pulocationid" integer,
        "ratecodeid" integer,
        "store_and_fwd_flag" text,
        "tip_amount" real,
        "tolls_amount" real,
        "total_amount" real,
        "trip_distance" real,
        "vendorid
        " integer
    )
    WITH (
        "column_policy" = 'dynamic',
        "number_of_replicas" = '1',
        "refresh_interval" = 10000
    );

And importing the data:

    COPY "nyc_taxi" FROM 'https://s3.amazonaws.com/crate.sampledata/nyc.yellowcab/yc.2019.07-12.gz' WITH (compression = 'gzip');

On a single node with 2GB heap.

(Another workaround to get the query working would be to use the new
`overload_protection` settings and reduce the allowed concurrency)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
