### PR TITLE
Update checkstyle to 9.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
+org.gradle.jvmargs=-Xmx1100M

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -117,7 +117,7 @@ forbiddenApisMain {
 
 
 checkstyle {
-    toolVersion = "8.41"
+    toolVersion = "9.0.1"
     def checkstyle_dir = "$rootDir/gradle/checkstyle/"
     configProperties = [
         'checkstyleDir' : checkstyle_dir,

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/NullLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/NullLiteral.java
@@ -24,7 +24,7 @@ package io.crate.sql.tree;
 public class NullLiteral extends Literal {
     public static final NullLiteral INSTANCE = new NullLiteral();
 
-    private NullLiteral(){
+    private NullLiteral() {
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/NoopPlan.java
+++ b/server/src/main/java/io/crate/planner/NoopPlan.java
@@ -35,7 +35,7 @@ public final class NoopPlan implements Plan {
 
     public static final Plan INSTANCE = new NoopPlan();
 
-    private NoopPlan(){
+    private NoopPlan() {
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://checkstyle.org/releasenotes.html#Release_9.0.1

Unfortunately it raised the memory requirement quite a bit. Had to bump
the gradle Xmx value from the default 512M to 1100M. Otherwise it ran
into a `gradle build daemon has been stopped: JVM garbage collector
thrashing and after running out of JVM memory` error.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
