### PR TITLE
Remove `collectionValueToIterable`

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -32,7 +32,6 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.ObjectType;
 
-import static io.crate.expression.operator.any.AnyOperators.collectionValueToIterable;
 
 public class AnyLikeOperator extends Operator<Object> {
 
@@ -90,6 +89,6 @@ public class AnyLikeOperator extends Operator<Object> {
         if (collectionReference == null || value == null) {
             return null;
         }
-        return doEvaluate(value, collectionValueToIterable(collectionReference));
+        return doEvaluate(value, (Iterable<?>) collectionReference);
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -30,7 +30,6 @@ import io.crate.types.DataType;
 
 import java.util.function.IntPredicate;
 
-import static io.crate.expression.operator.any.AnyOperators.collectionValueToIterable;
 
 public final class AnyOperator extends Operator<Object> {
 
@@ -87,6 +86,6 @@ public final class AnyOperator extends Operator<Object> {
         if (items == null || item == null) {
             return null;
         }
-        return doEvaluate(item, collectionValueToIterable(items));
+        return doEvaluate(item, (Iterable<?>) items);
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperators.java
@@ -30,9 +30,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.ComparisonExpression;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.IntPredicate;
 
 import static io.crate.expression.operator.any.AnyOperator.OPERATOR_PREFIX;
@@ -99,17 +97,6 @@ public final class AnyOperators {
                         type.cmp
                     )
             );
-        }
-    }
-
-    public static Iterable<?> collectionValueToIterable(Object collectionRef) throws IllegalArgumentException {
-        if (collectionRef instanceof Object[]) {
-            return Arrays.asList((Object[]) collectionRef);
-        } else if (collectionRef instanceof Collection) {
-            return (Collection<?>) collectionRef;
-        } else {
-            throw new IllegalArgumentException(
-                String.format(Locale.ENGLISH, "cannot cast %s to Iterable", collectionRef));
         }
     }
 

--- a/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
+++ b/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
@@ -24,7 +24,6 @@ package io.crate.lucene;
 import com.google.common.collect.Iterables;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.operator.LikeOperators.CaseSensitivity;
-import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -79,8 +78,8 @@ abstract class AbstractAnyQuery implements FunctionToQuery {
     /**
      * converts Strings to BytesRef on the fly
      */
-    static Iterable<?> toIterable(Object value) {
-        return Iterables.transform(AnyOperators.collectionValueToIterable(value), new com.google.common.base.Function<Object, Object>() {
+    static Iterable<?> iterableWithByteRefs(Object value) {
+        return Iterables.transform((Iterable<?>) value, new com.google.common.base.Function<Object, Object>() {
             @Nullable
             @Override
             public Object apply(@Nullable Object input) {

--- a/server/src/main/java/io/crate/lucene/AnyEqQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyEqQuery.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static io.crate.lucene.AbstractAnyQuery.toIterable;
+import static io.crate.lucene.AbstractAnyQuery.iterableWithByteRefs;
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 
 class AnyEqQuery implements FunctionToQuery {
@@ -91,7 +91,7 @@ class AnyEqQuery implements FunctionToQuery {
                                                 Object candidate,
                                                 LuceneQueryBuilder.Context context) {
         ArrayList<Object> terms = new ArrayList<>();
-        gatherLeafs(toIterable(candidate), terms::add);
+        gatherLeafs(iterableWithByteRefs(candidate), terms::add);
 
         return new BooleanQuery.Builder()
             .add(fieldType.termsQuery(terms, context.queryShardContext), BooleanClause.Occur.MUST)

--- a/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
@@ -28,7 +28,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 
 import io.crate.expression.operator.LikeOperators.CaseSensitivity;
-import io.crate.expression.operator.any.AnyOperators;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.Reference;
 
@@ -44,12 +43,13 @@ class AnyLikeQuery extends AbstractAnyQuery {
     }
 
     @Override
-    protected Query refMatchesAnyArrayLiteral(Reference candidate, Literal array, LuceneQueryBuilder.Context context) {
+    protected Query refMatchesAnyArrayLiteral(Reference candidate, Literal<?> array, LuceneQueryBuilder.Context context) {
         // col like ANY (['a', 'b']) --> or(like(col, 'a'), like(col, 'b'))
         String fqn = candidate.column().fqn();
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         booleanQuery.setMinimumNumberShouldMatch(1);
-        for (Object value : AnyOperators.collectionValueToIterable(array.value())) {
+        Iterable<?> values = (Iterable<?>) array.value();
+        for (Object value : values) {
             booleanQuery.add(caseSensitivity.likeQuery(fqn, (String) value), BooleanClause.Occur.SHOULD);
         }
         return booleanQuery.build();

--- a/server/src/main/java/io/crate/lucene/AnyNeqQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyNeqQuery.java
@@ -31,6 +31,8 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
+import static io.crate.lucene.AbstractAnyQuery.iterableWithByteRefs;
+
 class AnyNeqQuery extends AbstractAnyQuery {
 
     @Override
@@ -66,7 +68,7 @@ class AnyNeqQuery extends AbstractAnyQuery {
         }
 
         BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
-        for (Object value : toIterable(array.value())) {
+        for (Object value : iterableWithByteRefs(array.value())) {
             andBuilder.add(fieldType.termQuery(value, context.queryShardContext()), BooleanClause.Occur.MUST);
         }
         return Queries.not(andBuilder.build());

--- a/server/src/main/java/io/crate/lucene/AnyRangeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyRangeQuery.java
@@ -29,6 +29,8 @@ import org.apache.lucene.search.Query;
 
 import java.io.IOException;
 
+import static io.crate.lucene.AbstractAnyQuery.iterableWithByteRefs;
+
 class AnyRangeQuery extends AbstractAnyQuery {
 
     private final RangeQuery rangeQuery;
@@ -54,7 +56,7 @@ class AnyRangeQuery extends AbstractAnyQuery {
         // col < ANY ([1,2,3]) --> or(col<1, col<2, col<3)
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         booleanQuery.setMinimumNumberShouldMatch(1);
-        for (Object value : toIterable(array.value())) {
+        for (Object value : iterableWithByteRefs(array.value())) {
             booleanQuery.add(
                 inverseRangeQuery.toQuery(candidate, value, context::getFieldTypeOrNull, context.queryShardContext),
                 BooleanClause.Occur.SHOULD);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The function was used to handle both `Object[]` and `Collection<?>`
because a long time ago we could have either. But for quite some time
now any values of type `ArrayType` must be a `Collection` so we can
remove it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
