### PR TITLE
Run forbiddenApis via GHA/Java17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,19 @@ jobs:
         with:
           arguments: :server:test -Dtests.crate.run-windows-incompatible=${{ matrix.os == 'ubuntu-latest' }}
 
+  forbiddenApis:
+    name: forbiddenApisMain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Gradle Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Run forbiddenApisMain
+        run: |
+          ./gradlew forbiddenApisMain
+
   linkcheck:
     name: Sphinx linkcheck
     runs-on: ubuntu-latest

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           steps {
             sh 'git clean -xdff'
             checkout scm
-            sh './gradlew --no-daemon --parallel -Dtests.crate.slow=true -PtestForks=8 test checkstyleMain forbiddenApisMain jacocoReport'
+            sh './gradlew --no-daemon --parallel -Dtests.crate.slow=true -PtestForks=8 test checkstyleMain jacocoReport'
 
             // Upload coverage report to Codecov.
             // https://about.codecov.io/blog/introducing-codecovs-new-uploader/

--- a/libs/es-plugin-classloader/src/main/java/org/elasticsearch/plugins/ExtendedPluginsClassLoader.java
+++ b/libs/es-plugin-classloader/src/main/java/org/elasticsearch/plugins/ExtendedPluginsClassLoader.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.plugins;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,7 +51,6 @@ public class ExtendedPluginsClassLoader extends ClassLoader {
      * Return a new classloader across the parent and extended loaders.
      */
     public static ExtendedPluginsClassLoader create(ClassLoader parent, List<ClassLoader> extendedLoaders) {
-        return AccessController.doPrivileged((PrivilegedAction<ExtendedPluginsClassLoader>)
-            () -> new ExtendedPluginsClassLoader(parent, extendedLoaders));
+        return new ExtendedPluginsClassLoader(parent, extendedLoaders);
     }
 }

--- a/plugins/es-discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/es-discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -41,8 +41,6 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -56,20 +54,15 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Reloa
     public static final String EC2 = "ec2";
 
     static {
-        // Initializing Jackson requires RuntimePermission accessDeclaredMembers
-        // The ClientConfiguration class requires RuntimePermission getClassLoader
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            try {
-                // kick jackson to do some static caching of declared members info
-                Jackson.jsonNodeOf("{}");
-                // ClientConfiguration clinit has some classloader problems
-                // TODO: fix that
-                Class.forName("com.amazonaws.ClientConfiguration");
-            } catch (final ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-            return null;
-        });
+        try {
+            // kick jackson to do some static caching of declared members info
+            Jackson.jsonNodeOf("{}");
+            // ClientConfiguration clinit has some classloader problems
+            // TODO: fix that
+            Class.forName("com.amazonaws.ClientConfiguration");
+        } catch (final ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private final Settings settings;

--- a/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
+++ b/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
@@ -45,9 +45,7 @@ final class HdfsBlobStore implements BlobStore {
 
     HdfsBlobStore(FileContext fileContext, String path, int bufferSize, boolean readOnly, boolean haEnabled) throws IOException {
         this.fileContext = fileContext;
-        // Only restrict permissions if not running with HA
-        boolean restrictPermissions = (haEnabled == false);
-        this.securityContext = new HdfsSecurityContext(fileContext.getUgi(), restrictPermissions);
+        this.securityContext = new HdfsSecurityContext(fileContext.getUgi());
         this.bufferSize = bufferSize;
         this.root = execute(fileContext1 -> fileContext1.makeQualified(new Path(path)));
         this.readOnly = readOnly;
@@ -110,10 +108,8 @@ final class HdfsBlobStore implements BlobStore {
         if (closed) {
             throw new AlreadyClosedException("HdfsBlobStore is closed: " + this);
         }
-        return securityContext.doPrivilegedOrThrow(() -> {
-            securityContext.ensureLogin();
-            return operation.run(fileContext);
-        });
+        securityContext.ensureLogin();
+        return operation.run(fileContext);
     }
 
     @Override

--- a/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
+++ b/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsPlugin.java
@@ -39,17 +39,15 @@ import org.elasticsearch.repositories.Repository;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
 
 public final class HdfsPlugin extends Plugin implements RepositoryPlugin {
 
-    // initialize some problematic classes with elevated privileges
+    // initialize some problematic classes
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) HdfsPlugin::evilHadoopInit);
-        AccessController.doPrivileged((PrivilegedAction<Void>) HdfsPlugin::eagerInit);
+        HdfsPlugin.evilHadoopInit();
+        HdfsPlugin.eagerInit();
     }
 
     @SuppressForbidden(reason = "Needs a security hack for hadoop on windows, until HADOOP-XXXX is fixed")

--- a/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -47,7 +47,6 @@ import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Locale;
 
@@ -221,11 +220,7 @@ public final class HdfsRepository extends BlobStoreRepository {
 
     @Override
     protected HdfsBlobStore createBlobStore() {
-        // initialize our blobstore using elevated privileges.
-        final HdfsBlobStore blobStore =
-            AccessController.doPrivileged((PrivilegedAction<HdfsBlobStore>)
-                () -> createBlobstore(uri, pathSetting, getMetadata().settings()));
-        return blobStore;
+        return createBlobstore(uri, pathSetting, getMetadata().settings());
     }
 
     @Override

--- a/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsSecurityContext.java
+++ b/plugins/es-repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsSecurityContext.java
@@ -21,18 +21,8 @@ package org.elasticsearch.repositories.hdfs;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.lang.reflect.ReflectPermission;
-import java.net.SocketPermission;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.util.Arrays;
-import javax.security.auth.AuthPermission;
-import javax.security.auth.PrivateCredentialPermission;
-import javax.security.auth.kerberos.ServicePermission;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.elasticsearch.env.Environment;
@@ -45,46 +35,6 @@ import org.elasticsearch.env.Environment;
  */
 class HdfsSecurityContext {
 
-    private static final Permission[] SIMPLE_AUTH_PERMISSIONS;
-    private static final Permission[] KERBEROS_AUTH_PERMISSIONS;
-
-    static {
-        // We can do FS ops with only a few elevated permissions:
-        SIMPLE_AUTH_PERMISSIONS = new Permission[]{
-            new SocketPermission("*", "connect"),
-            // 1) hadoop dynamic proxy is messy with access rules
-            new ReflectPermission("suppressAccessChecks"),
-            // 2) allow hadoop to add credentials to our Subject
-            new AuthPermission("modifyPrivateCredentials"),
-            // 3) RPC Engine requires this for re-establishing pooled connections over the lifetime of the client
-            new PrivateCredentialPermission("org.apache.hadoop.security.Credentials * \"*\"", "read")
-        };
-
-        // If Security is enabled, we need all the following elevated permissions:
-        KERBEROS_AUTH_PERMISSIONS = new Permission[] {
-            new SocketPermission("*", "connect"),
-            // 1) hadoop dynamic proxy is messy with access rules
-            new ReflectPermission("suppressAccessChecks"),
-            // 2) allow hadoop to add credentials to our Subject
-            new AuthPermission("modifyPrivateCredentials"),
-            // 3) allow hadoop to act as the logged in Subject
-            new AuthPermission("doAs"),
-            // 4) Listen and resolve permissions for kerberos server principals
-            new SocketPermission("localhost:0", "listen,resolve"),
-            // We add the following since hadoop requires the client to re-login when the kerberos ticket expires:
-            // 5) All the permissions needed for UGI to do its weird JAAS hack
-            new RuntimePermission("getClassLoader"),
-            new RuntimePermission("setContextClassLoader"),
-            // 6) Additional permissions for the login modules
-            new AuthPermission("modifyPrincipals"),
-            new PrivateCredentialPermission("org.apache.hadoop.security.Credentials * \"*\"", "read"),
-            new PrivateCredentialPermission("javax.security.auth.kerberos.KerberosTicket * \"*\"", "read"),
-            new PrivateCredentialPermission("javax.security.auth.kerberos.KeyTab * \"*\"", "read")
-            // Included later:
-            // 7) allow code to initiate kerberos connections as the logged in user
-            // Still far and away fewer permissions than the original full plugin policy
-        };
-    }
 
     /**
      * Locates the keytab file in the environment and verifies that it exists.
@@ -103,49 +53,9 @@ class HdfsSecurityContext {
     }
 
     private final UserGroupInformation ugi;
-    private final boolean restrictPermissions;
-    private final Permission[] restrictedExecutionPermissions;
 
-    HdfsSecurityContext(UserGroupInformation ugi, boolean restrictPermissions) {
+    HdfsSecurityContext(UserGroupInformation ugi) {
         this.ugi = ugi;
-        this.restrictPermissions = restrictPermissions;
-        this.restrictedExecutionPermissions = renderPermissions(ugi);
-    }
-
-    private Permission[] renderPermissions(UserGroupInformation ugi) {
-        Permission[] permissions;
-        if (ugi.isFromKeytab()) {
-            // KERBEROS
-            // Leave room to append one extra permission based on the logged in user's info.
-            int permlen = KERBEROS_AUTH_PERMISSIONS.length + 1;
-            permissions = new Permission[permlen];
-
-            System.arraycopy(KERBEROS_AUTH_PERMISSIONS, 0, permissions, 0, KERBEROS_AUTH_PERMISSIONS.length);
-
-            // Append a kerberos.ServicePermission to only allow initiating kerberos connections
-            // as the logged in user.
-            permissions[permissions.length - 1] = new ServicePermission(ugi.getUserName(), "initiate");
-        } else {
-            // SIMPLE
-            permissions = Arrays.copyOf(SIMPLE_AUTH_PERMISSIONS, SIMPLE_AUTH_PERMISSIONS.length);
-        }
-        return permissions;
-    }
-
-    private Permission[] getRestrictedExecutionPermissions() {
-        return restrictedExecutionPermissions;
-    }
-
-    <T> T doPrivilegedOrThrow(PrivilegedExceptionAction<T> action) throws IOException {
-        try {
-            if (restrictPermissions) {
-                return AccessController.doPrivileged(action, null, this.getRestrictedExecutionPermissions());
-            } else {
-                return AccessController.doPrivileged(action);
-            }
-        } catch (PrivilegedActionException e) {
-            throw (IOException) e.getCause();
-        }
     }
 
     void ensureLogin() {

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -31,8 +31,6 @@ import org.elasticsearch.repositories.Repository;
 
 import io.crate.analyze.repositories.TypeSettings;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,18 +44,15 @@ import static org.elasticsearch.repositories.s3.S3RepositorySettings.SECRET_KEY_
 public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            try {
-                // kick jackson to do some static caching of declared members info
-                Jackson.jsonNodeOf("{}");
-                // ClientConfiguration clinit has some classloader problems
-                // TODO: fix that
-                Class.forName("com.amazonaws.ClientConfiguration");
-            } catch (final ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-            return null;
-        });
+        try {
+            // kick jackson to do some static caching of declared members info
+            Jackson.jsonNodeOf("{}");
+            // ClientConfiguration clinit has some classloader problems
+            // TODO: fix that
+            Class.forName("com.amazonaws.ClientConfiguration");
+        } catch (final ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected final S3Service service;

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -221,9 +221,7 @@ public class EsExecutors {
 
         EsThreadFactory(String namePrefix) {
             this.namePrefix = namePrefix;
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() :
-                    Thread.currentThread().getThreadGroup();
+            this.group = Thread.currentThread().getThreadGroup();
         }
 
         @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The forbiddenApisMain task runs under the same JVM that gradle runs with
and doesn't honor the `forkOptions.javaHome` setting.

Running the check with Java 11 prevents us from using newer language
features like records.

This also removes some `SecurityManager` related code, because the signature is forbidden under JDK17 as the SecurityManager is deprecated for removal

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
