### PR TITLE
Extract toQuery methods from scalar to dedicated interface

### DIFF
--- a/server/src/main/java/io/crate/auth/AuthenticationHttpAuthHandlerRegistry.java
+++ b/server/src/main/java/io/crate/auth/AuthenticationHttpAuthHandlerRegistry.java
@@ -21,7 +21,6 @@
 
 package io.crate.auth;
 
-import io.crate.auth.Authentication;
 import io.crate.plugin.PipelineRegistry;
 
 import org.elasticsearch.common.inject.Inject;

--- a/server/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.TreeMap;
 
 public class FetchProjection extends Projection {

--- a/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
+++ b/server/src/main/java/io/crate/lucene/AbstractAnyQuery.java
@@ -21,7 +21,13 @@
 
 package io.crate.lucene;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Iterables;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.operator.LikeOperators.CaseSensitivity;
 import io.crate.expression.symbol.Function;
@@ -29,11 +35,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.types.DataTypes;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
 
 abstract class AbstractAnyQuery implements FunctionToQuery {
 
@@ -48,7 +49,7 @@ abstract class AbstractAnyQuery implements FunctionToQuery {
     }
 
     @Override
-    public Query apply(Function function, LuceneQueryBuilder.Context context) throws IOException {
+    public Query toQuery(Function function, LuceneQueryBuilder.Context context) {
         Symbol left = function.arguments().get(0);
         Symbol collectionSymbol = function.arguments().get(1);
         if (!DataTypes.isArray(collectionSymbol.valueType())) {
@@ -103,7 +104,7 @@ abstract class AbstractAnyQuery implements FunctionToQuery {
      */
     protected abstract Query literalMatchesAnyArrayRef(Literal<?> candidate,
                                                        Reference array,
-                                                       LuceneQueryBuilder.Context context) throws IOException;
+                                                       LuceneQueryBuilder.Context context);
 
     /**
      * Generate a query for:
@@ -117,5 +118,5 @@ abstract class AbstractAnyQuery implements FunctionToQuery {
      */
     protected abstract Query refMatchesAnyArrayLiteral(Reference candidate,
                                                        Literal<?> array,
-                                                       LuceneQueryBuilder.Context context) throws IOException;
+                                                       LuceneQueryBuilder.Context context);
 }

--- a/server/src/main/java/io/crate/lucene/AnyEqQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyEqQuery.java
@@ -47,7 +47,7 @@ class AnyEqQuery implements FunctionToQuery {
 
     @Nullable
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         List<Symbol> args = input.arguments();
 
         Symbol candidate = args.get(0);

--- a/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyLikeQuery.java
@@ -21,7 +21,6 @@
 
 package io.crate.lucene;
 
-import java.io.IOException;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -38,7 +37,7 @@ class AnyLikeQuery extends AbstractAnyQuery {
     }
 
     @Override
-    protected Query literalMatchesAnyArrayRef(Literal candidate, Reference array, LuceneQueryBuilder.Context context) throws IOException {
+    protected Query literalMatchesAnyArrayRef(Literal candidate, Reference array, LuceneQueryBuilder.Context context) {
         return caseSensitivity.likeQuery(array.column().fqn(), (String) candidate.value());
     }
 

--- a/server/src/main/java/io/crate/lucene/AnyNeqQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyNeqQuery.java
@@ -29,14 +29,13 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
-import java.io.IOException;
 
 import static io.crate.lucene.AbstractAnyQuery.iterableWithByteRefs;
 
 class AnyNeqQuery extends AbstractAnyQuery {
 
     @Override
-    protected Query literalMatchesAnyArrayRef(Literal<?> candidate, Reference array, LuceneQueryBuilder.Context context) throws IOException {
+    protected Query literalMatchesAnyArrayRef(Literal<?> candidate, Reference array, LuceneQueryBuilder.Context context) {
         // 1 != any ( col ) -->  gt 1 or lt 1
         String columnName = array.column().fqn();
         Object value = candidate.value();

--- a/server/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
@@ -21,7 +21,6 @@
 
 package io.crate.lucene;
 
-import java.io.IOException;
 import java.util.Locale;
 
 import org.apache.lucene.index.Term;
@@ -48,7 +47,7 @@ class AnyNotLikeQuery extends AbstractAnyQuery {
     }
 
     @Override
-    protected Query literalMatchesAnyArrayRef(Literal candidate, Reference array, LuceneQueryBuilder.Context context) throws IOException {
+    protected Query literalMatchesAnyArrayRef(Literal candidate, Reference array, LuceneQueryBuilder.Context context) {
         String regexString = LikeOperators.patternToRegex((String) candidate.value(), LikeOperators.DEFAULT_ESCAPE, false);
         regexString = regexString.substring(1, regexString.length() - 1);
         String notLike = negateWildcard(regexString);

--- a/server/src/main/java/io/crate/lucene/AnyRangeQuery.java
+++ b/server/src/main/java/io/crate/lucene/AnyRangeQuery.java
@@ -27,7 +27,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 
-import java.io.IOException;
 
 import static io.crate.lucene.AbstractAnyQuery.iterableWithByteRefs;
 
@@ -42,7 +41,7 @@ class AnyRangeQuery extends AbstractAnyQuery {
     }
 
     @Override
-    protected Query literalMatchesAnyArrayRef(Literal candidate, Reference array, LuceneQueryBuilder.Context context) throws IOException {
+    protected Query literalMatchesAnyArrayRef(Literal candidate, Reference array, LuceneQueryBuilder.Context context) {
         // 1 < ANY (array_col) --> array_col > 1
         return rangeQuery.toQuery(
             array,

--- a/server/src/main/java/io/crate/lucene/CIDRRangeQuery.java
+++ b/server/src/main/java/io/crate/lucene/CIDRRangeQuery.java
@@ -34,7 +34,7 @@ import java.net.InetAddress;
 class CIDRRangeQuery implements FunctionToQuery {
 
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         RefAndLiteral refAndLiteral = RefAndLiteral.of(input);
         if (refAndLiteral == null) {
             return null;

--- a/server/src/main/java/io/crate/lucene/IsNullQuery.java
+++ b/server/src/main/java/io/crate/lucene/IsNullQuery.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.query.ExistsQueryBuilder;
 class IsNullQuery implements FunctionToQuery {
 
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         assert input != null : "input must not be null";
         assert input.arguments().size() == 1 : "function's number of arguments must be 1";
         Symbol arg = input.arguments().get(0);

--- a/server/src/main/java/io/crate/lucene/NotQuery.java
+++ b/server/src/main/java/io/crate/lucene/NotQuery.java
@@ -111,7 +111,7 @@ final class NotQuery implements FunctionToQuery {
 
 
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         assert input != null : "function must not be null";
         assert input.arguments().size() == 1 : "function's number of arguments must be 1";
         /**

--- a/server/src/main/java/io/crate/lucene/RangeQuery.java
+++ b/server/src/main/java/io/crate/lucene/RangeQuery.java
@@ -66,7 +66,7 @@ class RangeQuery implements FunctionToQuery {
     }
 
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         RefAndLiteral refAndLiteral = RefAndLiteral.of(input);
         if (refAndLiteral == null) {
             return null;

--- a/server/src/main/java/io/crate/lucene/RegexMatchQueryCaseInsensitive.java
+++ b/server/src/main/java/io/crate/lucene/RegexMatchQueryCaseInsensitive.java
@@ -33,7 +33,7 @@ import io.crate.lucene.match.CrateRegexQuery;
 class RegexMatchQueryCaseInsensitive implements FunctionToQuery {
 
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         RefAndLiteral refAndLiteral = RefAndLiteral.of(input);
         if (refAndLiteral == null) {
             return null;

--- a/server/src/main/java/io/crate/lucene/RegexpMatchQuery.java
+++ b/server/src/main/java/io/crate/lucene/RegexpMatchQuery.java
@@ -39,7 +39,7 @@ class RegexpMatchQuery implements FunctionToQuery {
     }
 
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         RefAndLiteral refAndLiteral = RefAndLiteral.of(input);
         if (refAndLiteral == null) {
             return null;

--- a/server/src/main/java/io/crate/lucene/ToMatchQuery.java
+++ b/server/src/main/java/io/crate/lucene/ToMatchQuery.java
@@ -45,7 +45,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.locationtech.spatial4j.shape.Shape;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,7 +52,7 @@ import java.util.Map;
 class ToMatchQuery implements FunctionToQuery {
 
     @Override
-    public Query apply(Function input, LuceneQueryBuilder.Context context) throws IOException {
+    public Query toQuery(Function input, LuceneQueryBuilder.Context context) {
         List<Symbol> arguments = input.arguments();
         assert arguments.size() == 4 : "invalid number of arguments";
         assert Symbol.isLiteral(arguments.get(0), DataTypes.UNTYPED_OBJECT) :
@@ -128,7 +127,7 @@ class ToMatchQuery implements FunctionToQuery {
             "Invalid match type: %s. Analyzer should have made sure that it is valid", matchType));
     }
 
-    private static Query stringMatch(LuceneQueryBuilder.Context context, List<Symbol> arguments, Object queryTerm) throws IOException {
+    private static Query stringMatch(LuceneQueryBuilder.Context context, List<Symbol> arguments, Object queryTerm) {
         @SuppressWarnings("unchecked")
         Map<String, Object> fields = (Map) ((Literal) arguments.get(0)).value();
         String queryString = (String) queryTerm;
@@ -168,7 +167,7 @@ class ToMatchQuery implements FunctionToQuery {
                                           Map.Entry<String, Object> entry,
                                           String queryString,
                                           String matchType,
-                                          Map<String, Object> options) throws IOException {
+                                          Map<String, Object> options) {
         Query query = MatchQueries.singleMatch(
             queryShardContext,
             entry.getKey(),

--- a/server/src/main/java/io/crate/lucene/match/MatchQueries.java
+++ b/server/src/main/java/io/crate/lucene/match/MatchQueries.java
@@ -28,7 +28,6 @@ import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.index.search.MultiMatchQuery;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 
@@ -47,7 +46,7 @@ public final class MatchQueries {
                                     String fieldName,
                                     String queryString,
                                     @Nullable String matchType,
-                                    @Nullable Map<String, Object> options) throws IOException {
+                                    @Nullable Map<String, Object> options) {
         MultiMatchQueryType type = getType(matchType);
         ParsedOptions parsedOptions = OptionParser.parse(type, options);
 
@@ -74,7 +73,7 @@ public final class MatchQueries {
                                    @Nullable String matchType,
                                    Map<String, Float> fieldNames,
                                    String queryString,
-                                   Map<String, Object> options) throws IOException {
+                                   Map<String, Object> options) {
         MultiMatchQueryType type = MatchQueries.getType(matchType);
         ParsedOptions parsedOptions = OptionParser.parse(type, options);
 

--- a/server/src/main/java/io/crate/protocols/postgres/types/RegclassType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/RegclassType.java
@@ -23,7 +23,6 @@ package io.crate.protocols.postgres.types;
 
 import java.nio.charset.StandardCharsets;
 
-import io.crate.protocols.postgres.types.PGType.TypeCategory;
 import io.crate.types.Regclass;
 import io.netty.buffer.ByteBuf;
 

--- a/server/src/main/java/io/crate/user/CreateUserRequest.java
+++ b/server/src/main/java/io/crate/user/CreateUserRequest.java
@@ -21,7 +21,6 @@
 
 package io.crate.user;
 
-import io.crate.user.SecureHash;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import javax.annotation.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;

--- a/server/src/main/java/io/crate/user/TransportAlterUserAction.java
+++ b/server/src/main/java/io/crate/user/TransportAlterUserAction.java
@@ -42,8 +42,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import io.crate.user.AlterUserRequest;
-import io.crate.user.WriteUserResponse;
 import io.crate.user.metadata.UsersMetadata;
 
 public class TransportAlterUserAction extends TransportMasterNodeAction<AlterUserRequest, WriteUserResponse> {

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -216,7 +216,7 @@ public class MatchQuery {
         }
     }
 
-    public Query parse(Type type, String fieldName, Object value) throws IOException {
+    public Query parse(Type type, String fieldName, Object value) {
         MappedFieldType fieldType = context.fieldMapper(fieldName);
         if (fieldType == null) {
             return newUnmappedFieldQuery(fieldName);

--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.MultiMatchQueryType;
 import org.elasticsearch.index.query.QueryShardContext;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,7 +54,7 @@ public class MultiMatchQuery extends MatchQuery {
         super(context);
     }
 
-    private Query parseAndApply(Type type, String fieldName, Object value, String minimumShouldMatch, Float boostValue) throws IOException {
+    private Query parseAndApply(Type type, String fieldName, Object value, String minimumShouldMatch, Float boostValue) {
         Query query = parse(type, fieldName, value);
         query = Queries.maybeApplyMinimumShouldMatch(query, minimumShouldMatch);
         if (query != null && boostValue != null && boostValue != DEFAULT_BOOST && query instanceof MatchNoDocsQuery == false) {
@@ -64,7 +63,7 @@ public class MultiMatchQuery extends MatchQuery {
         return query;
     }
 
-    public Query parse(MultiMatchQueryType type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) throws IOException {
+    public Query parse(MultiMatchQueryType type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) {
         final Query result;
         // reset query builder
         queryBuilder = null;
@@ -106,7 +105,7 @@ public class MultiMatchQuery extends MatchQuery {
         public List<Query> buildGroupedQueries(MultiMatchQueryType type,
                                                Map<String,
                                                Float> fieldNames,
-                                               Object value, String minimumShouldMatch) throws IOException {
+                                               Object value, String minimumShouldMatch) {
             List<Query> queries = new ArrayList<>();
             for (String fieldName : fieldNames.keySet()) {
                 Float boostValue = fieldNames.get(fieldName);
@@ -118,7 +117,7 @@ public class MultiMatchQuery extends MatchQuery {
             return queries;
         }
 
-        public Query parseGroup(Type type, String field, Float boostValue, Object value, String minimumShouldMatch) throws IOException {
+        public Query parseGroup(Type type, String field, Float boostValue, Object value, String minimumShouldMatch) {
             return parseAndApply(type, field, value, minimumShouldMatch, boostValue);
         }
 
@@ -161,7 +160,7 @@ public class MultiMatchQuery extends MatchQuery {
         }
 
         @Override
-        public List<Query> buildGroupedQueries(MultiMatchQueryType type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) throws IOException {
+        public List<Query> buildGroupedQueries(MultiMatchQueryType type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) {
             Map<Analyzer, List<FieldAndFieldType>> groups = new HashMap<>();
             List<Query> queries = new ArrayList<>();
             for (Map.Entry<String, Float> entry : fieldNames.entrySet()) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/11669

This is required to be able to implement the interface within
`MatchPredicate` - which isn't a `Scalar` but only a
`FunctionImplementation`.

It doesn't add the methods to `FunctionImplementation` itself because
aggregations also implement that interface and we cannot turn
aggregations into Lucene queries.

This re-purposes the existing `FunctionToQuery` interface - the "old"
way of using it is still considered deprecated.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
