### PR TITLE
Add create subscription implementation including full logical replication

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -202,6 +202,10 @@ information about the currently applied cluster settings.
     | settings['overload_protection']['dml']['max_concurrency']                         | integer          |
     | settings['overload_protection']['dml']['min_concurrency']                         | integer          |
     | settings['overload_protection']['dml']['queue_size']                              | integer          |
+    | settings['replication']                                                           | object           |
+    | settings['replication']['logical']                                                | object           |
+    | settings['replication']['logical']['ops_batch_size']                              | integer          |
+    | settings['replication']['logical']['reads_poll_duration']                         | text             |
     | settings['stats']                                                                 | object           |
     | settings['stats']['breaker']                                                      | object           |
     | settings['stats']['breaker']['log']                                               | object           |

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1235,6 +1235,7 @@ a node. There are several pools, but the important ones include:
 * ``search``: For count/search operations, defaults to fixed
 * ``get``: For queries on ``sys.shards`` and ``sys.nodes``, defaults to fixed.
 * ``refresh``: For refresh operations, defaults to cache
+* ``logical_replication``: For operations used by the logical replication, defaults to fixed.
 
 .. _thread_pool.<name>.type:
 

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPools.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPools.java
@@ -34,6 +34,7 @@ import static org.elasticsearch.threadpool.ThreadPool.Names.FORCE_MERGE;
 import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
 import static org.elasticsearch.threadpool.ThreadPool.Names.GET;
 import static org.elasticsearch.threadpool.ThreadPool.Names.LISTENER;
+import static org.elasticsearch.threadpool.ThreadPool.Names.LOGICAL_REPLICATION;
 import static org.elasticsearch.threadpool.ThreadPool.Names.MANAGEMENT;
 import static org.elasticsearch.threadpool.ThreadPool.Names.REFRESH;
 import static org.elasticsearch.threadpool.ThreadPool.Names.SEARCH;
@@ -188,5 +189,10 @@ public class ThreadPools implements ThreadPoolsMXBean {
     @Override
     public ThreadPoolInfo getFetchShardStore() {
         return getThreadPoolInfo(FETCH_SHARD_STORE);
+    }
+
+    @Override
+    public ThreadPoolInfo getLogicalReplication() {
+        return getThreadPoolInfo(LOGICAL_REPLICATION);
     }
 }

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPoolsMXBean.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPoolsMXBean.java
@@ -47,4 +47,6 @@ public interface ThreadPoolsMXBean {
     ThreadPools.ThreadPoolInfo getFetchShardStarted();
 
     ThreadPools.ThreadPoolInfo getFetchShardStore();
+
+    ThreadPools.ThreadPoolInfo getLogicalReplication();
 }

--- a/server/src/main/java/io/crate/exceptions/RelationAlreadyExists.java
+++ b/server/src/main/java/io/crate/exceptions/RelationAlreadyExists.java
@@ -37,6 +37,11 @@ public final class RelationAlreadyExists extends ConflictException implements Ta
         this.relationName = relationName;
     }
 
+    public RelationAlreadyExists(RelationName relationName, String message) {
+        super(message);
+        this.relationName = relationName;
+    }
+
     RelationAlreadyExists(String tableName, Throwable e) {
         super(String.format(Locale.ENGLISH, MESSAGE_TMPL, tableName), e);
         this.relationName = RelationName.fromIndexName(tableName);

--- a/server/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/server/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -49,6 +49,7 @@ import io.crate.license.TransportSetLicenseAction;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.replication.logical.action.TransportCreatePublicationAction;
 import io.crate.replication.logical.action.TransportDropPublicationAction;
+import io.crate.replication.logical.action.TransportCreateSubscriptionAction;
 import io.crate.statistics.TransportAnalyzeAction;
 import org.elasticsearch.common.inject.AbstractModule;
 
@@ -88,5 +89,6 @@ public class TransportExecutorModule extends AbstractModule {
 
         bind(TransportCreatePublicationAction.class).asEagerSingleton();
         bind(TransportDropPublicationAction.class).asEagerSingleton();
+        bind(TransportCreateSubscriptionAction.class).asEagerSingleton();
     }
 }

--- a/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -26,6 +26,7 @@ import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
 import io.crate.execution.jobs.NodeLimits;
 import io.crate.memory.MemoryManagerFactory;
+import io.crate.replication.logical.LogicalReplicationSettings;
 import io.crate.statistics.TableStatsService;
 import io.crate.types.DataTypes;
 import io.crate.udc.service.UDCService;
@@ -88,7 +89,11 @@ public final class CrateSettings implements ClusterStateListener {
         UDCService.UDC_INITIAL_DELAY_SETTING,
         UDCService.UDC_INTERVAL_SETTING,
 
-        MemoryManagerFactory.MEMORY_ALLOCATION_TYPE
+        MemoryManagerFactory.MEMORY_ALLOCATION_TYPE,
+
+        // Logical Replication
+        LogicalReplicationSettings.REPLICATION_CHANGE_BATCH_SIZE,
+        LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION
     );
 
     private static final List<Setting<?>> EXPOSED_ES_SETTINGS = List.of(

--- a/server/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/server/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -38,7 +38,9 @@ import io.crate.expression.udf.TransportDropUserDefinedFunctionAction;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
+import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.action.TransportCreatePublicationAction;
+import io.crate.replication.logical.action.TransportCreateSubscriptionAction;
 import io.crate.replication.logical.action.TransportDropPublicationAction;
 import io.crate.statistics.TransportAnalyzeAction;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
@@ -81,6 +83,8 @@ public class DependencyCarrier {
     private final NodeLimits nodeLimits;
     private final TransportCreatePublicationAction createPublicationAction;
     private final TransportDropPublicationAction dropPublicationAction;
+    private final TransportCreateSubscriptionAction createSubscriptionAction;
+    private final LogicalReplicationService logicalReplicationService;
 
     @Inject
     public DependencyCarrier(Settings settings,
@@ -105,7 +109,9 @@ public class DependencyCarrier {
                              RepositoryService repositoryService,
                              RepositoryParamValidator repositoryParamValidator,
                              TransportCreatePublicationAction createPublicationAction,
-                             TransportDropPublicationAction dropPublicationAction) {
+                             TransportDropPublicationAction dropPublicationAction,
+                             TransportCreateSubscriptionAction createSubscriptionAction,
+                             LogicalReplicationService logicalReplicationService) {
         this.settings = settings;
         this.transportActionProvider = transportActionProvider;
         this.phasesTaskFactory = phasesTaskFactory;
@@ -130,6 +136,8 @@ public class DependencyCarrier {
         this.repositoryParamValidator = repositoryParamValidator;
         this.createPublicationAction = createPublicationAction;
         this.dropPublicationAction = dropPublicationAction;
+        this.createSubscriptionAction = createSubscriptionAction;
+        this.logicalReplicationService = logicalReplicationService;
     }
 
     public Schemas schemas() {
@@ -234,5 +242,13 @@ public class DependencyCarrier {
 
     public TransportDropPublicationAction dropPublicationAction() {
         return dropPublicationAction;
+    }
+
+    public TransportCreateSubscriptionAction createSubscriptionAction() {
+        return createSubscriptionAction;
+    }
+
+    public LogicalReplicationService logicalReplicationService() {
+        return logicalReplicationService;
     }
 }

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -124,9 +124,11 @@ import io.crate.planner.statement.SetSessionAuthorizationPlan;
 import io.crate.planner.statement.SetSessionPlan;
 import io.crate.profile.ProfilingContext;
 import io.crate.profile.Timer;
+import io.crate.replication.logical.analyze.AnalyzedCreatePublication;
+import io.crate.replication.logical.analyze.AnalyzedCreateSubscription;
 import io.crate.replication.logical.analyze.AnalyzedDropPublication;
 import io.crate.replication.logical.plan.CreatePublicationPlan;
-import io.crate.replication.logical.analyze.AnalyzedCreatePublication;
+import io.crate.replication.logical.plan.CreateSubscriptionPlan;
 import io.crate.replication.logical.plan.DropPublicationPlan;
 import io.crate.sql.tree.SetSessionAuthorizationStatement;
 import io.crate.statistics.TableStats;
@@ -548,6 +550,12 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     public Plan visitDropPublication(AnalyzedDropPublication dropPublication,
                                      PlannerContext context) {
         return new DropPublicationPlan(dropPublication);
+    }
+
+    @Override
+    public Plan visitCreateSubscription(AnalyzedCreateSubscription createSubscription,
+                                        PlannerContext context) {
+        return new CreateSubscriptionPlan(createSubscription);
     }
 }
 

--- a/server/src/main/java/io/crate/plugin/SQLModule.java
+++ b/server/src/main/java/io/crate/plugin/SQLModule.java
@@ -28,6 +28,8 @@ import io.crate.metadata.DanglingArtifactsService;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.PostgresNetty;
+import io.crate.replication.logical.repository.PublisherRestoreService;
+import io.crate.replication.logical.ShardReplicationService;
 import io.crate.rest.action.RestSQLAction;
 import io.crate.statistics.TableStats;
 import io.crate.statistics.TableStatsService;
@@ -48,5 +50,7 @@ public class SQLModule extends AbstractModule {
         bind(UserDefinedFunctionService.class).asEagerSingleton();
         bind(RestSQLAction.class).asEagerSingleton();
         bind(DanglingArtifactsService.class).asEagerSingleton();
+        bind(PublisherRestoreService.class).asEagerSingleton();
+        bind(ShardReplicationService.class).asEagerSingleton();
     }
 }

--- a/server/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/server/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -58,6 +58,14 @@ import io.crate.monitor.MonitorModule;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.ssl.SslContextProviderService;
 import io.crate.protocols.ssl.SslSettings;
+import io.crate.replication.logical.LogicalReplicationSettings;
+import io.crate.replication.logical.action.GetFileChunkAction;
+import io.crate.replication.logical.action.GetStoreMetadataAction;
+import io.crate.replication.logical.action.PublicationsStateAction;
+import io.crate.replication.logical.action.ReleasePublisherResourcesAction;
+import io.crate.replication.logical.action.ReplayChangesAction;
+import io.crate.replication.logical.action.ShardChangesAction;
+import io.crate.replication.logical.engine.SubscriberEngine;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.user.UserManagementModule;
@@ -79,13 +87,19 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.mapper.ArrayMapper;
 import org.elasticsearch.index.mapper.ArrayTypeParser;
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.seqno.RetentionLeaseActions;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ClusterPlugin;
+import org.elasticsearch.plugins.EnginePlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportResponse;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -93,9 +107,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.UnaryOperator;
 
-public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, ClusterPlugin {
+
+public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, ClusterPlugin, EnginePlugin {
 
     private final Settings settings;
     @Nullable
@@ -131,6 +147,9 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
         settings.add(SslSettings.SSL_KEYSTORE_PASSWORD);
         settings.add(SslSettings.SSL_KEYSTORE_KEY_PASSWORD);
         settings.add(SslSettings.SSL_RESOURCE_POLL_INTERVAL);
+
+        // Logical replication
+        settings.add(LogicalReplicationSettings.REPLICATION_SUBSCRIBED_INDEX);
 
         settings.addAll(CrateSettings.CRATE_CLUSTER_SETTINGS);
 
@@ -314,5 +333,28 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
     @Override
     public void onIndexModule(IndexModule indexModule) {
         indexModule.addIndexEventListener(indexEventListenerProxy);
+    }
+
+    @Override
+    public List<ActionHandler<? extends TransportRequest, ? extends TransportResponse>> getActions() {
+        return List.of(
+            new ActionHandler<>(RetentionLeaseActions.Add.INSTANCE, RetentionLeaseActions.Add.TransportAction.class),
+            new ActionHandler<>(RetentionLeaseActions.Remove.INSTANCE, RetentionLeaseActions.Remove.TransportAction.class),
+            new ActionHandler<>(RetentionLeaseActions.Renew.INSTANCE, RetentionLeaseActions.Renew.TransportAction.class),
+            new ActionHandler<>(PublicationsStateAction.INSTANCE, PublicationsStateAction.TransportAction.class),
+            new ActionHandler<>(GetFileChunkAction.INSTANCE, GetFileChunkAction.TransportAction.class),
+            new ActionHandler<>(GetStoreMetadataAction.INSTANCE, GetStoreMetadataAction.TransportAction.class),
+            new ActionHandler<>(ReleasePublisherResourcesAction.INSTANCE, ReleasePublisherResourcesAction.TransportAction.class),
+            new ActionHandler<>(ShardChangesAction.INSTANCE, ShardChangesAction.TransportAction.class),
+            new ActionHandler<>(ReplayChangesAction.INSTANCE, ReplayChangesAction.TransportAction.class)
+        );
+    }
+
+    @Override
+    public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
+        if (indexSettings.getSettings().get(LogicalReplicationSettings.REPLICATION_SUBSCRIBED_INDEX.getKey()) != null) {
+            return Optional.of(SubscriberEngine::new);
+        }
+        return Optional.empty();
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -21,62 +21,441 @@
 
 package io.crate.replication.logical;
 
+import io.crate.common.io.IOUtils;
+import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.RelationAlreadyExists;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.action.PublicationsStateAction;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import io.crate.replication.logical.repository.LogicalReplicationRepository;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreClusterStateListener;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.snapshots.RestoreInfo;
+import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
+import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.transport.RemoteClusterAwareClient;
+import org.elasticsearch.transport.RemoteClusterConnection;
+import org.elasticsearch.transport.RemoteConnectionStrategy;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
 
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
-public class LogicalReplicationService implements ClusterStateListener {
+import static io.crate.replication.logical.repository.LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX;
+import static io.crate.replication.logical.repository.LogicalReplicationRepository.TYPE;
+import static org.elasticsearch.action.support.master.MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
-    private SubscriptionsMetadata subscriptionsMetadata;
-    private PublicationsMetadata publicationsMetadata;
+public class LogicalReplicationService extends RemoteClusterAware implements ClusterStateListener, Closeable {
 
-    public LogicalReplicationService(ClusterService clusterService) {
+    private static final Logger LOGGER = LogManager.getLogger(LogicalReplicationService.class);
+
+    private final TransportService transportService;
+    private final ClusterService clusterService;
+    private final ThreadPool threadPool;
+    private RepositoriesService repositoriesService;
+    private RestoreService restoreService;
+
+    private final Map<String, RemoteClusterConnection> remoteClusters = ConcurrentCollections.newConcurrentMap();
+    private final Map<String, String> subscribedIndices = ConcurrentCollections.newConcurrentMap();
+    private volatile SubscriptionsMetadata currentSubscriptionsMetadata = new SubscriptionsMetadata();
+    private volatile PublicationsMetadata currentPublicationsMetadata = new PublicationsMetadata();
+
+    public LogicalReplicationService(Settings settings,
+                                     ClusterService clusterService,
+                                     TransportService transportService,
+                                     ThreadPool threadPool) {
+        super(settings);
+        this.transportService = transportService;
+        this.clusterService = clusterService;
+        this.threadPool = threadPool;
         clusterService.addListener(this);
+    }
+
+    public void repositoriesService(RepositoriesService repositoriesService) {
+        this.repositoriesService = repositoriesService;
+    }
+
+    public void restoreService(RestoreService restoreService) {
+        this.restoreService = restoreService;
     }
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (!event.metadataChanged()) {
-            return;
-        }
-
         var prevMetadata = event.previousState().metadata();
         var newMetadata = event.state().metadata();
 
         SubscriptionsMetadata prevSubscriptionsMetadata = prevMetadata.custom(SubscriptionsMetadata.TYPE);
         SubscriptionsMetadata newSubscriptionsMetadata = newMetadata.custom(SubscriptionsMetadata.TYPE);
 
-        if (prevSubscriptionsMetadata != newSubscriptionsMetadata) {
-            subscriptionsMetadata = newSubscriptionsMetadata;
+        if ((prevSubscriptionsMetadata == null && newSubscriptionsMetadata != null)
+            || (prevSubscriptionsMetadata != null && prevSubscriptionsMetadata.equals(newSubscriptionsMetadata) == false)) {
+            currentSubscriptionsMetadata = newSubscriptionsMetadata;
+            onChangedSubscriptions(prevSubscriptionsMetadata, newSubscriptionsMetadata);
         }
 
         PublicationsMetadata prevPublicationsMetadata = prevMetadata.custom(PublicationsMetadata.TYPE);
         PublicationsMetadata newPublicationsMetadata = newMetadata.custom(PublicationsMetadata.TYPE);
 
-        if (prevPublicationsMetadata != newPublicationsMetadata) {
-            publicationsMetadata = newPublicationsMetadata;
+        if ((prevPublicationsMetadata == null && newPublicationsMetadata != null)
+            || (prevPublicationsMetadata != null && prevPublicationsMetadata.equals(newPublicationsMetadata) == false)) {
+            currentPublicationsMetadata = newPublicationsMetadata;
         }
     }
 
+    private void onChangedSubscriptions(@Nullable SubscriptionsMetadata prevSubscriptionsMetadata,
+                                        SubscriptionsMetadata newSubscriptionsMetadata) {
+        Map<String, Subscription> oldSubscriptions = prevSubscriptionsMetadata == null
+            ? Collections.emptyMap() : prevSubscriptionsMetadata.subscription();
+        var newSubscriptions = newSubscriptionsMetadata.subscription();
+
+        for (var entry : newSubscriptions.entrySet()) {
+            var subscriptionName = entry.getKey();
+            if (oldSubscriptions.get(subscriptionName) == null) {
+                assert repositoriesService != null
+                    : "RepositoriesService must be set immediately after LogicalReplicationService construction";
+
+                LOGGER.debug("Adding new logical replication repository for subscription '{}'", subscriptionName);
+                repositoriesService.registerInternalRepository(REMOTE_REPOSITORY_PREFIX + subscriptionName, TYPE);
+
+                LOGGER.debug("Start logical replication for subscription '{}'", subscriptionName);
+                startReplication(subscriptionName, entry.getValue(), new ActionListener<>() {
+
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        LOGGER.debug("Acknowledged logical replication for subscription '{}'", subscriptionName);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        LOGGER.debug("Failure for logical replication for subscription", e);
+                    }
+                });
+            }
+        }
+        for (var entry : oldSubscriptions.entrySet()) {
+            var subscriptionName = entry.getKey();
+            if (newSubscriptions.get(subscriptionName) == null) {
+                assert repositoriesService != null
+                    : "RepositoriesService must be set immediately after LogicalReplicationService construction";
+                LOGGER.debug("Removing logical replication repository for dropped subscription '{}'",
+                             subscriptionName);
+                repositoriesService.unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + subscriptionName);
+            }
+        }
+    }
 
     public Map<String, Subscription> subscriptions() {
-        if (subscriptionsMetadata == null) {
-            return Collections.emptyMap();
-        }
-        return subscriptionsMetadata.subscription();
+        return currentSubscriptionsMetadata.subscription();
     }
 
     public Map<String, Publication> publications() {
-        if (publicationsMetadata == null) {
-            return Collections.emptyMap();
+        return currentPublicationsMetadata.publications();
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(remoteClusters.values());
+    }
+
+    @Override
+    protected void updateRemoteCluster(String clusterAlias, Settings settings) {
+        updateRemoteConnection(clusterAlias, settings);
+    }
+
+    @Override
+    public Transport.Connection getConnection(DiscoveryNode node, String cluster) {
+        return getRemoteClusterConnection(cluster).getConnection(node);
+    }
+
+    @Override
+    public Transport.Connection getConnection(String cluster) {
+        return getRemoteClusterConnection(cluster).getConnection();
+    }
+
+    @Override
+    public void ensureConnected(String clusterAlias, ActionListener<Void> listener) {
+        getRemoteClusterConnection(clusterAlias).ensureConnected(listener);
+    }
+
+    RemoteClusterConnection getRemoteClusterConnection(String cluster) {
+        RemoteClusterConnection connection = remoteClusters.get(cluster);
+        if (connection == null) {
+            throw new NoSuchRemoteClusterException(cluster);
         }
-        return publicationsMetadata.publications();
+        return connection;
+    }
+
+    @Override
+    public Client getRemoteClusterClient(ThreadPool threadPool,
+                                         String clusterAlias) {
+        if (remoteClusters.containsKey(clusterAlias) == false) {
+            throw new NoSuchRemoteClusterException(clusterAlias);
+        }
+        return new RemoteClusterAwareClient(settings, threadPool, transportService, clusterAlias, this);
+    }
+
+    public void updateRemoteConnection(String name, Settings connectionSettings) {
+        CountDownLatch latch = new CountDownLatch(1);
+        updateRemoteConnection(name, connectionSettings, ActionListener.wrap(latch::countDown));
+
+        try {
+            // Wait 10 seconds for a connections. We must use a latch instead of a future because we
+            // are on the cluster state thread and our custom future implementation will throw an
+            // assertion.
+            if (latch.await(10, TimeUnit.SECONDS) == false) {
+                LOGGER.warn("failed to connect to new remote cluster {} within {}",
+                            name,
+                            TimeValue.timeValueSeconds(10));
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public synchronized void updateRemoteConnection(String name,
+                                                    Settings connectionSettings,
+                                                    ActionListener<Void> listener) {
+        RemoteClusterConnection remote = this.remoteClusters.get(name);
+        if (RemoteConnectionStrategy.isConnectionEnabled(connectionSettings) == false) {
+            try {
+                IOUtils.close(remote);
+            } catch (IOException e) {
+                LOGGER.warn("failed to close remote cluster connections for cluster: " + name, e);
+            }
+            remoteClusters.remove(name);
+            listener.onResponse(null);
+            return;
+        }
+
+        if (remote == null) {
+            // this is a new cluster we have to add a new representation
+            remote = new RemoteClusterConnection(settings, connectionSettings, name, transportService);
+            remoteClusters.put(name, remote);
+            remote.ensureConnected(listener);
+        } else if (remote.shouldRebuildConnection(connectionSettings)) {
+            // Changes to connection configuration. Must tear down existing connection
+            try {
+                IOUtils.close(remote);
+            } catch (IOException e) {
+                LOGGER.warn("failed to close remote cluster connections for cluster: " + name, e);
+            }
+            remoteClusters.remove(name);
+            remote = new RemoteClusterConnection(settings, connectionSettings, name, transportService);
+            remoteClusters.put(name, remote);
+            remote.ensureConnected(listener);
+        } else {
+            // No changes to connection configuration.
+            listener.onResponse(null);
+        }
+    }
+
+    public boolean isSubscribedIndex(String indexName) {
+        return subscribedIndices.containsKey(indexName);
+    }
+
+    @Nullable
+    public String subscriptionName(String indexName) {
+        return subscribedIndices.get(indexName);
+    }
+
+    @Nullable
+    public Subscription subscription(String indexName) {
+        var subscriptionName = subscribedIndices.get(indexName);
+        if (subscriptionName != null) {
+            return currentSubscriptionsMetadata.subscription().get(subscriptionName);
+        }
+        return null;
+    }
+
+    public void startReplication(String subscriptionName,
+                                 Subscription subscription,
+                                 ActionListener<AcknowledgedResponse> listener) {
+        getPublicationState(
+            subscriptionName,
+            subscription,
+            new ActionListener<>() {
+
+                @Override
+                public void onResponse(PublicationsStateAction.Response stateResponse) {
+                    verifyTablesDoNotExist(
+                        subscriptionName,
+                        stateResponse,
+                        r -> {
+                            for (var index : stateResponse.concreteIndices()) {
+                                subscribedIndices.put(index, subscriptionName);
+                            }
+                            initiateReplication(subscriptionName, subscription, stateResponse, listener);
+                        },
+                        listener::onFailure
+                    );
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            }
+        );
+    }
+
+    public void getPublicationState(String subscriptionName,
+                                    Subscription subscription,
+                                    ActionListener<PublicationsStateAction.Response> listener) {
+        updateRemoteConnection(
+            subscriptionName,
+            subscription.connectionInfo().settings(),
+            ActionListener.delegateFailure(
+                listener,
+                (delegatedListener, response) -> {
+                    var remoteClient = getRemoteClusterClient(
+                        threadPool,
+                        subscriptionName
+                    );
+                    remoteClient.execute(
+                        PublicationsStateAction.INSTANCE,
+                        new PublicationsStateAction.Request(subscription.publications()),
+                        listener
+                    );
+                }
+            )
+        );
+    }
+
+    public void verifyTablesDoNotExist(String subscriptionName,
+                                       PublicationsStateAction.Response stateResponse,
+                                       Consumer<Void> onSuccess,
+                                       Consumer<Exception> onFailure) {
+        var metadata = clusterService.state().metadata();
+        Consumer<RelationName> onExists = (relation) -> {
+            var message = String.format(
+                Locale.ENGLISH,
+                "Subscription '%s' cannot be created as included relation '%s' already exists",
+                subscriptionName,
+                relation
+            );
+            onFailure.accept(new RelationAlreadyExists(relation, message));
+        };
+        for (var index : stateResponse.concreteIndices()) {
+            if (metadata.hasIndex(index)) {
+                onExists.accept(RelationName.fromIndexName(index));
+                return;
+            }
+        }
+        for (var template : stateResponse.concreteTemplates()) {
+            if (metadata.templates().containsKey(template)) {
+                onExists.accept(PartitionName.fromIndexOrTemplate(template).relationName());
+                return;
+            }
+        }
+        onSuccess.accept(null);
+    }
+
+
+    private void initiateReplication(String subscriptionName,
+                                     Subscription subscription,
+                                     PublicationsStateAction.Response stateResponse,
+                                     ActionListener<AcknowledgedResponse> listener) {
+        var publisherClusterRepoName = LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX + subscriptionName;
+        final RestoreService.RestoreRequest restoreRequest =
+            new RestoreService.RestoreRequest(
+                publisherClusterRepoName,
+                LogicalReplicationRepository.LATEST,
+                stateResponse.concreteIndices().toArray(new String[0]),
+                stateResponse.concreteTemplates().toArray(new String[0]),
+                IndicesOptions.LENIENT_EXPAND_OPEN,
+                null,
+                null,
+                subscription.settings(),
+                DEFAULT_MASTER_NODE_TIMEOUT,
+                false,
+                true,
+                Settings.EMPTY,
+                Strings.EMPTY_ARRAY,
+                "restore_logical_replication_snapshot[" + subscriptionName + "]",
+                true,
+                false,
+                Strings.EMPTY_ARRAY,
+                false,
+                Strings.EMPTY_ARRAY
+            );
+
+        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+
+            @Override
+            protected void doRun() {
+                restoreService.restoreSnapshot(
+                    restoreRequest,
+                    ActionListener.delegateFailure(
+                        listener,
+                        (delegatedListener, response) ->
+                            afterReplicationStarted(delegatedListener, response)
+                    )
+                );
+            }
+
+            @Override
+            public void onAfter() {
+                super.onAfter();
+                listener.onResponse(new AcknowledgedResponse(true));
+            }
+        });
+    }
+
+    private void afterReplicationStarted(ActionListener<AcknowledgedResponse> listener,
+                                         RestoreService.RestoreCompletionResponse response) {
+        RestoreClusterStateListener.createAndRegisterListener(
+            clusterService,
+            response,
+            ActionListener.delegateFailure(listener, (delegatedListener, restoreSnapshotResponse) -> {
+                RestoreInfo restoreInfo = restoreSnapshotResponse.getRestoreInfo();
+                if (restoreInfo == null) {
+                    LOGGER.error(
+                        "Restore failed, restoreInfo = NULL, seems like a master failure happened while restoring");
+                    delegatedListener.onResponse(new AcknowledgedResponse(false));
+                } else if (restoreInfo.failedShards() == 0) {
+                    LOGGER.debug("Restore success, following will start once shards are active");
+                    delegatedListener.onResponse(new AcknowledgedResponse(true));
+                } else {
+                    assert restoreInfo.failedShards() > 0 : "Some failed shards are expected";
+                    LOGGER.error("Failed to restore {}/{} shards",
+                                 restoreInfo.failedShards(),
+                                 restoreInfo.totalShards());
+                    delegatedListener.onResponse(new AcknowledgedResponse(false));
+                }
+            })
+        );
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical;
+
+import io.crate.common.unit.TimeValue;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+@Singleton
+public class LogicalReplicationSettings {
+
+    public static final Setting<Integer> REPLICATION_CHANGE_BATCH_SIZE = Setting.intSetting(
+        "replication.logical.ops_batch_size", 50000, 16,
+        Setting.Property.Dynamic, Setting.Property.NodeScope
+    );
+
+    public static final Setting<TimeValue> REPLICATION_READ_POLL_DURATION = Setting.timeSetting(
+        "replication.logical.reads_poll_duration",
+        TimeValue.timeValueMillis(50),
+        TimeValue.timeValueMillis(1),
+        TimeValue.timeValueSeconds(1),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Internal index setting marking an index as subscribed/replicated
+     */
+    public static final Setting<String> REPLICATION_SUBSCRIBED_INDEX = Setting.simpleString(
+        "index.replication.logical.subscribed",
+        Setting.Property.InternalIndex,
+        Setting.Property.IndexScope
+    );
+
+
+    private long batchSize;
+    private TimeValue pollDelay;
+
+    @Inject
+    public LogicalReplicationSettings(Settings settings, ClusterService clusterService) {
+        batchSize = REPLICATION_CHANGE_BATCH_SIZE.get(settings);
+        pollDelay = REPLICATION_READ_POLL_DURATION.get(settings);
+
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(REPLICATION_CHANGE_BATCH_SIZE, this::batchSize);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(REPLICATION_READ_POLL_DURATION, this::pollDelay);
+    }
+
+    public long batchSize() {
+        return batchSize;
+    }
+
+    public void batchSize(long batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public TimeValue pollDelay() {
+        return pollDelay;
+    }
+
+    public void pollDelay(TimeValue pollDelay) {
+        this.pollDelay = pollDelay;
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/ShardReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/ShardReplicationService.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical;
+
+import io.crate.plugin.IndexEventListenerProxy;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.IndexEventListener;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ShardReplicationService implements Closeable {
+
+    private static final Logger LOGGER = Loggers.getLogger(ShardReplicationService.class);
+
+    private final LogicalReplicationService logicalReplicationService;
+    private final LogicalReplicationSettings replicationSettings;
+    private final Client client;
+    private final ThreadPool threadPool;
+    private final Map<ShardId, ShardReplicationChangesTracker> shards = new ConcurrentHashMap<>();
+
+    @Inject
+    public ShardReplicationService(IndexEventListenerProxy indexEventListenerProxy,
+                                   LogicalReplicationService logicalReplicationService,
+                                   LogicalReplicationSettings replicationSettings,
+                                   Client client,
+                                   ThreadPool threadPool) {
+        this.logicalReplicationService = logicalReplicationService;
+        this.replicationSettings = replicationSettings;
+        this.client = client;
+        this.threadPool = threadPool;
+        indexEventListenerProxy.addLast(new LifecycleListener());
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (var tracker : shards.values()) {
+            tracker.close();
+        }
+    }
+
+    @Nullable
+    private Client getRemoteClusterClient(String indexName) {
+        var subscriptionName = logicalReplicationService.subscriptionName(indexName);
+        if (subscriptionName != null) {
+            return logicalReplicationService.getRemoteClusterClient(threadPool, subscriptionName);
+        }
+        return null;
+    }
+
+    private class LifecycleListener implements IndexEventListener {
+
+        @Override
+        public void afterIndexShardStarted(IndexShard indexShard) {
+            if (indexShard.routingEntry().primary()) {
+                var subscription = logicalReplicationService.subscription(indexShard.shardId().getIndexName());
+                if (subscription != null) {
+                    var tracker = new ShardReplicationChangesTracker(
+                        indexShard,
+                        replicationSettings,
+                        threadPool,
+                        ShardReplicationService.this::getRemoteClusterClient,
+                        client
+                    );
+                    shards.put(indexShard.shardId(), tracker);
+                    tracker.start();
+                }
+            }
+        }
+
+        @Override
+        public void beforeIndexShardClosed(ShardId shardId,
+                                           @Nullable IndexShard indexShard,
+                                           Settings indexSettings) {
+            var tracker = shards.remove(shardId);
+            if (tracker != null) {
+                try {
+                    tracker.close();
+                } catch (IOException e) {
+                    LOGGER.error("Error while closing shard changes tracker of shardId=" + shardId, e);
+                }
+            }
+        }
+
+        @Override
+        public void afterIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+            var tracker = shards.remove(shardId);
+            if (tracker != null) {
+                try {
+                    tracker.close();
+                } catch (IOException e) {
+                    LOGGER.error("Error while closing shard changes tracker of shardId=" + shardId, e);
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/CreateSubscriptionRequest.java
+++ b/server/src/main/java/io/crate/replication/logical/action/CreateSubscriptionRequest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.replication.logical.metadata.ConnectionInfo;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.util.List;
+
+public class CreateSubscriptionRequest extends AcknowledgedRequest<CreateSubscriptionRequest> {
+
+    private final String owner;
+    private final String name;
+    private final ConnectionInfo connectionInfo;
+    private final List<String> publications;
+    private final Settings settings;
+
+    public CreateSubscriptionRequest(String owner,
+                                     String name,
+                                     ConnectionInfo connectionInfo,
+                                     List<String> publications,
+                                     Settings settings) {
+        this.owner = owner;
+        this.name = name;
+        this.connectionInfo = connectionInfo;
+        this.publications = publications;
+        this.settings = settings;
+    }
+
+    public CreateSubscriptionRequest(StreamInput in) throws IOException {
+        super(in);
+        this.owner = in.readString();
+        this.name = in.readString();
+        connectionInfo = new ConnectionInfo(in);
+        this.publications = List.of(in.readStringArray());
+        settings = Settings.readSettingsFromStream(in);
+    }
+
+    public String owner() {
+        return owner;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public ConnectionInfo connectionInfo() {
+        return connectionInfo;
+    }
+
+    public List<String> publications() {
+        return publications;
+    }
+
+    public Settings settings() {
+        return settings;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(owner);
+        out.writeString(name);
+        connectionInfo.writeTo(out);
+        out.writeStringArray(publications.toArray(new String[0]));
+        Settings.writeSettingsToStream(settings, out);
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.replication.logical.repository.PublisherRestoreService;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardsIterator;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.StoreFileMetadata;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class GetFileChunkAction extends ActionType<GetFileChunkAction.Response> {
+
+    public static final String NAME = "internal:crate:replication/logical/file_chunk/get";
+    public static final GetFileChunkAction INSTANCE = new GetFileChunkAction();
+
+    public GetFileChunkAction() {
+        super(NAME);
+    }
+
+    @Override
+    public Writeable.Reader<Response> getResponseReader() {
+        return Response::new;
+    }
+
+    @Singleton
+    public static class TransportAction extends TransportSingleShardAction<Request, Response> {
+
+        private final IndicesService indicesService;
+        private final PublisherRestoreService publisherRestoreService;
+
+        @Inject
+        public TransportAction(ThreadPool threadPool,
+                               ClusterService clusterService,
+                               TransportService transportService,
+                               IndicesService indicesService,
+                               PublisherRestoreService publisherRestoreService,
+                               IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(
+                NAME,
+                threadPool,
+                clusterService,
+                transportService,
+                indexNameExpressionResolver,
+                Request::new,
+                ThreadPool.Names.GET
+            );
+            this.indicesService = indicesService;
+            this.publisherRestoreService = publisherRestoreService;
+            TransportActionProxy.registerProxyAction(transportService, NAME, Response::new);
+        }
+
+        @Override
+        protected Response shardOperation(Request request,
+                                          ShardId shardId) throws IOException {
+            var indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShard(shardId.id());
+            var store = indexShard.store();
+            var buffer = new byte[request.length()];
+            var bytesRead = 0;
+
+            store.incRef();
+            var fileMetaData = request.storeFileMetadata();
+            try (var currentInput = publisherRestoreService.openInputStream(
+                request.restoreUUID(), request, fileMetaData.name(), fileMetaData.length())) {
+                var offset = request.offset();
+                if (offset < fileMetaData.length()) {
+                    currentInput.skip(offset);
+                    bytesRead = currentInput.read(buffer);
+                }
+            } finally {
+                store.decRef();
+            }
+
+            return new Response(
+                request.storeFileMetadata(),
+                request.offset(),
+                new BytesArray(buffer, 0, bytesRead)
+            );
+        }
+
+        @Override
+        protected Writeable.Reader<Response> getResponseReader() {
+            return Response::new;
+        }
+
+        @Override
+        protected boolean resolveIndex(Request request) {
+            return true;
+        }
+
+        @Nullable
+        @Override
+        protected ShardsIterator shards(ClusterState state,
+                                        InternalRequest request) {
+            return state.routingTable().shardRoutingTable(request.request().publisherShardId()).primaryShardIt();
+        }
+    }
+
+    public static class Request extends RestoreShardRequest<Request> {
+
+        private final StoreFileMetadata storeFileMetadata;
+        private final long offset;
+        private final int length;
+
+        public Request(String restoreUUID,
+                       DiscoveryNode node,
+                       ShardId publisherShardId,
+                       String subscriberClusterName,
+                       ShardId subscriberShardId,
+                       StoreFileMetadata storeFileMetadata,
+                       long offset,
+                       int length) {
+            super(restoreUUID, node, publisherShardId, subscriberClusterName, subscriberShardId);
+            this.storeFileMetadata = storeFileMetadata;
+            this.offset = offset;
+            this.length = length;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            storeFileMetadata = new StoreFileMetadata(in);
+            offset = in.readLong();
+            length = in.readInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            storeFileMetadata.writeTo(out);
+            out.writeLong(offset);
+            out.writeInt(length);
+        }
+
+        public StoreFileMetadata storeFileMetadata() {
+            return storeFileMetadata;
+        }
+
+        public long offset() {
+            return offset;
+        }
+
+        public int length() {
+            return length;
+        }
+    }
+
+    public static class Response extends TransportResponse {
+
+        private final StoreFileMetadata storeFileMetadata;
+        private final long offset;
+        private final BytesReference data;
+
+        public Response(StoreFileMetadata storeFileMetadata,
+                        long offset,
+                        BytesReference data) {
+            this.storeFileMetadata = storeFileMetadata;
+            this.offset = offset;
+            this.data = data;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            storeFileMetadata = new StoreFileMetadata(in);
+            offset = in.readLong();
+            data = in.readBytesReference();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            storeFileMetadata.writeTo(out);
+            out.writeLong(offset);
+            out.writeBytesReference(data);
+        }
+
+        public StoreFileMetadata storeFileMetadata() {
+            return storeFileMetadata;
+        }
+
+        public long offset() {
+            return offset;
+        }
+
+        public BytesReference data() {
+            return data;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/GetStoreMetadataAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/GetStoreMetadataAction.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.replication.logical.repository.PublisherRestoreService;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardsIterator;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class GetStoreMetadataAction extends ActionType<GetStoreMetadataAction.Response> {
+
+    public static final String NAME = "internal:crate:replication/logical/store/file_metadata";
+    public static final GetStoreMetadataAction INSTANCE = new GetStoreMetadataAction();
+
+    public GetStoreMetadataAction() {
+        super(NAME);
+    }
+
+    @Override
+    public Writeable.Reader<Response> getResponseReader() {
+        return Response::new;
+    }
+
+    @Singleton
+    public static class TransportAction extends TransportSingleShardAction<Request, Response> {
+
+        private static final Logger LOGGER = Loggers.getLogger(TransportAction.class);
+
+        private final PublisherRestoreService publisherRestoreService;
+
+        @Inject
+        public TransportAction(ThreadPool threadPool,
+                               ClusterService clusterService,
+                               TransportService transportService,
+                               PublisherRestoreService publisherRestoreService,
+                               IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(
+                NAME,
+                threadPool,
+                clusterService,
+                transportService,
+                indexNameExpressionResolver,
+                Request::new,
+                ThreadPool.Names.LOGICAL_REPLICATION
+            );
+            this.publisherRestoreService = publisherRestoreService;
+            TransportActionProxy.registerProxyAction(transportService, NAME, Response::new);
+        }
+
+        @Override
+        protected Response shardOperation(Request request,
+                                          ShardId shardId) throws IOException {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Processing request: " + request.toString());
+            }
+            var metadataSnapshot = publisherRestoreService.createRestoreContext(
+                request.restoreUUID(),
+                request
+            ).metadataSnapshot();
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("MetadataSnapshot: {}", metadataSnapshot.asMap());
+            }
+            return new Response(metadataSnapshot);
+        }
+
+        @Override
+        protected Writeable.Reader<Response> getResponseReader() {
+            return Response::new;
+        }
+
+        @Override
+        protected boolean resolveIndex(Request request) {
+            return true;
+        }
+
+        @Nullable
+        @Override
+        protected ShardsIterator shards(ClusterState state,
+                                        InternalRequest request) {
+            return state.routingTable().shardRoutingTable(request.request().publisherShardId()).primaryShardIt();
+        }
+    }
+
+    public static class Request extends RestoreShardRequest<Request> {
+
+        public Request(String restoreUUID,
+                       DiscoveryNode node,
+                       ShardId publisherShardId,
+                       String subscriberClusterName,
+                       ShardId subscriberShardId) {
+            super(restoreUUID, node, publisherShardId, subscriberClusterName, subscriberShardId);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+
+    public static class Response extends TransportResponse {
+
+        private final Store.MetadataSnapshot metadataSnapshot;
+
+        public Response(Store.MetadataSnapshot metadataSnapshot) {
+            this.metadataSnapshot = metadataSnapshot;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            metadataSnapshot = new Store.MetadataSnapshot(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            metadataSnapshot.writeTo(out);
+        }
+
+        public Store.MetadataSnapshot metadataSnapshot() {
+            return metadataSnapshot;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.execution.engine.collect.sources.InformationSchemaIterables;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationInfo;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.exceptions.PublicationUnknownException;
+import io.crate.replication.logical.metadata.Publication;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PublicationsStateAction extends ActionType<PublicationsStateAction.Response> {
+
+    public static final String NAME = "internal:crate:replication/logical/publication/state";
+    public static final PublicationsStateAction INSTANCE = new PublicationsStateAction();
+
+    private static final Logger LOGGER = Loggers.getLogger(PublicationsStateAction.class);
+
+    public PublicationsStateAction() {
+        super(NAME);
+    }
+
+    @Override
+    public Writeable.Reader<Response> getResponseReader() {
+        return Response::new;
+    }
+
+    @Singleton
+    public static class TransportAction extends TransportMasterNodeReadAction<Request, Response> {
+
+        private final LogicalReplicationService logicalReplicationService;
+        private final Schemas schemas;
+
+        @Inject
+        public TransportAction(TransportService transportService,
+                               ClusterService clusterService,
+                               ThreadPool threadPool,
+                               IndexNameExpressionResolver indexNameExpressionResolver,
+                               LogicalReplicationService logicalReplicationService,
+                               Schemas schemas) {
+            super(Settings.EMPTY,
+                  NAME,
+                  false,
+                  transportService,
+                  clusterService,
+                  threadPool,
+                  indexNameExpressionResolver,
+                  Request::new);
+            this.logicalReplicationService = logicalReplicationService;
+            this.schemas = schemas;
+
+            TransportActionProxy.registerProxyAction(transportService, NAME, Response::new);
+        }
+
+        @Override
+        protected String executor() {
+            return ThreadPool.Names.SAME;
+        }
+
+        @Override
+        protected Response read(StreamInput in) throws IOException {
+            return new Response(in);
+        }
+
+        @Override
+        protected void masterOperation(Request request,
+                                       ClusterState state,
+                                       ActionListener<Response> listener) throws Exception {
+            ArrayList<RelationName> relationNames = new ArrayList<>();
+            ArrayList<String> concreteIndices = new ArrayList<>();
+            ArrayList<String> concreteTemplates = new ArrayList<>();
+
+            for (var publicationName : request.publications()) {
+                var publication = logicalReplicationService.publications().get(publicationName);
+                if (publication == null) {
+                    listener.onFailure(new PublicationUnknownException(publicationName));
+                    return;
+                }
+
+                List<RelationName> relationNamesOfPublication = resolveRelationsNames(publication, schemas);
+                for (var relationName : relationNamesOfPublication) {
+
+                    var indexNameOrTemplateName = relationName.indexNameOrAlias();
+                    if (state.metadata().hasIndex(indexNameOrTemplateName)) {
+                        concreteIndices.add(indexNameOrTemplateName);
+                    } else {
+                        var templateName = PartitionName.templateName(relationName.schema(), relationName.name());
+                        var indexTemplate = state.metadata().templates().get(templateName);
+                        if (indexTemplate == null) {
+                            continue;
+                        }
+                        concreteTemplates.add(templateName);
+                        var partitionIndices = Arrays.asList(indexNameExpressionResolver.concreteIndices(
+                            state, IndicesOptions.lenientExpandOpen(), indexNameOrTemplateName));
+                        partitionIndices.forEach(i -> concreteIndices.add(i.getName()));
+                    }
+                    relationNames.add(relationName);
+                }
+            }
+            var response = new Response(
+                relationNames,
+                concreteIndices,
+                concreteTemplates
+            );
+            listener.onResponse(response);
+        }
+
+        @Override
+        protected ClusterBlockException checkBlock(Request request,
+                                                   ClusterState state) {
+            return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        }
+
+        @VisibleForTesting
+        static List<RelationName> resolveRelationsNames(Publication publication, Schemas schemas) {
+            List<RelationName> relationNames;
+            if (publication.isForAllTables()) {
+                relationNames = InformationSchemaIterables.tablesStream(schemas)
+                    .filter(t -> {
+                        if (t instanceof DocTableInfo dt) {
+                            boolean softDeletes;
+                            if ((softDeletes = IndexSettings.INDEX_SOFT_DELETES_SETTING.get(dt.parameters())) == false) {
+                                LOGGER.warn(
+                                    "Table '{}' won't be replicated as the required table setting " +
+                                    "'soft_deletes.enabled' is set to: {}",
+                                    dt.ident(),
+                                    softDeletes
+                                );
+                                return false;
+                            }
+                            return true;
+                        }
+                        return false;
+                    })
+                    .map(RelationInfo::ident)
+                    .toList();
+            } else {
+                relationNames = publication.tables();
+            }
+            return relationNames;
+        }
+    }
+
+    public static class Request extends MasterNodeReadRequest<Request> {
+
+        private final List<String> publications;
+
+        public Request(List<String> publications) {
+            this.publications = publications;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            publications = in.readList(StreamInput::readString);
+        }
+
+        public List<String> publications() {
+            return publications;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeStringCollection(publications);
+        }
+    }
+
+    public static class Response extends TransportResponse {
+
+        private final List<RelationName> tables;
+        private final List<String> concreteIndices;
+        private final List<String> concreteTemplates;
+
+        public Response(List<RelationName> tables,
+                        List<String> concreteIndices,
+                        List<String> concreteTemplates) {
+            this.tables = tables;
+            this.concreteIndices = concreteIndices;
+            this.concreteTemplates = concreteTemplates;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            tables = in.readList(RelationName::new);
+            concreteIndices = in.readList(StreamInput::readString);
+            concreteTemplates = in.readList(StreamInput::readString);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeCollection(tables);
+            out.writeStringCollection(concreteIndices);
+            out.writeStringCollection(concreteTemplates);
+        }
+
+        public List<RelationName> tables() {
+            return tables;
+        }
+
+        public List<String> concreteIndices() {
+            return concreteIndices;
+        }
+
+        public List<String> concreteTemplates() {
+            return concreteTemplates;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.replication.logical.repository.PublisherRestoreService;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardsIterator;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class ReleasePublisherResourcesAction extends ActionType<AcknowledgedResponse> {
+
+    public static final String NAME = "internal:crate:replication/logical/resources/release";
+    public static final ReleasePublisherResourcesAction INSTANCE = new ReleasePublisherResourcesAction();
+
+    public ReleasePublisherResourcesAction() {
+        super(NAME);
+    }
+
+    @Override
+    public Writeable.Reader<AcknowledgedResponse> getResponseReader() {
+        return AcknowledgedResponse::new;
+    }
+
+    @Singleton
+    public static class TransportAction extends TransportSingleShardAction<Request, AcknowledgedResponse> {
+
+        private static final Logger LOGGER = Loggers.getLogger(TransportAction.class);
+
+        private final PublisherRestoreService publisherRestoreService;
+
+        @Inject
+        public TransportAction(ThreadPool threadPool,
+                               ClusterService clusterService,
+                               TransportService transportService,
+                               PublisherRestoreService publisherRestoreService,
+                               IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(
+                NAME,
+                threadPool,
+                clusterService,
+                transportService,
+                indexNameExpressionResolver,
+                Request::new,
+                ThreadPool.Names.GET
+            );
+            this.publisherRestoreService = publisherRestoreService;
+            TransportActionProxy.registerProxyAction(
+                transportService,
+                NAME,
+                AcknowledgedResponse::new
+            );
+        }
+
+        @Override
+        protected AcknowledgedResponse shardOperation(Request request,
+                                                      ShardId shardId) throws IOException {
+            LOGGER.info("Releasing resources for {} with restore-id as {}", shardId, request.restoreUUID());
+            publisherRestoreService.removeRestoreContext(request.restoreUUID());
+            return new AcknowledgedResponse(true);
+        }
+
+        @Override
+        protected Writeable.Reader<AcknowledgedResponse> getResponseReader() {
+            return AcknowledgedResponse::new;
+        }
+
+        @Override
+        protected boolean resolveIndex(Request request) {
+            return true;
+        }
+
+        @Nullable
+        @Override
+        protected ShardsIterator shards(ClusterState state,
+                                        InternalRequest request) {
+            return state.routingTable().shardRoutingTable(request.request().publisherShardId()).primaryShardIt();
+        }
+    }
+
+    public static class Request extends RestoreShardRequest<Request> {
+
+        public Request(String restoreUUID,
+                       DiscoveryNode node,
+                       ShardId publisherShardId,
+                       String subscriberClusterName,
+                       ShardId subscriberShardId) {
+            super(restoreUUID, node, publisherShardId, subscriberClusterName, subscriberShardId);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
+import org.elasticsearch.action.support.replication.TransportWriteAction;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ReplayChangesAction extends ActionType<ReplicationResponse> {
+
+    public static final String NAME = "internal:crate:replication/logical/shard/changes/replay";
+
+    public static final ReplayChangesAction INSTANCE = new ReplayChangesAction();
+
+    public ReplayChangesAction() {
+        super(NAME);
+    }
+
+    @Singleton
+    public static class TransportAction
+        extends TransportWriteAction<Request, Request, ReplicationResponse> {
+
+        @Inject
+        public TransportAction(TransportService transportService,
+                               ClusterService clusterService,
+                               IndicesService indicesService,
+                               ThreadPool threadPool,
+                               ShardStateAction shardStateAction) {
+            super(NAME,
+                  transportService,
+                  clusterService,
+                  indicesService,
+                  threadPool,
+                  shardStateAction,
+                  Request::new,
+                  Request::new,
+                  ThreadPool.Names.WRITE,
+                  false);
+
+            TransportActionProxy.registerProxyAction(transportService, NAME, ReplicationResponse::new);
+        }
+
+        @Override
+        protected ReplicationResponse newResponseInstance(StreamInput in) throws IOException {
+            return new ReplicationResponse(in);
+        }
+
+        @Override
+        protected void shardOperationOnPrimary(Request request,
+                                               IndexShard primary,
+                                               ActionListener<PrimaryResult<Request, ReplicationResponse>> listener) {
+            ActionListener.completeWith(
+                listener,
+                () -> new WritePrimaryResult<>(
+                    request,
+                    new ReplicationResponse(),
+                    performOnPrimary(request, primary),
+                    null,
+                    primary
+                )
+            );
+        }
+
+        public Translog.Location performOnPrimary(Request request, IndexShard primary) throws Exception {
+            Translog.Location location = null;
+
+            for (var translogOp : request.changes()) {
+                final var op = withPrimaryTerm(translogOp, primary.getOperationPrimaryTerm());
+                if (primary.getMaxSeqNoOfUpdatesOrDeletes() < request.maxSeqNoOfUpdatesOrDeletes()) {
+                    primary.advanceMaxSeqNoOfUpdatesOrDeletes(request.maxSeqNoOfUpdatesOrDeletes());
+                }
+                var result = primary.applyTranslogOperation(op, Engine.Operation.Origin.PRIMARY);
+                if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
+                    throw new RuntimeException("Mapping update required");
+                }
+
+                location = syncOperationResultOrThrow(result, location);
+            }
+            return location;
+        }
+
+        @Override
+        protected WriteReplicaResult<Request> shardOperationOnReplica(Request request,
+                                                                      IndexShard replica) throws Exception {
+            Translog.Location location = performOnReplica(request, replica);
+            return new WriteReplicaResult<>(request, location, null, replica, logger);
+        }
+
+        private Translog.Location performOnReplica(Request request,
+                                                   IndexShard replica) throws Exception {
+            Translog.Location location = null;
+
+            for (var translogOp : request.changes()) {
+                final var op = withPrimaryTerm(translogOp, replica.getOperationPrimaryTerm());
+                var result = replica.applyTranslogOperation(op, Engine.Operation.Origin.REPLICA);
+                if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
+                    throw new TransportReplicationAction.RetryOnReplicaException(
+                        replica.shardId(),
+                        "Mappings are not available on the replica yet, triggered update: " + result.getRequiredMappingUpdate());
+                }
+
+                location = syncOperationResultOrThrow(result, location);
+            }
+            return location;
+
+        }
+
+        private static Translog.Operation withPrimaryTerm(Translog.Operation op, long operationPrimaryTerm) {
+            return switch (op.opType()) {
+                case CREATE, INDEX -> {
+                    var sourceOp = (Translog.Index) op;
+                    yield new Translog.Index(
+                        sourceOp.id(),
+                        sourceOp.seqNo(),
+                        operationPrimaryTerm,
+                        sourceOp.version(),
+                        BytesReference.toBytes(sourceOp.source()),
+                        sourceOp.routing(),
+                        Translog.UNSET_AUTO_GENERATED_TIMESTAMP
+                    );
+                }
+                case DELETE -> {
+                    var sourceOp = (Translog.Delete) op;
+                    yield new Translog.Delete(
+                        sourceOp.id(),
+                        sourceOp.uid(),
+                        sourceOp.seqNo(),
+                        operationPrimaryTerm,
+                        sourceOp.version()
+                    );
+                }
+                case NO_OP -> {
+                    var sourceOp = (Translog.NoOp) op;
+                    yield new Translog.NoOp(
+                        sourceOp.seqNo(),
+                        operationPrimaryTerm,
+                        sourceOp.reason()
+                    );
+                }
+            };
+        }
+    }
+
+    public static class Request extends ReplicationRequest<Request> {
+
+        private final List<Translog.Operation> changes;
+        private final long maxSeqNoOfUpdatesOrDeletes;
+
+        public Request(ShardId shardId,
+                       List<Translog.Operation> changes,
+                       long maxSeqNoOfUpdatesOrDeletes) {
+            super(shardId);
+            this.changes = changes;
+            this.maxSeqNoOfUpdatesOrDeletes = maxSeqNoOfUpdatesOrDeletes;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            changes = in.readList(Translog.Operation::readOperation);
+            maxSeqNoOfUpdatesOrDeletes = in.readLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeCollection(changes, Translog.Operation::writeOperation);
+            out.writeLong(maxSeqNoOfUpdatesOrDeletes);
+        }
+
+        public List<Translog.Operation> changes() {
+            return changes;
+        }
+
+        public long maxSeqNoOfUpdatesOrDeletes() {
+            return maxSeqNoOfUpdatesOrDeletes;
+        }
+
+        @Override
+        public String toString() {
+            return "ReplayChangesRequest{" +
+                   "changes=" + changes +
+                   ", maxSeqNoOfUpdatesOrDeletes=" + maxSeqNoOfUpdatesOrDeletes +
+                   ", shardId=" + shardId +
+                   '}';
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/RestoreShardRequest.java
+++ b/server/src/main/java/io/crate/replication/logical/action/RestoreShardRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.transport.RemoteClusterAwareRequest;
+
+import java.io.IOException;
+
+public class RestoreShardRequest<T extends SingleShardRequest<T>> extends SingleShardRequest<T>
+    implements RemoteClusterAwareRequest {
+
+    private final String restoreUUID;
+    private final DiscoveryNode node;
+    private final ShardId publisherShardId;
+    private final String subscriberClusterName;
+    private final ShardId subscriberShardId;
+
+    public RestoreShardRequest(String restoreUUID,
+                               DiscoveryNode node,
+                               ShardId publisherShardId,
+                               String subscriberClusterName,
+                               ShardId subscriberShardId) {
+        super(publisherShardId.getIndexName());
+        this.restoreUUID = restoreUUID;
+        this.node = node;
+        this.publisherShardId = publisherShardId;
+        this.subscriberClusterName = subscriberClusterName;
+        this.subscriberShardId = subscriberShardId;
+    }
+
+    public RestoreShardRequest(StreamInput in) throws IOException {
+        super(in);
+        this.restoreUUID = in.readString();
+        this.node = new DiscoveryNode(in);
+        this.publisherShardId = new ShardId(in);
+        this.subscriberClusterName = in.readString();
+        this.subscriberShardId = new ShardId(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(restoreUUID);
+        node.writeTo(out);
+        publisherShardId.writeTo(out);
+        out.writeString(subscriberClusterName);
+        subscriberShardId.writeTo(out);
+    }
+
+    @Override
+    public DiscoveryNode getPreferredTargetNode() {
+        return node;
+    }
+
+    public ShardId publisherShardId() {
+        return publisherShardId;
+    }
+
+    public String subscriberClusterName() {
+        return subscriberClusterName;
+    }
+
+    public ShardId subscriberShardId() {
+        return subscriberShardId;
+    }
+
+    public String restoreUUID() {
+        return restoreUUID;
+    }
+
+    @Override
+    public String toString() {
+        return "RestoreShardRequest{" +
+               "restoreUUID='" + restoreUUID + '\'' +
+               ", node=" + node +
+               ", publisherShardId=" + publisherShardId +
+               ", subscriberClusterName='" + subscriberClusterName + '\'' +
+               ", subscriberShardId=" + subscriberShardId +
+               ", index='" + index + '\'' +
+               '}';
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.exceptions.MissingShardOperationsException;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.ShardsIterator;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.MissingHistoryOperationsException;
+import org.elasticsearch.index.seqno.RetentionLease;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+
+public class ShardChangesAction extends ActionType<ShardChangesAction.Response> {
+
+    public static final String NAME = "internal:crate:replication/logical/shard/changes";
+    public static final ShardChangesAction INSTANCE = new ShardChangesAction();
+
+    public ShardChangesAction() {
+        super(NAME);
+    }
+
+    @Override
+    public Writeable.Reader<Response> getResponseReader() {
+        return Response::new;
+    }
+
+    @Singleton
+    public static class TransportAction extends TransportSingleShardAction<Request, Response> {
+
+        public static final TimeValue WAIT_FOR_NEW_OPS_TIMEOUT = TimeValue.timeValueMinutes(1);
+        private static final Logger LOGGER = Loggers.getLogger(TransportAction.class);
+
+        private final IndicesService indicesService;
+
+        @Inject
+        public TransportAction(ThreadPool threadPool,
+                               ClusterService clusterService,
+                               TransportService transportService,
+                               IndicesService indicesService,
+                               IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(NAME,
+                  threadPool,
+                  clusterService,
+                  transportService,
+                  indexNameExpressionResolver,
+                  Request::new,
+                  ThreadPool.Names.LOGICAL_REPLICATION);
+            this.indicesService = indicesService;
+            TransportActionProxy.registerProxyAction(transportService, NAME, Response::new);
+        }
+
+        @Override
+        protected Response shardOperation(Request request, ShardId shardId) throws IOException {
+            var indexService = indicesService.indexServiceSafe(shardId.getIndex());
+            var indexShard = indexService.getShard(shardId.id());
+            var seqNoStats = indexShard.seqNoStats();
+            // At this point globalCheckpoint is at least fromSeqNo
+            var toSeqNo = Math.min(seqNoStats.getGlobalCheckpoint(), request.toSeqNo());
+            var fromSeqNo = request.fromSeqNo();
+
+            List<Translog.Operation> ops = new ArrayList<>();
+
+            // TODO: read changes from translog, see org.opensearch.replication.seqno.RemoteClusterTranslogService
+
+            LOGGER.info("Fetching changes from lucene for {} - from:{}, to:{}",
+                        request.shardId(), request.fromSeqNo(), toSeqNo);
+            var source = "logical-replication";
+            try (Translog.Snapshot snapshot = indexShard.newChangesSnapshot(source, fromSeqNo, toSeqNo, true)) {
+                var op = snapshot.next();
+                while (op != null) {
+                    ops.add(op);
+                    op = snapshot.next();
+                }
+            } catch (MissingHistoryOperationsException e) {
+                final Collection<RetentionLease> retentionLeases = indexShard.getRetentionLeases().leases();
+                final String message = "Operations are no longer available for replicating. " +
+                                       "Existing retention leases [" + retentionLeases + "]; maybe increase the retention lease period setting " +
+                                       "[" + IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING.getKey() + "]?";
+                throw new MissingShardOperationsException(RelationName.fromIndexName(shardId.getIndexName()), message);
+            }
+
+            return new Response(
+                ops,
+                fromSeqNo,
+                indexShard.getMaxSeqNoOfUpdatesOrDeletes(),
+                seqNoStats.getGlobalCheckpoint(),
+                indexService.getMetadata().getVersion()
+            );
+        }
+
+        @Override
+        protected void asyncShardOperation(Request request,
+                                           ShardId shardId,
+                                           ActionListener<Response> listener) throws IOException {
+            var indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShard(shardId.id());
+            if (indexShard.getLastSyncedGlobalCheckpoint() < request.fromSeqNo()) {
+                // There are no new operations to sync. Do a long poll and wait for GlobalCheckpoint to advance. If
+                // the checkpoint doesn't advance by the timeout this throws an ESTimeoutException which the caller
+                // should catch and start a new poll.
+
+                indexShard.addGlobalCheckpointListener(
+                    request.fromSeqNo(),
+                    (globalCheckpoint, e) -> {
+                        if (globalCheckpoint != UNASSIGNED_SEQ_NO) {
+                            // At this point indexShard.lastKnownGlobalCheckpoint  has advanced but it may not yet have been synced
+                            // to the translog, which means we can't return those changes. Return to the caller to retry.
+                            // TODO: Figure out a better way to wait for the global checkpoint to be synced to the translog
+                            if (globalCheckpoint < request.fromSeqNo()) {
+                                assert globalCheckpoint >
+                                       indexShard.getLastSyncedGlobalCheckpoint() : "Checkpoint didn't advance at all";
+                                listener.onFailure(new ElasticsearchTimeoutException("global checkpoint not synced."));
+                                return;
+                            }
+                            try {
+                                super.asyncShardOperation(request, shardId, listener);
+                            } catch (IOException ioException) {
+                                listener.onFailure(ioException);
+                            }
+                        } else {
+                            assert e != null : "Exception expected if globalCheckout != " + UNASSIGNED_SEQ_NO;
+                            if (e instanceof TimeoutException) {
+                                LOGGER.trace("Waiting for advanced globalCheckpoint timed out", e);
+                            } else {
+                                LOGGER.error("Error occurred while waiting for advanced globalCheckpoint", e);
+                            }
+                            listener.onFailure(e);
+                        }
+                    },
+                    WAIT_FOR_NEW_OPS_TIMEOUT
+                );
+
+            } else {
+                super.asyncShardOperation(request, shardId, listener);
+            }
+        }
+
+        @Override
+        protected Writeable.Reader<Response> getResponseReader() {
+            return Response::new;
+        }
+
+        @Override
+        protected boolean resolveIndex(Request request) {
+            return true;
+        }
+
+        @Nullable
+        @Override
+        protected ShardsIterator shards(ClusterState state,
+                                        TransportSingleShardAction<Request, Response>.InternalRequest request) {
+            return state.routingTable().shardRoutingTable(
+                request.request().shardId().getIndexName(),
+                request.request().shardId().id()
+            ).activeInitializingShardsRandomIt();
+        }
+    }
+
+    public static class Request extends SingleShardRequest<Request> {
+
+        private final ShardId shardId;
+        private final long fromSeqNo;
+        private final long toSeqNo;
+
+        public Request(ShardId shardId, long fromSeqNo, long toSeqNo) {
+            super(shardId.getIndexName());
+            this.shardId = shardId;
+            this.fromSeqNo = fromSeqNo;
+            this.toSeqNo = toSeqNo;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.shardId = new ShardId(in);
+            this.fromSeqNo = in.readLong();
+            this.toSeqNo = in.readVLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            shardId.writeTo(out);
+            out.writeLong(fromSeqNo);
+            out.writeVLong(toSeqNo);
+        }
+
+        public ShardId shardId() {
+            return shardId;
+        }
+
+        public long fromSeqNo() {
+            return fromSeqNo;
+        }
+
+        public long toSeqNo() {
+            return toSeqNo;
+        }
+    }
+
+    public static class Response extends TransportResponse {
+
+        private final List<Translog.Operation> changes;
+        private final long fromSeqNo;
+        private final long maxSeqNoOfUpdatesOrDeletes;
+        private final long lastSyncedGlobalCheckpoint;
+        private final long version;
+
+        public Response(List<Translog.Operation> changes,
+                        long fromSeqNo,
+                        long maxSeqNoOfUpdatesOrDeletes,
+                        long lastSyncedGlobalCheckpoint,
+                        long version) {
+            this.changes = changes;
+            this.fromSeqNo = fromSeqNo;
+            this.maxSeqNoOfUpdatesOrDeletes = maxSeqNoOfUpdatesOrDeletes;
+            this.lastSyncedGlobalCheckpoint = lastSyncedGlobalCheckpoint;
+            this.version = version;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            changes = in.readList(Translog.Operation::readOperation);
+            fromSeqNo = in.readVLong();
+            maxSeqNoOfUpdatesOrDeletes = in.readLong();
+            lastSyncedGlobalCheckpoint = in.readLong();
+            version = in.readVLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeCollection(changes, Translog.Operation::writeOperation);
+            out.writeVLong(fromSeqNo);
+            out.writeLong(maxSeqNoOfUpdatesOrDeletes);
+            out.writeLong(lastSyncedGlobalCheckpoint);
+            out.writeVLong(version);
+        }
+
+        public List<Translog.Operation> changes() {
+            return changes;
+        }
+
+        public long fromSeqNo() {
+            return fromSeqNo;
+        }
+
+        public long maxSeqNoOfUpdatesOrDeletes() {
+            return maxSeqNoOfUpdatesOrDeletes;
+        }
+
+        public long lastSyncedGlobalCheckpoint() {
+            return lastSyncedGlobalCheckpoint;
+        }
+
+        public long version() {
+            return version;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublicationAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublicationAction.java
@@ -23,6 +23,7 @@ package io.crate.replication.logical.action;
 
 import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
 import io.crate.replication.logical.exceptions.PublicationAlreadyExistsException;
 import io.crate.replication.logical.metadata.Publication;
@@ -77,7 +78,8 @@ public class TransportCreatePublicationAction extends AbstractDDLTransportAction
 
                 // Ensure tables exists
                 for (var relation : request.tables()) {
-                    if (currentMetadata.hasIndex(relation.indexNameOrAlias()) == false) {
+                    if (currentMetadata.hasIndex(relation.indexNameOrAlias()) == false
+                        && currentMetadata.templates().containsKey(PartitionName.templateName(relation.schema(), relation.name())) == false) {
                         throw new RelationUnknown(relation);
                     }
                 }

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsException;
+import io.crate.replication.logical.metadata.Subscription;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+
+public class TransportCreateSubscriptionAction extends TransportMasterNodeAction<CreateSubscriptionRequest, AcknowledgedResponse> {
+
+    public static final String ACTION_NAME = "internal:crate:replication/logical/subscription/create";
+
+    private final String source;
+    private final LogicalReplicationService logicalReplicationService;
+
+    @Inject
+    public TransportCreateSubscriptionAction(TransportService transportService,
+                                             ClusterService clusterService,
+                                             LogicalReplicationService logicalReplicationService,
+                                             ThreadPool threadPool,
+                                             IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(ACTION_NAME,
+              transportService,
+              clusterService,
+              threadPool,
+              CreateSubscriptionRequest::new,
+              indexNameExpressionResolver);
+        this.logicalReplicationService = logicalReplicationService;
+        this.source = "create-subscription";
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected AcknowledgedResponse read(StreamInput in) throws IOException {
+        return new AcknowledgedResponse(in);
+    }
+
+    @Override
+    protected void masterOperation(CreateSubscriptionRequest request,
+                                   ClusterState state,
+                                   ActionListener<AcknowledgedResponse> listener) throws Exception {
+
+        Subscription subscription = new Subscription(
+            request.owner(),
+            request.connectionInfo(),
+            request.publications(),
+            request.settings()
+        );
+
+        logicalReplicationService.getPublicationState(
+            request.name(),
+            subscription,
+            ActionListener.wrap(
+                response ->
+                    logicalReplicationService.verifyTablesDoNotExist(
+                        request.name(),
+                        response,
+                        r -> submitClusterStateTask(request, subscription, listener),
+                        listener::onFailure
+                    ),
+                listener::onFailure
+            )
+        );
+    }
+
+    private void submitClusterStateTask(CreateSubscriptionRequest request,
+                                        Subscription subscription,
+                                        ActionListener<AcknowledgedResponse> listener) {
+        clusterService.submitStateUpdateTask(
+            source,
+            new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    Metadata currentMetadata = currentState.metadata();
+                    Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
+
+                    var oldMetadata = (SubscriptionsMetadata) mdBuilder.getCustom(SubscriptionsMetadata.TYPE);
+                    if (oldMetadata != null && oldMetadata.subscription().containsKey(request.name())) {
+                        throw new SubscriptionAlreadyExistsException(request.name());
+                    }
+
+                    var newMetadata = SubscriptionsMetadata.newInstance(oldMetadata);
+                    newMetadata.subscription().put(request.name(), subscription);
+                    assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
+                    mdBuilder.putCustom(SubscriptionsMetadata.TYPE, newMetadata);
+
+                    return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    listener.onFailure(e);
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    listener.onResponse(new AcknowledgedResponse(true));
+                }
+            }
+        );
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(CreateSubscriptionRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/engine/SubscriberEngine.java
+++ b/server/src/main/java/io/crate/replication/logical/engine/SubscriberEngine.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.engine;
+
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.InternalEngine;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+
+public class SubscriberEngine extends InternalEngine {
+
+    public SubscriberEngine(EngineConfig engineConfig) {
+        super(engineConfig);
+    }
+
+    @Override
+    protected long generateSeqNoForOperationOnPrimary(final Operation operation) {
+        assert operation.origin() == Operation.Origin.PRIMARY;
+        assert operation.seqNo() >= 0 : "replicated operation should have an assigned seq no. but was: " + operation.seqNo();
+        markSeqNoAsSeen(operation.seqNo());
+        return operation.seqNo();
+    }
+
+    @Override
+    protected boolean assertPrimaryIncomingSequenceNumber(Operation.Origin origin, long seqNo) {
+        assert seqNo != SequenceNumbers.UNASSIGNED_SEQ_NO :
+            "Expected valid sequence number for replicated op but was unassigned";
+        return true;
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/exceptions/MissingShardOperationsException.java
+++ b/server/src/main/java/io/crate/replication/logical/exceptions/MissingShardOperationsException.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.exceptions;
+
+import io.crate.exceptions.ResourceUnknownException;
+import io.crate.exceptions.TableScopeException;
+import io.crate.metadata.RelationName;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class MissingShardOperationsException extends ResourceUnknownException implements TableScopeException {
+
+    private final RelationName relationName;
+
+    public MissingShardOperationsException(RelationName relationName, String msg) {
+        super(msg);
+        this.relationName = relationName;
+    }
+
+    @Override
+    public Collection<RelationName> getTableIdents() {
+        return Collections.singletonList(relationName);
+    }
+
+}

--- a/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
@@ -38,7 +38,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
+
+import static org.elasticsearch.transport.RemoteConnectionStrategy.REMOTE_CONNECTION_MODE;
+import static org.elasticsearch.transport.SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS;
 
 public class ConnectionInfo implements Writeable {
 
@@ -54,10 +58,12 @@ public class ConnectionInfo implements Writeable {
         DataTypes.STRING
     );
 
-    private static final List<String> SUPPORTED_SETTINGS = List.of(
+    private static final Set<String> SUPPORTED_SETTINGS = Set.of(
         USERNAME.getKey(),
         PASSWORD.getKey(),
-        SSLMODE.getKey()
+        SSLMODE.getKey(),
+        REMOTE_CONNECTION_MODE.getKey(),
+        REMOTE_CLUSTER_SEEDS.getKey()
     );
 
     private static final String DEFAULT_PORT = "4300";
@@ -153,7 +159,7 @@ public class ConnectionInfo implements Writeable {
         this.settings = settings;
     }
 
-    ConnectionInfo(StreamInput in) throws IOException {
+    public ConnectionInfo(StreamInput in) throws IOException {
         hosts = Arrays.stream(in.readStringArray()).toList();
         settings = Settings.readSettingsFromStream(in);
     }

--- a/server/src/main/java/io/crate/replication/logical/metadata/PublicationsMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/PublicationsMetadata.java
@@ -64,7 +64,7 @@ public class PublicationsMetadata extends AbstractNamedDiffable<Metadata.Custom>
         }
     }
 
-    private PublicationsMetadata() {
+    public PublicationsMetadata() {
         this(new HashMap<>());
     }
 

--- a/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
@@ -63,7 +63,7 @@ public class SubscriptionsMetadata extends AbstractNamedDiffable<Metadata.Custom
         }
     }
 
-    private SubscriptionsMetadata() {
+    public SubscriptionsMetadata() {
         this(new HashMap<>());
     }
 

--- a/server/src/main/java/io/crate/replication/logical/package-info.java
+++ b/server/src/main/java/io/crate/replication/logical/package-info.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+/**
+ * <p>
+ *     The logical replication package contains all code related for replicating tables "logically" from a different
+ *     (remote) cluster. It follow closely the logical replication specification of PostgreSQL in such a way that only
+ *     tables exposed via publication's can be replicated by subscribing to a publication.
+ * </p>
+ *
+ * <p>
+ *     Internally, logical replication execution can be split into following main topics:
+ * </p>
+ * <ul>
+ *     <li>Connection management to the remote cluster, handled on a high level by
+ *     {@link io.crate.replication.logical.LogicalReplicationService}</li>
+ *     <li>Requesting current available tables of a publication
+ *     {@link io.crate.replication.logical.action.PublicationsStateAction}</li>
+ *     <li>Restore all tables exposed by the publication including the current data
+ *     {@link io.crate.replication.logical.repository}</li>
+ *     <li>Track data, mapping and setting changes on the remote cluster and apply them locally
+ *     {@link io.crate.replication.logical.ShardReplicationChangesTracker}</li>
+ * </ul>
+ */
+
+package io.crate.replication.logical;

--- a/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
@@ -24,12 +24,12 @@ package io.crate.replication.logical.plan;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
-import io.crate.replication.logical.action.CreatePublicationRequest;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.replication.logical.action.CreatePublicationRequest;
 import io.crate.replication.logical.analyze.AnalyzedCreatePublication;
 
 public class CreatePublicationPlan implements Plan {

--- a/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.plan;
+
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
+import io.crate.exceptions.InvalidArgumentException;
+import io.crate.execution.support.OneRowActionListener;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.replication.logical.action.CreateSubscriptionRequest;
+import io.crate.replication.logical.analyze.AnalyzedCreateSubscription;
+import io.crate.replication.logical.metadata.ConnectionInfo;
+import io.crate.types.DataTypes;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+import static io.crate.analyze.GenericPropertiesConverter.genericPropertiesToSettings;
+
+public class CreateSubscriptionPlan implements Plan {
+
+    private final AnalyzedCreateSubscription analyzedCreateSubscription;
+
+    public CreateSubscriptionPlan(AnalyzedCreateSubscription analyzedCreateSubscription) {
+        this.analyzedCreateSubscription = analyzedCreateSubscription;
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
+        Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext(),
+            x,
+            params,
+            subQueryResults
+        );
+
+        var url = validateAndConvertToString(eval.apply(analyzedCreateSubscription.connectionInfo()));
+        var connectionInfo = ConnectionInfo.fromURL(url);
+        var settings = genericPropertiesToSettings(analyzedCreateSubscription.properties().map(eval));
+
+        for (var setting : settings.names()) {
+            throw new InvalidArgumentException(
+                String.format(Locale.ENGLISH, "Setting '%s' is not support on CREATE SUBSCRIPTION", setting)
+            );
+        }
+
+        var request = new CreateSubscriptionRequest(
+            plannerContext.transactionContext().sessionContext().sessionUser().name(),
+            analyzedCreateSubscription.name(),
+            connectionInfo,
+            analyzedCreateSubscription.publications(),
+            settings
+        );
+
+        dependencies.createSubscriptionAction()
+            .execute(
+                request,
+                new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : 1L))
+            );
+    }
+
+    private static String validateAndConvertToString(Object uri) {
+        if (uri instanceof String str) {
+            return str;
+        }
+        throw new IllegalArgumentException("fileUri must be of type STRING. Got " + DataTypes.guessType(uri));
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -1,0 +1,500 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.repository;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.LogicalReplicationSettings;
+import io.crate.replication.logical.action.GetStoreMetadataAction;
+import io.crate.replication.logical.action.PublicationsStateAction;
+import io.crate.replication.logical.action.ReleasePublisherResourcesAction;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.IndexCommit;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.StepListener;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotShardFailure;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.ConnectTransportException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Derived from org.opensearch.replication.repository.RemoteClusterRepository
+ */
+public class LogicalReplicationRepository extends AbstractLifecycleComponent implements Repository {
+
+    private static final Logger LOGGER = LogManager.getLogger(LogicalReplicationRepository.class);
+
+    public static final Setting<ByteSizeValue> RECOVERY_CHUNK_SIZE =
+        Setting.byteSizeSetting("replication.logical.indices.recovery.chunk_size",
+                                new ByteSizeValue(1, ByteSizeUnit.MB),
+                                new ByteSizeValue(1, ByteSizeUnit.KB),
+                                new ByteSizeValue(1, ByteSizeUnit.GB),
+                                Setting.Property.Dynamic,
+                                Setting.Property.NodeScope
+        );
+
+
+
+    public static final String TYPE = "logical_replication";
+    public static final String LATEST = "_latest_";
+    public static final String REMOTE_REPOSITORY_PREFIX = "_logical_replication_";
+    private static final SnapshotId SNAPSHOT_ID = new SnapshotId(LATEST, LATEST);
+    public static final long REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC = 60000L;
+
+    private final LogicalReplicationService logicalReplicationService;
+    private final RepositoryMetadata metadata;
+    private final String subscriptionName;
+    private final ThreadPool threadPool;
+    private final Settings settings;
+    private final ClusterService clusterService;
+
+    public LogicalReplicationRepository(Settings settings,
+                                        ClusterService clusterService,
+                                        LogicalReplicationService logicalReplicationService,
+                                        RepositoryMetadata metadata,
+                                        ThreadPool threadPool) {
+        this.settings = settings;
+        this.clusterService = clusterService;
+        this.logicalReplicationService = logicalReplicationService;
+        this.metadata = metadata;
+        assert metadata.name().startsWith(REMOTE_REPOSITORY_PREFIX)
+            : "SubscriptionRepository metadata.name() must start with: " + REMOTE_REPOSITORY_PREFIX;
+        //noinspection ConstantConditions
+        this.subscriptionName = Strings.split(metadata.name(), REMOTE_REPOSITORY_PREFIX)[1];
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    protected void doStart() {
+
+    }
+
+    @Override
+    protected void doStop() {
+
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+
+    }
+
+    @Override
+    public RepositoryMetadata getMetadata() {
+        return metadata;
+    }
+
+    public void getSnapshotInfo(SnapshotId snapshotId, ActionListener<SnapshotInfo> listener) {
+        assert SNAPSHOT_ID.equals(snapshotId) : "SubscriptionRepository only supports " + SNAPSHOT_ID + " as the SnapshotId";
+        StepListener<PublicationsStateAction.Response> responseStepListener = new StepListener<>();
+        getPublicationsState(responseStepListener);
+        responseStepListener.whenComplete(stateResponse -> {
+            listener.onResponse(new SnapshotInfo(snapshotId,
+                                             stateResponse.concreteIndices(),
+                                             SnapshotState.SUCCESS,
+                                             Version.CURRENT));
+        }, listener::onFailure);
+    }
+
+    @Override
+    public void getSnapshotGlobalMetadata(SnapshotId snapshotId, ActionListener<Metadata> listener) {
+        StepListener<PublicationsStateAction.Response> responseStepListener = new StepListener<>();
+        getPublicationsState(responseStepListener);
+        responseStepListener.whenComplete(stateResponse -> {
+            var indices = stateResponse.concreteIndices().toArray(new String[0]);
+            StepListener<ClusterState> clusterStateStepListener = new StepListener<>();
+            getRemoteClusterState(clusterStateStepListener, indices);
+            clusterStateStepListener.whenComplete(
+                remoteClusterState -> listener.onResponse(remoteClusterState.metadata()),
+                listener::onFailure
+            );
+        }, listener::onFailure);
+    }
+
+    @Override
+    public void getSnapshotIndexMetadata(SnapshotId snapshotId,
+                                         Collection<IndexId> indexIds,
+                                         ActionListener<Collection<IndexMetadata>> listener) {
+        assert SNAPSHOT_ID.equals(snapshotId) : "SubscriptionRepository only supports " + SNAPSHOT_ID + " as the SnapshotId";
+        var remoteIndices = indexIds.stream().map(IndexId::getName).toArray(String[]::new);
+        StepListener<ClusterState> stepListener = new StepListener<>();
+        getRemoteClusterState(stepListener, remoteIndices);
+        stepListener.whenComplete(remoteClusterState -> {
+            var result = new ArrayList<IndexMetadata>();
+            for (var i : remoteClusterState.metadata().indices()) {
+                var indexName = i.key;
+                var indexMetadata = i.value;
+                // Add replication specific settings, this setting will trigger a custom engine, see {@link SQLPlugin#getEngineFactory}
+                var builder = Settings.builder().put(indexMetadata.getSettings());
+                builder.put(LogicalReplicationSettings.REPLICATION_SUBSCRIBED_INDEX.getKey(), indexName);
+
+                var indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder);
+                indexMetadata.getAliases().valuesIt().forEachRemaining(a -> indexMdBuilder.putAlias(a.get()));
+                result.add(indexMdBuilder.build());
+            }
+            listener.onResponse(result);
+        }, listener::onFailure);
+    }
+
+    public void getSnapshotIndexMetadata(SnapshotId snapshotId, IndexId index, ActionListener<IndexMetadata> listener) throws IOException {
+        assert SNAPSHOT_ID.equals(snapshotId) : "SubscriptionRepository only supports " + SNAPSHOT_ID + " as the SnapshotId";
+        StepListener<ClusterState> stepListener = new StepListener<>();
+        getRemoteClusterState(stepListener, index.getName());
+        stepListener.whenComplete(remoteClusterState -> {
+            var indexMetadata = remoteClusterState.metadata().index(index.getName());
+            // Add replication specific settings, this setting will trigger a custom engine, see {@link SQLPlugin#getEngineFactory}
+            var builder = Settings.builder().put(indexMetadata.getSettings());
+            builder.put(LogicalReplicationSettings.REPLICATION_SUBSCRIBED_INDEX.getKey(), index.getName());
+
+            var indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder);
+            indexMetadata.getAliases().valuesIt().forEachRemaining(a -> indexMdBuilder.putAlias(a.get()));
+            listener.onResponse(indexMdBuilder.build());
+        }, listener::onFailure);
+    }
+
+    @Override
+    public void getRepositoryData(ActionListener<RepositoryData> listener) {
+        StepListener<PublicationsStateAction.Response> responseStepListener = new StepListener<>();
+        getPublicationsState(responseStepListener);
+        responseStepListener.whenComplete(stateResponse -> {
+            StepListener<ClusterState> clusterStateStepListener = new StepListener<>();
+            getRemoteClusterState(clusterStateStepListener, stateResponse.concreteIndices().toArray(new String[0]));
+            clusterStateStepListener.whenComplete(remoteClusterState -> {
+                var remoteMetadata = remoteClusterState.metadata();
+                var shardGenerations = ShardGenerations.builder();
+
+                var it = remoteMetadata.getIndices().valuesIt();
+                while (it.hasNext()) {
+                    var indexMetadata = it.next();
+                    var indexId = new IndexId(indexMetadata.getIndex().getName(), indexMetadata.getIndexUUID());
+                    for (int i = 0; i < indexMetadata.getNumberOfShards(); i++) {
+                        shardGenerations.put(indexId, i, "dummy");
+                    }
+                }
+                var repositoryData = RepositoryData.EMPTY
+                    .addSnapshot(SNAPSHOT_ID, SnapshotState.SUCCESS, Version.CURRENT, shardGenerations.build());
+                listener.onResponse(repositoryData);
+            }, listener::onFailure);
+        }, listener::onFailure);
+    }
+
+    @Override
+    public void finalizeSnapshot(SnapshotId snapshotId,
+                                 ShardGenerations shardGenerations,
+                                 long startTime,
+                                 String failure,
+                                 int totalShards,
+                                 List<SnapshotShardFailure> shardFailures,
+                                 long repositoryStateId,
+                                 boolean includeGlobalState,
+                                 Metadata clusterMetadata,
+                                 boolean writeShardGens,
+                                 ActionListener<SnapshotInfo> listener) {
+        throw new UnsupportedOperationException("Operation not permitted");
+    }
+
+    @Override
+    public void deleteSnapshot(SnapshotId snapshotId,
+                               long repositoryStateId,
+                               boolean writeShardGens, ActionListener<Void> listener) {
+        throw new UnsupportedOperationException("Operation not permitted");
+    }
+
+    @Override
+    public String startVerification() {
+        throw new UnsupportedOperationException("Operation not permitted");
+    }
+
+    @Override
+    public void endVerification(String verificationToken) {
+        throw new UnsupportedOperationException("Operation not permitted");
+    }
+
+    @Override
+    public void verify(String verificationToken, DiscoveryNode localNode) {
+        throw new UnsupportedOperationException("Operation not permitted");
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public void snapshotShard(Store store,
+                              MapperService mapperService,
+                              SnapshotId snapshotId,
+                              IndexId indexId,
+                              IndexCommit snapshotIndexCommit,
+                              IndexShardSnapshotStatus snapshotStatus,
+                              boolean writeShardGens, ActionListener<String> listener) {
+        throw new UnsupportedOperationException("Operation not permitted");
+    }
+
+    @Override
+    public void updateState(ClusterState state) {
+        throw new UnsupportedOperationException("Operation not permitted");
+    }
+
+
+    @Override
+    public void restoreShard(Store store,
+                             SnapshotId snapshotId,
+                             IndexId indexId,
+                             ShardId snapshotShardId,
+                             RecoveryState recoveryState,
+                             ActionListener<Void> listener) {
+        // TODO: implement RETRY logic
+        store.incRef();
+        restoreShardUsingMultiChunkTransfer(store, indexId, snapshotShardId, recoveryState, listener);
+        // We will do decRef and releaseResources ultimately, not while during our retries/restarts of
+        // restoreShard .
+
+    }
+
+    private void restoreShardUsingMultiChunkTransfer(Store store,
+                                                     IndexId indexId,
+                                                     ShardId snapshotShardId,
+                                                     RecoveryState recoveryState,
+                                                     ActionListener<Void> listener) {
+        var subscriberShardId = store.shardId();
+        // 1. Get all the files info from the publisher cluster for this shardId
+        StepListener<ClusterState> clusterStateStepListener = new StepListener<>();
+        getRemoteClusterState(true, true, clusterStateStepListener, indexId.getName());
+        clusterStateStepListener.whenComplete(publisherClusterState -> {
+            var publisherShardRouting = publisherClusterState.routingTable()
+                .shardRoutingTable(
+                    snapshotShardId.getIndexName(),
+                    snapshotShardId.getId()
+                )
+                .primaryShard();
+            var publisherShardNode = publisherClusterState.nodes().get(publisherShardRouting.currentNodeId());
+            // Get the index UUID of the publisher cluster for the metadata request
+            var publisherShardId = new ShardId(
+                snapshotShardId.getIndexName(),
+                publisherClusterState.metadata().index(indexId.getName()).getIndexUUID(),
+                snapshotShardId.getId()
+            );
+            var restoreUUID = UUIDs.randomBase64UUID();
+            var getStoreMetadataRequest = new GetStoreMetadataAction.Request(
+                restoreUUID,
+                publisherShardNode,
+                publisherShardId,
+                clusterService.getClusterName().value(),
+                subscriberShardId
+            );
+
+            var remoteClient = getRemoteClusterClient();
+
+            // Gets the remote store metadata
+            StepListener<GetStoreMetadataAction.Response> responseStepListener = new StepListener<>();
+            remoteClient.execute(GetStoreMetadataAction.INSTANCE, getStoreMetadataRequest, responseStepListener);
+            responseStepListener.whenComplete(metadataResponse -> {
+                var metadataSnapshot = metadataResponse.metadataSnapshot();
+
+                // 2. Request for individual files from publisher cluster for this shardId
+                // make sure the store is not released until we are done.
+                var fileMetadata = new ArrayList<>(metadataSnapshot.asMap().values());
+                var multiChunkTransfer = new RemoteClusterMultiChunkTransfer(
+                    LOGGER,
+                    clusterService.getClusterName().value(),
+                    store,
+                    RecoverySettings.INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING.get(settings),
+                    restoreUUID,
+                    //metadata,
+                    publisherShardNode,
+                    publisherShardId,
+                    fileMetadata,
+                    remoteClient,
+                    threadPool,
+                    recoveryState,
+                    RECOVERY_CHUNK_SIZE.get(settings),
+                    new ActionListener<>() {
+                        @Override
+                        public void onResponse(Void unused) {
+                            LOGGER.info("Restore successful for {}", store.shardId());
+                            store.decRef();
+                            releasePublisherResources(restoreUUID,
+                                                      publisherShardNode,
+                                                      publisherShardId,
+                                                      subscriberShardId);
+                            listener.onResponse(null);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            LOGGER.error("Restore of " + store.shardId() + " failed due to ", e);
+                            if (e instanceof ConnectTransportException) {
+                                // TODO: retry
+                                LOGGER.info("TODO: Retry restore shard for ${store.shardId()}");
+                            } else {
+                                LOGGER.error("Not retrying restore shard for {}", store.shardId());
+                                store.decRef();
+                                releasePublisherResources(restoreUUID,
+                                                          publisherShardNode,
+                                                          publisherShardId,
+                                                          subscriberShardId);
+                                listener.onFailure(e);
+                            }
+
+                        }
+                    }
+                );
+                if (fileMetadata.isEmpty()) {
+                    LOGGER.info("Initializing with empty store for shard: {}", snapshotShardId.getId());
+                    try {
+                        store.createEmpty(store.indexSettings().getIndexVersionCreated().luceneVersion);
+                        listener.onResponse(null);
+                    } catch (IOException e) {
+                        listener.onFailure(new UncheckedIOException(e));
+                    } finally {
+                        store.decRef();
+                        releasePublisherResources(restoreUUID, publisherShardNode, publisherShardId, subscriberShardId);
+                    }
+                } else {
+                    multiChunkTransfer.start();
+                }
+            }, listener::onFailure);
+        }, listener::onFailure);
+    }
+
+    private Client getRemoteClusterClient() {
+        return logicalReplicationService.getRemoteClusterClient(threadPool, subscriptionName);
+    }
+
+    private void getRemoteClusterState(ActionListener<ClusterState> listener, String... remoteIndices) {
+        getRemoteClusterState(false, false, listener, remoteIndices);
+    }
+
+    private void getRemoteClusterState(boolean includeNodes, boolean includeRouting, ActionListener<ClusterState> listener, String... remoteIndices) {
+        var clusterStateRequest = getRemoteClusterClient().admin().cluster().prepareState()
+            .clear()
+            .setIndices(remoteIndices)
+            .setMetadata(true)
+            .setNodes(includeNodes)
+            .setRoutingTable(includeRouting)
+            .setIndicesOptions(IndicesOptions.strictSingleIndexNoExpandForbidClosed())
+            .setWaitForTimeOut(new TimeValue(REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC))
+            .request();
+        getRemoteClusterClient().admin().cluster().execute(
+            ClusterStateAction.INSTANCE, clusterStateRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(ClusterStateResponse clusterStateResponse) {
+                    ClusterState remoteState = clusterStateResponse.getState();
+                    LOGGER.trace("Successfully fetched the cluster state from remote repository {}", remoteState);
+                    listener.onResponse(clusterStateResponse.getState());
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+    }
+
+    private PublicationsStateAction.Response getPublicationsState() {
+        return getRemoteClusterClient().execute(
+            PublicationsStateAction.INSTANCE,
+            new PublicationsStateAction.Request(logicalReplicationService.subscriptions().get(subscriptionName).publications())
+        ).actionGet(REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC);
+    }
+
+    private void getPublicationsState(ActionListener<PublicationsStateAction.Response> listener) {
+        getRemoteClusterClient().execute(
+            PublicationsStateAction.INSTANCE,
+            new PublicationsStateAction.Request(logicalReplicationService.subscriptions().get(subscriptionName).publications()),
+            listener
+        );
+    }
+
+    private void releasePublisherResources(String restoreUUID,
+                                           DiscoveryNode publisherShardNode,
+                                           ShardId publisherShardId,
+                                           ShardId subcriberShardId) {
+        var releaseResourcesReq = new ReleasePublisherResourcesAction.Request(
+            restoreUUID,
+            publisherShardNode,
+            publisherShardId,
+            clusterService.getClusterName().value(),
+            subcriberShardId
+        );
+        getRemoteClusterClient().execute(
+            ReleasePublisherResourcesAction.INSTANCE,
+            releaseResourcesReq,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                    if (acknowledgedResponse.isAcknowledged()) {
+                        LOGGER.info("Successfully released resources at the publisher cluster for {} at {}",
+                                    publisherShardId,
+                                    publisherShardNode
+                        );
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    LOGGER.error("Releasing publisher resource failed due to ", e);
+                }
+            }
+        );
+    }
+
+}

--- a/server/src/main/java/io/crate/replication/logical/repository/PublisherRestoreService.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/PublisherRestoreService.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.repository;
+
+import io.crate.common.io.IOUtils;
+import io.crate.replication.logical.action.RestoreShardRequest;
+import io.crate.replication.logical.seqno.RetentionLeaseHelper;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.seqno.RetentionLeaseActions;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.indices.IndicesService;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/*
+ * Restore source service tracks all the ongoing restore operations
+ * relying on the leader shards. Once the restore is completed the
+ * relevant resources are released. Also, listens on the index events
+ * to update the resources
+ *
+ * Derived from org.opensearch.replication.repository.RemoteClusterRestoreLeaderService
+ */
+public class PublisherRestoreService extends AbstractLifecycleComponent {
+
+    private final IndicesService indicesService;
+    private final NodeClient nodeClient;
+    private final Map<String, RestoreContext> onGoingRestores = ConcurrentCollections.newConcurrentMap();
+    private final Set<Closeable> closableResources = ConcurrentCollections.newConcurrentSet();
+
+    @Inject
+    public PublisherRestoreService(IndicesService indicesService, NodeClient nodeClient) {
+        this.indicesService = indicesService;
+        this.nodeClient = nodeClient;
+    }
+
+    @Override
+    protected void doStart() {
+
+    }
+
+    @Override
+    protected void doStop() {
+
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        IOUtils.close(closableResources);
+    }
+
+    public RestoreContext createRestoreContext(String restoreUUID,
+                                               RestoreShardRequest request) {
+        return onGoingRestores.putIfAbsent(restoreUUID, constructRestoreContext(restoreUUID, request));
+    }
+
+    private RestoreContext getRestoreContextSafe(String restoreUUID) {
+        var restoreContext = onGoingRestores.get(restoreUUID);
+        if (restoreContext == null) {
+            throw new IllegalStateException("missing restoreContext");
+        }
+        return restoreContext;
+    }
+
+    public InputStreamIndexInput openInputStream(String restoreUUID,
+                                                 RestoreShardRequest request,
+                                                 String fileName,
+                                                 long length) {
+        var leaderIndexShard = indicesService.getShardOrNull(request.publisherShardId());
+        if (leaderIndexShard == null) {
+            throw new UnsupportedOperationException(
+                String.format(Locale.ENGLISH, "Shard [%s] missing", request.publisherShardId()));
+        }
+        var restoreContext = getRestoreContextSafe(restoreUUID);
+        var indexInput = restoreContext.openInput(fileName);
+
+        return new InputStreamIndexInput(indexInput, length) {
+            @Override
+            public void close() throws IOException {
+                super.close();
+                IOUtils.close(indexInput);
+            }
+        };
+    }
+
+    public RestoreContext constructRestoreContext(String restoreUUID,
+                                                  RestoreShardRequest request) {
+        var leaderIndexShard = indicesService.getShardOrNull(request.publisherShardId());
+        if (leaderIndexShard == null) {
+            throw new UnsupportedOperationException(
+                String.format(Locale.ENGLISH, "Shard [%s] missing", request.publisherShardId()));
+        }
+        /**
+         * ODFE Replication supported for >= CrateDB 4.5. History of operations directly from
+         * lucene index. With the retention lock set - safe commit should have all the history
+         * upto the current retention leases.
+         */
+        var retentionLock = leaderIndexShard.acquireHistoryRetentionLock(Engine.HistorySource.INDEX);
+        closableResources.add(retentionLock);
+
+        /**
+         * Construct restore via safe index commit
+         * at the leader cluster. All the references from this commit
+         * should be available until it is closed.
+         */
+        var indexCommitRef = leaderIndexShard.acquireSafeIndexCommit();
+
+        var store = leaderIndexShard.store();
+        var metadataSnapshot = Store.MetadataSnapshot.EMPTY;
+
+        store.incRef();
+        try {
+            metadataSnapshot = store.getMetadata(indexCommitRef.getIndexCommit());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            store.decRef();
+        }
+
+        // Identifies the seq no to start the replication operations from
+        var fromSeqNo = RetentionLeaseActions.RETAIN_ALL;
+
+        // Passing nodeclient of the leader to acquire the retention lease on leader shard
+        var retentionLeaseHelper = new RetentionLeaseHelper(request.subscriberClusterName(), nodeClient);
+        // Adds the retention lease for fromSeqNo for the next stage of the replication.
+        retentionLeaseHelper.addRetentionLease(
+            request.publisherShardId(),
+            fromSeqNo,
+            request.subscriberShardId(),
+            LogicalReplicationRepository.REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC
+        );
+
+        /**
+         * At this point, it should be safe to release retention lock as the retention lease
+         * is acquired from the local checkpoint and the rest of the follower replay actions
+         * can be performed using this retention lease.
+         */
+        try {
+            retentionLock.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        var restoreContext = new RestoreContext(indexCommitRef, metadataSnapshot);
+        onGoingRestores.put(restoreUUID, restoreContext);
+
+        closableResources.add(restoreContext);
+        return restoreContext;
+    }
+
+    public void removeRestoreContext(String restoreUUID) {
+        var restoreContext = onGoingRestores.remove(restoreUUID);
+        if (restoreContext != null) {
+            restoreContext.close();
+        }
+    }
+
+
+    public static class RestoreContext implements Closeable {
+
+        private static final int INITIAL_FILE_CACHE_CAPACITY = 20;
+
+        private final Engine.IndexCommitRef indexCommitRef;
+        private final Store.MetadataSnapshot metadataSnapshot;
+        private final HashMap<String, IndexInput> currentFiles = new HashMap<>(INITIAL_FILE_CACHE_CAPACITY);
+
+        public RestoreContext(Engine.IndexCommitRef indexCommitRef,
+                              Store.MetadataSnapshot metadataSnapshot) {
+            this.indexCommitRef = indexCommitRef;
+            this.metadataSnapshot = metadataSnapshot;
+        }
+
+        public IndexInput openInput(String fileName) {
+            var currentIndexInput = currentFiles.getOrDefault(fileName, null);
+            if (currentIndexInput != null) {
+                return currentIndexInput.clone();
+            }
+
+            try {
+                currentIndexInput = indexCommitRef.getIndexCommit().getDirectory().openInput(fileName,
+                                                                                             IOContext.READONCE);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            currentFiles.put(fileName, currentIndexInput);
+            return currentIndexInput;
+        }
+
+        @Override
+        public void close() {
+            IOUtils.closeWhileHandlingException(currentFiles.values());
+            IOUtils.closeWhileHandlingException(indexCommitRef);
+        }
+
+        public Store.MetadataSnapshot metadataSnapshot() {
+            return metadataSnapshot;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/repository/RemoteClusterMultiChunkTransfer.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/RemoteClusterMultiChunkTransfer.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.repository;
+
+import io.crate.replication.logical.action.GetFileChunkAction;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.index.store.StoreFileMetadata;
+import org.elasticsearch.indices.recovery.MultiChunkTransfer;
+import org.elasticsearch.indices.recovery.MultiFileWriter;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+
+public class RemoteClusterMultiChunkTransfer extends MultiChunkTransfer<StoreFileMetadata, RemoteClusterRepositoryFileChunk> {
+
+    private static final String RESTORE_SHARD_TEMP_FILE_PREFIX = "CLUSTER_REPO_TEMP_";
+    private static final Logger LOGGER = Loggers.getLogger(RemoteClusterMultiChunkTransfer.class);
+
+    private final DiscoveryNode remoteNode;
+    private final String restoreUUID;
+    private final ShardId remoteShardId;
+    private final String localClusterName;
+    private final RecoveryState recoveryState;
+    private final Client client;
+    private final ThreadPool threadPool;
+    private final ByteSizeValue chunkSize;
+    private final String tempFilePrefix;
+    private final MultiFileWriter multiFileWriter;
+    private final Object lock = new Object();
+    private long offset = 0L;
+
+    public RemoteClusterMultiChunkTransfer(Logger logger,
+                                           String localClusterName,
+                                           Store localStore,
+                                           int maxConcurrentChunks,
+                                           String restoreUUID,
+                                           DiscoveryNode remoteNode,
+                                           ShardId remoteShardId,
+                                           List<StoreFileMetadata> remoteFiles,
+                                           Client client,
+                                           ThreadPool threadPool,
+                                           RecoveryState recoveryState,
+                                           ByteSizeValue chunkSize,
+                                           ActionListener<Void> listener) {
+        super(logger, listener, maxConcurrentChunks, remoteFiles);
+        this.localClusterName = localClusterName;
+        this.restoreUUID = restoreUUID;
+        this.remoteNode = remoteNode;
+        this.remoteShardId = remoteShardId;
+        this.recoveryState = recoveryState;
+        this.client = client;
+        this.threadPool = threadPool;
+        this.chunkSize = chunkSize;
+        this.tempFilePrefix = RESTORE_SHARD_TEMP_FILE_PREFIX + restoreUUID + ".";
+        this.multiFileWriter = new MultiFileWriter(localStore, recoveryState.getIndex(), tempFilePrefix, logger, () -> {});
+
+        // Add all the available files to show the recovery status
+        for (var fileMetadata : remoteFiles) {
+            recoveryState.getIndex().addFileDetail(fileMetadata.name(), fileMetadata.length(), false);
+        }
+    }
+
+    @Override
+    protected RemoteClusterRepositoryFileChunk nextChunkRequest(StoreFileMetadata resource) throws IOException {
+        var chunkReq = new RemoteClusterRepositoryFileChunk(resource, offset, chunkSize.bytesAsInt());
+        offset += chunkSize.bytesAsInt();
+        return chunkReq;
+    }
+
+    @Override
+    protected void executeChunkRequest(RemoteClusterRepositoryFileChunk request,
+                                       ActionListener<Void> listener) {
+        var getFileChunkRequest = new GetFileChunkAction.Request(
+            restoreUUID,
+            remoteNode,
+            remoteShardId,
+            localClusterName,
+            recoveryState.getShardId(),
+            request.storeFileMetadata(),
+            request.offset(),
+            request.length()
+        );
+
+
+        client.execute(
+            GetFileChunkAction.INSTANCE,
+            getFileChunkRequest,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(GetFileChunkAction.Response response) {
+                    LOGGER.debug("Filename: {}, response_size: {}, response_offset: {}",
+                                 request.storeFileMetadata().name(),
+                                 response.data().length(),
+                                 response.offset()
+                    );
+                    try {
+                        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(
+                            () -> {
+                                synchronized (lock) {
+                                    try {
+                                        multiFileWriter.writeFileChunk(
+                                            response.storeFileMetadata(),
+                                            response.offset(),
+                                            response.data(),
+                                            request.lastChunk()
+                                        );
+                                        listener.onResponse(null);
+                                    } catch (IOException e) {
+                                        listener.onFailure(new UncheckedIOException(e));
+                                    }
+                                }
+                            }
+                        );
+                    } catch (EsRejectedExecutionException e) {
+                        onFailure(e);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    LOGGER.error("Failed to fetch file chunk for " + request.storeFileMetadata().name() +
+                                 " with offset " + request.offset() + ": ",
+                                 e
+                    );
+                    listener.onFailure(e);
+                }
+            }
+        );
+    }
+
+    @Override
+    protected void handleError(StoreFileMetadata resource, Exception e) throws Exception {
+        LOGGER.error("Error while transferring segments ", e);
+    }
+
+    @Override
+    protected void onNewResource(StoreFileMetadata resource) throws IOException {
+        offset = 0L;
+    }
+
+    @Override
+    public void close() throws IOException {
+        multiFileWriter.renameAllTempFiles();
+        multiFileWriter.close();
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/repository/RemoteClusterRepositoryFileChunk.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/RemoteClusterRepositoryFileChunk.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.repository;
+
+import org.elasticsearch.index.store.StoreFileMetadata;
+import org.elasticsearch.indices.recovery.MultiChunkTransfer;
+
+public class RemoteClusterRepositoryFileChunk implements MultiChunkTransfer.ChunkRequest {
+
+    private final StoreFileMetadata storeFileMetadata;
+    private final long offset;
+    private final int length;
+
+    public RemoteClusterRepositoryFileChunk(StoreFileMetadata storeFileMetadata, long offset, int length) {
+        this.storeFileMetadata = storeFileMetadata;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    @Override
+    public boolean lastChunk() {
+        return storeFileMetadata.length() <= offset + length;
+    }
+
+    public StoreFileMetadata storeFileMetadata() {
+        return storeFileMetadata;
+    }
+
+    public long offset() {
+        return offset;
+    }
+
+    public int length() {
+        return length;
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/seqno/RetentionLeaseHelper.java
+++ b/server/src/main/java/io/crate/replication/logical/seqno/RetentionLeaseHelper.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.seqno;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.seqno.RetentionLeaseActions;
+import org.elasticsearch.index.seqno.RetentionLeaseAlreadyExistsException;
+import org.elasticsearch.index.seqno.RetentionLeaseInvalidRetainingSeqNoException;
+import org.elasticsearch.index.seqno.RetentionLeaseNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+
+/*
+ * Derived from org.opensearch.replication.seqno.RemoteClusterRetentionLeaseHelper
+ */
+public class RetentionLeaseHelper {
+
+    private static final Logger LOGGER = Loggers.getLogger(RetentionLeaseHelper.class);
+
+    private static String retentionLeaseSource(String subscriberClusterName) {
+        return "replication:" + subscriberClusterName;
+    }
+
+    private static String retentionLeaseIdForShard(String subscriberClusterName, ShardId subscriberShardId) {
+        var retentionLeaseSource = retentionLeaseSource(subscriberClusterName);
+        return retentionLeaseSource + ":" + subscriberShardId;
+    }
+
+
+    private final String publisherClusterName;
+    private final Client client;
+    private final String retentionLeaseSource;
+
+    public RetentionLeaseHelper(String publisherClusterName, Client client) {
+        this.publisherClusterName = publisherClusterName;
+        this.client = client;
+        this.retentionLeaseSource = "logical_replication:" + publisherClusterName;
+    }
+
+
+    public void addRetentionLease(ShardId publisherShardId, long seqNo, ShardId subscriberShardId) {
+        var retentionLeaseId = retentionLeaseIdForShard(publisherClusterName, subscriberShardId);
+        var request = new RetentionLeaseActions.AddOrRenewRequest(publisherShardId, retentionLeaseId, seqNo, retentionLeaseSource);
+        try {
+            client.execute(RetentionLeaseActions.Add.INSTANCE, request);
+        } catch (RetentionLeaseAlreadyExistsException e) {
+            LOGGER.error(e.getMessage());
+            LOGGER.info("Renew retention lease as it already exists {} with {}", retentionLeaseId, seqNo);
+            // Only one retention lease should exists for the subscriber shard
+            // Ideally, this should have got cleaned-up
+            renewRetentionLease(publisherShardId, seqNo, subscriberShardId);
+        }
+    }
+
+    public boolean verifyRetentionLeaseExist(ShardId leaderShardId, ShardId followerShardId) {
+        var retentionLeaseId = retentionLeaseIdForShard(publisherClusterName, followerShardId);
+        // Currently there is no API to describe/list the retention leases .
+        // So we are verifying the existence of lease by trying to renew a lease by same name .
+        // If retention lease doesn't exist, this will throw an RetentionLeaseNotFoundException exception
+        // If it does it will try to RENEW that one with -1 seqno , which should  either
+        // throw RetentionLeaseInvalidRetainingSeqNoException if a retention lease exists with higher seq no.
+        // which will exist in all probability
+        // Or if a retention lease already exists with -1 seqno, it will renew that .
+        var request = new RetentionLeaseActions.AddOrRenewRequest(
+            leaderShardId, retentionLeaseId, RetentionLeaseActions.RETAIN_ALL, retentionLeaseSource);
+        try {
+            client.execute(RetentionLeaseActions.Renew.INSTANCE, request);
+        } catch (RetentionLeaseInvalidRetainingSeqNoException e) {
+            return true;
+        } catch (RetentionLeaseNotFoundException e) {
+            return false;
+        }
+        return true;
+    }
+
+    public void attemptRetentionLeaseRemoval(ShardId publisherShardId, ShardId subscriberShardId) {
+        var retentionLeaseId = retentionLeaseIdForShard(publisherClusterName, subscriberShardId);
+        var request = new RetentionLeaseActions.RemoveRequest(publisherShardId, retentionLeaseId);
+        try {
+            client.execute(RetentionLeaseActions.Remove.INSTANCE, request);
+            LOGGER.info("Removed retention lease with id - {}", retentionLeaseId);
+        } catch (RetentionLeaseNotFoundException e) {
+            // log error and bail
+            LOGGER.error(e.getMessage());
+        } catch (Exception e) {
+            // We are not bubbling up the exception as the stop action/ task cleanup should succeed
+            // even if we fail to remove the retention lease from leader cluster
+            LOGGER.error("Exception in removing retention lease", e);
+        }
+    }
+
+    /**
+     * Remove these once the callers are moved to above APIs
+     */
+    public void addRetentionLease(ShardId publisherShardId, long seqNo, ShardId subscriberShardId, long timeout) {
+        var retentionLeaseId = retentionLeaseIdForShard(publisherClusterName, subscriberShardId);
+        var request = new RetentionLeaseActions.AddOrRenewRequest(publisherShardId, retentionLeaseId, seqNo, retentionLeaseSource);
+        try {
+            client.execute(RetentionLeaseActions.Add.INSTANCE, request).actionGet(timeout);
+        } catch (RetentionLeaseAlreadyExistsException e) {
+            LOGGER.error(e.getMessage());
+            LOGGER.info("Renew retention lease as it already exists {} with {}", retentionLeaseId, seqNo);
+            // Only one retention lease should exists for the follower shard
+            // Ideally, this should have got cleaned-up
+            renewRetentionLease(publisherShardId, seqNo, subscriberShardId, timeout);
+        }
+    }
+
+    public void renewRetentionLease(ShardId publisherShardId, long seqNo, ShardId subscriberShardId) {
+        var retentionLeaseId = retentionLeaseIdForShard(publisherClusterName, subscriberShardId);
+        var request = new RetentionLeaseActions.AddOrRenewRequest(publisherShardId, retentionLeaseId, seqNo, retentionLeaseSource);
+        client.execute(RetentionLeaseActions.Renew.INSTANCE, request);
+
+    }
+
+    public void renewRetentionLease(ShardId publisherShardId, long seqNo, ShardId subscriberShardId, long timeout) {
+        var retentionLeaseId = retentionLeaseIdForShard(publisherClusterName, subscriberShardId);
+        var request = new RetentionLeaseActions.AddOrRenewRequest(publisherShardId, retentionLeaseId, seqNo, retentionLeaseSource);
+        client.execute(RetentionLeaseActions.Renew.INSTANCE, request).actionGet(timeout);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreClusterStateListener.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreClusterStateListener.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.snapshots.restore;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.snapshots.RestoreInfo;
+import org.elasticsearch.snapshots.RestoreService;
+
+import static org.elasticsearch.snapshots.RestoreService.restoreInProgress;
+
+public class RestoreClusterStateListener implements ClusterStateListener {
+
+    private static final Logger LOGGER = LogManager.getLogger(RestoreClusterStateListener.class);
+
+    private final ClusterService clusterService;
+    private final String uuid;
+    private final ActionListener<RestoreSnapshotResponse> listener;
+
+
+    private RestoreClusterStateListener(ClusterService clusterService, RestoreService.RestoreCompletionResponse response,
+                                        ActionListener<RestoreSnapshotResponse> listener) {
+        this.clusterService = clusterService;
+        this.uuid = response.getUuid();
+        this.listener = listener;
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent changedEvent) {
+        final RestoreInProgress.Entry prevEntry = restoreInProgress(changedEvent.previousState(), uuid);
+        final RestoreInProgress.Entry newEntry = restoreInProgress(changedEvent.state(), uuid);
+        if (prevEntry == null) {
+            // When there is a master failure after a restore has been started, this listener might not be registered
+            // on the current master and as such it might miss some intermediary cluster states due to batching.
+            // Clean up listener in that case and acknowledge completion of restore operation to client.
+            clusterService.removeListener(this);
+            listener.onResponse(new RestoreSnapshotResponse((RestoreInfo) null));
+        } else if (newEntry == null) {
+            clusterService.removeListener(this);
+            ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards = prevEntry.shards();
+            assert prevEntry.state().completed() : "expected completed snapshot state but was " + prevEntry.state();
+            assert RestoreService.completed(shards) : "expected all restore entries to be completed";
+            RestoreInfo ri = new RestoreInfo(prevEntry.snapshot().getSnapshotId().getName(),
+                                             prevEntry.indices(),
+                                             shards.size(),
+                                             shards.size() - RestoreService.failedShards(shards));
+            RestoreSnapshotResponse response = new RestoreSnapshotResponse(ri);
+            LOGGER.debug("restore of [{}] completed", prevEntry.snapshot().getSnapshotId());
+            listener.onResponse(response);
+        } else {
+            // restore not completed yet, wait for next cluster state update
+        }
+    }
+
+    /**
+     * Creates a cluster state listener and registers it with the cluster service. The listener passed as a
+     * parameter will be called when the restore is complete.
+     */
+    public static void createAndRegisterListener(ClusterService clusterService, RestoreService.RestoreCompletionResponse response,
+                                                 ActionListener<RestoreSnapshotResponse> listener) {
+        clusterService.addListener(new RestoreClusterStateListener(clusterService, response, listener));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
-import javax.annotation.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -30,6 +29,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.snapshots.RestoreInfo;
 import org.elasticsearch.transport.TransportResponse;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -47,6 +47,15 @@ public class RestoreSnapshotResponse extends TransportResponse implements ToXCon
 
     public RestoreSnapshotResponse(StreamInput in) throws IOException {
         restoreInfo = in.readOptionalWriteable(RestoreInfo::new);
+    }
+
+    /**
+     * Returns restore information if snapshot was completed before this method returned, null otherwise
+     *
+     * @return restore information or null
+     */
+    public RestoreInfo getRestoreInfo() {
+        return restoreInfo;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -21,28 +21,19 @@ package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.snapshots.RestoreInfo;
 import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.RestoreService.RestoreCompletionResponse;
-import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-
-import static org.elasticsearch.snapshots.RestoreService.restoreInProgress;
 
 /**
  * Transport action for restore snapshot operation
@@ -102,39 +93,7 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
             @Override
             public void onResponse(RestoreCompletionResponse restoreCompletionResponse) {
                 if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {
-                    final Snapshot snapshot = restoreCompletionResponse.getSnapshot();
-                    String uuid = restoreCompletionResponse.getUuid();
-
-                    ClusterStateListener clusterStateListener = new ClusterStateListener() {
-                        @Override
-                        public void clusterChanged(ClusterChangedEvent changedEvent) {
-                            final RestoreInProgress.Entry prevEntry = restoreInProgress(changedEvent.previousState(), uuid);
-                            final RestoreInProgress.Entry newEntry = restoreInProgress(changedEvent.state(), uuid);
-                            if (prevEntry == null) {
-                                // When there is a master failure after a restore has been started, this listener might not be registered
-                                // on the current master and as such it might miss some intermediary cluster states due to batching.
-                                // Clean up listener in that case and acknowledge completion of restore operation to client.
-                                clusterService.removeListener(this);
-                                listener.onResponse(new RestoreSnapshotResponse((RestoreInfo) null));
-                            } else if (newEntry == null) {
-                                clusterService.removeListener(this);
-                                ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards = prevEntry.shards();
-                                assert prevEntry.state().completed() : "expected completed snapshot state but was " + prevEntry.state();
-                                assert RestoreService.completed(shards) : "expected all restore entries to be completed";
-                                RestoreInfo ri = new RestoreInfo(prevEntry.snapshot().getSnapshotId().getName(),
-                                    prevEntry.indices(),
-                                    shards.size(),
-                                    shards.size() - RestoreService.failedShards(shards));
-                                RestoreSnapshotResponse response = new RestoreSnapshotResponse(ri);
-                                logger.debug("restore of [{}] completed", snapshot);
-                                listener.onResponse(response);
-                            } else {
-                                // restore not completed yet, wait for next cluster state update
-                            }
-                        }
-                    };
-
-                    clusterService.addListener(clusterStateListener);
+                    RestoreClusterStateListener.createAndRegisterListener(clusterService, restoreCompletionResponse, listener);
                 } else {
                     listener.onResponse(new RestoreSnapshotResponse(restoreCompletionResponse.getRestoreInfo()));
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.cluster.state;
 
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.Writeable;
 
 public class ClusterStateAction extends ActionType<ClusterStateResponse> {
 
@@ -28,5 +29,10 @@ public class ClusterStateAction extends ActionType<ClusterStateResponse> {
 
     private ClusterStateAction() {
         super(NAME);
+    }
+
+    @Override
+    public Writeable.Reader<ClusterStateResponse> getResponseReader() {
+        return ClusterStateResponse::new;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support.single.shard;
+
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.transport.TransportRequest;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public abstract class SingleShardRequest<Request extends SingleShardRequest<Request>> extends TransportRequest implements IndicesRequest {
+
+    public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.strictSingleIndexNoExpandForbidClosed();
+
+    /**
+     * The concrete index name
+     *
+     * Whether index property is optional depends on the concrete implementation. If index property is required the
+     * concrete implementation should use {@link #validateNonNullIndex()} to check if the index property has been set
+     */
+    @Nullable
+    protected String index;
+    ShardId internalShardId;
+
+    public SingleShardRequest() {
+    }
+
+    public SingleShardRequest(StreamInput in) throws IOException {
+        super(in);
+        if (in.readBoolean()) {
+            internalShardId = new ShardId(in);
+        }
+        index = in.readOptionalString();
+        // no need to pass threading over the network, they are always false when coming throw a thread pool
+    }
+
+    protected SingleShardRequest(String index) {
+        this.index = index;
+    }
+
+    protected void validateNonNullIndex() {
+        if (index == null) {
+            throw new IllegalArgumentException("index is missing");
+        }
+    }
+
+    /**
+     * @return The concrete index this request is targeted for or <code>null</code> if index is optional.
+     *         Whether index property is optional depends on the concrete implementation. If index property
+     *         is required the concrete implementation should use {@link #validateNonNullIndex()} to check
+     *         if the index property has been set
+     */
+    @Nullable
+    public String index() {
+        return index;
+    }
+
+    /**
+     * Sets the index.
+     */
+    @SuppressWarnings("unchecked")
+    public final Request index(String index) {
+        this.index = index;
+        return (Request) this;
+    }
+
+    @Override
+    public String[] indices() {
+        return new String[]{index};
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        return INDICES_OPTIONS;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalWriteable(internalShardId);
+        out.writeOptionalString(index);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support.single.shard;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.support.ChannelActionListener;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.support.TransportActions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardsIterator;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+import static org.elasticsearch.action.support.TransportActions.isShardNotAvailableException;
+
+/**
+ * A base class for operations that need to perform a read operation on a single shard copy. If the operation fails,
+ * the read operation can be performed on other shard copies. Concrete implementations can provide their own list
+ * of candidate shards to try the read operation on.
+ */
+public abstract class TransportSingleShardAction<Request extends SingleShardRequest<Request>, Response extends TransportResponse>
+    extends TransportAction<Request, Response> {
+
+    protected final ThreadPool threadPool;
+    protected final ClusterService clusterService;
+    protected final TransportService transportService;
+    protected final IndexNameExpressionResolver indexNameExpressionResolver;
+
+    private final String transportShardAction;
+    private final String executor;
+
+    protected final Logger logger = Loggers.getLogger(getClass());
+
+    protected TransportSingleShardAction(String actionName,
+                                         ThreadPool threadPool,
+                                         ClusterService clusterService,
+                                         TransportService transportService,
+                                         IndexNameExpressionResolver indexNameExpressionResolver,
+                                         Writeable.Reader<Request> request,
+                                         String executor) {
+        super(actionName);
+        this.threadPool = threadPool;
+        this.clusterService = clusterService;
+        this.transportService = transportService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+
+        this.transportShardAction = actionName + "[s]";
+        this.executor = executor;
+
+        if (!isSubAction()) {
+            transportService.registerRequestHandler(actionName, ThreadPool.Names.SAME, request, new TransportHandler());
+        }
+        transportService.registerRequestHandler(transportShardAction, ThreadPool.Names.SAME, request, new ShardTransportHandler());
+    }
+
+    /**
+     * Tells whether the action is a main one or a subaction. Used to decide whether we need to register
+     * the main transport handler. In fact if the action is a subaction, its execute method
+     * will be called locally to its parent action.
+     */
+    protected boolean isSubAction() {
+        return false;
+    }
+
+    @Override
+    protected void doExecute(Request request, ActionListener<Response> listener) {
+        new AsyncSingleAction(request, listener).start();
+    }
+
+    protected abstract Response shardOperation(Request request, ShardId shardId) throws IOException;
+
+    protected void asyncShardOperation(Request request, ShardId shardId, ActionListener<Response> listener) throws IOException {
+        threadPool.executor(getExecutor(request, shardId))
+            .execute(ActionRunnable.supply(listener, () -> shardOperation(request, shardId)));
+    }
+
+    protected abstract Writeable.Reader<Response> getResponseReader();
+
+    protected abstract boolean resolveIndex(Request request);
+
+    protected ClusterBlockException checkGlobalBlock(ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
+    }
+
+    protected ClusterBlockException checkRequestBlock(ClusterState state, InternalRequest request) {
+        return state.blocks().indexBlockedException(ClusterBlockLevel.READ, request.concreteIndex());
+    }
+
+    protected void resolveRequest(ClusterState state, InternalRequest request) {
+
+    }
+
+    /**
+     * Returns the candidate shards to execute the operation on or <code>null</code> the execute
+     * the operation locally (the node that received the request)
+     */
+    @Nullable
+    protected abstract ShardsIterator shards(ClusterState state, InternalRequest request);
+
+    class AsyncSingleAction {
+
+        private final ActionListener<Response> listener;
+        private final ShardsIterator shardIt;
+        private final InternalRequest internalRequest;
+        private final DiscoveryNodes nodes;
+        private volatile Exception lastFailure;
+
+        private AsyncSingleAction(Request request, ActionListener<Response> listener) {
+            this.listener = listener;
+
+            ClusterState clusterState = clusterService.state();
+            if (logger.isTraceEnabled()) {
+                logger.trace("executing [{}] based on cluster state version [{}]", request, clusterState.version());
+            }
+            nodes = clusterState.nodes();
+            ClusterBlockException blockException = checkGlobalBlock(clusterState);
+            if (blockException != null) {
+                throw blockException;
+            }
+
+            String concreteSingleIndex;
+            if (resolveIndex(request)) {
+                concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, request).getName();
+            } else {
+                concreteSingleIndex = request.index();
+            }
+            this.internalRequest = new InternalRequest(request, concreteSingleIndex);
+            resolveRequest(clusterState, internalRequest);
+
+            blockException = checkRequestBlock(clusterState, internalRequest);
+            if (blockException != null) {
+                throw blockException;
+            }
+
+            this.shardIt = shards(clusterState, internalRequest);
+        }
+
+        public void start() {
+            if (shardIt == null) {
+                // just execute it on the local node
+                final Writeable.Reader<Response> reader = getResponseReader();
+                transportService.sendRequest(
+                    clusterService.localNode(),
+                    transportShardAction,
+                    internalRequest.request(),
+                    new TransportResponseHandler<Response>() {
+                        @Override
+                        public Response read(StreamInput in) throws IOException {
+                            return reader.read(in);
+                        }
+
+                        @Override
+                        public String executor() {
+                            return ThreadPool.Names.SAME;
+                        }
+
+                        @Override
+                        public void handleResponse(final Response response) {
+                            listener.onResponse(response);
+                        }
+
+                        @Override
+                        public void handleException(TransportException exp) {
+                            listener.onFailure(exp);
+                        }
+                    }
+                );
+            } else {
+                perform(null);
+            }
+        }
+
+        private void onFailure(ShardRouting shardRouting, Exception e) {
+            if (e != null) {
+                logger.trace(() -> new ParameterizedMessage("{}: failed to execute [{}]", shardRouting,
+                                                            internalRequest.request()), e);
+            }
+            perform(e);
+        }
+
+        private void perform(@Nullable final Exception currentFailure) {
+            Exception lastFailure = this.lastFailure;
+            if (lastFailure == null || TransportActions.isReadOverrideException(currentFailure)) {
+                lastFailure = currentFailure;
+                this.lastFailure = currentFailure;
+            }
+            final ShardRouting shardRouting = shardIt.nextOrNull();
+            if (shardRouting == null) {
+                Exception failure = lastFailure;
+                if (failure == null || isShardNotAvailableException(failure)) {
+                    failure = new NoShardAvailableActionException(null,
+                                                                  LoggerMessageFormat.format(
+                                                                      "No shard available for [{}]",
+                                                                      internalRequest.request()), failure);
+                } else {
+                    logger.debug(() -> new ParameterizedMessage("{}: failed to execute [{}]", null,
+                                                                internalRequest.request()), failure);
+                }
+                listener.onFailure(failure);
+                return;
+            }
+            DiscoveryNode node = nodes.get(shardRouting.currentNodeId());
+            if (node == null) {
+                onFailure(shardRouting, new NoShardAvailableActionException(shardRouting.shardId()));
+            } else {
+                internalRequest.request().internalShardId = shardRouting.shardId();
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                        "sending request [{}] to shard [{}] on node [{}]",
+                        internalRequest.request(),
+                        internalRequest.request().internalShardId,
+                        node
+                    );
+                }
+                final Writeable.Reader<Response> reader = getResponseReader();
+                transportService.sendRequest(
+                    node,
+                    transportShardAction,
+                    internalRequest.request(),
+                    new TransportResponseHandler<Response>() {
+
+                        @Override
+                        public Response read(StreamInput in) throws IOException {
+                            return reader.read(in);
+                        }
+
+                        @Override
+                        public String executor() {
+                            return ThreadPool.Names.SAME;
+                        }
+
+                        @Override
+                        public void handleResponse(final Response response) {
+                            listener.onResponse(response);
+                        }
+
+                        @Override
+                        public void handleException(TransportException exp) {
+                            onFailure(shardRouting, exp);
+                        }
+                    }
+                );
+            }
+        }
+    }
+
+    private class TransportHandler implements TransportRequestHandler<Request> {
+
+        @Override
+        public void messageReceived(Request request, final TransportChannel channel) throws Exception {
+            // if we have a local operation, execute it on a thread since we don't spawn
+            execute(request, new ChannelActionListener<>(channel, actionName, request));
+        }
+    }
+
+    private class ShardTransportHandler implements TransportRequestHandler<Request> {
+
+        @Override
+        public void messageReceived(final Request request, final TransportChannel channel) throws Exception {
+            if (logger.isTraceEnabled()) {
+                logger.trace("executing [{}] on shard [{}]", request, request.internalShardId);
+            }
+            asyncShardOperation(request,
+                                request.internalShardId,
+                                new ChannelActionListener<>(channel, transportShardAction, request));
+        }
+    }
+
+    /**
+     * Internal request class that gets built on each node. Holds the original request plus additional info.
+     */
+    protected class InternalRequest {
+        final Request request;
+        final String concreteIndex;
+
+        InternalRequest(Request request, String concreteIndex) {
+            this.request = request;
+            this.concreteIndex = concreteIndex;
+        }
+
+        public Request request() {
+            return request;
+        }
+
+        public String concreteIndex() {
+            return concreteIndex;
+        }
+    }
+
+    protected String getExecutor(Request request, ShardId shardId) {
+        return executor;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -145,13 +145,13 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
     private void rangeCheck(Translog.Operation op) {
         if (op == null) {
             if (lastSeenSeqNo < toSeqNo) {
-                throw new IllegalStateException("Not all operations between from_seqno [" + fromSeqNo + "] " +
+                throw new MissingHistoryOperationsException("Not all operations between from_seqno [" + fromSeqNo + "] " +
                     "and to_seqno [" + toSeqNo + "] found; prematurely terminated last_seen_seqno [" + lastSeenSeqNo + "]");
             }
         } else {
             final long expectedSeqNo = lastSeenSeqNo + 1;
             if (op.seqNo() != expectedSeqNo) {
-                throw new IllegalStateException("Not all operations between from_seqno [" + fromSeqNo + "] " +
+                throw new MissingHistoryOperationsException("Not all operations between from_seqno [" + fromSeqNo + "] " +
                     "and to_seqno [" + toSeqNo + "] found; expected seqno [" + expectedSeqNo + "]; found [" + op + "]");
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/MissingHistoryOperationsException.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/MissingHistoryOperationsException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.engine;
+
+/**
+ * Exception indicating that not all requested operations from {@link LuceneChangesSnapshot}
+ * are available.
+ */
+public final class MissingHistoryOperationsException extends IllegalStateException {
+
+    MissingHistoryOperationsException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.seqno;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.single.shard.SingleShardRequest;
+import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.ShardsIterator;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * This class holds all actions related to retention leases. Note carefully that these actions are executed under a primary permit. Care is
+ * taken to thread the listener through the invocations so that for the sync APIs we do not notify the listener until these APIs have
+ * responded with success. Additionally, note the use of
+ * {@link TransportSingleShardAction#asyncShardOperation(SingleShardRequest, ShardId, ActionListener)} to handle the case when acquiring
+ * permits goes asynchronous because acquiring permits is blocked
+ */
+public class RetentionLeaseActions {
+
+    public static final long RETAIN_ALL = -1;
+
+    abstract static class TransportRetentionLeaseAction<T extends Request<T>> extends TransportSingleShardAction<T, Response> {
+
+        private final IndicesService indicesService;
+
+        @Inject
+        TransportRetentionLeaseAction(
+            final String name,
+            final ThreadPool threadPool,
+            final ClusterService clusterService,
+            final TransportService transportService,
+            final IndexNameExpressionResolver indexNameExpressionResolver,
+            final IndicesService indicesService,
+            final Writeable.Reader<T> requestSupplier) {
+            super(
+                name,
+                threadPool,
+                clusterService,
+                transportService,
+                indexNameExpressionResolver,
+                requestSupplier,
+                ThreadPool.Names.MANAGEMENT);
+            this.indicesService = Objects.requireNonNull(indicesService);
+        }
+
+        @Override
+        protected ShardsIterator shards(final ClusterState state, final InternalRequest request) {
+            return state
+                .routingTable()
+                .shardRoutingTable(request.concreteIndex(), request.request().getShardId().id())
+                .primaryShardIt();
+        }
+
+        @Override
+        protected void asyncShardOperation(T request, ShardId shardId, final ActionListener<Response> listener) {
+            final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
+            final IndexShard indexShard = indexService.getShard(shardId.id());
+            indexShard.acquirePrimaryOperationPermit(
+                ActionListener.delegateFailure(listener, (delegatedListener, releasable) -> {
+                    try (Releasable ignore = releasable) {
+                        doRetentionLeaseAction(indexShard, request, delegatedListener);
+                    }
+                }),
+                ThreadPool.Names.SAME,
+                request);
+        }
+
+        @Override
+        protected Response shardOperation(final T request, final ShardId shardId) {
+            throw new UnsupportedOperationException();
+        }
+
+        abstract void doRetentionLeaseAction(IndexShard indexShard, T request, ActionListener<Response> listener);
+
+        @Override
+        protected Writeable.Reader<Response> getResponseReader() {
+            return Response::new;
+        }
+
+        @Override
+        protected boolean resolveIndex(final T request) {
+            return false;
+        }
+
+    }
+
+    public static class Add extends ActionType<Response> {
+
+        public static final Add INSTANCE = new Add();
+        public static final String ACTION_NAME = "indices:admin/seq_no/add_retention_lease";
+
+        private Add() {
+            super(ACTION_NAME);
+        }
+
+        public static class TransportAction extends TransportRetentionLeaseAction<AddOrRenewRequest> {
+
+            @Inject
+            public TransportAction(
+                final ThreadPool threadPool,
+                final ClusterService clusterService,
+                final TransportService transportService,
+                final IndexNameExpressionResolver indexNameExpressionResolver,
+                final IndicesService indicesService) {
+                super(
+                    ACTION_NAME,
+                    threadPool,
+                    clusterService,
+                    transportService,
+                    indexNameExpressionResolver,
+                    indicesService,
+                    AddOrRenewRequest::new);
+            }
+
+            @Override
+            void doRetentionLeaseAction(final IndexShard indexShard,
+                                        final AddOrRenewRequest request,
+                                        final ActionListener<Response> listener) {
+                indexShard.addRetentionLease(
+                    request.getId(),
+                    request.getRetainingSequenceNumber(),
+                    request.getSource(),
+                    ActionListener.map(listener, r -> new Response()));
+            }
+
+            @Override
+            protected Writeable.Reader<Response> getResponseReader() {
+                return Response::new;
+            }
+
+        }
+    }
+
+    public static class Renew extends ActionType<Response> {
+
+        public static final Renew INSTANCE = new Renew();
+        public static final String ACTION_NAME = "indices:admin/seq_no/renew_retention_lease";
+
+        private Renew() {
+            super(ACTION_NAME);
+        }
+
+        public static class TransportAction extends TransportRetentionLeaseAction<AddOrRenewRequest> {
+
+            @Inject
+            public TransportAction(
+                final ThreadPool threadPool,
+                final ClusterService clusterService,
+                final TransportService transportService,
+                final IndexNameExpressionResolver indexNameExpressionResolver,
+                final IndicesService indicesService) {
+                super(
+                    ACTION_NAME,
+                    threadPool,
+                    clusterService,
+                    transportService,
+                    indexNameExpressionResolver,
+                    indicesService,
+                    AddOrRenewRequest::new);
+            }
+
+
+            @Override
+            void doRetentionLeaseAction(final IndexShard indexShard,
+                                        final AddOrRenewRequest request,
+                                        final ActionListener<Response> listener) {
+                indexShard.renewRetentionLease(request.getId(), request.getRetainingSequenceNumber(), request.getSource());
+                listener.onResponse(new Response());
+            }
+
+        }
+    }
+
+    public static class Remove extends ActionType<Response> {
+
+        public static final Remove INSTANCE = new Remove();
+        public static final String ACTION_NAME = "indices:admin/seq_no/remove_retention_lease";
+
+        private Remove() {
+            super(ACTION_NAME);
+        }
+
+        public static class TransportAction extends TransportRetentionLeaseAction<RemoveRequest> {
+
+            @Inject
+            public TransportAction(
+                final ThreadPool threadPool,
+                final ClusterService clusterService,
+                final TransportService transportService,
+                final IndexNameExpressionResolver indexNameExpressionResolver,
+                final IndicesService indicesService) {
+                super(
+                    ACTION_NAME,
+                    threadPool,
+                    clusterService,
+                    transportService,
+                    indexNameExpressionResolver,
+                    indicesService,
+                    RemoveRequest::new);
+            }
+
+
+            @Override
+            void doRetentionLeaseAction(final IndexShard indexShard, final RemoveRequest request, final ActionListener<Response> listener) {
+                indexShard.removeRetentionLease(
+                    request.getId(),
+                    ActionListener.map(listener, r -> new Response()));
+            }
+
+        }
+    }
+
+    private abstract static class Request<T extends SingleShardRequest<T>> extends SingleShardRequest<T> {
+
+        private final ShardId shardId;
+
+        public ShardId getShardId() {
+            return shardId;
+        }
+
+        private final String id;
+
+        public String getId() {
+            return id;
+        }
+
+        Request(StreamInput in) throws IOException {
+            super(in);
+            shardId = new ShardId(in);
+            id = in.readString();
+        }
+
+        Request(final ShardId shardId, final String id) {
+            super(Objects.requireNonNull(shardId).getIndexName());
+            this.shardId = shardId;
+            this.id = Objects.requireNonNull(id);
+        }
+
+        @Override
+        public void writeTo(final StreamOutput out) throws IOException {
+            super.writeTo(out);
+            shardId.writeTo(out);
+            out.writeString(id);
+        }
+
+    }
+
+    public static class AddOrRenewRequest extends Request<AddOrRenewRequest> {
+
+        private final long retainingSequenceNumber;
+
+        public long getRetainingSequenceNumber() {
+            return retainingSequenceNumber;
+        }
+
+        private final String source;
+
+        public String getSource() {
+            return source;
+        }
+
+        AddOrRenewRequest(StreamInput in) throws IOException {
+            super(in);
+            retainingSequenceNumber = in.readZLong();
+            source = in.readString();
+        }
+
+        public AddOrRenewRequest(final ShardId shardId, final String id, final long retainingSequenceNumber, final String source) {
+            super(shardId, id);
+            if (retainingSequenceNumber < 0 && retainingSequenceNumber != RETAIN_ALL) {
+                throw new IllegalArgumentException("retaining sequence number [" + retainingSequenceNumber + "] out of range");
+            }
+            this.retainingSequenceNumber = retainingSequenceNumber;
+            this.source = Objects.requireNonNull(source);
+        }
+
+        @Override
+        public void writeTo(final StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeZLong(retainingSequenceNumber);
+            out.writeString(source);
+        }
+
+    }
+
+    public static class RemoveRequest extends Request<RemoveRequest> {
+
+        RemoveRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public RemoveRequest(final ShardId shardId, final String id) {
+            super(shardId, id);
+        }
+
+    }
+
+    public static class Response extends TransportResponse {
+
+        public Response() {
+        }
+
+        Response(final StreamInput in) throws IOException {
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -514,7 +514,10 @@ public class Node implements Closeable {
             final HttpServerTransport httpServerTransport = newHttpTransport(networkModule);
 
             final LogicalReplicationService logicalReplicationService = new LogicalReplicationService(
-                clusterService
+                settings,
+                clusterService,
+                transportService,
+                threadPool
             );
 
             RepositoriesModule repositoriesModule = new RepositoriesModule(
@@ -522,14 +525,16 @@ public class Node implements Closeable {
                 pluginsService.filterPlugins(RepositoryPlugin.class),
                 transportService,
                 clusterService,
+                logicalReplicationService,
                 threadPool,
                 xContentRegistry
             );
             modules.add(repositoriesModule);
 
             RepositoriesService repositoryService = repositoriesModule.repositoryService();
+            logicalReplicationService.repositoriesService(repositoryService);
 
-            SnapshotsService snapshotsService = new SnapshotsService(
+            final SnapshotsService snapshotsService = new SnapshotsService(
                 settings,
                 clusterService,
                 clusterModule.getIndexNameExpressionResolver(),
@@ -537,7 +542,7 @@ public class Node implements Closeable {
                 threadPool
             );
 
-            SnapshotShardsService snapshotShardsService = new SnapshotShardsService(
+            final SnapshotShardsService snapshotShardsService = new SnapshotShardsService(
                 settings,
                 clusterService,
                 repositoryService,
@@ -556,6 +561,7 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 shardLimitValidator
             );
+            logicalReplicationService.restoreService(restoreService);
 
             final RerouteService rerouteService = new BatchedRerouteService(
                 clusterService,

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.repositories;
 
+import io.crate.analyze.repositories.TypeSettings;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.repository.LogicalReplicationRepository;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -28,8 +31,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.threadpool.ThreadPool;
-
-import io.crate.analyze.repositories.TypeSettings;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Collections;
@@ -48,6 +49,7 @@ public class RepositoriesModule extends AbstractModule {
                               List<RepositoryPlugin> repoPlugins,
                               TransportService transportService,
                               ClusterService clusterService,
+                              LogicalReplicationService logicalReplicationService,
                               ThreadPool threadPool,
                               NamedXContentRegistry namedXContentRegistry) {
         Map<String, Repository.Factory> factories = new HashMap<>();
@@ -63,6 +65,26 @@ public class RepositoriesModule extends AbstractModule {
                 return new FsRepository(metadata, env, namedXContentRegistry, clusterService);
             }
         });
+        factories.put(
+            LogicalReplicationRepository.TYPE,
+            new Repository.Factory() {
+                @Override
+                public Repository create(RepositoryMetadata metadata) throws Exception {
+                    return new LogicalReplicationRepository(
+                        clusterService.getSettings(),
+                        clusterService,
+                        logicalReplicationService,
+                        metadata,
+                        threadPool
+                    );
+                }
+
+                @Override
+                public TypeSettings settings() {
+                    return new TypeSettings(List.of(), List.of());
+                }
+            }
+        );
 
         for (RepositoryPlugin repoPlugin : repoPlugins) {
             Map<String, Repository.Factory> newRepoTypes = repoPlugin.getRepositories(env, namedXContentRegistry, clusterService);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -19,24 +19,24 @@
 
 package org.elasticsearch.snapshots;
 
+import io.crate.common.unit.TimeValue;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.RestStatus;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -231,7 +231,12 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private final List<SnapshotShardFailure> shardFailures;
 
     public SnapshotInfo(SnapshotId snapshotId, List<String> indices, SnapshotState state) {
-        this(snapshotId, indices, state, null, null, 0L, 0L, 0, 0, Collections.emptyList(), null);
+        this(snapshotId, indices, state, null);
+
+    }
+
+    public SnapshotInfo(SnapshotId snapshotId, List<String> indices, SnapshotState state, Version version) {
+        this(snapshotId, indices, state, null, version, 0L, 0L, 0, 0, Collections.emptyList(), null);
     }
 
     public SnapshotInfo(SnapshotId snapshotId, List<String> indices, long startTime, Boolean includeGlobalState) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -28,17 +28,17 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 
-final class RemoteClusterAwareClient extends AbstractClient {
+public final class RemoteClusterAwareClient extends AbstractClient {
 
     private final TransportService service;
     private final String clusterAlias;
     private final RemoteClusterAware remoteClusterAware;
 
-    RemoteClusterAwareClient(Settings settings,
-                             ThreadPool threadPool,
-                             TransportService service,
-                             String clusterAlias,
-                             RemoteClusterAware remoteClusterAware) {
+    public RemoteClusterAwareClient(Settings settings,
+                                    ThreadPool threadPool,
+                                    TransportService service,
+                                    String clusterAlias,
+                                    RemoteClusterAware remoteClusterAware) {
         super(settings, threadPool);
         this.service = service;
         this.clusterAlias = clusterAlias;

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -61,10 +61,10 @@ public final class RemoteClusterConnection implements Closeable {
      * @param clusterAlias     the configured alias of the cluster to connect to
      * @param transportService the local nodes transport service
      */
-    RemoteClusterConnection(Settings nodeSettings,
-                            Settings connectionSettings,
-                            String clusterAlias,
-                            TransportService transportService) {
+    public RemoteClusterConnection(Settings nodeSettings,
+                                   Settings connectionSettings,
+                                   String clusterAlias,
+                                   TransportService transportService) {
         this.transportService = transportService;
         ConnectionProfile profile = RemoteConnectionStrategy.buildConnectionProfile(nodeSettings, connectionSettings);
         this.remoteConnectionManager = new RemoteConnectionManager(clusterAlias,
@@ -84,7 +84,7 @@ public final class RemoteClusterConnection implements Closeable {
      * Ensures that this cluster is connected. If the cluster is connected this operation
      * will invoke the listener immediately.
      */
-    void ensureConnected(ActionListener<Void> listener) {
+    public void ensureConnected(ActionListener<Void> listener) {
         if (remoteConnectionManager.size() == 0) {
             connectionStrategy.connect(listener);
         } else {
@@ -154,11 +154,11 @@ public final class RemoteClusterConnection implements Closeable {
      * Returns a connection to the remote cluster, preferably a direct connection to the provided {@link DiscoveryNode}.
      * If such node is not connected, the returned connection will be a proxy connection that redirects to it.
      */
-    Transport.Connection getConnection(DiscoveryNode remoteClusterNode) {
+    public Transport.Connection getConnection(DiscoveryNode remoteClusterNode) {
         return remoteConnectionManager.getConnection(remoteClusterNode);
     }
 
-    Transport.Connection getConnection() {
+    public Transport.Connection getConnection() {
         return remoteConnectionManager.getAnyRemoteConnection();
     }
 
@@ -176,14 +176,6 @@ public final class RemoteClusterConnection implements Closeable {
         return connectionStrategy.assertNoRunningConnections();
     }
 
-    boolean isNodeConnected(final DiscoveryNode node) {
-        return remoteConnectionManager.nodeConnected(node);
-    }
-
-    int getNumNodesConnected() {
-        return remoteConnectionManager.size();
-    }
-
     private static ConnectionManager createConnectionManager(ConnectionProfile connectionProfile,
                                                              TransportService transportService) {
         return new ClusterConnectionManager(connectionProfile, transportService.transport);
@@ -193,7 +185,7 @@ public final class RemoteClusterConnection implements Closeable {
         return remoteConnectionManager;
     }
 
-    boolean shouldRebuildConnection(Settings newSettings) {
+    public boolean shouldRebuildConnection(Settings newSettings) {
         return connectionStrategy.shouldRebuildConnection(newSettings);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -533,7 +533,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(877, response.rowCount());
+        assertEquals(881, response.rowCount());
     }
 
     @Test
@@ -722,7 +722,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
         execute("select max(ordinal_position) from information_schema.columns");
         assertEquals(1, response.rowCount());
 
-        assertEquals(119, response.rows()[0][0]);
+        assertEquals(122, response.rows()[0][0]);
 
         execute("create table t1 (id integer, col1 string)");
         ensureGreen();

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -21,24 +21,224 @@
 
 package io.crate.integrationtests;
 
+import io.crate.action.sql.SQLOperations;
+import io.crate.exceptions.RelationAlreadyExists;
+import io.crate.plugin.SQLPlugin;
+import io.crate.protocols.postgres.PostgresNetty;
+import io.crate.replication.logical.LogicalReplicationSettings;
+import io.crate.testing.SQLResponse;
+import io.crate.testing.SQLTransportExecutor;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.MockHttpTransport;
+import org.elasticsearch.test.NodeConfigurationSource;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.MockTcpTransportPlugin;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.elasticsearch.transport.TransportService;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static io.crate.testing.TestingHelpers.printedTable;
+import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.hamcrest.Matchers.is;
 
-public class LogicalReplicationITest extends SQLIntegrationTestCase {
+public class LogicalReplicationITest extends ESTestCase {
+
+    InternalTestCluster publisherCluster;
+    SQLTransportExecutor publisherSqlExecutor;
+
+    InternalTestCluster subscriberCluster;
+    SQLTransportExecutor subscriberSqlExecutor;
+
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(
+            SQLPlugin.class,
+            Netty4Plugin.class
+        );
+    }
+
+    @Before
+    public void setupClusters() throws IOException, InterruptedException {
+        Collection<Class<? extends Plugin>> mockPlugins = List.of(
+            ESIntegTestCase.TestSeedPlugin.class,
+            MockHttpTransport.TestPlugin.class,
+            MockTransportService.TestPlugin.class,
+            MockTcpTransportPlugin.class,
+            InternalSettingsPlugin.class
+        );
+
+        publisherCluster = new InternalTestCluster(
+            randomLong(),
+            createTempDir(),
+            true,
+            true,
+            2,
+            2,
+            "publishing_cluster",
+            createNodeConfigurationSource(),
+            0,
+            "publisher",
+            Stream.concat(nodePlugins().stream(), mockPlugins.stream())
+                .collect(Collectors.toList()),
+            true
+        );
+        publisherCluster.beforeTest(random());
+        publisherCluster.ensureAtLeastNumDataNodes(2);
+        publisherSqlExecutor = sqlExecutor(publisherCluster);
+
+        subscriberCluster = new InternalTestCluster(
+            randomLong(),
+            createTempDir(),
+            false,
+            true,
+            1,
+            1,
+            "subscribing_cluster",
+            createNodeConfigurationSource(),
+            0,
+            "subscriber",
+            Stream.concat(nodePlugins().stream(), mockPlugins.stream())
+                .collect(Collectors.toList()),
+            true
+        );
+        subscriberCluster.beforeTest(random());
+        subscriberCluster.ensureAtLeastNumDataNodes(1);
+        subscriberSqlExecutor = sqlExecutor(subscriberCluster);
+    }
 
     @After
-    public void cleanUp() throws Exception {
-        execute("DROP PUBLICATION IF EXISTS pub1");
+    public void clearCluster() throws Exception {
+        try {
+            publisherCluster.beforeIndexDeletion();
+            publisherCluster.assertSeqNos();
+            publisherCluster.assertSameDocIdsOnShards();
+            publisherCluster.assertConsistentHistoryBetweenTranslogAndLuceneIndex();
+
+            subscriberCluster.beforeIndexDeletion();
+            subscriberCluster.assertSeqNos();
+            subscriberCluster.assertSameDocIdsOnShards();
+            subscriberCluster.assertConsistentHistoryBetweenTranslogAndLuceneIndex();
+        } finally {
+            publisherCluster.wipe(Collections.emptySet());
+            publisherCluster.close();
+            subscriberCluster.wipe(Collections.emptySet());
+            subscriberCluster.close();
+        }
+    }
+
+    private SQLResponse executeOnPublisher(String sql) {
+        return publisherSqlExecutor.exec(sql);
+    }
+
+    private long[] executeBulkOnPublisher(String sql, @Nullable Object[][] bulkArgs) {
+        return publisherSqlExecutor.execBulk(sql, bulkArgs);
+    }
+
+    private SQLResponse executeOnSubscriber(String sql) {
+        return subscriberSqlExecutor.exec(sql);
+    }
+
+    private static NodeConfigurationSource createNodeConfigurationSource() {
+        Settings.Builder builder = Settings.builder();
+        // disables a port scan for other nodes by setting seeds to an empty list
+        builder.putList(DISCOVERY_SEED_HOSTS_SETTING.getKey());
+        builder.putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file");
+        builder.put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType());
+        // reduce time waiting for changes and rather poll faster
+        builder.put(LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION.getKey(), "10ms");
+        // reduce batch size to test repeated polling of changes
+        builder.put(LogicalReplicationSettings.REPLICATION_CHANGE_BATCH_SIZE.getKey(), "20");
+        return new NodeConfigurationSource() {
+            @Override
+            public Settings nodeSettings(int nodeOrdinal) {
+                return builder.build();
+            }
+
+            @Override
+            public Path nodeConfigPath(int nodeOrdinal) {
+                return null;
+            }
+
+            @Override
+            public Settings transportClientSettings() {
+                return super.transportClientSettings();
+            }
+
+            @Override
+            public Collection<Class<? extends Plugin>> transportClientPlugins() {
+                return List.of(getTestTransportPlugin());
+            }
+        };
+    }
+
+    private static SQLTransportExecutor sqlExecutor(InternalTestCluster cluster) {
+        return new SQLTransportExecutor(
+            new SQLTransportExecutor.ClientProvider() {
+                @Override
+                public Client client() {
+                    return ESIntegTestCase.client();
+                }
+
+                @Override
+                public String pgUrl() {
+                    PostgresNetty postgresNetty = cluster.getInstance(PostgresNetty.class);
+                    BoundTransportAddress boundTransportAddress = postgresNetty.boundAddress();
+                    if (boundTransportAddress != null) {
+                        InetSocketAddress address = boundTransportAddress.publishAddress().address();
+                        return String.format(Locale.ENGLISH, "jdbc:postgresql://%s:%d/?ssl=%s&sslmode=%s",
+                                             address.getHostName(), address.getPort(), false, "disable");
+                    }
+                    return null;
+                }
+
+                @Override
+                public SQLOperations sqlOperations() {
+                    return cluster.getInstance(SQLOperations.class);
+                }
+            }
+        );
+    }
+
+    private String publisherConnectionUrl() {
+        var transportService = publisherCluster.getInstance(TransportService.class);
+        InetSocketAddress address = transportService.boundAddress().publishAddress().address();
+        return String.format(
+            Locale.ENGLISH,
+            "crate://%s:%d?mode=sniff&seeds=%s:%d",
+            address.getHostName(),
+            address.getPort(),
+            address.getHostName(),
+            address.getPort()
+        );
     }
 
     @Test
     public void test_create_publication_for_concrete_table() {
-        execute("CREATE TABLE doc.t1 (id INT)");
-        execute("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
-        var response = execute(
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT)");
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
+        var response = executeOnPublisher(
             "SELECT oid, p.pubname, pubowner, puballtables, schemaname, tablename, pubinsert, pubupdate, pubdelete" +
             " FROM pg_publication p" +
             " JOIN pg_publication_tables t ON p.pubname = t.pubname" +
@@ -49,10 +249,10 @@ public class LogicalReplicationITest extends SQLIntegrationTestCase {
 
     @Test
     public void test_create_publication_for_all_tables() {
-        execute("CREATE TABLE doc.t1 (id INT)");
-        execute("CREATE PUBLICATION pub1 FOR ALL TABLES");
-        execute("CREATE TABLE my_schema.t2 (id INT)");
-        var response = execute(
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT)");
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR ALL TABLES");
+        executeOnPublisher("CREATE TABLE my_schema.t2 (id INT)");
+        var response = executeOnPublisher(
             "SELECT oid, p.pubname, pubowner, puballtables, schemaname, tablename, pubinsert, pubupdate, pubdelete" +
             " FROM pg_publication p" +
             " JOIN pg_publication_tables t ON p.pubname = t.pubname" +
@@ -64,13 +264,172 @@ public class LogicalReplicationITest extends SQLIntegrationTestCase {
 
     @Test
     public void test_drop_publication() {
-        execute("CREATE TABLE doc.t3 (id INT)");
-        execute("CREATE PUBLICATION pub2 FOR TABLE doc.t3");
-        execute("DROP PUBLICATION pub2");
+        executeOnPublisher("CREATE TABLE doc.t3 (id INT)");
+        executeOnPublisher("CREATE PUBLICATION pub2 FOR TABLE doc.t3");
+        executeOnPublisher("DROP PUBLICATION pub2");
 
-        execute("SELECT * FROM pg_publication WHERE pubname = 'pub2'");
+        var response = executeOnPublisher("SELECT * FROM pg_publication WHERE pubname = 'pub2'");
         assertThat(response.rowCount(), is(0L));
-        execute("SELECT * FROM pg_publication_tables WHERE pubname = 'pub2'");
+        response = executeOnPublisher("SELECT * FROM pg_publication_tables WHERE pubname = 'pub2'");
         assertThat(response.rowCount(), is(0L));
+    }
+
+    @Test
+    public void test_subscribing_to_single_publication() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        executeOnSubscriber("REFRESH TABLE doc.t1");
+        var response = executeOnSubscriber("SELECT * FROM doc.t1");
+        assertThat(printedTable(response.rows()), is("1\n" +
+                                                     "2\n"));
+    }
+
+    @Test
+    public void test_subscribing_to_publication_while_table_exists_raises_error() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
+
+        executeOnSubscriber("CREATE TABLE doc.t1 (id int)");
+        assertThrows(
+            "Subscription 'sub1' cannot be created as included relation 'doc.t1' already exists",
+            RelationAlreadyExists.class,
+            () -> executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1")
+        );
+    }
+
+    @Test
+    public void test_subscribing_to_single_publication_with_multiple_tables() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
+
+        executeOnPublisher("CREATE TABLE doc.t2 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t2 (id) VALUES (3), (4)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1, doc.t2");
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        executeOnSubscriber("REFRESH TABLE doc.t1");
+        var response = executeOnSubscriber("SELECT * FROM doc.t1");
+        assertThat(printedTable(response.rows()), is("1\n" +
+                                                     "2\n"));
+
+        executeOnSubscriber("REFRESH TABLE doc.t2");
+        response = executeOnSubscriber("SELECT * FROM doc.t2");
+        assertThat(printedTable(response.rows()), is("3\n" +
+                                                     "4\n"));
+    }
+
+    @Test
+    public void test_subscribing_to_single_publication_with_partitioned_table() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT, p INT) CLUSTERED INTO 1 SHARDS PARTITIONED BY (p) WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id, p) VALUES (1, 1), (2, 2)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        executeOnSubscriber("REFRESH TABLE doc.t1");
+        var response = executeOnSubscriber("SELECT * FROM doc.t1");
+        assertThat(printedTable(response.rows()), is("1| 1\n" +
+                                                     "2| 2\n"));
+    }
+
+    @Test
+    public void test_subscribing_to_single_publication_for_all_tables() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT, p INT) CLUSTERED INTO 1 SHARDS PARTITIONED BY (p) WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id, p) VALUES (1, 1), (2, 2)");
+        executeOnPublisher("CREATE TABLE my_schema.t2 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO my_schema.t2 (id) VALUES (1), (2)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR ALL TABLES");
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        executeOnSubscriber("REFRESH TABLE doc.t1");
+        var response = executeOnSubscriber("SELECT * FROM doc.t1");
+        assertThat(printedTable(response.rows()), is("1| 1\n" +
+                                                     "2| 2\n"));
+
+        executeOnSubscriber("REFRESH TABLE my_schema.t2");
+        response = executeOnSubscriber("SELECT * FROM my_schema.t2");
+        assertThat(printedTable(response.rows()), is("1\n" +
+                                                     "2\n"));
+    }
+
+    @Test
+    public void test_subscribed_tables_are_followed_and_updated() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        executeOnSubscriber("REFRESH TABLE doc.t1");
+        var response = executeOnSubscriber("SELECT * FROM doc.t1");
+        assertThat(printedTable(response.rows()), is("1\n" +
+                                                     "2\n"));
+
+        int numDocs = 100; // <- should be greater than REPLICATION_CHANGE_BATCH_SIZE to test repeated polls
+        var bulkArgs = new Object[numDocs][1];
+        for (int i = 0; i < numDocs; i++) {
+            bulkArgs[i][0] = i;
+        }
+        executeBulkOnPublisher("INSERT INTO doc.t1 (id) VALUES (?)", bulkArgs);
+
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE doc.t1");
+            var res = executeOnSubscriber("SELECT * FROM doc.t1");
+            assertThat(res.rowCount(), is((long) (numDocs + 2)));
+        }, 10, TimeUnit.SECONDS);
+    }
+
+    private void ensureGreenOnSubscriber() throws Exception {
+        assertBusy(() -> {
+            try {
+                var response = executeOnSubscriber(
+                    "SELECT health, count(*) FROM sys.health GROUP BY 1");
+                assertThat(response.rowCount(), is(1L));
+                assertThat(response.rows()[0][0], is("GREEN"));
+            } catch (Exception e) {
+                fail();
+            }
+        }, 10, TimeUnit.SECONDS);
+
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/LogicalReplicationSettingsTest.java
+++ b/server/src/test/java/io/crate/replication/logical/LogicalReplicationSettingsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical;
+
+import io.crate.plugin.SQLPlugin;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_CHANGE_BATCH_SIZE;
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION;
+import static org.hamcrest.Matchers.is;
+
+public class LogicalReplicationSettingsTest extends CrateDummyClusterServiceUnitTest {
+
+    @Override
+    protected Collection<Setting<?>> additionalClusterSettings() {
+        return new SQLPlugin(Settings.EMPTY).getSettings();
+    }
+
+    @Test
+    public void testSettingsChanged() {
+        var replicationSettings = new LogicalReplicationSettings(Settings.EMPTY, clusterService);
+
+        ClusterState newState = ClusterState.builder(clusterService.state())
+            .metadata(Metadata.builder().transientSettings(
+                Settings.builder()
+                    .put(REPLICATION_CHANGE_BATCH_SIZE.getKey(), 20)
+                    .put(REPLICATION_READ_POLL_DURATION.getKey(), "1s")
+                    .build()
+            ))
+            .build();
+        ClusterServiceUtils.setState(clusterService, newState);
+        assertThat(replicationSettings.batchSize(), is(20L));
+        assertThat(replicationSettings.pollDelay().millis(), is(1000L));
+    }
+}

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.metadata.Publication;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.test.MockLogAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+
+public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTest {
+
+    private MockLogAppender appender;
+
+    @Before
+    public void appendLogger() throws Exception {
+        appender = new MockLogAppender();
+        appender.start();
+        Loggers.addAppender(Loggers.getLogger(PublicationsStateAction.class), appender);
+
+    }
+
+    @After
+    public void removeLogger() {
+        Loggers.removeAppender(Loggers.getLogger(PublicationsStateAction.class), appender);
+        appender.stop();
+    }
+
+    @Test
+    public void test_resolve_relation_names_for_all_tables_ignores_table_with_soft_delete_disabled() throws Exception {
+        var s = SQLExecutor.builder(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int)")
+            .addTable("CREATE TABLE doc.t2 (id int) with (\"soft_deletes.enabled\" = false)")
+            .build();
+        var publication = new Publication("some_user", true, List.of());
+
+        var expectedLogMessage = "Table 'doc.t2' won't be replicated as the required table setting " +
+                                 "'soft_deletes.enabled' is set to: false";
+        appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+            expectedLogMessage,
+            Loggers.getLogger(PublicationsStateAction.class).getName(),
+            Level.WARN,
+            expectedLogMessage
+        ));
+
+        var resolvedRelations = PublicationsStateAction.TransportAction.resolveRelationsNames(
+            publication,
+            s.schemas()
+        );
+        assertThat(resolvedRelations, contains(new RelationName("doc", "t1")));
+        appender.assertAllExpectationsMatched();
+    }
+}

--- a/server/src/testFixtures/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
+++ b/server/src/testFixtures/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
@@ -74,7 +74,7 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
 
     @Before
     public void setupDummyClusterService() {
-        clusterService = createClusterService(additionalClusterSettings(), Version.CURRENT);
+        clusterService = createClusterService(additionalClusterSettings().stream().filter(Setting::hasNodeScope).toList(), Version.CURRENT);
     }
 
     @After

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -133,8 +133,11 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.plugins.AnalysisPlugin;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -302,7 +305,13 @@ public class SQLExecutor {
                 new BalancedShardsAllocator(Settings.EMPTY),
                 EmptyClusterInfoService.INSTANCE
             );
-            logicalReplicationService = new LogicalReplicationService(clusterService);
+            logicalReplicationService = new LogicalReplicationService(
+                Settings.EMPTY,
+                clusterService,
+                mock(TransportService.class),
+                mock(ThreadPool.class)
+            );
+            logicalReplicationService.repositoriesService(mock(RepositoriesService.class));
 
             publishInitialClusterState();
         }

--- a/server/src/testFixtures/java/org/elasticsearch/test/MockLogAppender.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/MockLogAppender.java
@@ -189,6 +189,9 @@ public class MockLogAppender extends AbstractAppender {
         if (name.startsWith("org.elasticsearch.")) {
             name = name.substring("org.elasticsearch.".length());
         }
+        if (name.startsWith("io.crate.")) {
+            return name;
+        }
         return COMMON_PREFIX + name;
     }
 }


### PR DESCRIPTION
Add basic logic replication support by creating a subscription on a remote
publication.
Exposed tables by the publication will be created on the subscriber and data
is initially restored by using a concret repository.
Afterwards, each shard on the subscriber side will track and apply changes from
the remote shard on the publisher side.
This is implemented by a shard listener, once active and if subscription is enabled,
tracking will start. On shard closing or deletion, tracking will stop.

ToDo's are tracked now at #11832.

The whole implementation is heavily inspired by and partly derived from OpenSearch's CCR plugin
(https://github.com/opensearch-project/cross-cluster-replication)
