### PR TITLE
Improve error message for invalid STORAGE WITH options

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -341,7 +341,7 @@ public class AnalyzedColumnDefinition<T> {
                 }
             } else {
                 throw new IllegalArgumentException(
-                    String.format(Locale.ENGLISH, "Invalid storage option \"%s\"", storageSettings.get(property)));
+                    String.format(Locale.ENGLISH, "Invalid STORAGE WITH option `%s`", property));
             }
         }
     }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1447,4 +1447,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "user_name={default_expr=CURRENT_USER, position=1, type=keyword}"
         ));
     }
+
+    @Test
+    public void test_create_table_with_invalid_storage_option_errors_with_invalid_property_name() throws Exception {
+        assertThrowsMatches(
+            () -> analyze("create table tbl (name text storage with (foobar = true))"),
+            IllegalArgumentException.class,
+            "Invalid STORAGE WITH option `foobar`"
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If you provided an invalid option name, the error message included the
value instead of the option name. E.g. `Invalid storage option "true"` - which isn't too helpful.



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
