### PR TITLE
Add remote connection/cluster related code, derived from ES

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionType.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionType.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse;
@@ -42,6 +43,13 @@ public class ActionType<Response extends TransportResponse> {
      */
     public String name() {
         return this.name;
+    }
+
+    /**
+     * Get a reader that can create a new instance of the class from a {@link org.elasticsearch.common.io.stream.StreamInput}
+     */
+    public Writeable.Reader<Response> getResponseReader() {
+        throw new UnsupportedOperationException("Not implemented by " + this.getClass());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ListenableFuture;
+import org.elasticsearch.common.util.concurrent.RunOnce;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This class manages node connections within a cluster. The connection is opened by the underlying transport.
+ * Once the connection is opened, this class manages the connection. This includes closing the connection when
+ * the connection manager is closed.
+ */
+public class ClusterConnectionManager implements ConnectionManager {
+
+    private static final Logger LOGGER = LogManager.getLogger(ClusterConnectionManager.class);
+
+    private final ConcurrentMap<DiscoveryNode, Transport.Connection> connectedNodes = ConcurrentCollections.newConcurrentMap();
+    private final ConcurrentMap<DiscoveryNode, ListenableFuture<Void>> pendingConnections = ConcurrentCollections.newConcurrentMap();
+    private final AbstractRefCounted connectingRefCounter = new AbstractRefCounted("connection manager") {
+        @Override
+        protected void closeInternal() {
+            Iterator<Map.Entry<DiscoveryNode, Transport.Connection>> iterator = connectedNodes.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<DiscoveryNode, Transport.Connection> next = iterator.next();
+                try {
+                    IOUtils.closeWhileHandlingException(next.getValue());
+                } finally {
+                    iterator.remove();
+                }
+            }
+            closeLatch.countDown();
+        }
+    };
+    private final Transport transport;
+    private final ConnectionProfile defaultProfile;
+    private final AtomicBoolean closing = new AtomicBoolean(false);
+    private final CountDownLatch closeLatch = new CountDownLatch(1);
+    private final DelegatingNodeConnectionListener connectionListener = new DelegatingNodeConnectionListener();
+
+    public ClusterConnectionManager(Settings settings, Transport transport) {
+        this(ConnectionProfile.buildDefaultConnectionProfile(settings), transport);
+    }
+
+    public ClusterConnectionManager(ConnectionProfile connectionProfile, Transport transport) {
+        this.transport = transport;
+        this.defaultProfile = connectionProfile;
+    }
+
+    @Override
+    public void addListener(TransportConnectionListener listener) {
+        this.connectionListener.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(TransportConnectionListener listener) {
+        this.connectionListener.removeListener(listener);
+    }
+
+    @Override
+    public void openConnection(DiscoveryNode node, ConnectionProfile connectionProfile, ActionListener<Transport.Connection> listener) {
+        ConnectionProfile resolvedProfile = ConnectionProfile.resolveConnectionProfile(connectionProfile, defaultProfile);
+        internalOpenConnection(node, resolvedProfile, listener);
+    }
+
+    /**
+     * Connects to a node with the given connection profile. If the node is already connected this method has no effect.
+     * Once a successful is established, it can be validated before being exposed.
+     * The ActionListener will be called on the calling thread or the generic thread pool.
+     */
+    @Override
+    public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
+                              ConnectionValidator connectionValidator,
+                              ActionListener<Void> listener) throws ConnectTransportException {
+        final ConnectionProfile resolvedProfile = ConnectionProfile.resolveConnectionProfile(connectionProfile, defaultProfile);
+        if (node == null) {
+            listener.onFailure(new ConnectTransportException(null, "can't connect to a null node"));
+            return;
+        }
+
+        if (connectingRefCounter.tryIncRef() == false) {
+            listener.onFailure(new IllegalStateException("connection manager is closed"));
+            return;
+        }
+
+        if (connectedNodes.containsKey(node)) {
+            connectingRefCounter.decRef();
+            listener.onResponse(null);
+            return;
+        }
+
+        final ListenableFuture<Void> currentListener = new ListenableFuture<>();
+        final ListenableFuture<Void> existingListener = pendingConnections.putIfAbsent(node, currentListener);
+        if (existingListener != null) {
+            try {
+                // wait on previous entry to complete connection attempt
+                existingListener.addListener(listener, EsExecutors.directExecutor());
+            } finally {
+                connectingRefCounter.decRef();
+            }
+            return;
+        }
+
+        currentListener.addListener(listener, EsExecutors.directExecutor());
+
+        final RunOnce releaseOnce = new RunOnce(connectingRefCounter::decRef);
+        internalOpenConnection(node, resolvedProfile, ActionListener.wrap(conn -> {
+            connectionValidator.validate(conn, resolvedProfile, ActionListener.wrap(
+                ignored -> {
+                    assert Transports.assertNotTransportThread("connection validator success");
+                    try {
+                        if (connectedNodes.putIfAbsent(node, conn) != null) {
+                            LOGGER.debug("existing connection to node [{}], closing new redundant connection", node);
+                            IOUtils.closeWhileHandlingException(conn);
+                        } else {
+                            LOGGER.debug("connected to node [{}]", node);
+                            try {
+                                connectionListener.onNodeConnected(node, conn);
+                            } finally {
+                                final Transport.Connection finalConnection = conn;
+                                conn.addCloseListener(ActionListener.wrap(() -> {
+                                    LOGGER.trace("unregistering {} after connection close and marking as disconnected", node);
+                                    connectedNodes.remove(node, finalConnection);
+                                    connectionListener.onNodeDisconnected(node, conn);
+                                }));
+                            }
+                        }
+                    } finally {
+                        ListenableFuture<Void> future = pendingConnections.remove(node);
+                        assert future == currentListener : "Listener in pending map is different than the expected listener";
+                        releaseOnce.run();
+                        future.onResponse(null);
+                    }
+                }, e -> {
+                    assert Transports.assertNotTransportThread("connection validator failure");
+                    IOUtils.closeWhileHandlingException(conn);
+                    failConnectionListeners(node, releaseOnce, e, currentListener);
+                }));
+        }, e -> {
+            assert Transports.assertNotTransportThread("internalOpenConnection failure");
+            failConnectionListeners(node, releaseOnce, e, currentListener);
+        }));
+    }
+
+    /**
+     * Returns a connection for the given node if the node is connected.
+     * Connections returned from this method must not be closed. The lifecycle of this connection is
+     * maintained by this connection manager
+     *
+     * @throws NodeNotConnectedException if the node is not connected
+     * @see #connectToNode(DiscoveryNode, ConnectionProfile, ConnectionValidator, ActionListener)
+     */
+    @Override
+    public Transport.Connection getConnection(DiscoveryNode node) {
+        Transport.Connection connection = connectedNodes.get(node);
+        if (connection == null) {
+            throw new NodeNotConnectedException(node, "Node not connected");
+        }
+        return connection;
+    }
+
+    /**
+     * Returns {@code true} if the node is connected.
+     */
+    @Override
+    public boolean nodeConnected(DiscoveryNode node) {
+        return connectedNodes.containsKey(node);
+    }
+
+    /**
+     * Disconnected from the given node, if not connected, will do nothing.
+     */
+    @Override
+    public void disconnectFromNode(DiscoveryNode node) {
+        Transport.Connection nodeChannels = connectedNodes.remove(node);
+        if (nodeChannels != null) {
+            // if we found it and removed it we close
+            nodeChannels.close();
+        }
+    }
+
+    /**
+     * Returns the number of nodes this manager is connected to.
+     */
+    @Override
+    public int size() {
+        return connectedNodes.size();
+    }
+
+    @Override
+    public Set<DiscoveryNode> getAllConnectedNodes() {
+        return Collections.unmodifiableSet(connectedNodes.keySet());
+    }
+
+    @Override
+    public void close() {
+        internalClose(true);
+    }
+
+    @Override
+    public void closeNoBlock() {
+        internalClose(false);
+    }
+
+    private void internalClose(boolean waitForPendingConnections) {
+        assert Transports.assertNotTransportThread("Closing ConnectionManager");
+        if (closing.compareAndSet(false, true)) {
+            connectingRefCounter.decRef();
+            if (waitForPendingConnections) {
+                try {
+                    closeLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+    }
+
+    private void internalOpenConnection(DiscoveryNode node, ConnectionProfile connectionProfile,
+                                        ActionListener<Transport.Connection> listener) {
+        transport.openConnection(node, connectionProfile, ActionListener.map(listener, connection -> {
+            assert Transports.assertNotTransportThread("internalOpenConnection success");
+            try {
+                connectionListener.onConnectionOpened(connection);
+            } finally {
+                connection.addCloseListener(ActionListener.wrap(() -> connectionListener.onConnectionClosed(connection)));
+            }
+            if (connection.isClosed()) {
+                throw new ConnectTransportException(node, "a channel closed while connecting");
+            }
+            return connection;
+        }));
+    }
+
+    private void failConnectionListeners(DiscoveryNode node, RunOnce releaseOnce, Exception e, ListenableFuture<Void> expectedListener) {
+        ListenableFuture<Void> future = pendingConnections.remove(node);
+        releaseOnce.run();
+        if (future != null) {
+            assert future == expectedListener : "Listener in pending map is different than the expected listener";
+            future.onFailure(e);
+        }
+    }
+
+    @Override
+    public ConnectionProfile getConnectionProfile() {
+        return defaultProfile;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
@@ -19,262 +19,48 @@
 
 package org.elasticsearch.transport;
 
-import java.io.Closeable;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.component.Lifecycle;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
-import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.ListenableFuture;
-import org.elasticsearch.common.util.concurrent.RunOnce;
 
-import io.crate.common.io.IOUtils;
-import java.util.Collections;
+import java.io.Closeable;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * This class manages node connections. The connection is opened by the underlying transport. Once the
- * connection is opened, this class manages the connection. This includes keep-alive pings and closing
- * the connection when the connection manager is closed.
- */
-public class ConnectionManager implements Closeable {
+public interface ConnectionManager extends Closeable {
 
-    private static final Logger LOGGER = LogManager.getLogger(ConnectionManager.class);
+    void addListener(TransportConnectionListener listener);
 
-    private final ConcurrentMap<DiscoveryNode, Transport.Connection> connectedNodes = ConcurrentCollections.newConcurrentMap();
-    private final ConcurrentMap<DiscoveryNode, ListenableFuture<Void>> pendingConnections = ConcurrentCollections.newConcurrentMap();
-    private final AbstractRefCounted connectingRefCounter = new AbstractRefCounted("connection manager") {
-        @Override
-        protected void closeInternal() {
-            closeLatch.countDown();
-        }
-    };
-    private final Transport transport;
-    private final ConnectionProfile defaultProfile;
-    private final Lifecycle lifecycle = new Lifecycle();
-    private final AtomicBoolean closing = new AtomicBoolean(false);
-    private final CountDownLatch closeLatch = new CountDownLatch(1);
-    private final DelegatingNodeConnectionListener connectionListener = new DelegatingNodeConnectionListener();
+    void removeListener(TransportConnectionListener listener);
 
-    public ConnectionManager(Settings settings, Transport transport) {
-        this(ConnectionProfile.buildDefaultConnectionProfile(settings), transport);
-    }
+    void openConnection(DiscoveryNode node, ConnectionProfile connectionProfile, ActionListener<Transport.Connection> listener);
 
-    public ConnectionManager(ConnectionProfile connectionProfile, Transport transport) {
-        this.transport = transport;
-        this.defaultProfile = connectionProfile;
-        this.lifecycle.moveToStarted();
-    }
+    void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
+                       ConnectionValidator connectionValidator,
+                       ActionListener<Void> listener) throws ConnectTransportException;
 
-    public void addListener(TransportConnectionListener listener) {
-        this.connectionListener.listeners.addIfAbsent(listener);
-    }
+    Transport.Connection getConnection(DiscoveryNode node);
 
-    public void removeListener(TransportConnectionListener listener) {
-        this.connectionListener.listeners.remove(listener);
-    }
+    boolean nodeConnected(DiscoveryNode node);
 
-    public void openConnection(DiscoveryNode node,
-                               ConnectionProfile connectionProfile,
-                               ActionListener<Transport.Connection> listener) {
-        ConnectionProfile resolvedProfile = ConnectionProfile.resolveConnectionProfile(connectionProfile, defaultProfile);
-        internalOpenConnection(node, resolvedProfile, listener);
-    }
+    void disconnectFromNode(DiscoveryNode node);
+
+    Set<DiscoveryNode> getAllConnectedNodes();
+
+    int size();
+
+    @Override
+    void close();
+
+    void closeNoBlock();
+
+    ConnectionProfile getConnectionProfile();
 
     @FunctionalInterface
-    public interface ConnectionValidator {
+    interface ConnectionValidator {
         void validate(Transport.Connection connection, ConnectionProfile profile, ActionListener<Void> listener);
     }
 
-    /**
-     * Connects to a node with the given connection profile. If the node is already connected this method has no effect.
-     * Once a successful is established, it can be validated before being exposed.
-     * The ActionListener will be called on the calling thread or the generic thread pool.
-     */
-    public void connectToNode(DiscoveryNode node,
-                              ConnectionProfile connectionProfile,
-                              ConnectionValidator connectionValidator,
-                              ActionListener<Void> listener) throws ConnectTransportException {
-        if (node == null) {
-            listener.onFailure(new ConnectTransportException(null, "can't connect to a null node"));
-            return;
-        }
-
-        if (connectingRefCounter.tryIncRef() == false) {
-            listener.onFailure(new IllegalStateException("connection manager is closed"));
-            return;
-        }
-
-        if (connectedNodes.containsKey(node)) {
-            connectingRefCounter.decRef();
-            listener.onResponse(null);
-            return;
-        }
-        final ListenableFuture<Void> currentListener = new ListenableFuture<>();
-        final ListenableFuture<Void> existingListener = pendingConnections.putIfAbsent(node, currentListener);
-        if (existingListener != null) {
-            try {
-                // wait on previous entry to complete connection attempt
-                existingListener.addListener(listener, EsExecutors.directExecutor());
-            } finally {
-                connectingRefCounter.decRef();
-            }
-            return;
-        }
-        currentListener.addListener(listener, EsExecutors.directExecutor());
-        final RunOnce releaseOnce = new RunOnce(connectingRefCounter::decRef);
-        ConnectionProfile resolvedProfile = ConnectionProfile.resolveConnectionProfile(connectionProfile, defaultProfile);
-        internalOpenConnection(
-            node,
-            resolvedProfile,
-            ActionListener.wrap(
-                conn -> {
-                    connectionValidator.validate(
-                        conn,
-                        resolvedProfile,
-                        ActionListener.wrap(
-                            ignored -> {
-                                assert Transports.assertNotTransportThread("connection validator success");
-                                try {
-                                    if (connectedNodes.putIfAbsent(node, conn) != null) {
-                                        LOGGER.debug("existing connection to node [{}], closing new redundant connection", node);
-                                        IOUtils.closeWhileHandlingException(conn);
-                                    } else {
-                                        LOGGER.debug("connected to node [{}]", node);
-                                        try {
-                                            connectionListener.onNodeConnected(node, conn);
-                                        } finally {
-                                            final Transport.Connection finalConnection = conn;
-                                            conn.addCloseListener(ActionListener.wrap(() -> {
-                                                LOGGER.trace("unregistering {} after connection close and marking as disconnected", node);
-                                                connectedNodes.remove(node, finalConnection);
-                                                connectionListener.onNodeDisconnected(node, conn);
-                                            }));
-                                        }
-                                    }
-                                } finally {
-                                    ListenableFuture<Void> future = pendingConnections.remove(node);
-                                    assert future == currentListener : "Listener in pending map is different than the expected listener";
-                                    releaseOnce.run();
-                                    future.onResponse(null);
-                                }
-                            },
-                            e -> {
-                                assert Transports.assertNotTransportThread("connection validator failure");
-                                IOUtils.closeWhileHandlingException(conn);
-                                failConnectionListeners(node, releaseOnce, e, currentListener);
-                            }
-                        )
-                    );
-                },
-                e -> {
-                    assert Transports.assertNotTransportThread("internalOpenConnection failure");
-                    failConnectionListeners(node, releaseOnce, e, currentListener);
-                }
-            )
-        );
-    }
-
-    /**
-     * Returns a connection for the given node if the node is connected.
-     * Connections returned from this method must not be closed. The lifecycle of this connection is
-     * maintained by this connection manager
-     *
-     * @throws NodeNotConnectedException if the node is not connected
-     * @see #connectToNode(DiscoveryNode, ConnectionProfile, ConnectionValidator, ActionListener)
-     */
-    public Transport.Connection getConnection(DiscoveryNode node) {
-        Transport.Connection connection = connectedNodes.get(node);
-        if (connection == null) {
-            throw new NodeNotConnectedException(node, "Node not connected");
-        }
-        return connection;
-    }
-
-    /**
-     * Returns {@code true} if the node is connected.
-     */
-    public boolean nodeConnected(DiscoveryNode node) {
-        return connectedNodes.containsKey(node);
-    }
-
-    /**
-     * Disconnected from the given node, if not connected, will do nothing.
-     */
-    public void disconnectFromNode(DiscoveryNode node) {
-        Transport.Connection nodeChannels = connectedNodes.remove(node);
-        if (nodeChannels != null) {
-            // if we found it and removed it we close
-            nodeChannels.close();
-        }
-    }
-
-    /**
-     * Returns the number of nodes this manager is connected to.
-     */
-    public int size() {
-        return connectedNodes.size();
-    }
-
-    /**
-     * Returns the set of nodes this manager is connected to.
-     */
-    public Set<DiscoveryNode> connectedNodes() {
-        return Collections.unmodifiableSet(connectedNodes.keySet());
-    }
-
-    @Override
-    public void close() {
-        assert Transports.assertNotTransportThread("Closing ConnectionManager");
-        if (closing.compareAndSet(false, true)) {
-            connectingRefCounter.decRef();
-            try {
-                closeLatch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(e);
-            }
-            Iterator<Map.Entry<DiscoveryNode, Transport.Connection>> iterator = connectedNodes.entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<DiscoveryNode, Transport.Connection> next = iterator.next();
-                try {
-                    IOUtils.closeWhileHandlingException(next.getValue());
-                } finally {
-                    iterator.remove();
-                }
-            }
-        }
-    }
-
-    private void internalOpenConnection(DiscoveryNode node,
-                                        ConnectionProfile connectionProfile,
-                                        ActionListener<Transport.Connection> listener) {
-        transport.openConnection(node, connectionProfile, ActionListener.map(listener, connection -> {
-            assert Transports.assertNotTransportThread("internalOpenConnection success");
-            try {
-                connectionListener.onConnectionOpened(connection);
-            } finally {
-                connection.addCloseListener(ActionListener.wrap(() -> connectionListener.onConnectionClosed(connection)));
-            }
-            if (connection.isClosed()) {
-                throw new ConnectTransportException(node, "a channel closed while connecting");
-            }
-            return connection;
-        }));
-    }
-
-    private static final class DelegatingNodeConnectionListener implements TransportConnectionListener {
+    final class DelegatingNodeConnectionListener implements TransportConnectionListener {
 
         private final CopyOnWriteArrayList<TransportConnectionListener> listeners = new CopyOnWriteArrayList<>();
 
@@ -305,21 +91,13 @@ public class ConnectionManager implements Closeable {
                 listener.onConnectionClosed(connection);
             }
         }
-    }
 
-    private void failConnectionListeners(DiscoveryNode node,
-                                         RunOnce releaseOnce,
-                                         Exception e,
-                                         ListenableFuture<Void> expectedListener) {
-        ListenableFuture<Void> future = pendingConnections.remove(node);
-        releaseOnce.run();
-        if (future != null) {
-            assert future == expectedListener : "Listener in pending map is different than the expected listener";
-            future.onFailure(e);
+        public void addListener(TransportConnectionListener listener) {
+            listeners.addIfAbsent(listener);
         }
-    }
 
-    ConnectionProfile getConnectionProfile() {
-        return defaultProfile;
+        public void removeListener(TransportConnectionListener listener) {
+            listeners.remove(listener);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/NoSeedNodeLeftException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NoSeedNodeLeftException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Thrown after failed to connect to all seed nodes of the remote cluster.
+ */
+public class NoSeedNodeLeftException extends ElasticsearchException {
+
+    public NoSeedNodeLeftException(String clusterName) {
+        super("no seed node left for cluster: [" + clusterName + "]");
+    }
+
+    public NoSeedNodeLeftException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/NoSuchRemoteClusterException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NoSuchRemoteClusterException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * An exception that remote cluster is missing or
+ * connectivity to the remote connection is failing
+ */
+public final class NoSuchRemoteClusterException extends ResourceNotFoundException {
+
+    public NoSuchRemoteClusterException(String clusterName) {
+        //No node available for cluster
+        super("no such remote cluster: [" + clusterName + "]");
+    }
+
+    public NoSuchRemoteClusterException(StreamInput in) throws IOException {
+        super(in);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.CountDown;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.common.settings.Setting.intSetting;
+
+public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
+
+    /**
+     * The remote address for the proxy. The connections will be opened to the configured address.
+     */
+    public static final Setting<String> PROXY_ADDRESS = Setting.simpleString(
+        "proxy_address",
+        new StrategyValidator<>("proxy_address", ConnectionStrategy.PROXY, s -> {
+            if (Strings.hasLength(s)) {
+                parsePort(s);
+            }
+        }), Setting.Property.Dynamic);
+
+    /**
+     * The maximum number of socket connections that will be established to a remote cluster. The default is 18.
+     */
+    public static final Setting<Integer> REMOTE_SOCKET_CONNECTIONS = intSetting(
+        "proxy_socket_connections",
+        18,
+        1,
+        new StrategyValidator<>("proxy_socket_connections", ConnectionStrategy.PROXY),
+        Setting.Property.Dynamic);
+
+    static final int CHANNELS_PER_CONNECTION = 1;
+
+    private static final int MAX_CONNECT_ATTEMPTS_PER_RUN = 3;
+
+    private final int maxNumConnections;
+    private final String configuredAddress;
+    private final Supplier<TransportAddress> address;
+    private final AtomicReference<ClusterName> remoteClusterName = new AtomicReference<>();
+    private final ConnectionManager.ConnectionValidator clusterNameValidator;
+
+    ProxyConnectionStrategy(String clusterAlias,
+                            TransportService transportService,
+                            RemoteConnectionManager connectionManager,
+                            Settings connectionSettings) {
+        this(
+            clusterAlias,
+            transportService,
+            connectionManager,
+            REMOTE_SOCKET_CONNECTIONS.get(connectionSettings),
+            PROXY_ADDRESS.get(connectionSettings)
+        );
+    }
+
+    ProxyConnectionStrategy(String clusterAlias,
+                            TransportService transportService,
+                            RemoteConnectionManager connectionManager,
+                            int maxNumConnections,
+                            String configuredAddress) {
+        this(clusterAlias, transportService, connectionManager, maxNumConnections, configuredAddress,
+             () -> resolveAddress(configuredAddress));
+    }
+
+    ProxyConnectionStrategy(String clusterAlias,
+                            TransportService transportService,
+                            RemoteConnectionManager connectionManager,
+                            int maxNumConnections,
+                            String configuredAddress,
+                            Supplier<TransportAddress> address) {
+        super(clusterAlias, transportService, connectionManager);
+        this.maxNumConnections = maxNumConnections;
+        this.configuredAddress = configuredAddress;
+        assert Strings.isEmpty(configuredAddress) == false : "Cannot use proxy connection strategy with no configured addresses";
+        this.address = address;
+        this.clusterNameValidator = (newConnection, actualProfile, listener) ->
+            transportService.handshake(newConnection, actualProfile.getHandshakeTimeout().millis(), cn -> true,
+                                       ActionListener.map(listener, resp -> {
+                                           ClusterName remote = resp.getClusterName();
+                                           if (remoteClusterName.compareAndSet(null, remote)) {
+                                               return null;
+                                           } else {
+                                               if (remoteClusterName.get().equals(remote) == false) {
+                                                   DiscoveryNode node = newConnection.getNode();
+                                                   throw new ConnectTransportException(node, "handshake failed. unexpected remote cluster name " + remote);
+                                               }
+                                               return null;
+                                           }
+                                       }));
+    }
+
+    static Stream<Setting<?>> enablementSettings() {
+        return Stream.of(ProxyConnectionStrategy.PROXY_ADDRESS);
+    }
+
+    @Override
+    protected boolean shouldOpenMoreConnections() {
+        return connectionManager.size() < maxNumConnections;
+    }
+
+    @Override
+    protected boolean strategyMustBeRebuilt(Settings newSettings) {
+        String address = PROXY_ADDRESS.get(newSettings);
+        int numOfSockets = REMOTE_SOCKET_CONNECTIONS.get(newSettings);
+        return numOfSockets != maxNumConnections || configuredAddress.equals(address) == false;
+    }
+
+    @Override
+    protected ConnectionStrategy strategyType() {
+        return ConnectionStrategy.PROXY;
+    }
+
+    @Override
+    protected void connectImpl(ActionListener<Void> listener) {
+        performProxyConnectionProcess(listener);
+    }
+
+    private void performProxyConnectionProcess(ActionListener<Void> listener) {
+        openConnections(listener, 1);
+    }
+
+    private void openConnections(ActionListener<Void> finished, int attemptNumber) {
+        if (attemptNumber <= MAX_CONNECT_ATTEMPTS_PER_RUN) {
+            TransportAddress resolved = address.get();
+
+            int remaining = maxNumConnections - connectionManager.size();
+            ActionListener<Void> compositeListener = new ActionListener<Void>() {
+
+                private final AtomicInteger successfulConnections = new AtomicInteger(0);
+                private final CountDown countDown = new CountDown(remaining);
+
+                @Override
+                public void onResponse(Void v) {
+                    successfulConnections.incrementAndGet();
+                    if (countDown.countDown()) {
+                        if (shouldOpenMoreConnections()) {
+                            openConnections(finished, attemptNumber + 1);
+                        } else {
+                            finished.onResponse(v);
+                        }
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    if (countDown.countDown()) {
+                        openConnections(finished, attemptNumber + 1);
+                    }
+                }
+            };
+
+
+            for (int i = 0; i < remaining; ++i) {
+                String id = clusterAlias + "#" + resolved;
+                Map<String, String> attributes = Collections.emptyMap();
+                DiscoveryNode node = new DiscoveryNode(id, resolved, attributes, DiscoveryNodeRole.BUILT_IN_ROLES,
+                                                       Version.CURRENT.minimumCompatibilityVersion());
+
+                connectionManager.connectToNode(node, null, clusterNameValidator, new ActionListener<Void>() {
+                    @Override
+                    public void onResponse(Void v) {
+                        compositeListener.onResponse(v);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        logger.debug(new ParameterizedMessage("failed to open remote connection [remote cluster: {}, address: {}]",
+                                                              clusterAlias, resolved), e);
+                        compositeListener.onFailure(e);
+                    }
+                });
+            }
+        } else {
+            int openConnections = connectionManager.size();
+            if (openConnections == 0) {
+                finished.onFailure(new IllegalStateException("Unable to open any proxy connections to remote cluster [" + clusterAlias
+                                                             + "]"));
+            } else {
+                logger.debug("unable to open maximum number of connections [remote cluster: {}, opened: {}, maximum: {}]", clusterAlias,
+                             openConnections, maxNumConnections);
+                finished.onResponse(null);
+            }
+        }
+    }
+
+    private static TransportAddress resolveAddress(String address) {
+        return new TransportAddress(parseConfiguredAddress(address));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+/**
+ * Base class for all services and components that need up-to-date information about the registered remote clusters
+ */
+public abstract class RemoteClusterAware {
+
+    public static final char REMOTE_CLUSTER_INDEX_SEPARATOR = ':';
+    public static final String LOCAL_CLUSTER_GROUP_KEY = "";
+
+    protected final Settings settings;
+
+    /**
+     * Creates a new {@link RemoteClusterAware} instance
+     *
+     * @param settings the nodes level settings
+     */
+    protected RemoteClusterAware(Settings settings) {
+        this.settings = settings;
+    }
+
+    void validateAndUpdateRemoteCluster(String clusterAlias, Settings settings) {
+        if (RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.equals(clusterAlias)) {
+            throw new IllegalArgumentException("remote clusters must not have the empty string as its key");
+        }
+        updateRemoteCluster(clusterAlias, settings);
+    }
+
+    /**
+     * Subclasses must implement this to receive information about updated cluster aliases.
+     */
+    protected abstract void updateRemoteCluster(String clusterAlias, Settings settings);
+
+    /**
+     * Returns a connection to the given node on the given remote cluster
+     *
+     * @throws IllegalArgumentException if the remote cluster is unknown
+     */
+    public abstract Transport.Connection getConnection(DiscoveryNode node, String cluster);
+
+    public abstract Transport.Connection getConnection(String cluster);
+
+    /**
+     * Ensures that the given cluster alias is connected. If the cluster is connected this operation
+     * will invoke the listener immediately.
+     */
+    public abstract void ensureConnected(String clusterAlias, ActionListener<Void> listener);
+
+    /**
+     * Returns a client to the remote cluster if the given cluster alias exists.
+     *
+     * @param threadPool   the {@link ThreadPool} for the client
+     * @param clusterAlias the cluster alias the remote cluster is registered under
+     * @throws IllegalArgumentException if the given clusterAlias doesn't exist
+     */
+    public abstract Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias);
+
+
+    public static String buildRemoteIndexName(String clusterAlias, String indexName) {
+        return clusterAlias == null || LOCAL_CLUSTER_GROUP_KEY.equals(clusterAlias)
+            ? indexName : clusterAlias + REMOTE_CLUSTER_INDEX_SEPARATOR + indexName;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.support.AbstractClient;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+final class RemoteClusterAwareClient extends AbstractClient {
+
+    private final TransportService service;
+    private final String clusterAlias;
+    private final RemoteClusterAware remoteClusterAware;
+
+    RemoteClusterAwareClient(Settings settings,
+                             ThreadPool threadPool,
+                             TransportService service,
+                             String clusterAlias,
+                             RemoteClusterAware remoteClusterAware) {
+        super(settings, threadPool);
+        this.service = service;
+        this.clusterAlias = clusterAlias;
+        this.remoteClusterAware = remoteClusterAware;
+    }
+
+    @Override
+    protected <Request extends TransportRequest, Response extends TransportResponse> void doExecute(ActionType<Response> action,
+                                                                                                    Request request,
+                                                                                                    ActionListener<Response> listener) {
+        remoteClusterAware.ensureConnected(
+            clusterAlias,
+            ActionListener.wrap(
+                v -> {
+                    Transport.Connection connection;
+                    if (request instanceof RemoteClusterAwareRequest) {
+                        DiscoveryNode preferredTargetNode = ((RemoteClusterAwareRequest) request).getPreferredTargetNode();
+                        connection = remoteClusterAware.getConnection(preferredTargetNode, clusterAlias);
+                    } else {
+                        connection = remoteClusterAware.getConnection(clusterAlias);
+                    }
+                    service.sendRequest(connection, action.name(), request, TransportRequestOptions.EMPTY,
+                                        new ActionListenerResponseHandler<>(listener, action.getResponseReader()));
+                },
+                listener::onFailure
+            )
+        );
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+
+    public Client getRemoteClusterClient(String clusterAlias) {
+        return remoteClusterAware.getRemoteClusterClient(threadPool(), clusterAlias);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+public interface RemoteClusterAwareRequest {
+
+    /**
+     * Returns the preferred discovery node for this request. The remote cluster client will attempt to send
+     * this request directly to this node. Otherwise, it will send the request as a proxy action that will
+     * be routed by the remote cluster to this node.
+     *
+     * @return preferred discovery node
+     */
+    DiscoveryNode getPreferredTargetNode();
+
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.io.IOUtils;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * Represents a connection to a single remote cluster. In contrast to a local cluster a remote cluster is not joined such that the
+ * current node is part of the cluster and it won't receive cluster state updates from the remote cluster. Remote clusters are also not
+ * fully connected with the current node. From a connection perspective a local cluster forms a bi-directional star network while in the
+ * remote case we only connect to a subset of the nodes in the cluster in an uni-directional fashion.
+ * <p>
+ * This class also handles the discovery of nodes from the remote cluster. The initial list of seed nodes is only used to discover all nodes
+ * in the remote cluster and connects to all eligible nodes.
+ * <p>
+ * In the case of a disconnection, this class will issue a re-connect task to establish at most
+ * {@link SniffConnectionStrategy#REMOTE_NODE_CONNECTIONS} until either all eligible nodes are exhausted or the maximum number of
+ * connections per cluster has been reached.
+ */
+public final class RemoteClusterConnection implements Closeable {
+
+
+    private final TransportService transportService;
+    private final RemoteConnectionManager remoteConnectionManager;
+    private final RemoteConnectionStrategy connectionStrategy;
+
+    /**
+     * Creates a new {@link RemoteClusterConnection}
+     *
+     * @param nodeSettings     the nodes settings object
+     * @param clusterAlias     the configured alias of the cluster to connect to
+     * @param transportService the local nodes transport service
+     */
+    RemoteClusterConnection(Settings nodeSettings,
+                            Settings connectionSettings,
+                            String clusterAlias,
+                            TransportService transportService) {
+        this.transportService = transportService;
+        ConnectionProfile profile = RemoteConnectionStrategy.buildConnectionProfile(nodeSettings, connectionSettings);
+        this.remoteConnectionManager = new RemoteConnectionManager(clusterAlias,
+                                                                   createConnectionManager(profile, transportService));
+        this.connectionStrategy = RemoteConnectionStrategy.buildStrategy(
+            clusterAlias,
+            transportService,
+            remoteConnectionManager,
+            nodeSettings,
+            connectionSettings
+        );
+        // we register the transport service here as a listener to make sure we notify handlers on disconnect etc.
+        this.remoteConnectionManager.addListener(transportService);
+    }
+
+    /**
+     * Ensures that this cluster is connected. If the cluster is connected this operation
+     * will invoke the listener immediately.
+     */
+    void ensureConnected(ActionListener<Void> listener) {
+        if (remoteConnectionManager.size() == 0) {
+            connectionStrategy.connect(listener);
+        } else {
+            listener.onResponse(null);
+        }
+    }
+
+    /**
+     * Collects all nodes on the connected cluster and returns / passes a nodeID to {@link DiscoveryNode} lookup function
+     * that returns <code>null</code> if the node ID is not found.
+     * <p>
+     * The requests to get cluster state on the connected cluster are made in the system context because logically
+     * they are equivalent to checking a single detail in the local cluster state and should not require that the
+     * user who made the request that is using this method in its implementation is authorized to view the entire
+     * cluster state.
+     */
+    void collectNodes(ActionListener<Function<String, DiscoveryNode>> listener) {
+        Runnable runnable = () -> {
+            final ClusterStateRequest request = new ClusterStateRequest();
+            request.clear();
+            request.nodes(true);
+            request.local(true); // run this on the node that gets the request it's as good as any other
+            Transport.Connection connection = remoteConnectionManager.getAnyRemoteConnection();
+            transportService.sendRequest(
+                connection,
+                ClusterStateAction.NAME,
+                request,
+                TransportRequestOptions.EMPTY,
+                new TransportResponseHandler<ClusterStateResponse>() {
+
+                    @Override
+                    public ClusterStateResponse read(StreamInput in) throws IOException {
+                        return new ClusterStateResponse(in);
+                    }
+
+                    @Override
+                    public void handleResponse(ClusterStateResponse response) {
+                        DiscoveryNodes nodes = response.getState().nodes();
+                        listener.onResponse(nodes::get);
+                    }
+
+                    @Override
+                    public void handleException(TransportException exp) {
+                        listener.onFailure(exp);
+                    }
+
+                    @Override
+                    public String executor() {
+                        return ThreadPool.Names.SAME;
+                    }
+                }
+            );
+        };
+        try {
+            // just in case if we are not connected for some reason we try to connect and if we fail we have to notify the listener
+            // this will cause some back pressure on the search end and eventually will cause rejections but that's fine
+            // we can't proceed with a search on a cluster level.
+            // in the future we might want to just skip the remote nodes in such a case but that can already be implemented on the
+            // caller end since they provide the listener.
+            ensureConnected(ActionListener.wrap((x) -> runnable.run(), listener::onFailure));
+        } catch (Exception ex) {
+            listener.onFailure(ex);
+        }
+    }
+
+    /**
+     * Returns a connection to the remote cluster, preferably a direct connection to the provided {@link DiscoveryNode}.
+     * If such node is not connected, the returned connection will be a proxy connection that redirects to it.
+     */
+    Transport.Connection getConnection(DiscoveryNode remoteClusterNode) {
+        return remoteConnectionManager.getConnection(remoteClusterNode);
+    }
+
+    Transport.Connection getConnection() {
+        return remoteConnectionManager.getAnyRemoteConnection();
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(connectionStrategy, remoteConnectionManager);
+    }
+
+    public boolean isClosed() {
+        return connectionStrategy.isClosed();
+    }
+
+    // for testing only
+    boolean assertNoRunningConnections() {
+        return connectionStrategy.assertNoRunningConnections();
+    }
+
+    boolean isNodeConnected(final DiscoveryNode node) {
+        return remoteConnectionManager.nodeConnected(node);
+    }
+
+    int getNumNodesConnected() {
+        return remoteConnectionManager.size();
+    }
+
+    private static ConnectionManager createConnectionManager(ConnectionProfile connectionProfile,
+                                                             TransportService transportService) {
+        return new ClusterConnectionManager(connectionProfile, transportService.transport);
+    }
+
+    ConnectionManager getConnectionManager() {
+        return remoteConnectionManager;
+    }
+
+    boolean shouldRebuildConnection(Settings newSettings) {
+        return connectionStrategy.shouldRebuildConnection(newSettings);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RemoteConnectionManager implements ConnectionManager {
+
+    private final String clusterAlias;
+    private final ConnectionManager delegate;
+    private final AtomicLong counter = new AtomicLong();
+    private volatile List<DiscoveryNode> connectedNodes = Collections.emptyList();
+
+    RemoteConnectionManager(String clusterAlias, ConnectionManager delegate) {
+        this.clusterAlias = clusterAlias;
+        this.delegate = delegate;
+        this.delegate.addListener(new TransportConnectionListener() {
+            @Override
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
+                addConnectedNode(node);
+            }
+
+            @Override
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
+                removeConnectedNode(node);
+            }
+        });
+    }
+
+    @Override
+    public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
+                              ConnectionManager.ConnectionValidator connectionValidator,
+                              ActionListener<Void> listener) throws ConnectTransportException {
+        delegate.connectToNode(node, connectionProfile, connectionValidator, listener);
+    }
+
+    @Override
+    public void addListener(TransportConnectionListener listener) {
+        delegate.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(TransportConnectionListener listener) {
+        delegate.removeListener(listener);
+    }
+
+    @Override
+    public void openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Transport.Connection> listener) {
+        delegate.openConnection(node, profile, listener);
+    }
+
+    @Override
+    public Transport.Connection getConnection(DiscoveryNode node) {
+        try {
+            return delegate.getConnection(node);
+        } catch (NodeNotConnectedException e) {
+            return new ProxyConnection(getAnyRemoteConnection(), node);
+        }
+    }
+
+    @Override
+    public boolean nodeConnected(DiscoveryNode node) {
+        return delegate.nodeConnected(node);
+    }
+
+    @Override
+    public void disconnectFromNode(DiscoveryNode node) {
+        delegate.disconnectFromNode(node);
+    }
+
+    @Override
+    public ConnectionProfile getConnectionProfile() {
+        return delegate.getConnectionProfile();
+    }
+
+    public Transport.Connection getAnyRemoteConnection() {
+        List<DiscoveryNode> localConnectedNodes = this.connectedNodes;
+        long curr;
+        while ((curr = counter.incrementAndGet()) == Long.MIN_VALUE);
+        if (localConnectedNodes.isEmpty() == false) {
+            DiscoveryNode nextNode = localConnectedNodes.get(Math.toIntExact(Math.floorMod(curr, (long) localConnectedNodes.size())));
+            try {
+                return delegate.getConnection(nextNode);
+            } catch (NodeNotConnectedException e) {
+                // Ignore. We will manually create an iterator of open nodes
+            }
+        }
+        Set<DiscoveryNode> allConnectionNodes = getAllConnectedNodes();
+        for (DiscoveryNode connectedNode : allConnectionNodes) {
+            try {
+                return delegate.getConnection(connectedNode);
+            } catch (NodeNotConnectedException e) {
+                // Ignore. We will try the next one until all are exhausted.
+            }
+        }
+        throw new NoSuchRemoteClusterException(clusterAlias);
+    }
+
+    @Override
+    public Set<DiscoveryNode> getAllConnectedNodes() {
+        return delegate.getAllConnectedNodes();
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void close() {
+        delegate.closeNoBlock();
+    }
+
+    @Override
+    public void closeNoBlock() {
+        delegate.closeNoBlock();
+    }
+
+    private synchronized void addConnectedNode(DiscoveryNode addedNode) {
+        ArrayList<DiscoveryNode> newConnections = new ArrayList<>(this.connectedNodes);
+        newConnections.add(addedNode);
+        this.connectedNodes = Collections.unmodifiableList(newConnections);
+    }
+
+    private synchronized void removeConnectedNode(DiscoveryNode removedNode) {
+        int newSize = this.connectedNodes.size() - 1;
+        ArrayList<DiscoveryNode> newConnectedNodes = new ArrayList<>(newSize);
+        for (DiscoveryNode connectedNode : this.connectedNodes) {
+            if (connectedNode.equals(removedNode) == false) {
+                newConnectedNodes.add(connectedNode);
+            }
+        }
+        assert newConnectedNodes.size() == newSize : "Expected connection node count: " + newSize + ", Found: " + newConnectedNodes.size();
+        this.connectedNodes = Collections.unmodifiableList(newConnectedNodes);
+    }
+
+    static final class ProxyConnection implements Transport.Connection {
+        private final Transport.Connection connection;
+        private final DiscoveryNode targetNode;
+
+        private ProxyConnection(Transport.Connection connection, DiscoveryNode targetNode) {
+            this.connection = connection;
+            this.targetNode = targetNode;
+        }
+
+        @Override
+        public DiscoveryNode getNode() {
+            return targetNode;
+        }
+
+        @Override
+        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
+            throws IOException, TransportException {
+            connection.sendRequest(requestId, TransportActionProxy.getProxyAction(action),
+                                   TransportActionProxy.wrapRequest(targetNode, request), options);
+        }
+
+        @Override
+        public void close() {
+            assert false : "proxy connections must not be closed";
+        }
+
+        @Override
+        public void addCloseListener(ActionListener<Void> listener) {
+            connection.addCloseListener(listener);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return connection.isClosed();
+        }
+
+        @Override
+        public Version getVersion() {
+            return connection.getVersion();
+        }
+
+        @Override
+        public Object getCacheKey() {
+            return connection.getCacheKey();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.types.DataTypes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.common.settings.Setting.boolSetting;
+import static org.elasticsearch.common.settings.Setting.timeSetting;
+
+public abstract class RemoteConnectionStrategy implements TransportConnectionListener, Closeable {
+
+    enum ConnectionStrategy {
+        SNIFF(SniffConnectionStrategy.CHANNELS_PER_CONNECTION, SniffConnectionStrategy::enablementSettings) {
+            @Override
+            public String toString() {
+                return "sniff";
+            }
+        },
+        PROXY(ProxyConnectionStrategy.CHANNELS_PER_CONNECTION, ProxyConnectionStrategy::enablementSettings) {
+            @Override
+            public String toString() {
+                return "proxy";
+            }
+        };
+
+        private final int numberOfChannels;
+        private final Supplier<Stream<Setting<?>>> enablementSettings;
+
+        ConnectionStrategy(int numberOfChannels, Supplier<Stream<Setting<?>>> enablementSettings) {
+            this.numberOfChannels = numberOfChannels;
+            this.enablementSettings = enablementSettings;
+        }
+
+        public int getNumberOfChannels() {
+            return numberOfChannels;
+        }
+
+        public Supplier<Stream<Setting<?>>> getEnablementSettings() {
+            return enablementSettings;
+        }
+    }
+
+    /**
+     * The name of a node attribute to select nodes that should be connected to in the remote cluster.
+     * For instance a node can be configured with {@code node.attr.gateway: true} in order to be eligible as a gateway node between
+     * clusters. In that case {@code search.remote.node.attr: gateway} can be used to filter out other nodes in the remote cluster.
+     * The value of the setting is expected to be a boolean, {@code true} for nodes that can become gateways, {@code false} otherwise.
+     */
+    public static final Setting<String> REMOTE_NODE_ATTRIBUTE =
+        Setting.simpleString("cluster.remote.node.attr", Setting.Property.NodeScope);
+
+    public static final Setting<ConnectionStrategy> REMOTE_CONNECTION_MODE = new Setting<>(
+            "mode",
+            ConnectionStrategy.SNIFF.name(),
+            value -> ConnectionStrategy.valueOf(value.toUpperCase(Locale.ROOT)),
+            DataTypes.STRING,
+            Setting.Property.Dynamic);
+
+    public static final Setting<Boolean> REMOTE_CONNECTION_COMPRESS = boolSetting(
+        "transport.compress",
+        TransportSettings.TRANSPORT_COMPRESS.getDefault(Settings.EMPTY),
+        Setting.Property.Dynamic);
+
+    public static final Setting<TimeValue> REMOTE_CONNECTION_PING_SCHEDULE = timeSetting(
+        "transport.ping_schedule",
+        TransportSettings.PING_SCHEDULE.getDefault(Settings.EMPTY),
+        Setting.Property.Dynamic);
+
+    protected final Logger logger = LogManager.getLogger(getClass());
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final Object mutex = new Object();
+    private ActionListener<Void> listener;
+
+    protected final TransportService transportService;
+    protected final RemoteConnectionManager connectionManager;
+    protected final String clusterAlias;
+
+    RemoteConnectionStrategy(String clusterAlias,
+                             TransportService transportService,
+                             RemoteConnectionManager connectionManager) {
+        this.clusterAlias = clusterAlias;
+        this.transportService = transportService;
+        this.connectionManager = connectionManager;
+        connectionManager.addListener(this);
+    }
+
+    static ConnectionProfile buildConnectionProfile(Settings nodeSettings,
+                                                    Settings connectionSettings) {
+        ConnectionStrategy mode = REMOTE_CONNECTION_MODE.get(connectionSettings);
+        boolean compress = REMOTE_CONNECTION_COMPRESS.exists(connectionSettings)
+            ? REMOTE_CONNECTION_COMPRESS.get(connectionSettings)
+            : TransportSettings.TRANSPORT_COMPRESS.get(nodeSettings);
+        TimeValue pingInterval = REMOTE_CONNECTION_PING_SCHEDULE.exists(connectionSettings)
+            ? REMOTE_CONNECTION_PING_SCHEDULE.get(connectionSettings)
+            : TransportSettings.PING_SCHEDULE.get(nodeSettings);
+        ConnectionProfile.Builder builder = new ConnectionProfile.Builder()
+            .setConnectTimeout(TransportSettings.CONNECT_TIMEOUT.get(nodeSettings))
+            .setHandshakeTimeout(TransportSettings.CONNECT_TIMEOUT.get(nodeSettings))
+            .setCompressionEnabled(compress)
+            .setPingInterval(pingInterval)
+            .addConnections(0, TransportRequestOptions.Type.BULK, TransportRequestOptions.Type.STATE,
+                            TransportRequestOptions.Type.RECOVERY, TransportRequestOptions.Type.PING)
+            .addConnections(mode.numberOfChannels, TransportRequestOptions.Type.REG);
+        return builder.build();
+    }
+
+    static RemoteConnectionStrategy buildStrategy(String clusterAlias,
+                                                  TransportService transportService,
+                                                  RemoteConnectionManager connectionManager,
+                                                  Settings nodeSettings,
+                                                  Settings connectionSettings) {
+        ConnectionStrategy mode = REMOTE_CONNECTION_MODE.get(connectionSettings);
+        switch (mode) {
+            case SNIFF:
+                return new SniffConnectionStrategy(
+                    clusterAlias,
+                    transportService,
+                    connectionManager,
+                    nodeSettings,
+                    connectionSettings
+                );
+            case PROXY:
+                return new ProxyConnectionStrategy(
+                    clusterAlias,
+                    transportService,
+                    connectionManager,
+                    connectionSettings
+                );
+            default:
+                throw new AssertionError("Invalid connection strategy" + mode);
+        }
+    }
+
+    public static boolean isConnectionEnabled(Settings connectionSettings) {
+        ConnectionStrategy mode = REMOTE_CONNECTION_MODE.get(connectionSettings);
+        if (mode.equals(ConnectionStrategy.SNIFF)) {
+            List<String> seeds = SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS.get(connectionSettings);
+            return seeds.isEmpty() == false;
+        } else {
+            String address = ProxyConnectionStrategy.PROXY_ADDRESS.get(connectionSettings);
+            return Strings.isEmpty(address) == false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static boolean isConnectionEnabled(Map<Setting<?>, Object> connectionSettings) {
+        ConnectionStrategy mode = (ConnectionStrategy) connectionSettings.get(REMOTE_CONNECTION_MODE);
+        if (mode.equals(ConnectionStrategy.SNIFF)) {
+            List<String> seeds = (List<String>) connectionSettings.get(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS);
+            return seeds.isEmpty() == false;
+        } else {
+            String address = (String) connectionSettings.get(ProxyConnectionStrategy.PROXY_ADDRESS);
+            return Strings.isEmpty(address) == false;
+        }
+    }
+
+    static InetSocketAddress parseConfiguredAddress(String configuredAddress) {
+        final String host = parseHost(configuredAddress);
+        final int port = parsePort(configuredAddress);
+        InetAddress hostAddress;
+        try {
+            hostAddress = InetAddress.getByName(host);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("unknown host [" + host + "]", e);
+        }
+        return new InetSocketAddress(hostAddress, port);
+    }
+
+    static String parseHost(final String configuredAddress) {
+        return configuredAddress.substring(0, indexOfPortSeparator(configuredAddress));
+    }
+
+    static int parsePort(String remoteHost) {
+        try {
+            int port = Integer.parseInt(remoteHost.substring(indexOfPortSeparator(remoteHost) + 1));
+            if (port <= 0) {
+                throw new IllegalArgumentException("port number must be > 0 but was: [" + port + "]");
+            }
+            return port;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("failed to parse port", e);
+        }
+    }
+
+    private static int indexOfPortSeparator(String remoteHost) {
+        int portSeparator = remoteHost.lastIndexOf(':'); // in case we have a IPv6 address ie. [::1]:9300
+        if (portSeparator == -1 || portSeparator == remoteHost.length()) {
+            throw new IllegalArgumentException("remote hosts need to be configured as [host:port], found [" + remoteHost + "] instead");
+        }
+        return portSeparator;
+    }
+
+    /**
+     * Triggers a connect round unless there is one running already. If there is a connect round running, the listener will either
+     * be queued or rejected and failed.
+     */
+    void connect(ActionListener<Void> listener) {
+        boolean runConnect;
+        boolean closed;
+        synchronized (mutex) {
+            closed = this.closed.get();
+            runConnect = this.listener == null;
+            if (closed == false) {
+                this.listener = listener;
+            }
+        }
+        if (closed) {
+            listener.onFailure(new AlreadyClosedException("connect handler is already closed"));
+            return;
+        }
+        if (runConnect) {
+            Executor executor = transportService.getThreadPool().executor(ThreadPool.Names.MANAGEMENT);
+            executor.execute(new AbstractRunnable() {
+                @Override
+                public void onFailure(Exception e) {
+                    var listener = getAndClearListeners();
+                    if (listener != null) {
+                        listener.onFailure(e);
+                    }
+                }
+
+                @Override
+                protected void doRun() {
+                    connectImpl(new ActionListener<>() {
+                        @Override
+                        public void onResponse(Void aVoid) {
+                            var listener = getAndClearListeners();
+                            if (listener != null) {
+                                listener.onResponse(aVoid);
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            var listener = getAndClearListeners();
+                            if (listener != null) {
+                                listener.onFailure(e);
+                            }
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    boolean shouldRebuildConnection(Settings newSettings) {
+        ConnectionStrategy newMode = REMOTE_CONNECTION_MODE.get(newSettings);
+        if (newMode.equals(strategyType()) == false) {
+            return true;
+        } else {
+            Boolean compressionEnabled = REMOTE_CONNECTION_COMPRESS
+                .get(newSettings);
+            TimeValue pingSchedule = REMOTE_CONNECTION_PING_SCHEDULE
+                .get(newSettings);
+
+            ConnectionProfile oldProfile = connectionManager.getConnectionProfile();
+            ConnectionProfile.Builder builder = new ConnectionProfile.Builder(oldProfile);
+            builder.setCompressionEnabled(compressionEnabled);
+            builder.setPingInterval(pingSchedule);
+            ConnectionProfile newProfile = builder.build();
+            return connectionProfileChanged(oldProfile, newProfile) || strategyMustBeRebuilt(newSettings);
+        }
+    }
+
+    protected abstract boolean strategyMustBeRebuilt(Settings newSettings);
+
+    protected abstract ConnectionStrategy strategyType();
+
+    @Override
+    public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
+        if (shouldOpenMoreConnections()) {
+            // try to reconnect and fill up the slot of the disconnected node
+            connect(ActionListener.wrap(
+                ignore -> logger.trace("[{}] successfully connected after disconnect of {}", clusterAlias, node),
+                e -> logger.debug(() -> new ParameterizedMessage("[{}] failed to connect after disconnect of {}", clusterAlias, node), e)));
+        }
+    }
+
+    @Override
+    public void close() {
+        ActionListener<Void> toNotify = null;
+        synchronized (mutex) {
+            if (closed.compareAndSet(false, true)) {
+                connectionManager.removeListener(this);
+                toNotify = listener;
+                listener = null;
+            }
+        }
+        if (toNotify != null) {
+            try {
+                toNotify.onFailure(new AlreadyClosedException("connect handler is already closed"));
+            } catch (Exception e) {
+                throw new ElasticsearchException(e);
+            }
+        }
+    }
+
+    public boolean isClosed() {
+        return closed.get();
+    }
+
+    // for testing only
+    boolean assertNoRunningConnections() {
+        synchronized (mutex) {
+            assert listener == null : "Expecting connection listener to be NULL";
+        }
+        return true;
+    }
+
+    protected abstract boolean shouldOpenMoreConnections();
+
+    protected abstract void connectImpl(ActionListener<Void> listener);
+
+    @Nullable
+    private ActionListener<Void> getAndClearListeners() {
+        ActionListener<Void> result = null;
+        synchronized (mutex) {
+            if (listener != null) {
+                result = listener;
+                listener = null;
+            }
+        }
+        return result;
+    }
+
+    private boolean connectionProfileChanged(ConnectionProfile oldProfile, ConnectionProfile newProfile) {
+        return Objects.equals(oldProfile.getCompressionEnabled(), newProfile.getCompressionEnabled()) == false
+               || Objects.equals(oldProfile.getPingInterval(), newProfile.getPingInterval()) == false;
+    }
+
+    static class StrategyValidator<T> implements Setting.Validator<T> {
+
+        private final String key;
+        private final ConnectionStrategy expectedStrategy;
+        private final Consumer<T> valueChecker;
+
+        StrategyValidator(String key, ConnectionStrategy expectedStrategy) {
+            this(key, expectedStrategy, (v) -> {});
+        }
+
+        StrategyValidator(String key, ConnectionStrategy expectedStrategy, Consumer<T> valueChecker) {
+            this.key = key;
+            this.expectedStrategy = expectedStrategy;
+            this.valueChecker = valueChecker;
+        }
+
+        @Override
+        public void validate(T value) {
+            valueChecker.accept(value);
+        }
+
+        @Override
+        public void validate(T value, Map<Setting<?>, Object> settings) {
+            ConnectionStrategy modeType = (ConnectionStrategy) settings.get(REMOTE_CONNECTION_MODE);
+            if (modeType.equals(expectedStrategy) == false) {
+                throw new IllegalArgumentException("Setting \"" + key + "\" cannot be used with the configured \"" + REMOTE_CONNECTION_MODE.getKey()
+                                                   + "\" [required=" + expectedStrategy.name() + ", configured=" + modeType.name() + "]");
+            }
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            Stream<Setting<?>> settingStream = Stream.of(REMOTE_CONNECTION_MODE);
+            return settingStream.iterator();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -1,0 +1,481 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.Booleans;
+import io.crate.common.io.IOUtils;
+import io.crate.types.DataTypes;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.StepListener;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.common.settings.Setting.intSetting;
+
+public class SniffConnectionStrategy extends RemoteConnectionStrategy {
+
+    /**
+     * A list of initial seed nodes to discover eligible nodes from the remote cluster
+     */
+    public static final Setting<List<String>> REMOTE_CLUSTER_SEEDS = Setting.listSetting(
+        "seeds",
+        null,
+        s -> {
+            // validate seed address
+            parsePort(s);
+            return s;
+        },
+        s -> List.of(),
+        new StrategyValidator<>("seeds", ConnectionStrategy.SNIFF),
+        DataTypes.STRING_ARRAY,
+        Setting.Property.Dynamic);
+
+    /**
+     * A proxy address for the remote cluster. By default this is not set, meaning that Elasticsearch will connect directly to the nodes in
+     * the remote cluster using their publish addresses. If this setting is set to an IP address or hostname then Elasticsearch will connect
+     * to the nodes in the remote cluster using this address instead. Use of this setting is not recommended and it is deliberately
+     * undocumented as it does not work well with all proxies.
+     */
+    public static final Setting<String> REMOTE_CLUSTERS_PROXY = Setting.simpleString(
+        "proxy",
+        new StrategyValidator<>("proxy", ConnectionStrategy.SNIFF, s -> {
+            if (Strings.hasLength(s)) {
+                parsePort(s);
+            }
+        }),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope);
+
+    /**
+     * The maximum number of node connections that will be established to a remote cluster. For instance if there is only a single
+     * seed node, other nodes will be discovered up to the given number of nodes in this setting. The default is 3.
+     */
+    public static final Setting<Integer> REMOTE_NODE_CONNECTIONS = intSetting(
+        "node_connections",
+        3,
+        1,
+        new StrategyValidator<>("node_connections", ConnectionStrategy.SNIFF),
+        Setting.Property.Dynamic);
+
+
+    static final int CHANNELS_PER_CONNECTION = 6;
+
+    private static final Predicate<DiscoveryNode> DEFAULT_NODE_PREDICATE = (node) ->
+        Version.CURRENT.isCompatible(node.getVersion())
+        && (node.isMasterNode() == false || node.isDataNode());
+
+
+    private final List<String> configuredSeedNodes;
+    private final List<Supplier<DiscoveryNode>> seedNodes;
+    private final int maxNumRemoteConnections;
+    private final Predicate<DiscoveryNode> nodePredicate;
+    private final SetOnce<ClusterName> remoteClusterName = new SetOnce<>();
+    private final String proxyAddress;
+
+    SniffConnectionStrategy(String clusterAlias,
+                            TransportService transportService,
+                            RemoteConnectionManager connectionManager,
+                            Settings nodeSettings,
+                            Settings connectionSettings) {
+        this(
+            clusterAlias,
+            transportService,
+            connectionManager,
+            REMOTE_CLUSTERS_PROXY.get(connectionSettings),
+            REMOTE_NODE_CONNECTIONS.get(connectionSettings),
+            getNodePredicate(nodeSettings),
+            REMOTE_CLUSTER_SEEDS.get(connectionSettings)
+        );
+    }
+
+    SniffConnectionStrategy(String clusterAlias,
+                            TransportService transportService,
+                            RemoteConnectionManager connectionManager,
+                            String proxyAddress,
+                            int maxNumRemoteConnections,
+                            Predicate<DiscoveryNode> nodePredicate,
+                            List<String> configuredSeedNodes) {
+        this(clusterAlias,
+             transportService,
+             connectionManager,
+             proxyAddress,
+             maxNumRemoteConnections,
+             nodePredicate,
+             configuredSeedNodes,
+             configuredSeedNodes.stream().map(
+                 seedAddress ->
+                     (Supplier<DiscoveryNode>) () -> resolveSeedNode(clusterAlias, seedAddress, proxyAddress)).collect(
+                 Collectors.toList()));
+    }
+
+    SniffConnectionStrategy(String clusterAlias,
+                            TransportService transportService,
+                            RemoteConnectionManager connectionManager,
+                            String proxyAddress,
+                            int maxNumRemoteConnections,
+                            Predicate<DiscoveryNode> nodePredicate,
+                            List<String> configuredSeedNodes,
+                            List<Supplier<DiscoveryNode>> seedNodes) {
+        super(clusterAlias, transportService, connectionManager);
+        this.proxyAddress = proxyAddress;
+        this.maxNumRemoteConnections = maxNumRemoteConnections;
+        this.nodePredicate = nodePredicate;
+        this.configuredSeedNodes = configuredSeedNodes;
+        this.seedNodes = seedNodes;
+    }
+
+    static Stream<Setting<?>> enablementSettings() {
+        return Stream.of(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS);
+    }
+
+    @Override
+    protected boolean shouldOpenMoreConnections() {
+        return connectionManager.size() < maxNumRemoteConnections;
+    }
+
+    @Override
+    protected boolean strategyMustBeRebuilt(Settings newSettings) {
+        String proxy = REMOTE_CLUSTERS_PROXY.get(newSettings);
+        List<String> addresses = REMOTE_CLUSTER_SEEDS.get(newSettings);
+        int nodeConnections = REMOTE_NODE_CONNECTIONS.get(newSettings);
+        return nodeConnections != maxNumRemoteConnections || seedsChanged(configuredSeedNodes, addresses)
+               || proxyChanged(proxyAddress, proxy);
+    }
+
+    @Override
+    protected ConnectionStrategy strategyType() {
+        return ConnectionStrategy.SNIFF;
+    }
+
+    @Override
+    protected void connectImpl(ActionListener<Void> listener) {
+        collectRemoteNodes(seedNodes.iterator(), listener);
+    }
+
+    private void collectRemoteNodes(Iterator<Supplier<DiscoveryNode>> seedNodes, ActionListener<Void> listener) {
+        if (Thread.currentThread().isInterrupted()) {
+            listener.onFailure(new InterruptedException("remote connect thread got interrupted"));
+            return;
+        }
+
+        if (seedNodes.hasNext()) {
+            final Consumer<Exception> onFailure = e -> {
+                if (e instanceof ConnectTransportException ||
+                    e instanceof IOException ||
+                    e instanceof IllegalStateException) {
+                    // ISE if we fail the handshake with an version incompatible node
+                    if (seedNodes.hasNext()) {
+                        logger.debug(() -> new ParameterizedMessage(
+                                         "fetching nodes from external cluster [{}] failed moving to next seed node", clusterAlias),
+                                     e);
+                        collectRemoteNodes(seedNodes, listener);
+                        return;
+                    }
+                }
+                logger.warn(new ParameterizedMessage("fetching nodes from external cluster [{}] failed", clusterAlias),
+                            e);
+                listener.onFailure(e);
+            };
+
+            final DiscoveryNode seedNode = seedNodes.next().get();
+            logger.trace("[{}] opening transient connection to seed node: [{}]", clusterAlias, seedNode);
+            final StepListener<Transport.Connection> openConnectionStep = new StepListener<>();
+            try {
+                connectionManager.openConnection(seedNode, null, openConnectionStep);
+            } catch (Exception e) {
+                onFailure.accept(e);
+            }
+
+            final StepListener<TransportService.HandshakeResponse> handshakeStep = new StepListener<>();
+            openConnectionStep.whenComplete(connection -> {
+                ConnectionProfile connectionProfile = connectionManager.getConnectionProfile();
+                transportService.handshake(connection, connectionProfile.getHandshakeTimeout().millis(),
+                                           getRemoteClusterNamePredicate(), handshakeStep);
+            }, onFailure);
+
+            final StepListener<Void> fullConnectionStep = new StepListener<>();
+            handshakeStep.whenComplete(handshakeResponse -> {
+                final DiscoveryNode handshakeNode = handshakeResponse.getDiscoveryNode();
+
+                if (nodePredicate.test(handshakeNode) && shouldOpenMoreConnections()) {
+                    logger.trace("[{}] opening managed connection to seed node: [{}] proxy address: [{}]",
+                                 clusterAlias,
+                                 handshakeNode,
+                                 proxyAddress);
+                    final DiscoveryNode handshakeNodeWithProxy = maybeAddProxyAddress(proxyAddress, handshakeNode);
+                    connectionManager.connectToNode(handshakeNodeWithProxy,
+                                                    null,
+                                                    transportService.connectionValidator(handshakeNodeWithProxy),
+                                                    fullConnectionStep);
+                } else {
+                    fullConnectionStep.onResponse(null);
+                }
+            }, e -> {
+                final Transport.Connection connection = openConnectionStep.result();
+                final DiscoveryNode node = connection.getNode();
+                logger.debug(() -> new ParameterizedMessage("[{}] failed to handshake with seed node: [{}]",
+                                                            clusterAlias,
+                                                            node), e);
+                IOUtils.closeWhileHandlingException(connection);
+                onFailure.accept(e);
+            });
+
+            fullConnectionStep.whenComplete(aVoid -> {
+                if (remoteClusterName.get() == null) {
+                    TransportService.HandshakeResponse handshakeResponse = handshakeStep.result();
+                    assert handshakeResponse.getClusterName().value() != null;
+                    remoteClusterName.set(handshakeResponse.getClusterName());
+                }
+                final Transport.Connection connection = openConnectionStep.result();
+
+                ClusterStateRequest request = new ClusterStateRequest();
+                request.clear();
+                request.nodes(true);
+                // here we pass on the connection since we can only close it once the sendRequest returns otherwise
+                // due to the async nature (it will return before it's actually sent) this can cause the request to fail
+                // due to an already closed connection.
+                TransportService.TimeoutResponseHandler<ClusterStateResponse> responseHandler = new TransportService
+                    .TimeoutResponseHandler<>(new SniffClusterStateResponseHandler(connection, listener, seedNodes));
+                transportService.sendRequest(connection,
+                                             ClusterStateAction.NAME,
+                                             request,
+                                             TransportRequestOptions.EMPTY,
+                                             responseHandler);
+            }, e -> {
+                final Transport.Connection connection = openConnectionStep.result();
+                final DiscoveryNode node = connection.getNode();
+                logger.debug(() -> new ParameterizedMessage(
+                    "[{}] failed to open managed connection to seed node: [{}]", clusterAlias, node), e);
+                IOUtils.closeWhileHandlingException(openConnectionStep.result());
+                onFailure.accept(e);
+            });
+        } else {
+            listener.onFailure(new NoSeedNodeLeftException(clusterAlias));
+        }
+    }
+
+    /* This class handles the _state response from the remote cluster when sniffing nodes to connect to */
+    private class SniffClusterStateResponseHandler implements TransportResponseHandler<ClusterStateResponse> {
+
+        private final Transport.Connection connection;
+        private final ActionListener<Void> listener;
+        private final Iterator<Supplier<DiscoveryNode>> seedNodes;
+
+        SniffClusterStateResponseHandler(Transport.Connection connection, ActionListener<Void> listener,
+                                         Iterator<Supplier<DiscoveryNode>> seedNodes) {
+            this.connection = connection;
+            this.listener = listener;
+            this.seedNodes = seedNodes;
+        }
+
+        @Override
+        public ClusterStateResponse read(StreamInput in) throws IOException {
+            return new ClusterStateResponse(in);
+        }
+
+        @Override
+        public void handleResponse(ClusterStateResponse response) {
+            handleNodes(response.getState().nodes().getNodes().valuesIt());
+        }
+
+        private void handleNodes(Iterator<DiscoveryNode> nodesIter) {
+            while (nodesIter.hasNext()) {
+                final DiscoveryNode node = nodesIter.next();
+                if (nodePredicate.test(node) && shouldOpenMoreConnections()) {
+                    logger.trace("[{}] opening managed connection to node: [{}] proxy address: [{}]",
+                                 clusterAlias,
+                                 node,
+                                 proxyAddress);
+                    final DiscoveryNode nodeWithProxy = maybeAddProxyAddress(proxyAddress, node);
+                    connectionManager.connectToNode(
+                        nodeWithProxy,
+                        null,
+                        transportService.connectionValidator(node),
+                        new ActionListener<>() {
+                            @Override
+                            public void onResponse(Void aVoid) {
+                                handleNodes(nodesIter);
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                if (e instanceof ConnectTransportException ||
+                                    e instanceof IllegalStateException) {
+                                    // ISE if we fail the handshake with an version incompatible node
+                                    // fair enough we can't connect just move on
+                                    logger.debug(() -> new ParameterizedMessage(
+                                        "[{}] failed to open managed connection to node [{}]",
+                                        clusterAlias,
+                                        node), e);
+                                    handleNodes(nodesIter);
+                                } else {
+                                    logger.warn(new ParameterizedMessage(
+                                        "[{}] failed to open managed connection to node [{}]",
+                                        clusterAlias,
+                                        node), e);
+                                    IOUtils.closeWhileHandlingException(connection);
+                                    collectRemoteNodes(seedNodes, listener);
+                                }
+                            }
+                        });
+                    return;
+                }
+            }
+            // We have to close this connection before we notify listeners - this is mainly needed for test correctness
+            // since if we do it afterwards we might fail assertions that check if all high level connections are closed.
+            // from a code correctness perspective we could also close it afterwards.
+            IOUtils.closeWhileHandlingException(connection);
+            int openConnections = connectionManager.size();
+            if (openConnections == 0) {
+                listener.onFailure(new IllegalStateException(
+                    "Unable to open any connections to remote cluster [" + clusterAlias + "]"));
+            } else {
+                listener.onResponse(null);
+            }
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            logger.warn(new ParameterizedMessage("fetching nodes from external cluster {} failed", clusterAlias), exp);
+            try {
+                IOUtils.closeWhileHandlingException(connection);
+            } finally {
+                // once the connection is closed lets try the next node
+                collectRemoteNodes(seedNodes, listener);
+            }
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.MANAGEMENT;
+        }
+    }
+
+    private Predicate<ClusterName> getRemoteClusterNamePredicate() {
+        return new Predicate<ClusterName>() {
+            @Override
+            public boolean test(ClusterName c) {
+                return remoteClusterName.get() == null || c.equals(remoteClusterName.get());
+            }
+
+            @Override
+            public String toString() {
+                return remoteClusterName.get() == null ? "any cluster name"
+                    : "expected remote cluster name [" + remoteClusterName.get().value() + "]";
+            }
+        };
+    }
+
+    private static DiscoveryNode resolveSeedNode(String clusterAlias, String address, String proxyAddress) {
+        if (proxyAddress == null || proxyAddress.isEmpty()) {
+            TransportAddress transportAddress = new TransportAddress(parseConfiguredAddress(address));
+            return new DiscoveryNode(clusterAlias + "#" + transportAddress.toString(), transportAddress,
+                                     Version.CURRENT.minimumCompatibilityVersion());
+        } else {
+            TransportAddress transportAddress = new TransportAddress(parseConfiguredAddress(proxyAddress));
+            String hostName = RemoteConnectionStrategy.parseHost(proxyAddress);
+            return new DiscoveryNode("",
+                                     clusterAlias + "#" + address,
+                                     UUIDs.randomBase64UUID(),
+                                     hostName,
+                                     address,
+                                     transportAddress,
+                                     Collections.singletonMap("server_name", hostName),
+                                     DiscoveryNodeRole.BUILT_IN_ROLES,
+                                     Version.CURRENT.minimumCompatibilityVersion());
+        }
+    }
+
+    // Default visibility for tests
+    static Predicate<DiscoveryNode> getNodePredicate(Settings settings) {
+        if (RemoteConnectionStrategy.REMOTE_NODE_ATTRIBUTE.exists(settings)) {
+            // nodes can be tagged with node.attr.remote_gateway: true to allow a node to be a gateway node for cross cluster search
+            String attribute = RemoteConnectionStrategy.REMOTE_NODE_ATTRIBUTE.get(settings);
+            return DEFAULT_NODE_PREDICATE.and((node) -> Booleans.parseBoolean(node.getAttributes().getOrDefault(
+                attribute,
+                "false")));
+        }
+        return DEFAULT_NODE_PREDICATE;
+    }
+
+    private static DiscoveryNode maybeAddProxyAddress(String proxyAddress, DiscoveryNode node) {
+        if (proxyAddress == null || proxyAddress.isEmpty()) {
+            return node;
+        } else {
+            // resolve proxy address lazy here
+            InetSocketAddress proxyInetAddress = parseConfiguredAddress(proxyAddress);
+            return new DiscoveryNode(node.getName(),
+                                     node.getId(),
+                                     node.getEphemeralId(),
+                                     node.getHostName(),
+                                     node
+                                         .getHostAddress(),
+                                     new TransportAddress(proxyInetAddress),
+                                     node.getAttributes(),
+                                     node.getRoles(),
+                                     node.getVersion());
+        }
+    }
+
+    private boolean seedsChanged(final List<String> oldSeedNodes, final List<String> newSeedNodes) {
+        if (oldSeedNodes.size() != newSeedNodes.size()) {
+            return true;
+        }
+        Set<String> oldSeeds = new HashSet<>(oldSeedNodes);
+        Set<String> newSeeds = new HashSet<>(newSeedNodes);
+        return oldSeeds.equals(newSeeds) == false;
+    }
+
+    private boolean proxyChanged(String oldProxy, String newProxy) {
+        if (oldProxy == null || oldProxy.isEmpty()) {
+            return (newProxy == null || newProxy.isEmpty()) == false;
+        }
+
+        return Objects.equals(oldProxy, newProxy) == false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Function;
+
+/**
+ * TransportActionProxy allows an arbitrary action to be executed on a defined target node while the initial request is sent to a second
+ * node that acts as a request proxy to the target node. This is useful if a node is not directly connected to a target node but is
+ * connected to an intermediate node that establishes a transitive connection.
+ */
+public final class TransportActionProxy {
+
+    private TransportActionProxy() {
+        // no instance
+    }
+
+    private static class ProxyRequestHandler<T extends ProxyRequest> implements TransportRequestHandler<T> {
+
+        private final TransportService service;
+        private final String action;
+        private final Function<TransportRequest, Writeable.Reader<? extends TransportResponse>> responseFunction;
+
+        ProxyRequestHandler(TransportService service, String action, Function<TransportRequest,
+            Writeable.Reader<? extends TransportResponse>> responseFunction) {
+            this.service = service;
+            this.action = action;
+            this.responseFunction = responseFunction;
+        }
+
+        @Override
+        public void messageReceived(T request, TransportChannel channel) throws Exception {
+            DiscoveryNode targetNode = request.targetNode;
+            TransportRequest wrappedRequest = request.wrapped;
+            service.sendRequest(targetNode, action, wrappedRequest,
+                                new ProxyResponseHandler<>(channel, responseFunction.apply(wrappedRequest)));
+        }
+    }
+
+    private static class ProxyResponseHandler<T extends TransportResponse> implements TransportResponseHandler<T> {
+
+        private final Writeable.Reader<T> reader;
+        private final TransportChannel channel;
+
+        ProxyResponseHandler(TransportChannel channel, Writeable.Reader<T> reader) {
+            this.reader = reader;
+            this.channel = channel;
+        }
+
+        @Override
+        public T read(StreamInput in) throws IOException {
+            return reader.read(in);
+        }
+
+        @Override
+        public void handleResponse(T response) {
+            try {
+                channel.sendResponse(response);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            try {
+                channel.sendResponse(exp);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.SAME;
+        }
+    }
+
+    static class ProxyRequest<T extends TransportRequest> extends TransportRequest {
+        final T wrapped;
+        final DiscoveryNode targetNode;
+
+        ProxyRequest(T wrapped, DiscoveryNode targetNode) {
+            this.wrapped = wrapped;
+            this.targetNode = targetNode;
+        }
+
+        ProxyRequest(StreamInput in, Writeable.Reader<T> reader) throws IOException {
+            super(in);
+            targetNode = new DiscoveryNode(in);
+            wrapped = reader.read(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            targetNode.writeTo(out);
+            wrapped.writeTo(out);
+        }
+    }
+
+    /**
+     * Registers a proxy request handler that allows to forward requests for the given action to another node. To be used when the
+     * response type changes based on the upcoming request (quite rare)
+     */
+    public static void registerProxyActionWithDynamicResponseType(TransportService service, String action,
+                                                                  Function<TransportRequest,
+                                                                      Writeable.Reader<? extends TransportResponse>> responseFunction) {
+        RequestHandlerRegistry<? extends TransportRequest> requestHandler = service.getRequestHandler(action);
+        service.registerRequestHandler(getProxyAction(action), ThreadPool.Names.SAME, true, false,
+                                       in -> new ProxyRequest<>(in, requestHandler::newRequest), new ProxyRequestHandler<>(service, action, responseFunction));
+    }
+
+    /**
+     * Registers a proxy request handler that allows to forward requests for the given action to another node. To be used when the
+     * response type is always the same (most of the cases).
+     */
+    public static void registerProxyAction(TransportService service, String action,
+                                           Writeable.Reader<? extends TransportResponse> reader) {
+        RequestHandlerRegistry<? extends TransportRequest> requestHandler = service.getRequestHandler(action);
+        service.registerRequestHandler(getProxyAction(action), ThreadPool.Names.SAME, true, false,
+                                       in -> new ProxyRequest<>(in, requestHandler::newRequest), new ProxyRequestHandler<>(service, action, request -> reader));
+    }
+
+    private static final String PROXY_ACTION_PREFIX = "internal:transport/proxy/";
+
+    /**
+     * Returns the corresponding proxy action for the given action
+     */
+    public static String getProxyAction(String action) {
+        return PROXY_ACTION_PREFIX + action;
+    }
+
+    /**
+     * Wraps the actual request in a proxy request object that encodes the target node.
+     */
+    public static TransportRequest wrapRequest(DiscoveryNode node, TransportRequest request) {
+        return new ProxyRequest<>(request, node);
+    }
+
+    /**
+     * Unwraps a proxy request and returns the original request
+     */
+    public static TransportRequest unwrapRequest(TransportRequest request) {
+        if (request instanceof ProxyRequest) {
+            return ((ProxyRequest)request).wrapped;
+        }
+        return request;
+    }
+
+    /**
+     * Unwraps a proxy action and returns the underlying action
+     */
+    public static String unwrapAction(String action) {
+        assert isProxyAction(action) : "Attempted to unwrap non-proxy action: " + action;
+        return action.substring(PROXY_ACTION_PREFIX.length());
+    }
+
+    /**
+     * Returns <code>true</code> iff the given action is a proxy action
+     */
+    public static boolean isProxyAction(String action) {
+        return action.startsWith(PROXY_ACTION_PREFIX);
+    }
+
+    /**
+     * Returns <code>true</code> iff the given request is a proxy request
+     */
+    public static boolean isProxyRequest(TransportRequest request) {
+        return request instanceof ProxyRequest;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -148,7 +148,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
             threadPool,
             localNodeFactory,
             clusterSettings,
-            new ConnectionManager(settings, transport)
+            new ClusterConnectionManager(settings, transport)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -30,13 +30,13 @@ import org.elasticsearch.cluster.node.DiscoveryNodes.Builder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.discovery.PeerFinder.TransportAddressConnector;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.CapturingTransport.CapturedRequest;
 import org.elasticsearch.test.transport.StubbableConnectionManager;
 import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.transport.ClusterConnectionManager;
 import org.elasticsearch.transport.ConnectionManager;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -212,12 +212,14 @@ public class PeerFinderTests extends ESTestCase {
         localNode = newDiscoveryNode("local-node");
 
         ConnectionManager innerConnectionManager
-            = new ConnectionManager(settings, capturingTransport);
+            = new ClusterConnectionManager(settings, capturingTransport);
         StubbableConnectionManager connectionManager
-            = new StubbableConnectionManager(innerConnectionManager, settings, capturingTransport, deterministicTaskQueue.getThreadPool());
-        connectionManager.setDefaultNodeConnectedBehavior(cm -> {
-            assertTrue(Sets.haveEmptyIntersection(connectedNodes, disconnectedNodes));
-            return connectedNodes;
+            = new StubbableConnectionManager(innerConnectionManager);
+        connectionManager.setDefaultNodeConnectedBehavior((cm, discoveryNode) -> {
+            final boolean isConnected = connectedNodes.contains(discoveryNode);
+            final boolean isDisconnected = disconnectedNodes.contains(discoveryNode);
+            assert isConnected != isDisconnected : discoveryNode + ": isConnected=" + isConnected + ", isDisconnected=" + isDisconnected;
+            return isConnected;
         });
         connectionManager.setDefaultGetConnectionBehavior((cm, discoveryNode) -> capturingTransport.createConnection(discoveryNode));
         transportService = new TransportService(settings, capturingTransport, deterministicTaskQueue.getThreadPool(),

--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.collections.Tuple;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+public class ProxyConnectionStrategyTests extends ESTestCase {
+
+    private final String clusterAlias = "cluster-alias";
+    private final String modeKey = RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey();
+    private final Settings settings = Settings.builder().put(modeKey, "proxy").build();
+    private final ConnectionProfile profile = RemoteConnectionStrategy.buildConnectionProfile(Settings.EMPTY, settings);
+    private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
+    private MockTransportService startTransport(String id, Version version) {
+        return startTransport(id, version, Settings.EMPTY);
+    }
+
+    public MockTransportService startTransport(final String id, final Version version, final Settings settings) {
+        boolean success = false;
+        final Settings s = Settings.builder()
+            .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterAlias)
+            .put("node.name", id)
+            .put(settings)
+            .build();
+        MockTransportService newService = MockTransportService.createNewService(s, version, threadPool);
+        try {
+            newService.start();
+            newService.acceptIncomingRequests();
+            success = true;
+            return newService;
+        } finally {
+            if (success == false) {
+                newService.close();
+            }
+        }
+    }
+
+    public void testProxyStrategyWillOpenExpectedNumberOfConnectionsToAddress() {
+        try (MockTransportService transport1 = startTransport("node1", Version.CURRENT)) {
+            TransportAddress address1 = transport1.boundAddress().publishAddress();
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                int numOfConnections = randomIntBetween(4, 8);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    numOfConnections, address1.toString())) {
+                    assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                    assertEquals(numOfConnections, connectionManager.size());
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testProxyStrategyWillOpenNewConnectionsOnDisconnect() throws Exception {
+        try (MockTransportService transport1 = startTransport("node1", Version.CURRENT);
+             MockTransportService transport2 = startTransport("node2", Version.CURRENT)) {
+            TransportAddress address1 = transport1.boundAddress().publishAddress();
+            TransportAddress address2 = transport2.boundAddress().publishAddress();
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                int numOfConnections = randomIntBetween(4, 8);
+
+                AtomicBoolean useAddress1 = new AtomicBoolean(true);
+
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    numOfConnections, address1.toString(),
+                                                                                    alternatingResolver(address1, address2, useAddress1))) {
+                    assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                    assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address2)));
+
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                    long initialConnectionsToTransport2 = connectionManager.getAllConnectedNodes().stream()
+                        .filter(n -> n.getAddress().equals(address2))
+                        .count();
+                    assertEquals(0, initialConnectionsToTransport2);
+                    assertEquals(numOfConnections, connectionManager.size());
+                    assertTrue(strategy.assertNoRunningConnections());
+                    useAddress1.set(false);
+
+                    transport1.close();
+
+                    assertBusy(() -> {
+                        assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                        // Connections now pointing to transport2
+                        long finalConnectionsToTransport2 = connectionManager.getAllConnectedNodes().stream()
+                            .filter(n -> n.getAddress().equals(address2))
+                            .count();
+                        assertNotEquals(0, finalConnectionsToTransport2);
+                        assertEquals(numOfConnections, connectionManager.size());
+                        assertTrue(strategy.assertNoRunningConnections());
+                    });
+                }
+            }
+        }
+    }
+
+    public void testConnectFailsWithIncompatibleNodes() {
+        Version incompatibleVersion = Version.V_3_2_0;
+        try (MockTransportService transport1 = startTransport("incompatible-node", incompatibleVersion)) {
+            TransportAddress address1 = transport1.boundAddress().publishAddress();
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                int numOfConnections = randomIntBetween(4, 8);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    numOfConnections, address1.toString())) {
+
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    expectThrows(Exception.class, connectFuture::actionGet);
+
+                    assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                    assertEquals(0, connectionManager.size());
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testClusterNameValidationPreventConnectingToDifferentClusters() throws Exception {
+        Settings otherSettings = Settings.builder().put("cluster.name", "otherCluster").build();
+
+        try (MockTransportService transport1 = startTransport("cluster1", Version.CURRENT);
+             MockTransportService transport2 = startTransport("cluster2", Version.CURRENT, otherSettings)) {
+            TransportAddress address1 = transport1.boundAddress().publishAddress();
+            TransportAddress address2 = transport2.boundAddress().publishAddress();
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                int numOfConnections = randomIntBetween(4, 8);
+
+                AtomicBoolean useAddress1 = new AtomicBoolean(true);
+
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    numOfConnections, address1.toString(),
+                                                                                    alternatingResolver(address1, address2, useAddress1))) {
+                    assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                    assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address2)));
+
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                    assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address2)));
+                    useAddress1.set(false);
+
+                    transport1.close();
+
+                    assertBusy(() -> {
+                        assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
+                        assertTrue(strategy.assertNoRunningConnections());
+
+                        long finalConnectionsToTransport2 = connectionManager.getAllConnectedNodes().stream()
+                            .filter(n -> n.getAddress().equals(address2))
+                            .count();
+
+                        // Connections not pointing to transport2 because the cluster name is different
+                        assertEquals(0, finalConnectionsToTransport2);
+                        assertEquals(0, connectionManager.size());
+                    });
+                }
+            }
+        }
+    }
+
+    public void testProxyStrategyWillResolveAddressesEachConnect() throws Exception {
+        try (MockTransportService transport1 = startTransport("seed_node", Version.CURRENT)) {
+            TransportAddress address = transport1.boundAddress().publishAddress();
+
+            CountDownLatch multipleResolveLatch = new CountDownLatch(2);
+            Supplier<TransportAddress> addressSupplier = () -> {
+                multipleResolveLatch.countDown();
+                return address;
+            };
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                int numOfConnections = randomIntBetween(4, 8);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    numOfConnections, address.toString(), addressSupplier)) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    remoteConnectionManager.getAnyRemoteConnection().close();
+
+                    assertTrue(multipleResolveLatch.await(30L, TimeUnit.SECONDS));
+                }
+            }
+        }
+    }
+
+    public void testProxyStrategyWillNeedToBeRebuiltIfNumOfSocketsOrAddressesOrServerNameChange() {
+        try (MockTransportService remoteTransport = startTransport("node1", Version.CURRENT)) {
+            TransportAddress remoteAddress = remoteTransport.boundAddress().publishAddress();
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                int numOfConnections = randomIntBetween(4, 8);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    numOfConnections, remoteAddress.toString())) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(remoteAddress)));
+                    assertEquals(numOfConnections, connectionManager.size());
+                    assertTrue(strategy.assertNoRunningConnections());
+
+                    Setting<?> modeSetting = RemoteConnectionStrategy.REMOTE_CONNECTION_MODE;
+                    Setting<?> addressesSetting = ProxyConnectionStrategy.PROXY_ADDRESS;
+                    Setting<?> socketConnections = ProxyConnectionStrategy.REMOTE_SOCKET_CONNECTIONS;
+
+                    Settings noChange = Settings.builder()
+                        .put(modeSetting.getKey(), "proxy")
+                        .put(addressesSetting.getKey(), remoteAddress.toString())
+                        .put(socketConnections.getKey(), numOfConnections)
+                        .build();
+                    assertFalse(strategy.shouldRebuildConnection(noChange));
+                    Settings addressesChanged = Settings.builder()
+                        .put(modeSetting.getKey(), "proxy")
+                        .put(addressesSetting.getKey(), remoteAddress.toString())
+                        .build();
+                    assertTrue(strategy.shouldRebuildConnection(addressesChanged));
+                    Settings socketsChanged = Settings.builder()
+                        .put(modeSetting.getKey(), "proxy")
+                        .put(addressesSetting.getKey(), remoteAddress.toString())
+                        .put(socketConnections.getKey(), numOfConnections + 1)
+                        .build();
+                    assertTrue(strategy.shouldRebuildConnection(socketsChanged));
+                }
+            }
+        }
+    }
+
+    public void testModeSettingsCannotBeUsedWhenInDifferentMode() {
+        List<Tuple<Setting<?>, String>> restrictedSettings = Arrays.asList(
+            new Tuple<>(ProxyConnectionStrategy.PROXY_ADDRESS, "192.168.0.1:8080"),
+            new Tuple<>(ProxyConnectionStrategy.REMOTE_SOCKET_CONNECTIONS, "3"));
+
+        RemoteConnectionStrategy.ConnectionStrategy sniff = RemoteConnectionStrategy.ConnectionStrategy.SNIFF;
+
+        Settings settings = Settings.builder()
+            .put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey(), sniff.name())
+            .build();
+
+        for (Tuple<Setting<?>, String> restrictedSetting : restrictedSettings) {
+            Setting<?> concreteSetting = restrictedSetting.v1();
+            Settings invalid = Settings.builder().put(settings).put(concreteSetting.getKey(), restrictedSetting.v2()).build();
+            IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> concreteSetting.get(invalid));
+            String expected = "Setting \"" + concreteSetting.getKey() + "\" cannot be used with the configured " +
+                              "\"mode\" [required=PROXY, configured=SNIFF]";
+            assertEquals(expected, iae.getMessage());
+        }
+    }
+
+    private Supplier<TransportAddress> alternatingResolver(TransportAddress address1, TransportAddress address2,
+                                                           AtomicBoolean useAddress1) {
+        return () -> {
+            if (useAddress1.get()) {
+                return address1;
+            } else {
+                return address2;
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareTests.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class RemoteClusterAwareTests extends ESTestCase {
+
+    public void testBuildRemoteIndexName() {
+        {
+            String clusterAlias = randomAlphaOfLengthBetween(5, 10);
+            String index = randomAlphaOfLengthBetween(5, 10);
+            String remoteIndexName = RemoteClusterAware.buildRemoteIndexName(clusterAlias, index);
+            assertEquals(clusterAlias + ":" + index, remoteIndexName);
+        }
+        {
+            String index = randomAlphaOfLengthBetween(5, 10);
+            String clusterAlias = randomBoolean() ? null : RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            String remoteIndexName = RemoteClusterAware.buildRemoteIndexName(clusterAlias, index);
+            assertEquals(index, remoteIndexName);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -1,0 +1,490 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.transport;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import io.crate.common.SuppressForbidden;
+import io.crate.common.io.IOUtils;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+@Repeat(iterations = 20)
+public class RemoteClusterConnectionTests extends ESTestCase {
+
+    private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
+    private MockTransportService startTransport(String id, List<DiscoveryNode> knownNodes, Version version) {
+        return startTransport(id, knownNodes, version, threadPool);
+    }
+
+    public static MockTransportService startTransport(String id, List<DiscoveryNode> knownNodes, Version version, ThreadPool threadPool) {
+        return startTransport(id, knownNodes, version, threadPool, Settings.EMPTY);
+    }
+
+    public static MockTransportService startTransport(
+        final String id,
+        final List<DiscoveryNode> knownNodes,
+        final Version version,
+        final ThreadPool threadPool,
+        final Settings settings) {
+        boolean success = false;
+        final Settings s = Settings.builder().put(settings).put("node.name", id).build();
+        ClusterName clusterName = ClusterName.CLUSTER_NAME_SETTING.get(s);
+        MockTransportService newService = MockTransportService.createNewService(s, version, threadPool, null);
+        try {
+            newService.registerRequestHandler(ClusterStateAction.NAME, ThreadPool.Names.SAME, ClusterStateRequest::new,
+                                              (request, channel) -> {
+                                                  DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+                                                  for (DiscoveryNode node : knownNodes) {
+                                                      builder.add(node);
+                                                  }
+                                                  ClusterState build = ClusterState.builder(clusterName).nodes(builder.build()).build();
+                                                  channel.sendResponse(new ClusterStateResponse(clusterName, build, false));
+                                              });
+            newService.start();
+            newService.acceptIncomingRequests();
+            success = true;
+            return newService;
+        } finally {
+            if (success == false) {
+                newService.close();
+            }
+        }
+    }
+
+    @SuppressForbidden(reason = "calls getLocalHost here but it's fine in this case")
+    public void testSlowNodeCanBeCancelled() throws IOException, InterruptedException {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.bind(new InetSocketAddress(InetAddress.getLocalHost(), 0), 1);
+            socket.setReuseAddress(true);
+            DiscoveryNode seedNode = new DiscoveryNode("TEST", new TransportAddress(socket.getInetAddress(),
+                                                                                    socket.getLocalPort()), emptyMap(),
+                                                       emptySet(), Version.CURRENT);
+            CountDownLatch acceptedLatch = new CountDownLatch(1);
+            CountDownLatch closeRemote = new CountDownLatch(1);
+            Thread t = new Thread() {
+                @Override
+                public void run() {
+                    try (Socket accept = socket.accept()) {
+                        acceptedLatch.countDown();
+                        closeRemote.await(1, TimeUnit.SECONDS);
+                    } catch (IOException e) {
+                        // that's fine we might close
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            };
+            t.start();
+
+            try (MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null)) {
+                service.start();
+                service.acceptIncomingRequests();
+                CountDownLatch listenerCalled = new CountDownLatch(1);
+                AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+                String clusterAlias = "test-cluster";
+                Settings connectionSettings = buildRandomSettings(addresses(seedNode));
+                try (RemoteClusterConnection connection = new RemoteClusterConnection(Settings.EMPTY, connectionSettings, clusterAlias, service)) {
+                    ActionListener<Void> listener = ActionListener.wrap(x -> {
+                        listenerCalled.countDown();
+                        fail("expected exception");
+                    }, x -> {
+                        exceptionReference.set(x);
+                        listenerCalled.countDown();
+                    });
+                    connection.ensureConnected(listener);
+                    acceptedLatch.await(1, TimeUnit.SECONDS);
+                    connection.close(); // now close it, this should trigger an interrupt on the socket and we can move on
+                    assertTrue(connection.assertNoRunningConnections());
+                }
+                closeRemote.countDown();
+                listenerCalled.await(1, TimeUnit.SECONDS);
+                assertNotNull(exceptionReference.get());
+                expectThrows(AlreadyClosedException.class, () -> {
+                    throw exceptionReference.get();
+                });
+
+            }
+        }
+    }
+
+    private static List<String> addresses(final DiscoveryNode... seedNodes) {
+        return Arrays.stream(seedNodes).map(s -> s.getAddress().toString()).collect(Collectors.toList());
+    }
+
+    public void testCloseWhileConcurrentlyConnecting() throws IOException, InterruptedException, BrokenBarrierException, TimeoutException {
+        AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService seedTransport1 = startTransport("seed_node_1", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalDiscoNode();
+            DiscoveryNode seedNode1 = seedTransport1.getLocalDiscoNode();
+            knownNodes.add(seedTransport.getLocalDiscoNode());
+            knownNodes.add(discoverableTransport.getLocalDiscoNode());
+            knownNodes.add(seedTransport1.getLocalDiscoNode());
+            Collections.shuffle(knownNodes, random());
+            List<String> seedNodes = addresses(seedNode1, seedNode);
+            Collections.shuffle(seedNodes, random());
+
+            try (MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null)) {
+                service.start();
+                service.acceptIncomingRequests();
+                String clusterAlias = "test-cluster";
+                Settings connectionSettings = buildRandomSettings(seedNodes);
+                try (RemoteClusterConnection connection = new RemoteClusterConnection(Settings.EMPTY, connectionSettings, clusterAlias, service)) {
+                    int numThreads = randomIntBetween(4, 10);
+                    Thread[] threads = new Thread[numThreads];
+                    CyclicBarrier barrier = new CyclicBarrier(numThreads + 1);
+                    for (int i = 0; i < threads.length; i++) {
+                        final int numConnectionAttempts = randomIntBetween(10, 100);
+                        threads[i] = new Thread() {
+                            @Override
+                            public void run() {
+                                try {
+                                    barrier.await(1, TimeUnit.SECONDS);
+                                    CountDownLatch latch = new CountDownLatch(numConnectionAttempts);
+                                    for (int i = 0; i < numConnectionAttempts; i++) {
+                                        AtomicReference<Exception> executed = new AtomicReference<>();
+                                        ActionListener<Void> listener = ActionListener.wrap(
+                                            x -> {
+                                                if (executed.compareAndSet(null, new RuntimeException())) {
+                                                    latch.countDown();
+                                                } else {
+                                                    var error = new AssertionError("shit's been called twice", executed.get());
+                                                    exceptionRef.set(error);
+                                                    throw error;
+                                                }
+                                            },
+                                            x -> {
+                                                if (executed.compareAndSet(null, x)) {
+                                                    latch.countDown();
+                                                } else {
+                                                    final String message = x.getMessage();
+                                                    if ((executed.get().getClass() == x.getClass()
+                                                         && "operation was cancelled reason [connect handler is closed]".equals(message)
+                                                         && message.equals(executed.get().getMessage())) == false) {
+                                                        // we do cancel the operation and that means that if timing allows it, the caller
+                                                        // of a blocking call as well as the handler will get the exception from the
+                                                        // ExecutionCancelledException concurrently. unless that is the case we fail
+                                                        // if we get called more than once!
+                                                        AssertionError assertionError = new AssertionError("shit's been called twice", x);
+                                                        assertionError.addSuppressed(executed.get());
+                                                        exceptionRef.set(assertionError);
+                                                        throw assertionError;
+                                                    }
+                                                }
+                                                if (x instanceof RejectedExecutionException || x instanceof AlreadyClosedException) {
+                                                    // that's fine
+                                                } else {
+                                                    var error = new AssertionError(x);
+                                                    exceptionRef.set(error);
+                                                    throw error;
+                                                }
+                                            });
+                                        try {
+                                            connection.ensureConnected(listener);
+                                        } catch (Exception e) {
+                                            latch.countDown();
+                                            // it's ok if we're shutting down
+                                            assertThat(e.getMessage(), containsString("threadcontext is already closed"));
+                                        }
+                                    }
+                                    latch.await(1, TimeUnit.SECONDS);
+                                } catch (Exception ex) {
+                                    var error = new AssertionError(ex);
+                                    exceptionRef.set(error);
+                                    throw error;
+                                }
+                            }
+                        };
+                        threads[i].start();
+                    }
+                    barrier.await(1, TimeUnit.SECONDS);
+                }
+            }
+        }
+        assertThat(exceptionRef.get(), nullValue());
+    }
+
+    public void testCollectNodes() throws Exception {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalDiscoNode();
+            knownNodes.add(seedTransport.getLocalDiscoNode());
+            try (MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null)) {
+                service.start();
+                service.acceptIncomingRequests();
+                String clusterAlias = "test-cluster";
+                Settings connectionSettings = buildRandomSettings(addresses(seedNode));
+
+                try (RemoteClusterConnection connection = new RemoteClusterConnection(Settings.EMPTY, connectionSettings, clusterAlias, service)) {
+                    CountDownLatch responseLatch = new CountDownLatch(1);
+                    AtomicReference<Function<String, DiscoveryNode>> reference = new AtomicReference<>();
+                    AtomicReference<Exception> failReference = new AtomicReference<>();
+                    ActionListener<Function<String, DiscoveryNode>> shardsListener = ActionListener.wrap(
+                        x -> {
+                            reference.set(x);
+                            responseLatch.countDown();
+                        },
+                        x -> {
+                            failReference.set(x);
+                            responseLatch.countDown();
+                        });
+                    connection.collectNodes(shardsListener);
+                    responseLatch.await(1, TimeUnit.SECONDS);
+                    assertNull(failReference.get());
+                    assertNotNull(reference.get());
+                    Function<String, DiscoveryNode> function = reference.get();
+                    assertEquals(seedNode, function.apply(seedNode.getId()));
+                    assertNull(function.apply(seedNode.getId() + "foo"));
+                    assertTrue(connection.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testNoChannelsExceptREG() throws Exception {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalDiscoNode();
+            knownNodes.add(seedTransport.getLocalDiscoNode());
+            try (MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null)) {
+                service.start();
+                service.acceptIncomingRequests();
+                String clusterAlias = "test-cluster";
+                Settings connectionSettings = buildRandomSettings(addresses(seedNode));
+
+                try (RemoteClusterConnection connection = new RemoteClusterConnection(Settings.EMPTY, connectionSettings, clusterAlias, service)) {
+                    PlainActionFuture<Void> plainActionFuture = new PlainActionFuture<>();
+                    connection.ensureConnected(plainActionFuture);
+                    plainActionFuture.get(10, TimeUnit.SECONDS);
+
+                    for (TransportRequestOptions.Type type : TransportRequestOptions.Type.values()) {
+                        if (type != TransportRequestOptions.Type.REG) {
+                            assertThat(expectThrows(IllegalStateException.class,
+                                                    () -> connection.getConnection().sendRequest(randomNonNegativeLong(),
+                                                                                                 "arbitrary", TransportRequest.Empty.INSTANCE,
+                                                                                                 TransportRequestOptions.builder().withType(type).build())).getMessage(),
+                                       allOf(containsString("can't select"), containsString(type.toString())));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void testConnectedNodesConcurrentAccess() throws IOException, InterruptedException {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        List<MockTransportService> discoverableTransports = new CopyOnWriteArrayList<>();
+        try {
+            final int numDiscoverableNodes = randomIntBetween(5, 20);
+            List<DiscoveryNode> discoverableNodes = new ArrayList<>(numDiscoverableNodes);
+            for (int i = 0; i < numDiscoverableNodes; i++) {
+                MockTransportService transportService = startTransport("discoverable_node" + i, knownNodes, Version.CURRENT);
+                discoverableNodes.add(transportService.getLocalNode());
+                discoverableTransports.add(transportService);
+            }
+
+            List<String> seedNodes = new CopyOnWriteArrayList<>(randomSubsetOf(randomIntBetween(1, discoverableNodes.size()),
+                                                                               discoverableNodes.stream().map(d -> d.getAddress().toString()).collect(Collectors.toList())));
+            Collections.shuffle(seedNodes, random());
+
+            try (MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null)) {
+                service.start();
+                service.acceptIncomingRequests();
+
+                String clusterAlias = "test-cluster";
+                Settings connectionSettings = buildRandomSettings(seedNodes);
+                try (RemoteClusterConnection connection = new RemoteClusterConnection(Settings.EMPTY, connectionSettings, clusterAlias, service)) {
+                    final int numGetThreads = randomIntBetween(4, 10);
+                    final Thread[] getThreads = new Thread[numGetThreads];
+                    final int numModifyingThreads = randomIntBetween(4, 10);
+                    final Thread[] modifyingThreads = new Thread[numModifyingThreads];
+                    CyclicBarrier barrier = new CyclicBarrier(numGetThreads + numModifyingThreads);
+                    for (int i = 0; i < getThreads.length; i++) {
+                        final int numGetCalls = randomIntBetween(1000, 10000);
+                        getThreads[i] = new Thread(() -> {
+                            try {
+                                barrier.await(1, TimeUnit.SECONDS);
+                                for (int j = 0; j < numGetCalls; j++) {
+                                    try {
+                                        Transport.Connection lowLevelConnection = connection.getConnection();
+                                        assertNotNull(lowLevelConnection);
+                                    } catch (NoSuchRemoteClusterException e) {
+                                        // ignore, this is an expected exception
+                                    }
+                                }
+                            } catch (Exception ex) {
+                                throw new AssertionError(ex);
+                            }
+                        });
+                        getThreads[i].start();
+                    }
+
+                    for (int i = 0; i < modifyingThreads.length; i++) {
+                        final int numDisconnects = randomIntBetween(5, 10);
+                        modifyingThreads[i] = new Thread(() -> {
+                            try {
+                                barrier.await(1, TimeUnit.SECONDS);
+                                for (int j = 0; j < numDisconnects; j++) {
+                                    DiscoveryNode node = randomFrom(discoverableNodes);
+                                    try {
+                                        connection.getConnectionManager().getConnection(node);
+                                    } catch (NoSuchRemoteClusterException e) {
+                                        // Ignore
+                                    }
+                                }
+                            } catch (Exception ex) {
+                                throw new AssertionError(ex);
+                            }
+                        });
+                        modifyingThreads[i].start();
+                    }
+
+                    for (Thread thread : getThreads) {
+                        thread.join();
+                    }
+                    for (Thread thread : modifyingThreads) {
+                        thread.join();
+                    }
+                }
+            }
+        } finally {
+            IOUtils.closeWhileHandlingException(discoverableTransports);
+        }
+    }
+
+    public void testGetConnection() throws Exception {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService disconnectedTransport = startTransport("disconnected_node", knownNodes, Version.CURRENT)) {
+
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            knownNodes.add(seedNode);
+
+            DiscoveryNode disconnectedNode = disconnectedTransport.getLocalNode();
+
+            try (MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null)) {
+                service.start();
+                service.acceptIncomingRequests();
+                String clusterAlias = "test-cluster";
+                Settings connectionSettings = buildRandomSettings(addresses(seedNode));
+                try (RemoteClusterConnection connection = new RemoteClusterConnection(Settings.EMPTY, connectionSettings, clusterAlias, service)) {
+                    PlainActionFuture.get(fut -> connection.ensureConnected(ActionListener.map(fut, x -> null)));
+                    for (int i = 0; i < 10; i++) {
+                        //always a direct connection as the remote node is already connected
+                        Transport.Connection remoteConnection = connection.getConnection(seedNode);
+                        assertEquals(seedNode, remoteConnection.getNode());
+                    }
+                    for (int i = 0; i < 10; i++) {
+                        // we don't use the transport service connection manager so we will get a proxy connection for the local node
+                        Transport.Connection remoteConnection = connection.getConnection(service.getLocalNode());
+                        assertThat(remoteConnection, instanceOf(RemoteConnectionManager.ProxyConnection.class));
+                        assertThat(remoteConnection.getNode(), equalTo(service.getLocalNode()));
+                    }
+                    for (int i = 0; i < 10; i++) {
+                        // always a proxy connection as the target node is not connected
+                        Transport.Connection remoteConnection = connection.getConnection(disconnectedNode);
+                        assertThat(remoteConnection, instanceOf(RemoteConnectionManager.ProxyConnection.class));
+                        assertThat(remoteConnection.getNode(), sameInstance(disconnectedNode));
+                    }
+                }
+            }
+        }
+    }
+
+    private Settings buildRandomSettings(List<String> addresses) {
+        if (randomBoolean()) {
+            return buildProxySettings(addresses);
+        } else {
+            return buildSniffSettings(addresses);
+        }
+    }
+
+    private static Settings buildProxySettings(List<String> addresses) {
+        Settings.Builder builder = Settings.builder();
+        builder.put(ProxyConnectionStrategy.PROXY_ADDRESS.getKey(),
+                    addresses.get(0));
+        builder.put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey(), "proxy");
+        return builder.build();
+    }
+
+    private static Settings buildSniffSettings(List<String> seedNodes) {
+        Settings.Builder builder = Settings.builder();
+        builder.put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey(), "sniff");
+        builder.put(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS.getKey(),
+                    Strings.collectionToCommaDelimitedString(seedNodes));
+        return builder.build();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.ESTestCase;
+
+import java.net.InetAddress;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class RemoteConnectionManagerTests extends ESTestCase {
+
+    private Transport transport;
+    private RemoteConnectionManager remoteConnectionManager;
+    private ConnectionManager.ConnectionValidator validator = (connection, profile, listener) -> listener.onResponse(null);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        transport = mock(Transport.class);
+        remoteConnectionManager = new RemoteConnectionManager("remote-cluster", new ClusterConnectionManager(Settings.EMPTY, transport));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetConnection() {
+        TransportAddress address = new TransportAddress(InetAddress.getLoopbackAddress(), 1000);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
+            listener.onResponse(new TestRemoteConnection((DiscoveryNode) invocationOnMock.getArguments()[0]));
+            return null;
+        }).when(transport).openConnection(any(DiscoveryNode.class), any(ConnectionProfile.class), any(ActionListener.class));
+
+        DiscoveryNode node1 = new DiscoveryNode("node-1", address, Version.CURRENT);
+        PlainActionFuture<Void> future1 = PlainActionFuture.newFuture();
+        remoteConnectionManager.connectToNode(node1, null, validator, future1);
+        assertTrue(future1.isDone());
+
+        // Add duplicate connect attempt to ensure that we do not get duplicate connections in the round robin
+        remoteConnectionManager.connectToNode(node1, null, validator, PlainActionFuture.newFuture());
+
+        DiscoveryNode node2 = new DiscoveryNode("node-2", address, Version.CURRENT.minimumCompatibilityVersion());
+        PlainActionFuture<Void> future2 = PlainActionFuture.newFuture();
+        remoteConnectionManager.connectToNode(node2, null, validator, future2);
+        assertTrue(future2.isDone());
+
+        assertEquals(node1, remoteConnectionManager.getConnection(node1).getNode());
+        assertEquals(node2, remoteConnectionManager.getConnection(node2).getNode());
+
+        DiscoveryNode node4 = new DiscoveryNode("node-4", address, Version.CURRENT);
+        assertThat(remoteConnectionManager.getConnection(node4), instanceOf(RemoteConnectionManager.ProxyConnection.class));
+
+        // Test round robin
+        Set<Version> versions = new HashSet<>();
+        versions.add(remoteConnectionManager.getConnection(node4).getVersion());
+        versions.add(remoteConnectionManager.getConnection(node4).getVersion());
+
+        assertThat(versions, hasItems(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion()));
+
+        // Test that the connection is cleared from the round robin list when it is closed
+        remoteConnectionManager.getConnection(node1).close();
+
+        versions.clear();
+        versions.add(remoteConnectionManager.getConnection(node4).getVersion());
+        versions.add(remoteConnectionManager.getConnection(node4).getVersion());
+
+        assertThat(versions, hasItems(Version.CURRENT.minimumCompatibilityVersion()));
+        assertEquals(1, versions.size());
+    }
+
+    private static class TestRemoteConnection extends CloseableConnection {
+
+        private final DiscoveryNode node;
+
+        private TestRemoteConnection(DiscoveryNode node) {
+            this.node = node;
+        }
+
+        @Override
+        public DiscoveryNode getNode() {
+            return node;
+        }
+
+        @Override
+        public Version getVersion() {
+            return node.getVersion();
+        }
+
+        @Override
+        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
+            throws TransportException {
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.unit.TimeValue;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.mockito.Mockito.mock;
+
+public class RemoteConnectionStrategyTests extends ESTestCase {
+
+    public void testStrategyChangeMeansThatStrategyMustBeRebuilt() {
+        ClusterConnectionManager connectionManager = new ClusterConnectionManager(Settings.EMPTY, mock(Transport.class));
+        RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager("cluster-alias", connectionManager);
+        FakeConnectionStrategy first = new FakeConnectionStrategy("cluster-alias", mock(TransportService.class), remoteConnectionManager,
+                                                                  RemoteConnectionStrategy.ConnectionStrategy.PROXY);
+        Settings newSettings = Settings.builder()
+            .put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey(), "sniff")
+            .put(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS.getKey(), "127.0.0.1:9300")
+            .build();
+        assertTrue(first.shouldRebuildConnection(newSettings));
+    }
+
+    public void testSameStrategyChangeMeansThatStrategyDoesNotNeedToBeRebuilt() {
+        ClusterConnectionManager connectionManager = new ClusterConnectionManager(Settings.EMPTY, mock(Transport.class));
+        RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager("cluster-alias", connectionManager);
+        FakeConnectionStrategy first = new FakeConnectionStrategy("cluster-alias", mock(TransportService.class), remoteConnectionManager,
+                                                                  RemoteConnectionStrategy.ConnectionStrategy.PROXY);
+        Settings newSettings = Settings.builder()
+            .put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey(), "proxy")
+            .put(ProxyConnectionStrategy.PROXY_ADDRESS.getKey(), "127.0.0.1:9300")
+            .build();
+        assertFalse(first.shouldRebuildConnection(newSettings));
+    }
+
+    public void testChangeInConnectionProfileMeansTheStrategyMustBeRebuilt() {
+        ClusterConnectionManager connectionManager = new ClusterConnectionManager(TestProfiles.LIGHT_PROFILE, mock(Transport.class));
+        assertEquals(TimeValue.MINUS_ONE, connectionManager.getConnectionProfile().getPingInterval());
+        assertEquals(false, connectionManager.getConnectionProfile().getCompressionEnabled());
+        RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager("cluster-alias", connectionManager);
+        FakeConnectionStrategy first = new FakeConnectionStrategy("cluster-alias", mock(TransportService.class), remoteConnectionManager,
+                                                                  RemoteConnectionStrategy.ConnectionStrategy.PROXY);
+
+        Settings.Builder newBuilder = Settings.builder();
+        newBuilder.put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey(), "proxy");
+        newBuilder.put(ProxyConnectionStrategy.PROXY_ADDRESS.getKey(), "127.0.0.1:9300");
+        if (randomBoolean()) {
+            newBuilder.put(RemoteConnectionStrategy.REMOTE_CONNECTION_PING_SCHEDULE.getKey(),
+                           TimeValue.timeValueSeconds(5));
+        } else {
+            newBuilder.put(RemoteConnectionStrategy.REMOTE_CONNECTION_COMPRESS.getKey(), true);
+        }
+        assertTrue(first.shouldRebuildConnection(newBuilder.build()));
+    }
+
+    public void testCorrectChannelNumber() {
+        for (RemoteConnectionStrategy.ConnectionStrategy strategy : RemoteConnectionStrategy.ConnectionStrategy.values()) {
+            String settingKey = RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey();
+            Settings proxySettings = Settings.builder().put(settingKey, strategy.name()).build();
+            ConnectionProfile proxyProfile = RemoteConnectionStrategy.buildConnectionProfile(Settings.EMPTY, proxySettings);
+            assertEquals("Incorrect number of channels for " + strategy.name(),
+                         strategy.getNumberOfChannels(), proxyProfile.getNumConnections());
+        }
+    }
+
+    private static class FakeConnectionStrategy extends RemoteConnectionStrategy {
+
+        private final ConnectionStrategy strategy;
+
+        FakeConnectionStrategy(String clusterAlias, TransportService transportService, RemoteConnectionManager connectionManager,
+                               RemoteConnectionStrategy.ConnectionStrategy strategy) {
+            super(clusterAlias, transportService, connectionManager);
+            this.strategy = strategy;
+        }
+
+        @Override
+        protected boolean strategyMustBeRebuilt(Settings newSettings) {
+            return false;
+        }
+
+        @Override
+        protected ConnectionStrategy strategyType() {
+            return this.strategy;
+        }
+
+        @Override
+        protected boolean shouldOpenMoreConnections() {
+            return false;
+        }
+
+        @Override
+        protected void connectImpl(ActionListener<Void> listener) {
+
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -1,0 +1,689 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.collections.Tuple;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.test.transport.StubbableTransport;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SniffConnectionStrategyTests extends ESTestCase {
+
+    private final String clusterAlias = "cluster-alias";
+    private final String modeKey = RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey();
+    private final Settings settings = Settings.builder().put(modeKey, "sniff").build();
+    private final ConnectionProfile profile = RemoteConnectionStrategy.buildConnectionProfile(Settings.EMPTY, settings);
+    private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
+    private MockTransportService startTransport(String id, List<DiscoveryNode> knownNodes, Version version) {
+        return startTransport(id, knownNodes, version, Settings.EMPTY);
+    }
+
+    public MockTransportService startTransport(final String id, final List<DiscoveryNode> knownNodes, final Version version,
+                                               final Settings settings) {
+        boolean success = false;
+        final Settings s = Settings.builder()
+            .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterAlias)
+            .put("node.name", id)
+            .put(settings)
+            .build();
+        ClusterName clusterName = ClusterName.CLUSTER_NAME_SETTING.get(s);
+        MockTransportService newService = MockTransportService.createNewService(s, version, threadPool);
+        try {
+            newService.registerRequestHandler(ClusterStateAction.NAME, ThreadPool.Names.SAME, ClusterStateRequest::new,
+                                              (request, channel) -> {
+                                                  DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+                                                  for (DiscoveryNode node : knownNodes) {
+                                                      builder.add(node);
+                                                  }
+                                                  ClusterState build = ClusterState.builder(clusterName).nodes(builder.build()).build();
+                                                  channel.sendResponse(new ClusterStateResponse(clusterName, build, false));
+                                              });
+            newService.start();
+            newService.acceptIncomingRequests();
+            success = true;
+            return newService;
+        } finally {
+            if (success == false) {
+                newService.close();
+            }
+        }
+    }
+
+    public void testSniffStrategyWillConnectToAndDiscoverNodes() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode discoverableNode = discoverableTransport.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(discoverableNode);
+            Collections.shuffle(knownNodes, random());
+
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> true, seedNodes(seedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.nodeConnected(seedNode));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+
+            }
+        }
+    }
+
+    public void testSniffStrategyWillResolveDiscoveryNodesEachConnect() throws Exception {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode discoverableNode = discoverableTransport.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(discoverableNode);
+            Collections.shuffle(knownNodes, random());
+
+            CountDownLatch multipleResolveLatch = new CountDownLatch(2);
+            Supplier<DiscoveryNode> seedNodeSupplier = () -> {
+                multipleResolveLatch.countDown();
+                return seedNode;
+            };
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> true, seedNodes(seedNode), Collections.singletonList(seedNodeSupplier))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    // Closing connections leads to RemoteClusterConnection.ConnectHandler.collectRemoteNodes
+                    connectionManager.getConnection(seedNode).close();
+
+                    assertTrue(multipleResolveLatch.await(30L, TimeUnit.SECONDS));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                }
+            }
+        }
+    }
+
+    public void testSniffStrategyWillConnectToMaxAllowedNodesAndOpenNewConnectionsOnDisconnect() throws Exception {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport1 = startTransport("discoverable_node", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport2 = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode discoverableNode1 = discoverableTransport1.getLocalNode();
+            DiscoveryNode discoverableNode2 = discoverableTransport2.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(discoverableNode1);
+            knownNodes.add(discoverableNode2);
+            Collections.shuffle(knownNodes, random());
+
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 2, n -> true, seedNodes(seedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertEquals(2, connectionManager.size());
+                    assertTrue(connectionManager.nodeConnected(seedNode));
+
+                    // Assert that one of the discovered nodes is connected. After that, disconnect the connected
+                    // discovered node and ensure the other discovered node is eventually connected
+                    if (connectionManager.nodeConnected(discoverableNode1)) {
+                        assertTrue(connectionManager.nodeConnected(discoverableNode1));
+                        discoverableTransport1.close();
+                        assertBusy(() -> assertTrue(connectionManager.nodeConnected(discoverableNode2)));
+                    } else {
+                        assertTrue(connectionManager.nodeConnected(discoverableNode2));
+                        discoverableTransport2.close();
+                        assertBusy(() -> assertTrue(connectionManager.nodeConnected(discoverableNode1)));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testDiscoverWithSingleIncompatibleSeedNode() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        Version incompatibleVersion = Version.V_3_2_0;
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService incompatibleSeedTransport = startTransport("discoverable_node", knownNodes, incompatibleVersion);
+             MockTransportService discoverableTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode incompatibleSeedNode = incompatibleSeedTransport.getLocalNode();
+            DiscoveryNode discoverableNode = discoverableTransport.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(incompatibleSeedNode);
+            knownNodes.add(discoverableNode);
+            Collections.shuffle(knownNodes, random());
+
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> true, seedNodes(seedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertEquals(2, connectionManager.size());
+                    assertTrue(connectionManager.nodeConnected(seedNode));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    assertFalse(connectionManager.nodeConnected(incompatibleSeedNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testConnectFailsWithIncompatibleNodes() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        Version incompatibleVersion = Version.V_3_2_0;
+        try (MockTransportService incompatibleSeedTransport = startTransport("seed_node", knownNodes, incompatibleVersion)) {
+            DiscoveryNode incompatibleSeedNode = incompatibleSeedTransport.getLocalNode();
+            knownNodes.add(incompatibleSeedNode);
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> true, seedNodes(incompatibleSeedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+
+                    expectThrows(Exception.class, connectFuture::actionGet);
+                    assertFalse(connectionManager.nodeConnected(incompatibleSeedNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testFilterNodesWithNodePredicate() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode discoverableNode = discoverableTransport.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(discoverableNode);
+            DiscoveryNode rejectedNode = randomBoolean() ? seedNode : discoverableNode;
+            Collections.shuffle(knownNodes, random());
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> n.equals(rejectedNode) == false, seedNodes(seedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    if (rejectedNode.equals(seedNode)) {
+                        assertFalse(connectionManager.nodeConnected(seedNode));
+                        assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    } else {
+                        assertTrue(connectionManager.nodeConnected(seedNode));
+                        assertFalse(connectionManager.nodeConnected(discoverableNode));
+                    }
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testConnectFailsIfNoConnectionsOpened() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService closedTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode discoverableNode = closedTransport.getLocalNode();
+            knownNodes.add(discoverableNode);
+            closedTransport.close();
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                // Predicate excludes seed node as a possible connection
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> n.equals(seedNode) == false, seedNodes(seedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    final IllegalStateException ise = expectThrows(IllegalStateException.class, connectFuture::actionGet);
+                    assertEquals("Unable to open any connections to remote cluster [cluster-alias]", ise.getMessage());
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testClusterNameValidationPreventConnectingToDifferentClusters() throws Exception {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        List<DiscoveryNode> otherKnownNodes = new CopyOnWriteArrayList<>();
+
+        Settings otherSettings = Settings.builder().put("cluster.name", "otherCluster").build();
+
+        try (MockTransportService seed = startTransport("other_seed", knownNodes, Version.CURRENT);
+             MockTransportService discoverable = startTransport("other_discoverable", knownNodes, Version.CURRENT);
+             MockTransportService otherSeed = startTransport("other_seed", knownNodes, Version.CURRENT, otherSettings);
+             MockTransportService otherDiscoverable = startTransport("other_discoverable", knownNodes, Version.CURRENT, otherSettings)) {
+            DiscoveryNode seedNode = seed.getLocalNode();
+            DiscoveryNode discoverableNode = discoverable.getLocalNode();
+            DiscoveryNode otherSeedNode = otherSeed.getLocalNode();
+            DiscoveryNode otherDiscoverableNode = otherDiscoverable.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(discoverableNode);
+            Collections.shuffle(knownNodes, random());
+            Collections.shuffle(otherKnownNodes, random());
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> true, seedNodes(seedNode, otherSeedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.nodeConnected(seedNode));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+
+                    seed.close();
+
+                    assertBusy(strategy::assertNoRunningConnections);
+
+                    PlainActionFuture<Void> newConnect = PlainActionFuture.newFuture();
+                    strategy.connect(newConnect);
+                    IllegalStateException ise = expectThrows(IllegalStateException.class, newConnect::actionGet);
+                    assertThat(ise.getMessage(), allOf(
+                        startsWith("handshake with [{cluster-alias#"),
+                        endsWith(" failed: remote cluster name [otherCluster] " +
+                                 "does not match expected remote cluster name [" + clusterAlias + "]")));
+
+                    assertFalse(connectionManager.nodeConnected(seedNode));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    assertFalse(connectionManager.nodeConnected(otherSeedNode));
+                    assertFalse(connectionManager.nodeConnected(otherDiscoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testMultipleCallsToConnectEnsuresConnection() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode discoverableNode = discoverableTransport.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(discoverableNode);
+            Collections.shuffle(knownNodes, random());
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> true, seedNodes(seedNode))) {
+                    assertFalse(connectionManager.nodeConnected(seedNode));
+                    assertFalse(connectionManager.nodeConnected(discoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.nodeConnected(seedNode));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+
+                    // exec again we are already connected
+                    PlainActionFuture<Void> ensureConnectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(ensureConnectFuture);
+                    ensureConnectFuture.actionGet();
+
+                    assertTrue(connectionManager.nodeConnected(seedNode));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testConfiguredProxyAddressModeWillReplaceNodeAddress() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService accessible = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService unresponsive1 = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool);
+             MockTransportService unresponsive2 = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+            // We start in order to get a valid address + port, but do not start accepting connections as we
+            // will not actually connect to these transports
+            unresponsive1.start();
+            unresponsive2.start();
+            DiscoveryNode accessibleNode = accessible.getLocalNode();
+            DiscoveryNode discoverableNode = unresponsive2.getLocalNode();
+
+            // Use the address for the node that will not respond
+            DiscoveryNode unaddressableSeedNode = new DiscoveryNode(accessibleNode.getName(), accessibleNode.getId(),
+                                                                    accessibleNode.getEphemeralId(), accessibleNode.getHostName(), accessibleNode.getHostAddress(),
+                                                                    unresponsive1.getLocalNode().getAddress(), accessibleNode.getAttributes(), accessibleNode.getRoles(),
+                                                                    accessibleNode.getVersion());
+
+            knownNodes.add(unaddressableSeedNode);
+            knownNodes.add(discoverableNode);
+            Collections.shuffle(knownNodes, random());
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                StubbableTransport transport = new StubbableTransport(localService.transport);
+                AtomicReference<TransportAddress> discoverableNodeAddress = new AtomicReference<>();
+                transport.setDefaultConnectBehavior((delegate, node, profile, listener) -> {
+                    if (node.equals(discoverableNode)) {
+                        // Do not actually try to connect because the node will not respond. Just capture the
+                        // address for later assertion
+                        discoverableNodeAddress.set(node.getAddress());
+                        listener.onFailure(new ConnectTransportException(node, "general failure"));
+                    } else {
+                        delegate.openConnection(node, profile, listener);
+                    }
+                });
+
+                List<String> seedNodes = Collections.singletonList(accessibleNode.toString());
+                TransportAddress proxyAddress = accessibleNode.getAddress();
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    proxyAddress.toString(), 3, n -> true, seedNodes)) {
+                    assertFalse(connectionManager.nodeConnected(unaddressableSeedNode));
+                    assertFalse(connectionManager.nodeConnected(discoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.nodeConnected(unaddressableSeedNode));
+                    // Connection to discoverable will fail due to the stubbable transport
+                    assertFalse(connectionManager.nodeConnected(discoverableNode));
+                    assertEquals(proxyAddress, discoverableNodeAddress.get());
+                    assertTrue(strategy.assertNoRunningConnections());
+                }
+            }
+        }
+    }
+
+    public void testSniffStrategyWillNeedToBeRebuiltIfNumOfConnectionsOrSeedsOrProxyChange() {
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);
+             MockTransportService discoverableTransport = startTransport("discoverable_node", knownNodes, Version.CURRENT)) {
+            DiscoveryNode seedNode = seedTransport.getLocalNode();
+            DiscoveryNode discoverableNode = discoverableTransport.getLocalNode();
+            knownNodes.add(seedNode);
+            knownNodes.add(discoverableNode);
+            Collections.shuffle(knownNodes, random());
+
+
+            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+                localService.start();
+                localService.acceptIncomingRequests();
+
+                ClusterConnectionManager connectionManager = new ClusterConnectionManager(profile, localService.transport);
+                try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
+                     SniffConnectionStrategy strategy = new SniffConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
+                                                                                    null, 3, n -> true, seedNodes(seedNode))) {
+                    PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
+                    strategy.connect(connectFuture);
+                    connectFuture.actionGet();
+
+                    assertTrue(connectionManager.nodeConnected(seedNode));
+                    assertTrue(connectionManager.nodeConnected(discoverableNode));
+                    assertTrue(strategy.assertNoRunningConnections());
+
+                    Setting<?> seedSetting = SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS;
+                    Setting<?> proxySetting = SniffConnectionStrategy.REMOTE_CLUSTERS_PROXY;
+                    Setting<?> numConnections = SniffConnectionStrategy.REMOTE_NODE_CONNECTIONS;
+
+                    Settings noChange = Settings.builder()
+                        .put(seedSetting.getKey(), Strings.arrayToCommaDelimitedString(seedNodes(seedNode).toArray()))
+                        .put(numConnections.getKey(), 3)
+                        .build();
+                    assertFalse(strategy.shouldRebuildConnection(noChange));
+                    Settings seedsChanged = Settings.builder()
+                        .put(seedSetting.getKey(), Strings.arrayToCommaDelimitedString(seedNodes(discoverableNode).toArray()))
+                        .build();
+                    assertTrue(strategy.shouldRebuildConnection(seedsChanged));
+                    Settings proxyChanged = Settings.builder()
+                        .put(seedSetting.getKey(), Strings.arrayToCommaDelimitedString(seedNodes(seedNode).toArray()))
+                        .put(proxySetting.getKey(), "proxy_address:9300")
+                        .build();
+                    assertTrue(strategy.shouldRebuildConnection(proxyChanged));
+                    Settings connectionsChanged = Settings.builder()
+                        .put(seedSetting.getKey(), Strings.arrayToCommaDelimitedString(seedNodes(seedNode).toArray()))
+                        .put(numConnections.getKey(), 4)
+                        .build();
+                    assertTrue(strategy.shouldRebuildConnection(connectionsChanged));
+                }
+            }
+        }
+    }
+
+    public void testGetNodePredicateNodeRoles() {
+        TransportAddress address = new TransportAddress(TransportAddress.META_ADDRESS, 0);
+        Predicate<DiscoveryNode> nodePredicate = SniffConnectionStrategy.getNodePredicate(Settings.EMPTY);
+        {
+            DiscoveryNode all = new DiscoveryNode("id", address, Collections.emptyMap(),
+                                                  DiscoveryNodeRole.BUILT_IN_ROLES, Version.CURRENT);
+            assertTrue(nodePredicate.test(all));
+        }
+        {
+            DiscoveryNode dataMaster = new DiscoveryNode("id", address, Collections.emptyMap(),
+                                                         new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)), Version.CURRENT);
+            assertTrue(nodePredicate.test(dataMaster));
+        }
+        {
+            DiscoveryNode dedicatedMaster = new DiscoveryNode("id", address, Collections.emptyMap(),
+                                                              new HashSet<>(Arrays.asList(DiscoveryNodeRole.MASTER_ROLE)), Version.CURRENT);
+            assertFalse(nodePredicate.test(dedicatedMaster));
+        }
+        {
+            DiscoveryNode dedicatedData = new DiscoveryNode("id", address, Collections.emptyMap(),
+                                                            new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE)), Version.CURRENT);
+            assertTrue(nodePredicate.test(dedicatedData));
+        }
+        {
+            DiscoveryNode coordOnly = new DiscoveryNode("id", address, Collections.emptyMap(),
+                                                        Collections.emptySet(), Version.CURRENT);
+            assertTrue(nodePredicate.test(coordOnly));
+        }
+    }
+
+    public void testGetNodePredicateNodeVersion() {
+        TransportAddress address = new TransportAddress(TransportAddress.META_ADDRESS, 0);
+        Set<DiscoveryNodeRole> roles = DiscoveryNodeRole.BUILT_IN_ROLES;
+        Predicate<DiscoveryNode> nodePredicate = SniffConnectionStrategy.getNodePredicate(Settings.EMPTY);
+        Version version = VersionUtils.randomVersion(random());
+        DiscoveryNode node = new DiscoveryNode("id", address, Collections.emptyMap(), roles, version);
+        assertThat(nodePredicate.test(node), equalTo(Version.CURRENT.isCompatible(version)));
+    }
+
+    public void testGetNodePredicateNodeAttrs() {
+        TransportAddress address = new TransportAddress(TransportAddress.META_ADDRESS, 0);
+        Set<DiscoveryNodeRole> roles = DiscoveryNodeRole.BUILT_IN_ROLES;
+        Settings settings = Settings.builder().put("cluster.remote.node.attr", "gateway").build();
+        Predicate<DiscoveryNode> nodePredicate = SniffConnectionStrategy.getNodePredicate(settings);
+        {
+            DiscoveryNode nonGatewayNode = new DiscoveryNode("id", address, Collections.singletonMap("gateway", "false"),
+                                                             roles, Version.CURRENT);
+            assertFalse(nodePredicate.test(nonGatewayNode));
+            assertTrue(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY).test(nonGatewayNode));
+        }
+        {
+            DiscoveryNode gatewayNode = new DiscoveryNode("id", address, Collections.singletonMap("gateway", "true"),
+                                                          roles, Version.CURRENT);
+            assertTrue(nodePredicate.test(gatewayNode));
+            assertTrue(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY).test(gatewayNode));
+        }
+        {
+            DiscoveryNode noAttrNode = new DiscoveryNode("id", address, Collections.emptyMap(), roles, Version.CURRENT);
+            assertFalse(nodePredicate.test(noAttrNode));
+            assertTrue(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY).test(noAttrNode));
+        }
+    }
+
+    public void testGetNodePredicatesCombination() {
+        TransportAddress address = new TransportAddress(TransportAddress.META_ADDRESS, 0);
+        Settings settings = Settings.builder().put("cluster.remote.node.attr", "gateway").build();
+        Predicate<DiscoveryNode> nodePredicate = SniffConnectionStrategy.getNodePredicate(settings);
+        Set<DiscoveryNodeRole> dedicatedMasterRoles = new HashSet<>(Arrays.asList(DiscoveryNodeRole.MASTER_ROLE));
+        Set<DiscoveryNodeRole> allRoles = DiscoveryNodeRole.BUILT_IN_ROLES;
+        {
+            DiscoveryNode node = new DiscoveryNode("id", address, Collections.singletonMap("gateway", "true"),
+                                                   dedicatedMasterRoles, Version.CURRENT);
+            assertFalse(nodePredicate.test(node));
+        }
+        {
+            DiscoveryNode node = new DiscoveryNode("id", address, Collections.singletonMap("gateway", "false"),
+                                                   dedicatedMasterRoles, Version.CURRENT);
+            assertFalse(nodePredicate.test(node));
+        }
+        {
+            DiscoveryNode node = new DiscoveryNode("id", address, Collections.singletonMap("gateway", "false"),
+                                                   dedicatedMasterRoles, Version.CURRENT);
+            assertFalse(nodePredicate.test(node));
+        }
+        {
+            DiscoveryNode node = new DiscoveryNode("id", address, Collections.singletonMap("gateway", "true"),
+                                                   allRoles, Version.CURRENT);
+            assertTrue(nodePredicate.test(node));
+        }
+    }
+
+    public void testModeSettingsCannotBeUsedWhenInDifferentMode() {
+        List<Tuple<Setting<?>, String>> restrictedSettings = Arrays.asList(
+            new Tuple<>(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS, "192.168.0.1:8080"),
+            new Tuple<>(SniffConnectionStrategy.REMOTE_NODE_CONNECTIONS, "2"));
+
+        RemoteConnectionStrategy.ConnectionStrategy proxy = RemoteConnectionStrategy.ConnectionStrategy.PROXY;
+
+        String clusterName = "cluster_name";
+        Settings settings = Settings.builder()
+            .put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getKey(), proxy.name())
+            .build();
+
+        for (Tuple<Setting<?>, String> restrictedSetting : restrictedSettings) {
+            Setting<?> concreteSetting = restrictedSetting.v1();
+            Settings invalid = Settings.builder().put(settings).put(concreteSetting.getKey(), restrictedSetting.v2()).build();
+            IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () ->  concreteSetting.get(invalid));
+            String expected = "Setting \"" + concreteSetting.getKey() + "\" cannot be used with the configured " +
+                              "\"mode\" [required=SNIFF, configured=PROXY]";
+            assertEquals(expected, iae.getMessage());
+        }
+    }
+
+    private static List<String> seedNodes(final DiscoveryNode... seedNodes) {
+        return Arrays.stream(seedNodes).map(s -> s.getAddress().toString()).collect(Collectors.toList());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.transport;
+
+import io.crate.common.io.IOUtils;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+public class TransportActionProxyTests extends ESTestCase {
+    protected ThreadPool threadPool;
+    // we use always a non-alpha or beta version here otherwise minimumCompatibilityVersion will be different for the two used versions
+    private static final Version CURRENT_VERSION = Version.fromString(String.valueOf(Version.CURRENT.major) + ".0.0");
+    protected static final Version version0 = CURRENT_VERSION.minimumCompatibilityVersion();
+
+    protected DiscoveryNode nodeA;
+    protected MockTransportService serviceA;
+
+    protected static final Version version1 = Version.fromId(CURRENT_VERSION.externalId + 1);
+    protected DiscoveryNode nodeB;
+    protected MockTransportService serviceB;
+
+    protected DiscoveryNode nodeC;
+    protected MockTransportService serviceC;
+
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getClass().getName());
+        serviceA = buildService(version0); // this one supports dynamic tracer updates
+        nodeA = serviceA.getLocalDiscoNode();
+        serviceB = buildService(version1); // this one doesn't support dynamic tracer updates
+        nodeB = serviceB.getLocalDiscoNode();
+        serviceC = buildService(version1); // this one doesn't support dynamic tracer updates
+        nodeC = serviceC.getLocalDiscoNode();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        IOUtils.close(serviceA, serviceB, serviceC, () -> {
+            terminate(threadPool);
+        });
+    }
+
+    private MockTransportService buildService(final Version version) {
+        MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, version, threadPool, null);
+        service.start();
+        service.acceptIncomingRequests();
+        return service;
+
+    }
+
+
+    public void testSendMessage() throws InterruptedException {
+        serviceA.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new,
+                                        (request, channel) -> {
+                                            assertEquals(request.sourceNode, "TS_A");
+                                            SimpleTestResponse response = new SimpleTestResponse("TS_A");
+                                            channel.sendResponse(response);
+                                        });
+        TransportActionProxy.registerProxyAction(serviceA, "internal:test", SimpleTestResponse::new);
+        AbstractSimpleTransportTestCase.connectToNode(serviceA, nodeB);
+
+        serviceB.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new,
+                                        (request, channel) -> {
+                                            assertEquals(request.sourceNode, "TS_A");
+                                            SimpleTestResponse response = new SimpleTestResponse("TS_B");
+                                            channel.sendResponse(response);
+                                        });
+        TransportActionProxy.registerProxyAction(serviceB, "internal:test", SimpleTestResponse::new);
+        AbstractSimpleTransportTestCase.connectToNode(serviceB, nodeC);
+        serviceC.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new,
+                                        (request, channel) -> {
+                                            assertEquals(request.sourceNode, "TS_A");
+                                            SimpleTestResponse response = new SimpleTestResponse("TS_C");
+                                            channel.sendResponse(response);
+                                        });
+        TransportActionProxy.registerProxyAction(serviceC, "internal:test", SimpleTestResponse::new);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        serviceA.sendRequest(nodeB, TransportActionProxy.getProxyAction("internal:test"), TransportActionProxy.wrapRequest(nodeC,
+                                                                                                                           new SimpleTestRequest("TS_A")), new TransportResponseHandler<SimpleTestResponse>() {
+            @Override
+            public SimpleTestResponse read(StreamInput in) throws IOException {
+                return new SimpleTestResponse(in);
+            }
+
+            @Override
+            public void handleResponse(SimpleTestResponse response) {
+                try {
+                    assertEquals("TS_C", response.targetNode);
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                try {
+                    throw new AssertionError(exp);
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+        });
+        latch.await();
+    }
+
+    public void testException() throws InterruptedException {
+        serviceA.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new,
+                                        (request, channel) -> {
+                                            assertEquals(request.sourceNode, "TS_A");
+                                            SimpleTestResponse response = new SimpleTestResponse("TS_A");
+                                            channel.sendResponse(response);
+                                        });
+        TransportActionProxy.registerProxyAction(serviceA, "internal:test", SimpleTestResponse::new);
+        AbstractSimpleTransportTestCase.connectToNode(serviceA, nodeB);
+
+        serviceB.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new,
+                                        (request, channel) -> {
+                                            assertEquals(request.sourceNode, "TS_A");
+                                            SimpleTestResponse response = new SimpleTestResponse("TS_B");
+                                            channel.sendResponse(response);
+                                        });
+        TransportActionProxy.registerProxyAction(serviceB, "internal:test", SimpleTestResponse::new);
+        AbstractSimpleTransportTestCase.connectToNode(serviceB, nodeC);
+        serviceC.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new,
+                                        (request, channel) -> {
+                                            throw new ElasticsearchException("greetings from TS_C");
+                                        });
+        TransportActionProxy.registerProxyAction(serviceC, "internal:test", SimpleTestResponse::new);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        serviceA.sendRequest(nodeB, TransportActionProxy.getProxyAction("internal:test"), TransportActionProxy.wrapRequest(nodeC,
+                                                                                                                           new SimpleTestRequest("TS_A")), new TransportResponseHandler<SimpleTestResponse>() {
+            @Override
+            public SimpleTestResponse read(StreamInput in) throws IOException {
+                return new SimpleTestResponse(in);
+            }
+
+            @Override
+            public void handleResponse(SimpleTestResponse response) {
+                try {
+                    fail("expected exception");
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                try {
+                    Throwable cause = ExceptionsHelper.unwrapCause(exp);
+                    assertEquals("greetings from TS_C", cause.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+        });
+        latch.await();
+    }
+
+    public static class SimpleTestRequest extends TransportRequest {
+        String sourceNode;
+
+        public SimpleTestRequest(String sourceNode) {
+            this.sourceNode = sourceNode;
+        }
+        public SimpleTestRequest() {}
+
+        public SimpleTestRequest(StreamInput in) throws IOException {
+            super(in);
+            sourceNode = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sourceNode);
+        }
+    }
+
+    public static class SimpleTestResponse extends TransportResponse {
+        final String targetNode;
+
+        SimpleTestResponse(String targetNode) {
+            this.targetNode = targetNode;
+        }
+
+        SimpleTestResponse(StreamInput in) throws IOException {
+            this.targetNode = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(targetNode);
+        }
+    }
+
+    public void testGetAction() {
+        String action = "foo/bar";
+        String proxyAction = TransportActionProxy.getProxyAction(action);
+        assertTrue(proxyAction.endsWith(action));
+        assertEquals("internal:transport/proxy/foo/bar", proxyAction);
+    }
+
+    public void testUnwrap() {
+        TransportRequest transportRequest = TransportActionProxy.wrapRequest(nodeA, TransportService.HandshakeRequest.INSTANCE);
+        assertTrue(transportRequest instanceof TransportActionProxy.ProxyRequest);
+        assertSame(TransportService.HandshakeRequest.INSTANCE, TransportActionProxy.unwrapRequest(transportRequest));
+    }
+
+    public void testIsProxyAction() {
+        String action = "foo/bar";
+        String proxyAction = TransportActionProxy.getProxyAction(action);
+        assertTrue(TransportActionProxy.isProxyAction(proxyAction));
+        assertFalse(TransportActionProxy.isProxyAction(action));
+    }
+
+    public void testIsProxyRequest() {
+        assertTrue(TransportActionProxy.isProxyRequest(new TransportActionProxy.ProxyRequest<>(TransportRequest.Empty.INSTANCE, null)));
+        assertFalse(TransportActionProxy.isProxyRequest(TransportRequest.Empty.INSTANCE));
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransport.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.CloseableConnection;
-import org.elasticsearch.transport.ConnectionManager;
+import org.elasticsearch.transport.ClusterConnectionManager;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.SendRequestTransportException;
 import org.elasticsearch.transport.TransportException;
@@ -44,7 +44,6 @@ import org.elasticsearch.transport.TransportService;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -63,13 +62,8 @@ public class MockTransport extends StubbableTransport {
                                                    ThreadPool threadPool,
                                                    Function<BoundTransportAddress, DiscoveryNode> localNodeFactory,
                                                    @Nullable ClusterSettings clusterSettings) {
-        StubbableConnectionManager connectionManager = new StubbableConnectionManager(
-            new ConnectionManager(settings, this),
-            settings,
-            this,
-            threadPool
-        );
-        connectionManager.setDefaultNodeConnectedBehavior(cm -> Collections.emptySet());
+        StubbableConnectionManager connectionManager = new StubbableConnectionManager(new ClusterConnectionManager(settings, this));
+        connectionManager.setDefaultNodeConnectedBehavior((cm, node) -> false);
         connectionManager.setDefaultGetConnectionBehavior((cm, discoveryNode) -> createConnection(discoveryNode));
         return new TransportService(
             settings,

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -41,8 +41,8 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.ClusterConnectionManager;
 import org.elasticsearch.transport.ConnectTransportException;
-import org.elasticsearch.transport.ConnectionManager;
 import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.MockTcpTransport;
 import org.elasticsearch.transport.RequestHandlerRegistry;
@@ -89,6 +89,10 @@ public final class MockTransportService extends TransportService {
     private final List<Runnable> onStopListeners = new CopyOnWriteArrayList<>();
 
     public static class TestPlugin extends Plugin {
+    }
+
+    public static MockTransportService createNewService(Settings settings, Version version, ThreadPool threadPool) {
+        return createNewService(settings, version, threadPool, null);
     }
 
     public static MockTransportService createNewService(Settings settings,
@@ -179,10 +183,7 @@ public final class MockTransportService extends TransportService {
             localNodeFactory,
             clusterSettings,
             new StubbableConnectionManager(
-                new ConnectionManager(settings, transport),
-                settings,
-                transport,
-                threadPool
+                new ClusterConnectionManager(settings, transport)
             )
         );
         this.original = transport.getDelegate();
@@ -535,7 +536,7 @@ public final class MockTransportService extends TransportService {
      * @return {@code true} if no other get connection behavior was registered for this address before.
      */
     public boolean addGetConnectionBehavior(TransportAddress transportAddress, StubbableConnectionManager.GetConnectionBehavior behavior) {
-        return connectionManager().addConnectBehavior(transportAddress, behavior);
+        return connectionManager().addGetConnectionBehavior(transportAddress, behavior);
     }
 
     /**
@@ -583,5 +584,9 @@ public final class MockTransportService extends TransportService {
         } catch (InterruptedException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    public DiscoveryNode getLocalDiscoNode() {
+        return this.getLocalNode();
     }
 }


### PR DESCRIPTION
This logic is needed for logical replication (CCR).
The original code of ES is modified to be able to bind remote connections
to concrete entities (subscriptions) instead of register them globally.
