### PR TITLE
Fixed date_format() for day of month specifier

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -143,3 +143,7 @@ Fixes
 - Fixed an issue that caused ``UNION ALL`` statements to succeed or throw
   unexpected exceptions when the ``SELECT`` results for ``UNION ALL`` included
   object types with identically named but differently typed sub-columns.
+
+- Fixed an issue that caused ``date_format()`` to return wrong values when used
+  with the ``%D`` specifier (day of month as ordinal number) for 11th, 12th and
+  13th.

--- a/server/src/main/java/io/crate/expression/scalar/TimestampFormatter.java
+++ b/server/src/main/java/io/crate/expression/scalar/TimestampFormatter.java
@@ -78,19 +78,20 @@ public class TimestampFormatter {
                 builder.append(n);
                 if (n >= 11 && n <= 13) {
                     builder.append("th");
-                }
-                switch (n % 10) {
-                    case 1:
-                        builder.append("st");
-                        break;
-                    case 2:
-                        builder.append("nd");
-                        break;
-                    case 3:
-                        builder.append("rd");
-                        break;
-                    default:
-                        builder.append("th");
+                } else {
+                    switch (n % 10) {
+                        case 1:
+                            builder.append("st");
+                            break;
+                        case 2:
+                            builder.append("nd");
+                            break;
+                        case 3:
+                            builder.append("rd");
+                            break;
+                        default:
+                            builder.append("th");
+                    }
                 }
                 return builder.toString();
             }

--- a/server/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
@@ -227,4 +227,11 @@ public class DateFormatFunctionTest extends ScalarTestCase {
             Literal.of("%t%%%Z"),
             Literal.of(DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMPZ.implicitCast("2000-01-01")));
     }
+
+    @Test
+    public void testDayOfMonthWithEnglishSuffix() throws Exception {
+        assertNormalize("date_format('%D', '2021-10-01')", isLiteral("1st"));
+        assertNormalize("date_format('%D', '2021-10-12')", isLiteral("12th"));
+        assertNormalize("date_format('%D', '2021-10-22')", isLiteral("22nd"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixed an issue that caused ``date_format()`` to return wrong values when used
  with the `%D` specifier (Day of month as ordinal number) for 11th, 12th and
  13th.

closes https://github.com/crate/crate/issues/11828

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
