### PR TITLE
Remove `translog.disable_flush` from docs

### DIFF
--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -691,21 +691,6 @@ Sets size of transaction log prior to flushing.
   Size (bytes) of translog.
 
 
-.. _sql-create-table-translog-disable-flush:
-
-``translog.disable_flush``
---------------------------
-
-``enable``/``disable`` flushing.
-
-:value:
-  Set ``true`` to disable flushing, otherwise set to ``false``.
-
-.. CAUTION::
-
-   It is recommended to use ``disable_flush`` only for short periods of time.
-
-
 .. _sql-create-table-translog-interval:
 
 ``translog.interval``


### PR DESCRIPTION
The table setting `translog.disable_flush` has been removed in
CrateDB 2.0 and should be therefore also removed from the docs.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
