### PR TITLE
Seal AnyOperator

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -52,7 +52,8 @@ import io.crate.types.TypeSignature;
 /**
  * Abstract base class for implementations of {@code <probe> <op> ANY(<candidates>)}
  **/
-public abstract class AnyOperator extends Operator<Object> {
+public abstract sealed class AnyOperator extends Operator<Object>
+    permits AnyEqOperator, AnyNeqOperator, AnyRangeOperator, AnyLikeOperator, AnyNotLikeOperator {
 
     public static final String OPERATOR_PREFIX = "any_";
     public static final List<String> OPERATOR_NAMES = List.of(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The AnyOperator contains a list of all ANY related operators, so it
shouldn't be extensible without touching the base class.

Wanted to have this already in
https://github.com/crate/crate/pull/11804, but a checkstyle update was
necessary to support sealed classes.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
