### PR TITLE
reuse LoggingHandler as it's @Sharable

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -117,6 +117,8 @@ public class Netty4Transport extends TcpTransport {
 
     private BorrowedItem<EventLoopGroup> eventLoopGroup;
 
+    private final LoggingHandler loggingHandler = new LoggingHandler(LogLevel.TRACE);
+
 
 
     public Netty4Transport(Settings settings,
@@ -289,7 +291,7 @@ public class Netty4Transport extends TcpTransport {
         @Override
         protected void initChannel(Channel ch) throws Exception {
             maybeInjectSSL(ch);
-            ch.pipeline().addLast("logging", new LoggingHandler(LogLevel.TRACE));
+            ch.pipeline().addLast("logging", loggingHandler);
             // using a dot as a prefix means this cannot come from any settings parsed
             ch.pipeline().addLast("dispatcher", new Netty4MessageChannelHandler(pageCacheRecycler, Netty4Transport.this));
         }
@@ -335,7 +337,7 @@ public class Netty4Transport extends TcpTransport {
             Netty4TcpChannel nettyTcpChannel = new Netty4TcpChannel(ch, true, name, ch.newSucceededFuture());
             ch.attr(CHANNEL_KEY).set(nettyTcpChannel);
             serverAcceptedChannel(nettyTcpChannel);
-            ch.pipeline().addLast("logging", new LoggingHandler(LogLevel.TRACE));
+            ch.pipeline().addLast("logging", loggingHandler);
             ch.pipeline().addLast("dispatcher", new Netty4MessageChannelHandler(pageCacheRecycler, Netty4Transport.this));
         }
 


### PR DESCRIPTION
@Sharable Handlers [can be reused](https://netty.io/4.0/api/io/netty/channel/ChannelHandler.Sharable.html) - and LoggingHandler is marked as Sharable. Every node 2 node connection creates new instance of LogginHandler - this can be avoided by using one instance for all connections in a cluster


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
