### PR TITLE
Add a note about fixes backports to unreleased.rst

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -136,6 +136,10 @@ Changes
 Fixes
 =====
 
+.. If you add an entry here, the fix needs to be backported to the latest
+.. stable branch. You can add a version label (`v/X.Y`) to the pull request for
+.. an automated mergify backport.
+
 - Fixed an issue that caused ``UNION ALL`` statements to succeed or throw
   unexpected exceptions when the ``SELECT`` results for ``UNION ALL`` included
   object types with identically named but differently typed sub-columns.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To make people aware that fixes need to be backported.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
