### PR TITLE
Adapt Repository interface to make async and batched operations for the implementation possible

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -21,7 +21,9 @@ package org.elasticsearch.repositories;
 
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.apache.lucene.index.IndexCommit;
@@ -95,18 +97,27 @@ public interface Repository extends LifecycleComponent {
      * Returns global metadata associated with the snapshot.
      *
      * @param snapshotId the snapshot id to load the global metadata from
-     * @return the global metadata about the snapshot
+     * @param listener   listener invoked on completion
      */
-    Metadata getSnapshotGlobalMetadata(SnapshotId snapshotId);
+    void getSnapshotGlobalMetadata(SnapshotId snapshotId, ActionListener<Metadata> listener);
 
     /**
      * Returns the index metadata associated with the snapshot.
      *
      * @param snapshotId the snapshot id to load the index metadata from
      * @param index      the {@link IndexId} to load the metadata from
-     * @return the index metadata about the given index for the given snapshot
+     * @param listener   listener invoked on completion
      */
-    IndexMetadata getSnapshotIndexMetadata(SnapshotId snapshotId, IndexId index) throws IOException;
+    void getSnapshotIndexMetadata(SnapshotId snapshotId, IndexId indexId, ActionListener<IndexMetadata> listener) throws IOException;
+
+    /**
+     * Returns index metadata associated with the snapshot.
+     *
+     * @param snapshotId the snapshot id to load the index metadata from
+     * @param indexIds   the Collection of {@link IndexId} to load the metadata from
+     * @param listener   listener invoked on completion
+     */
+    void getSnapshotIndexMetadata(SnapshotId snapshotId, Collection<IndexId> indexIds, ActionListener<Collection<IndexMetadata>> listener);
 
     /**
      * Returns a {@link RepositoryData} to describe the data in the repository, including the snapshots
@@ -220,14 +231,13 @@ public interface Repository extends LifecycleComponent {
                       ActionListener<Void> listener);
 
     /**
-     * Retrieve shard snapshot status for the stored snapshot
+     * Retrieve multiple shard snapshot statuses for the stored snapshot
      *
-     * @param snapshotId snapshot id
-     * @param indexId    the snapshotted index id for the shard to get status for
-     * @param shardId    shard id
-     * @return snapshot status
+     * @param snapshotId    snapshot id
+     * @param shardIndexIds Map containing the shardId and the corresponding snapshotted indexId
+     * @param listener      listener to invoke once done
      */
-    IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, IndexId indexId, ShardId shardId);
+    void getShardSnapshotStatus(SnapshotId snapshotId, Map<ShardId, IndexId> shardIndexIds, ActionListener<Map<ShardId, IndexShardSnapshotStatus>> listener);
 
     /**
      * Update the repository with the incoming cluster state. This method is invoked from {@link RepositoriesService#applyClusterState} and

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -29,6 +29,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -655,12 +656,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             final Set<SnapshotId> survivingSnapshots = oldRepositoryData.getSnapshots(indexId).stream()
                 .filter(id -> id.equals(snapshotId) == false).collect(Collectors.toSet());
             executor.execute(ActionRunnable.wrap(deleteIndexMetadataListener, deleteIdxMetaListener -> {
-                final IndexMetadata indexMetadata;
+                final StepListener<IndexMetadata> snapshotIndexMetadataListener = new StepListener<>();
                 try {
-                    indexMetadata = getSnapshotIndexMetadata(snapshotId, indexId);
+                    getSnapshotIndexMetadata(snapshotId, indexId, snapshotIndexMetadataListener);
                 } catch (Exception ex) {
-                    LOGGER.warn(() ->
-                                    new ParameterizedMessage("[{}] [{}] failed to read metadata for index", snapshotId, indexId.getName()), ex);
+                    LOGGER.warn(() -> new ParameterizedMessage("[{}] [{}] failed to read metadata for index", snapshotId, indexId.getName()), ex);
                     // Just invoke the listener without any shard generations to count it down, this index will be cleaned up
                     // by the stale data cleanup in the end.
                     // TODO: Getting here means repository corruption. We should find a way of dealing with this instead of just ignoring
@@ -668,46 +668,55 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     deleteIdxMetaListener.onResponse(null);
                     return;
                 }
-                final int shardCount = indexMetadata.getNumberOfShards();
-                assert shardCount > 0 : "index did not have positive shard count, get [" + shardCount + "]";
-                // Listener for collecting the results of removing the snapshot from each shard's metadata in the current index
-                final ActionListener<ShardSnapshotMetaDeleteResult> allShardsListener =
-                    new GroupedActionListener<>(deleteIdxMetaListener, shardCount);
-                final Index index = indexMetadata.getIndex();
-                for (int shardId = 0; shardId < indexMetadata.getNumberOfShards(); shardId++) {
-                    final ShardId shard = new ShardId(index, shardId);
-                    executor.execute(new AbstractRunnable() {
-                        @Override
-                        protected void doRun() throws Exception {
-                            final BlobContainer shardContainer = shardContainer(indexId, shard);
-                            final Set<String> blobs = getShardBlobs(shard, shardContainer);
-                            final BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots;
-                            final String newGen;
-                            if (useUUIDs) {
-                                newGen = UUIDs.randomBase64UUID();
-                                blobStoreIndexShardSnapshots = buildBlobStoreIndexShardSnapshots(blobs, shardContainer,
-                                                                                                 oldRepositoryData.shardGenerations().getShardGen(indexId, shard.getId())).v1();
-                            } else {
-                                Tuple<BlobStoreIndexShardSnapshots, Long> tuple =
-                                    buildBlobStoreIndexShardSnapshots(blobs, shardContainer);
-                                newGen = Long.toString(tuple.v2() + 1);
-                                blobStoreIndexShardSnapshots = tuple.v1();
+                snapshotIndexMetadataListener.whenComplete(indexMetadata -> {
+                    final int shardCount = indexMetadata.getNumberOfShards();
+                    assert shardCount > 0 : "index did not have positive shard count, get [" + shardCount + "]";
+                    // Listener for collecting the results of removing the snapshot from each shard's metadata in the current index
+                    final ActionListener<ShardSnapshotMetaDeleteResult> allShardsListener =
+                        new GroupedActionListener<>(deleteIdxMetaListener, shardCount);
+                    final Index index = indexMetadata.getIndex();
+                    for (int shardId = 0; shardId < indexMetadata.getNumberOfShards(); shardId++) {
+                        final ShardId shard = new ShardId(index, shardId);
+                        executor.execute(new AbstractRunnable() {
+                            @Override
+                            protected void doRun() throws Exception {
+                                final BlobContainer shardContainer = shardContainer(indexId, shard);
+                                final Set<String> blobs = getShardBlobs(shard, shardContainer);
+                                final BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots;
+                                final String newGen;
+                                if (useUUIDs) {
+                                    newGen = UUIDs.randomBase64UUID();
+                                    blobStoreIndexShardSnapshots =
+                                        buildBlobStoreIndexShardSnapshots(blobs,
+                                                                          shardContainer,
+                                                                          oldRepositoryData.shardGenerations().getShardGen(indexId, shard.getId())).v1();
+                                } else {
+                                    Tuple<BlobStoreIndexShardSnapshots, Long> tuple =
+                                        buildBlobStoreIndexShardSnapshots(blobs, shardContainer);
+                                    newGen = Long.toString(tuple.v2() + 1);
+                                    blobStoreIndexShardSnapshots = tuple.v1();
+                                }
+                                allShardsListener.onResponse(deleteFromShardSnapshotMeta(survivingSnapshots,
+                                                                                         indexId,
+                                                                                         shard,
+                                                                                         snapshotId,
+                                                                                         shardContainer,
+                                                                                         blobs,
+                                                                                         blobStoreIndexShardSnapshots,
+                                                                                         newGen));
                             }
-                            allShardsListener.onResponse(deleteFromShardSnapshotMeta(survivingSnapshots, indexId, shard, snapshotId,
-                                                                                     shardContainer, blobs, blobStoreIndexShardSnapshots, newGen));
-                        }
 
-                        @Override
-                        public void onFailure(Exception ex) {
-                            LOGGER.warn(
-                                () -> new ParameterizedMessage("[{}] failed to delete shard data for shard [{}][{}]",
-                                                               snapshotId, indexId.getName(), shard.id()), ex);
-                            // Just passing null here to count down the listener instead of failing it, the stale data left behind
-                            // here will be retried in the next delete or repository cleanup
-                            allShardsListener.onResponse(null);
-                        }
-                    });
-                }
+                            @Override
+                            public void onFailure(Exception ex) {
+                                LOGGER.warn(
+                                    () -> new ParameterizedMessage("[{}] failed to delete shard data for shard [{}][{}]", snapshotId, indexId.getName(), shard.id()), ex);
+                                // Just passing null here to count down the listener instead of failing it, the stale data left behind
+                                // here will be retried in the next delete or repository cleanup
+                                allShardsListener.onResponse(null);
+                            }
+                        });
+                    }
+                }, onAllShardsCompleted::onFailure);
             }));
         }
     }
@@ -941,19 +950,32 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     @Override
-    public Metadata getSnapshotGlobalMetadata(final SnapshotId snapshotId) {
+    public void getSnapshotGlobalMetadata(final SnapshotId snapshotId, ActionListener<Metadata> listener) {
         try {
-            return globalMetadataFormat.read(blobContainer(), snapshotId.getUUID());
+            listener.onResponse(globalMetadataFormat.read(blobContainer(), snapshotId.getUUID()));
         } catch (NoSuchFileException ex) {
-            throw new SnapshotMissingException(metadata.name(), snapshotId, ex);
+            listener.onFailure(new SnapshotMissingException(metadata.name(), snapshotId, ex));
         } catch (IOException ex) {
-            throw new SnapshotException(metadata.name(), snapshotId, "failed to read global metadata", ex);
+            listener.onFailure(new SnapshotException(metadata.name(), snapshotId, "failed to read global metadata", ex));
         }
     }
 
     @Override
-    public IndexMetadata getSnapshotIndexMetadata(final SnapshotId snapshotId, final IndexId index) throws IOException {
-        return indexMetadataFormat.read(indexContainer(index), snapshotId.getUUID());
+    public void getSnapshotIndexMetadata(final SnapshotId snapshotId, final IndexId index, ActionListener<IndexMetadata> listener) throws IOException {
+        listener.onResponse(indexMetadataFormat.read(indexContainer(index), snapshotId.getUUID()));
+    }
+
+    @Override
+    public void getSnapshotIndexMetadata(SnapshotId snapshotId, Collection<IndexId> indexIds, ActionListener<Collection<IndexMetadata>> listener) {
+        try {
+            var result = new ArrayList<IndexMetadata>();
+            for (IndexId index : indexIds) {
+                result.add(indexMetadataFormat.read(indexContainer(index), snapshotId.getUUID()));
+            }
+            listener.onResponse(result);
+        } catch (IOException ex) {
+            listener.onFailure(ex);
+        }
     }
 
     private BlobPath indicesPath() {
@@ -1733,16 +1755,27 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     @Override
-    public IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, IndexId indexId, ShardId shardId) {
-        BlobStoreIndexShardSnapshot snapshot = loadShardSnapshot(shardContainer(indexId, shardId), snapshotId);
-        return IndexShardSnapshotStatus.newDone(
-            snapshot.startTime(),
-            snapshot.time(),
-            snapshot.incrementalFileCount(),
-            snapshot.totalFileCount(),
-            snapshot.incrementalSize(),
-            snapshot.totalSize(),
-            null); // Not adding a real generation here as it doesn't matter to callers
+    public void getShardSnapshotStatus(SnapshotId snapshotId, Map<ShardId,IndexId> shardIndexIds, ActionListener<Map<ShardId, IndexShardSnapshotStatus>> listener) {
+        try {
+            var result = new HashMap<ShardId, IndexShardSnapshotStatus>();
+            for (var shardIndexId : shardIndexIds.entrySet()) {
+                var shardId = shardIndexId.getKey();
+                var indexId = shardIndexId.getValue();
+                BlobStoreIndexShardSnapshot snapshot = loadShardSnapshot(shardContainer(indexId, shardId), snapshotId);
+                result.put(shardId, IndexShardSnapshotStatus.newDone(
+                    snapshot.startTime(),
+                    snapshot.time(),
+                    snapshot.incrementalFileCount(),
+                    snapshot.totalFileCount(),
+                    snapshot.incrementalSize(),
+                    snapshot.totalSize(),
+                    null)
+                ); // Not adding a real generation here as it doesn't matter to callers
+            }
+            listener.onResponse(result);
+        } catch (SnapshotException e) {
+            listener.onFailure(e);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -70,13 +70,13 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.ShardLimitValidator;
-import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -211,380 +211,376 @@ public class RestoreService implements ClusterStateApplier {
                     ? filterIndices(snapshotInfo.indices(), request.indices(), request.indicesOptions())
                     : List.of();
 
-                final Metadata.Builder metadataBuilder;
+                final StepListener<Metadata> globalMetadataListener = new StepListener<>();
                 if (request.includeCustomMetadata()
                     || request.includeGlobalSettings()
                     || request.allTemplates()
                     || (request.templates() != null && request.templates().length > 0)) {
-                    metadataBuilder = Metadata.builder(repository.getSnapshotGlobalMetadata(snapshotId));
+                    repository.getSnapshotGlobalMetadata(snapshotId, globalMetadataListener);
                 } else {
-                    metadataBuilder = Metadata.builder();
+                    globalMetadataListener.onResponse(Metadata.EMPTY_METADATA);
                 }
-
-                final List<IndexId> indexIdsInSnapshot = repositoryData.resolveIndices(indicesInSnapshot);
-                for (IndexId indexId : indexIdsInSnapshot) {
-                    metadataBuilder.put(repository.getSnapshotIndexMetadata(snapshotId, indexId), false);
-                }
-
-                final Metadata metadata = metadataBuilder.build();
-
-                // Apply renaming on index names, returning a map of names where
-                // the key is the renamed index and the value is the original name
-                final Map<String, String> indices = renamedIndices(request, indicesInSnapshot);
-
-                // Now we can start the actual restore process by adding shards to be recovered in the cluster state
-                // and updating cluster metadata (global and index) as needed
-                clusterService.submitStateUpdateTask("restore_snapshot[" + snapshotName + ']', new ClusterStateUpdateTask() {
-                    final String restoreUUID = UUIDs.randomBase64UUID();
-                    RestoreInfo restoreInfo = null;
-
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        RestoreInProgress restoreInProgress = currentState.custom(RestoreInProgress.TYPE);
-                        // Check if the snapshot to restore is currently being deleted
-                        SnapshotDeletionsInProgress deletionsInProgress = currentState.custom(SnapshotDeletionsInProgress.TYPE);
-                        if (deletionsInProgress != null
-                            && deletionsInProgress.getEntries().stream().anyMatch(entry -> entry.getSnapshot().equals(snapshot))) {
-                            throw new ConcurrentSnapshotExecutionException(snapshot,
-                                "cannot restore a snapshot while a snapshot deletion is in-progress [" +
-                                    deletionsInProgress.getEntries().get(0).getSnapshot() + "]");
+                globalMetadataListener.whenComplete(globalMetadata -> {
+                    var metadataBuilder = Metadata.builder(globalMetadata);
+                    var indexIdsInSnapshot = repositoryData.resolveIndices(indicesInSnapshot);
+                    var snapshotIndexMetadataListener = new StepListener<Collection<IndexMetadata>>();
+                    repository.getSnapshotIndexMetadata(snapshotId, indexIdsInSnapshot, snapshotIndexMetadataListener);
+                    snapshotIndexMetadataListener.whenComplete(snapshotIndexMetadata -> {
+                        for (IndexMetadata indexMetadata : snapshotIndexMetadata) {
+                            metadataBuilder.put(indexMetadata, false);
                         }
+                        final Metadata metadata = metadataBuilder.build();
+                        // Apply renaming on index names, returning a map of names where
+                        // the key is the renamed index and the value is the original name
+                        final Map<String, String> indices = renamedIndices(request, indicesInSnapshot);
 
-                        // Updating cluster state
-                        ClusterState.Builder builder = ClusterState.builder(currentState);
-                        Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
-                        ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
-                        RoutingTable.Builder rtBuilder = RoutingTable.builder(currentState.routingTable());
-                        ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards;
-                        Set<String> aliases = new HashSet<>();
+                        // Now we can start the actual restore process by adding shards to be recovered in the cluster state
+                        // and updating cluster metadata (global and index) as needed
+                        clusterService.submitStateUpdateTask("restore_snapshot[" + snapshotName + ']', new ClusterStateUpdateTask() {
+                            final String restoreUUID = UUIDs.randomBase64UUID();
+                            RestoreInfo restoreInfo = null;
 
-                        if (indices.isEmpty() == false) {
-                            // We have some indices to restore
-                            ImmutableOpenMap.Builder<ShardId, RestoreInProgress.ShardRestoreStatus> shardsBuilder =
-                                ImmutableOpenMap.builder();
-                            final Version minIndexCompatibilityVersion = currentState.getNodes().getMaxNodeVersion()
-                                .minimumIndexCompatibilityVersion();
-                            for (Map.Entry<String, String> indexEntry : indices.entrySet()) {
-                                String index = indexEntry.getValue();
-                                boolean partial = checkPartial(index);
-                                SnapshotRecoverySource recoverySource =
-                                    new SnapshotRecoverySource(restoreUUID, snapshot, snapshotInfo.version(), index);
-                                String renamedIndexName = indexEntry.getKey();
-                                IndexMetadata snapshotIndexMetadata = metadata.index(index);
-                                snapshotIndexMetadata = updateIndexSettings(snapshotIndexMetadata,
-                                    request.indexSettings(), request.ignoreIndexSettings());
-                                try {
-                                    snapshotIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(snapshotIndexMetadata,
-                                        minIndexCompatibilityVersion);
-                                } catch (Exception ex) {
-                                    throw new SnapshotRestoreException(snapshot, "cannot restore index [" + index +
-                                        "] because it cannot be upgraded", ex);
+                            @Override
+                            public ClusterState execute(ClusterState currentState) {
+                                RestoreInProgress restoreInProgress = currentState.custom(RestoreInProgress.TYPE);
+                                // Check if the snapshot to restore is currently being deleted
+                                SnapshotDeletionsInProgress deletionsInProgress = currentState.custom(SnapshotDeletionsInProgress.TYPE);
+                                if (deletionsInProgress != null
+                                    && deletionsInProgress.getEntries().stream().anyMatch(entry -> entry.getSnapshot().equals(snapshot))) {
+                                        throw new ConcurrentSnapshotExecutionException(snapshot, "cannot restore a snapshot while a snapshot deletion is in-progress [" +
+                                                                         deletionsInProgress.getEntries().get(0).getSnapshot() + "]");
                                 }
-                                // Check that the index is closed or doesn't exist
-                                IndexMetadata currentIndexMetadata = currentState.metadata().index(renamedIndexName);
-                                IntSet ignoreShards = new IntHashSet();
-                                final Index renamedIndex;
-                                if (currentIndexMetadata == null) {
-                                    // Index doesn't exist - create it and start recovery
-                                    // Make sure that the index we are about to create has a validate name
-                                    MetadataCreateIndexService.validateIndexName(renamedIndexName, currentState);
-                                    createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), currentState, false);
-                                    IndexMetadata.Builder indexMdBuilder = IndexMetadata.builder(snapshotIndexMetadata)
-                                        .state(IndexMetadata.State.OPEN)
-                                        .index(renamedIndexName);
-                                    indexMdBuilder.settings(Settings.builder()
-                                        .put(snapshotIndexMetadata.getSettings())
-                                        .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()));
-                                    shardLimitValidator.validateShardLimit(snapshotIndexMetadata.getSettings(), currentState);
-                                    if (!request.includeAliases() && !snapshotIndexMetadata.getAliases().isEmpty()) {
-                                        // Remove all aliases - they shouldn't be restored
-                                        indexMdBuilder.removeAllAliases();
+                                // Updating cluster state
+                                ClusterState.Builder builder = ClusterState.builder(currentState);
+                                Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
+                                ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+                                RoutingTable.Builder rtBuilder = RoutingTable.builder(currentState.routingTable());
+                                ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards;
+                                Set<String> aliases = new HashSet<>();
+
+                                if (indices.isEmpty() == false) {
+                                    // We have some indices to restore
+                                    ImmutableOpenMap.Builder<ShardId, RestoreInProgress.ShardRestoreStatus> shardsBuilder =
+                                                                         ImmutableOpenMap.builder();
+                                    final Version minIndexCompatibilityVersion = currentState.getNodes().getMaxNodeVersion()
+                                                                         .minimumIndexCompatibilityVersion();
+                                    for (Map.Entry<String, String> indexEntry : indices.entrySet()) {
+                                        String index = indexEntry.getValue();
+                                        boolean partial = checkPartial(index);
+                                        SnapshotRecoverySource recoverySource = new SnapshotRecoverySource(restoreUUID, snapshot, snapshotInfo.version(), index);
+                                        String renamedIndexName = indexEntry.getKey();
+                                        IndexMetadata snapshotIndexMetadata = metadata.index(index);
+                                        snapshotIndexMetadata = updateIndexSettings(snapshotIndexMetadata,
+                                        request.indexSettings(), request.ignoreIndexSettings());
+                                        try {
+                                            snapshotIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(snapshotIndexMetadata,
+                                                                                 minIndexCompatibilityVersion);
+                                        } catch (Exception ex) {
+                                            throw new SnapshotRestoreException(snapshot, "cannot restore index [" + index +
+                                                                                                                "] because it cannot be upgraded", ex);
+                                        }
+                                        // Check that the index is closed or doesn't exist
+                                        IndexMetadata currentIndexMetadata = currentState.metadata().index(renamedIndexName);
+                                        IntSet ignoreShards = new IntHashSet();
+                                        final Index renamedIndex;
+                                        if (currentIndexMetadata == null) {
+                                            // Index doesn't exist - create it and start recovery
+                                            // Make sure that the index we are about to create has a validate name
+                                            MetadataCreateIndexService.validateIndexName(renamedIndexName, currentState);
+                                            createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), currentState, false);
+                                            IndexMetadata.Builder indexMdBuilder = IndexMetadata.builder(snapshotIndexMetadata)
+                                                                                 .state(IndexMetadata.State.OPEN)
+                                                                                 .index(renamedIndexName);
+                                            indexMdBuilder.settings(Settings.builder()
+                                                .put(snapshotIndexMetadata.getSettings())
+                                                .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()));
+
+                                            shardLimitValidator.validateShardLimit(snapshotIndexMetadata.getSettings(), currentState);
+                                            if (!request.includeAliases() && !snapshotIndexMetadata.getAliases().isEmpty()) {
+                                                // Remove all aliases - they shouldn't be restored
+                                                indexMdBuilder.removeAllAliases();
+                                            } else {
+                                                for (ObjectCursor<String> alias : snapshotIndexMetadata.getAliases().keys()) {
+                                                    aliases.add(alias.value);
+                                                }
+                                            }
+                                            IndexMetadata updatedIndexMetadata = indexMdBuilder.build();
+                                            if (partial) {
+                                                populateIgnoredShards(index, ignoreShards);
+                                            }
+                                            rtBuilder.addAsNewRestore(updatedIndexMetadata, recoverySource, ignoreShards);
+                                            blocks.addBlocks(updatedIndexMetadata);
+                                            mdBuilder.put(updatedIndexMetadata, true);
+                                            renamedIndex = updatedIndexMetadata.getIndex();
+                                        } else {
+                                            validateExistingIndex(currentIndexMetadata, snapshotIndexMetadata, renamedIndexName, partial);
+                                            // Index exists and it's closed - open it in metadata and start recovery
+                                            IndexMetadata.Builder indexMdBuilder = IndexMetadata.builder(snapshotIndexMetadata).state(IndexMetadata.State.OPEN);
+                                            indexMdBuilder.version(Math.max(snapshotIndexMetadata.getVersion(), 1 + currentIndexMetadata.getVersion()));
+                                            indexMdBuilder.mappingVersion(Math.max(snapshotIndexMetadata.getMappingVersion(), 1 + currentIndexMetadata.getMappingVersion()));
+                                            indexMdBuilder.settingsVersion(Math.max(snapshotIndexMetadata.getSettingsVersion(), 1 + currentIndexMetadata.getSettingsVersion()));
+
+                                            for (int shard = 0; shard < snapshotIndexMetadata.getNumberOfShards(); shard++) {
+                                                indexMdBuilder.primaryTerm(shard, Math.max(snapshotIndexMetadata.primaryTerm(shard), currentIndexMetadata.primaryTerm(shard)));
+                                            }
+
+                                            if (!request.includeAliases()) {
+                                                // Remove all snapshot aliases
+                                                if (!snapshotIndexMetadata.getAliases().isEmpty()) {
+                                                    indexMdBuilder.removeAllAliases();
+                                                }
+                                                // Add existing aliases
+                                                for (ObjectCursor<AliasMetadata> alias : currentIndexMetadata.getAliases().values()) {
+                                                    indexMdBuilder.putAlias(alias.value);
+                                                }
+                                            } else {
+                                                for (ObjectCursor<String> alias : snapshotIndexMetadata.getAliases().keys()) {
+                                                    aliases.add(alias.value);
+                                                }
+                                            }
+                                            indexMdBuilder.settings(Settings.builder()
+                                                                        .put(snapshotIndexMetadata.getSettings())
+                                                                        .put(IndexMetadata.SETTING_INDEX_UUID, currentIndexMetadata.getIndexUUID()));
+                                            IndexMetadata updatedIndexMetadata = indexMdBuilder.index(renamedIndexName).build();
+                                            rtBuilder.addAsRestore(updatedIndexMetadata, recoverySource);
+                                            blocks.updateBlocks(updatedIndexMetadata);
+                                            mdBuilder.put(updatedIndexMetadata, true);
+                                            renamedIndex = updatedIndexMetadata.getIndex();
+                                        }
+                                        for (int shard = 0; shard < snapshotIndexMetadata.getNumberOfShards(); shard++) {
+                                            if (!ignoreShards.contains(shard)) {
+                                                shardsBuilder.put(new ShardId(renamedIndex, shard),
+                                                                  new RestoreInProgress.ShardRestoreStatus(clusterService.state().nodes().getLocalNodeId()));
+                                            } else {
+                                                shardsBuilder.put(new ShardId(renamedIndex, shard),
+                                                                  new RestoreInProgress.ShardRestoreStatus(clusterService.state().nodes().getLocalNodeId(), RestoreInProgress.State.FAILURE));
+                                            }
+                                        }
+                                    }
+
+                                    shards = shardsBuilder.build();
+                                    RestoreInProgress.Entry restoreEntry = new RestoreInProgress.Entry(
+                                        restoreUUID,
+                                        snapshot,
+                                        overallState(RestoreInProgress.State.INIT, shards),
+                                        List.copyOf(indices.keySet()),
+                                        shards
+                                    );
+
+                                    RestoreInProgress.Builder restoreInProgressBuilder;
+                                    if (restoreInProgress != null) {
+                                        restoreInProgressBuilder = new RestoreInProgress.Builder(restoreInProgress);
                                     } else {
-                                        for (ObjectCursor<String> alias : snapshotIndexMetadata.getAliases().keys()) {
-                                            aliases.add(alias.value);
-                                        }
+                                        restoreInProgressBuilder = new RestoreInProgress.Builder();
                                     }
-                                    IndexMetadata updatedIndexMetadata = indexMdBuilder.build();
-                                    if (partial) {
-                                        populateIgnoredShards(index, ignoreShards);
-                                    }
-                                    rtBuilder.addAsNewRestore(updatedIndexMetadata, recoverySource, ignoreShards);
-                                    blocks.addBlocks(updatedIndexMetadata);
-                                    mdBuilder.put(updatedIndexMetadata, true);
-                                    renamedIndex = updatedIndexMetadata.getIndex();
+                                    builder.putCustom(RestoreInProgress.TYPE, restoreInProgressBuilder.add(restoreEntry).build());
                                 } else {
-                                    validateExistingIndex(currentIndexMetadata, snapshotIndexMetadata, renamedIndexName, partial);
-                                    // Index exists and it's closed - open it in metadata and start recovery
-                                    IndexMetadata.Builder indexMdBuilder =
-                                        IndexMetadata.builder(snapshotIndexMetadata).state(IndexMetadata.State.OPEN);
-                                    indexMdBuilder.version(
-                                        Math.max(snapshotIndexMetadata.getVersion(), 1 + currentIndexMetadata.getVersion()));
-                                    indexMdBuilder.mappingVersion(
-                                        Math.max(snapshotIndexMetadata.getMappingVersion(), 1 + currentIndexMetadata.getMappingVersion()));
-                                    indexMdBuilder.settingsVersion(
-                                        Math.max(
-                                            snapshotIndexMetadata.getSettingsVersion(),
-                                            1 + currentIndexMetadata.getSettingsVersion()));
+                                    shards = ImmutableOpenMap.of();
+                                }
 
-                                    for (int shard = 0; shard < snapshotIndexMetadata.getNumberOfShards(); shard++) {
-                                        indexMdBuilder.primaryTerm(shard,
-                                            Math.max(snapshotIndexMetadata.primaryTerm(shard), currentIndexMetadata.primaryTerm(shard)));
+                                validateExistingTemplates();
+                                checkAliasNameConflicts(indices, aliases);
+                                // Restore templates (but do NOT overwrite existing templates)
+                                restoreTemplates(mdBuilder, currentState);
+
+                                // Restore global state if needed
+                                if (request.includeGlobalSettings() && metadata.persistentSettings() != null) {
+                                    Settings settings = metadata.persistentSettings();
+
+                                    // CrateDB patch to only restore defined settings
+                                    if (request.globalSettings().length > 0) {
+                                        var filteredSettingBuilder = Settings.builder();
+                                        for (String prefix : request.globalSettings()) {
+                                            filteredSettingBuilder.put(settings.filter(s -> s.startsWith(prefix)));
+                                        }
+                                        settings = filteredSettingBuilder.build();
                                     }
 
-                                    if (!request.includeAliases()) {
-                                        // Remove all snapshot aliases
-                                        if (!snapshotIndexMetadata.getAliases().isEmpty()) {
-                                            indexMdBuilder.removeAllAliases();
+                                    clusterSettings.validateUpdate(settings);
+                                    mdBuilder.persistentSettings(settings);
+                                }
+
+                                if (request.includeCustomMetadata() && metadata.customs() != null) {
+                                    // CrateDB patch to only restore defined custom metadata types
+                                    List<String> customMetadataTypes = Arrays.asList(request.customMetadataTypes());
+                                    boolean includeAll = customMetadataTypes.size() == 0;
+
+                                    for (ObjectObjectCursor<String, Metadata.Custom> cursor : metadata.customs()) {
+                                        if (!RepositoriesMetadata.TYPE.equals(cursor.key)) {
+                                            // Don't restore repositories while we are working with them
+                                            // TODO: Should we restore them at the end?
+
+                                            if (includeAll || customMetadataTypes.contains(cursor.key)) {
+                                                mdBuilder.putCustom(cursor.key, cursor.value);
+                                            }
                                         }
-                                        /// Add existing aliases
-                                        for (ObjectCursor<AliasMetadata> alias : currentIndexMetadata.getAliases().values()) {
-                                            indexMdBuilder.putAlias(alias.value);
+                                    }
+                                }
+
+                                if (completed(shards)) {
+                                    // We don't have any indices to restore - we are done
+                                    restoreInfo = new RestoreInfo(snapshotId.getName(), Collections.unmodifiableList(new ArrayList<>(indices.keySet())), shards.size(), shards.size() - failedShards(shards));
+                                }
+
+                                RoutingTable rt = rtBuilder.build();
+                                ClusterState updatedState = builder.metadata(mdBuilder).blocks(blocks).routingTable(rt).build();
+                                return allocationService.reroute(updatedState, "restored snapshot [" + snapshot + "]");
+                            }
+
+                            private void checkAliasNameConflicts(Map<String, String> renamedIndices, Set<String> aliases) {
+                                for (Map.Entry<String, String> renamedIndex : renamedIndices.entrySet()) {
+                                    if (aliases.contains(renamedIndex.getKey())) {
+                                        throw new SnapshotRestoreException(snapshot, "cannot rename index [" + renamedIndex.getValue() +
+                                                                                     "] into [" + renamedIndex.getKey() + "] because of conflict with an alias with the same name");
+                                    }
+                                }
+                            }
+
+                            private void populateIgnoredShards(String index, IntSet ignoreShards) {
+                                for (SnapshotShardFailure failure : snapshotInfo.shardFailures()) {
+                                    if (index.equals(failure.index())) {
+                                        ignoreShards.add(failure.shardId());
+                                    }
+                                }
+                            }
+
+                            private boolean checkPartial(String index) {
+                                // Make sure that index was fully snapshotted
+                                if (failed(snapshotInfo, index)) {
+                                    if (request.partial()) {
+                                        return true;
+                                    } else {
+                                        throw new SnapshotRestoreException(snapshot, "index [" + index + "] wasn't fully snapshotted - cannot " + "restore");
+                                    }
+                                } else {
+                                    return false;
+                                }
+                            }
+
+                            private void validateExistingIndex(
+                                IndexMetadata currentIndexMetadata,
+                                IndexMetadata snapshotIndexMetadata,
+                                String renamedIndex,
+                                boolean partial) {
+                                // Index exist - checking that it's closed
+                                if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
+                                    // TODO: Enable restore for open indices
+                                    throw new SnapshotRestoreException(snapshot, "cannot restore index [" + renamedIndex + "] because an open index " +
+                                                                                 "with same name already exists in the cluster. Either close or delete the existing index or restore the " +
+                                                                                 "index under a different name by providing a rename pattern and replacement name");
+                                }
+                                // Index exist - checking if it's partial restore
+                                if (partial) {
+                                    throw new SnapshotRestoreException(snapshot, "cannot restore partial index [" + renamedIndex + "] because such index already exists");
+                                }
+                                // Make sure that the number of shards is the same. That's the only thing that we cannot change
+                                if (currentIndexMetadata.getNumberOfShards() != snapshotIndexMetadata.getNumberOfShards()) {
+                                    throw new SnapshotRestoreException(snapshot, "cannot restore index [" + renamedIndex + "] with [" + currentIndexMetadata.getNumberOfShards() +
+                                                                                 "] shards from a snapshot of index [" + snapshotIndexMetadata.getIndex().getName() + "] with [" +
+                                                                                 snapshotIndexMetadata.getNumberOfShards() + "] shards");
+                                }
+                            }
+
+                            /**
+                             * Optionally updates index settings in indexMetadata by removing settings listed in ignoreSettings and
+                             * merging them with settings in changeSettings.
+                             */
+                            private IndexMetadata updateIndexSettings(IndexMetadata indexMetadata,
+                                                                       Settings changeSettings,
+                                                                       String[] ignoreSettings) {
+                                if (changeSettings.names().isEmpty() && ignoreSettings.length == 0) {
+                                    return indexMetadata;
+                                }
+                                Settings normalizedChangeSettings = Settings.builder().put(changeSettings).normalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX).build();
+                                IndexMetadata.Builder builder = IndexMetadata.builder(indexMetadata);
+                                Settings settings = indexMetadata.getSettings();
+                                Set<String> keyFilters = new HashSet<>();
+                                List<String> simpleMatchPatterns = new ArrayList<>();
+                                for (String ignoredSetting : ignoreSettings) {
+                                    if (!Regex.isSimpleMatchPattern(ignoredSetting)) {
+                                        if (UNREMOVABLE_SETTINGS.contains(ignoredSetting)) {
+                                            throw new SnapshotRestoreException(snapshot, "cannot remove setting [" + ignoredSetting + "] on restore");
+                                        } else {
+                                            keyFilters.add(ignoredSetting);
                                         }
                                     } else {
-                                        for (ObjectCursor<String> alias : snapshotIndexMetadata.getAliases().keys()) {
-                                            aliases.add(alias.value);
+                                        simpleMatchPatterns.add(ignoredSetting);
+                                    }
+                                }
+
+                                Predicate<String> settingsFilter = k -> {
+                                    if (UNREMOVABLE_SETTINGS.contains(k) == false) {
+                                        for (String filterKey : keyFilters) {
+                                            if (k.equals(filterKey)) {
+                                                return false;
+                                            }
+                                        }
+                                        for (String pattern : simpleMatchPatterns) {
+                                            if (Regex.simpleMatch(pattern, k)) {
+                                                return false;
+                                            }
                                         }
                                     }
-                                    indexMdBuilder.settings(Settings.builder()
-                                        .put(snapshotIndexMetadata.getSettings())
-                                        .put(IndexMetadata.SETTING_INDEX_UUID,
-                                            currentIndexMetadata.getIndexUUID()));
-                                    IndexMetadata updatedIndexMetadata = indexMdBuilder.index(renamedIndexName).build();
-                                    rtBuilder.addAsRestore(updatedIndexMetadata, recoverySource);
-                                    blocks.updateBlocks(updatedIndexMetadata);
-                                    mdBuilder.put(updatedIndexMetadata, true);
-                                    renamedIndex = updatedIndexMetadata.getIndex();
-                                }
-                                for (int shard = 0; shard < snapshotIndexMetadata.getNumberOfShards(); shard++) {
-                                    if (!ignoreShards.contains(shard)) {
-                                        shardsBuilder.put(new ShardId(renamedIndex, shard),
-                                            new RestoreInProgress.ShardRestoreStatus(clusterService.state().nodes().getLocalNodeId()));
-                                    } else {
-                                        shardsBuilder.put(new ShardId(renamedIndex, shard),
-                                            new RestoreInProgress.ShardRestoreStatus(clusterService.state().nodes().getLocalNodeId(),
-                                                RestoreInProgress.State.FAILURE));
-                                    }
-                                }
-                            }
-
-                            shards = shardsBuilder.build();
-                            RestoreInProgress.Entry restoreEntry = new RestoreInProgress.Entry(
-                                restoreUUID, snapshot, overallState(RestoreInProgress.State.INIT, shards),
-                                List.copyOf(indices.keySet()),
-                                shards
-                            );
-                            RestoreInProgress.Builder restoreInProgressBuilder;
-                            if (restoreInProgress != null) {
-                                restoreInProgressBuilder = new RestoreInProgress.Builder(restoreInProgress);
-                            } else {
-                                restoreInProgressBuilder = new RestoreInProgress.Builder();
-                            }
-                            builder.putCustom(RestoreInProgress.TYPE, restoreInProgressBuilder.add(restoreEntry).build());
-                        } else {
-                            shards = ImmutableOpenMap.of();
-                        }
-
-                        validateExistingTemplates();
-                        checkAliasNameConflicts(indices, aliases);
-                        // Restore templates (but do NOT overwrite existing templates)
-                        restoreTemplates(mdBuilder, currentState);
-
-                        // Restore global state if needed
-                        if (request.includeGlobalSettings() && metadata.persistentSettings() != null) {
-                            Settings settings = metadata.persistentSettings();
-
-                            // CrateDB patch to only restore defined settings
-                            if (request.globalSettings().length > 0) {
-                                var filteredSettingBuilder = Settings.builder();
-                                for (String prefix : request.globalSettings()) {
-                                    filteredSettingBuilder.put(settings.filter(s -> s.startsWith(prefix)));
-                                }
-                                settings = filteredSettingBuilder.build();
-                            }
-
-                            clusterSettings.validateUpdate(settings);
-                            mdBuilder.persistentSettings(settings);
-                        }
-
-                        if (request.includeCustomMetadata() && metadata.customs() != null) {
-                            // CrateDB patch to only restore defined custom metadata types
-                            List<String> customMetadataTypes = Arrays.asList(request.customMetadataTypes());
-                            boolean includeAll = customMetadataTypes.size() == 0;
-
-                            for (ObjectObjectCursor<String, Metadata.Custom> cursor : metadata.customs()) {
-                                if (!RepositoriesMetadata.TYPE.equals(cursor.key)) {
-                                    // Don't restore repositories while we are working with them
-                                    // TODO: Should we restore them at the end?
-
-                                    if (includeAll || customMetadataTypes.contains(cursor.key)) {
-                                        mdBuilder.putCustom(cursor.key, cursor.value);
-                                    }
-                                }
-                            }
-                        }
-
-                        if (completed(shards)) {
-                            // We don't have any indices to restore - we are done
-                            restoreInfo = new RestoreInfo(snapshotId.getName(),
-                                                          Collections.unmodifiableList(new ArrayList<>(indices.keySet())),
-                                                          shards.size(),
-                                                          shards.size() - failedShards(shards));
-                        }
-
-                        RoutingTable rt = rtBuilder.build();
-                        ClusterState updatedState = builder.metadata(mdBuilder).blocks(blocks).routingTable(rt).build();
-                        return allocationService.reroute(updatedState, "restored snapshot [" + snapshot + "]");
-                    }
-
-                    private void checkAliasNameConflicts(Map<String, String> renamedIndices, Set<String> aliases) {
-                        for (Map.Entry<String, String> renamedIndex : renamedIndices.entrySet()) {
-                            if (aliases.contains(renamedIndex.getKey())) {
-                                throw new SnapshotRestoreException(snapshot,
-                                    "cannot rename index [" + renamedIndex.getValue() + "] into [" + renamedIndex.getKey()
-                                        + "] because of conflict with an alias with the same name");
-                            }
-                        }
-                    }
-
-                    private void populateIgnoredShards(String index, IntSet ignoreShards) {
-                        for (SnapshotShardFailure failure : snapshotInfo.shardFailures()) {
-                            if (index.equals(failure.index())) {
-                                ignoreShards.add(failure.shardId());
-                            }
-                        }
-                    }
-
-                    private boolean checkPartial(String index) {
-                        // Make sure that index was fully snapshotted
-                        if (failed(snapshotInfo, index)) {
-                            if (request.partial()) {
-                                return true;
-                            } else {
-                                throw new SnapshotRestoreException(snapshot, "index [" + index + "] wasn't fully snapshotted - cannot " +
-                                    "restore");
-                            }
-                        } else {
-                            return false;
-                        }
-                    }
-
-                    private void validateExistingIndex(IndexMetadata currentIndexMetadata, IndexMetadata snapshotIndexMetadata,
-                        String renamedIndex, boolean partial) {
-                        // Index exist - checking that it's closed
-                        if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
-                            // TODO: Enable restore for open indices
-                            throw new SnapshotRestoreException(snapshot, "cannot restore index [" + renamedIndex
-                                + "] because an open index " +
-                                "with same name already exists in the cluster. Either close or delete the existing index or restore the " +
-                                "index under a different name by providing a rename pattern and replacement name");
-                        }
-                        // Index exist - checking if it's partial restore
-                        if (partial) {
-                            throw new SnapshotRestoreException(snapshot, "cannot restore partial index [" + renamedIndex
-                                + "] because such index already exists");
-                        }
-                        // Make sure that the number of shards is the same. That's the only thing that we cannot change
-                        if (currentIndexMetadata.getNumberOfShards() != snapshotIndexMetadata.getNumberOfShards()) {
-                            throw new SnapshotRestoreException(snapshot,
-                                "cannot restore index [" + renamedIndex + "] with [" + currentIndexMetadata.getNumberOfShards()
-                                    + "] shards from a snapshot of index [" + snapshotIndexMetadata.getIndex().getName() + "] with [" +
-                                    snapshotIndexMetadata.getNumberOfShards() + "] shards");
-                        }
-                    }
-
-                    /**
-                     * Optionally updates index settings in indexMetadata by removing settings listed in ignoreSettings and
-                     * merging them with settings in changeSettings.
-                     */
-                    private IndexMetadata updateIndexSettings(IndexMetadata indexMetadata, Settings changeSettings, String[] ignoreSettings) {
-                        if (changeSettings.names().isEmpty() && ignoreSettings.length == 0) {
-                            return indexMetadata;
-                        }
-                        Settings normalizedChangeSettings = Settings.builder().put(changeSettings).normalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX).build();
-                        IndexMetadata.Builder builder = IndexMetadata.builder(indexMetadata);
-                        Settings settings = indexMetadata.getSettings();
-                        Set<String> keyFilters = new HashSet<>();
-                        List<String> simpleMatchPatterns = new ArrayList<>();
-                        for (String ignoredSetting : ignoreSettings) {
-                            if (!Regex.isSimpleMatchPattern(ignoredSetting)) {
-                                if (UNREMOVABLE_SETTINGS.contains(ignoredSetting)) {
-                                    throw new SnapshotRestoreException(
-                                        snapshot, "cannot remove setting [" + ignoredSetting + "] on restore");
-                                } else {
-                                    keyFilters.add(ignoredSetting);
-                                }
-                            } else {
-                                simpleMatchPatterns.add(ignoredSetting);
-                            }
-                        }
-                        Predicate<String> settingsFilter = k -> {
-                            if (UNREMOVABLE_SETTINGS.contains(k) == false) {
-                                for (String filterKey : keyFilters) {
-                                    if (k.equals(filterKey)) {
-                                        return false;
-                                    }
-                                }
-                                for (String pattern : simpleMatchPatterns) {
-                                    if (Regex.simpleMatch(pattern, k)) {
-                                        return false;
-                                    }
-                                }
-                            }
-                            return true;
-                        };
-                        Settings.Builder settingsBuilder = Settings.builder()
-                            .put(settings.filter(settingsFilter))
-                            .put(normalizedChangeSettings.filter(k -> {
-                                if (UNMODIFIABLE_SETTINGS.contains(k)) {
-                                    throw new SnapshotRestoreException(snapshot, "cannot modify setting [" + k + "] on restore");
-                                } else {
                                     return true;
-                                }
-                            }));
-                        settingsBuilder.remove(IndexMetadata.VERIFIED_BEFORE_CLOSE_SETTING.getKey());
-                        return builder.settings(settingsBuilder).build();
-                    }
+                                };
 
-                    private void restoreTemplates(Metadata.Builder mdBuilder, ClusterState currentState) {
-                        List<String> toRestore = Arrays.asList(request.templates());
-                        if (metadata.templates() != null) {
-                            for (ObjectCursor<IndexTemplateMetadata> cursor : metadata.templates().values()) {
-                                if (currentState.metadata().templates().get(cursor.value.name()) == null
-                                    && (request.allTemplates() || toRestore.contains(cursor.value.name()))) {
-                                    mdBuilder.put(cursor.value);
+                                Settings.Builder settingsBuilder = Settings.builder()
+                                    .put(settings.filter(settingsFilter))
+                                    .put(normalizedChangeSettings.filter(k -> {
+                                        if (UNMODIFIABLE_SETTINGS.contains(k)) {
+                                            throw new SnapshotRestoreException(snapshot, "cannot modify setting [" + k + "] on restore");
+                                        } else {
+                                            return true;
+                                        }
+                                    }));
+                                settingsBuilder.remove(IndexMetadata.VERIFIED_BEFORE_CLOSE_SETTING.getKey());
+                                return builder.settings(settingsBuilder).build();
+                            }
+
+                            private void restoreTemplates(Metadata.Builder mdBuilder, ClusterState currentState) {
+                                List<String> toRestore = Arrays.asList(request.templates());
+                                if (metadata.templates() != null) {
+                                    for (ObjectCursor<IndexTemplateMetadata> cursor : metadata.templates().values()) {
+                                        if (currentState.metadata().templates().get(cursor.value.name()) == null
+                                            && (request.allTemplates() || toRestore.contains(cursor.value.name()))) {
+                                            mdBuilder.put(cursor.value);
+                                        }
+                                    }
                                 }
                             }
-                        }
-                    }
 
-                    private void validateExistingTemplates() {
-                        if (request.indicesOptions().ignoreUnavailable() || request.allTemplates()) {
-                            return;
-                        }
-                        for (String template : request.templates()) {
-                            if (!metadata.templates().containsKey(template)) {
-                                throw new ResourceNotFoundException("[{}] template not found", template);
+                            private void validateExistingTemplates() {
+                                if (request.indicesOptions().ignoreUnavailable() || request.allTemplates()) {
+                                    return;
+                                }
+                                for (String template : request.templates()) {
+                                    if (!metadata.templates().containsKey(template)) {
+                                        throw new ResourceNotFoundException("[{}] template not found", template);
+                                    }
+                                }
                             }
-                        }
-                    }
 
-                    @Override
-                    public void onFailure(String source, Exception e) {
-                        LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to restore snapshot", snapshotId), e);
-                        listener.onFailure(e);
-                    }
+                            @Override
+                            public void onFailure(String source, Exception e) {
+                                LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to restore snapshot", snapshotId), e);
+                                listener.onFailure(e);
+                            }
 
-                    @Override
-                    public TimeValue timeout() {
-                        return request.masterNodeTimeout();
-                    }
+                            @Override
+                            public TimeValue timeout() {
+                                return request.masterNodeTimeout();
+                            }
 
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        listener.onResponse(new RestoreCompletionResponse(restoreUUID, snapshot, restoreInfo));
-                    }
-                });
-            }, listener::onFailure);
+                            @Override
+                            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                                listener.onResponse(new RestoreCompletionResponse(restoreUUID, snapshot, restoreInfo));
+                            }
+                        });
+                    }, listener::onFailure);
+                }, listener::onFailure);
+            },listener::onFailure);
+
+
         } catch (Exception e) {
             LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to restore snapshot", request.repositoryName + ":" + request.snapshotName), e);
             listener.onFailure(e);

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -41,6 +41,8 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotShardFailure;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -68,13 +70,30 @@ public abstract class RestoreOnlyRepository implements Repository {
     }
 
     @Override
-    public Metadata getSnapshotGlobalMetadata(SnapshotId snapshotId) {
-        return null;
+    public void getSnapshotGlobalMetadata(SnapshotId snapshotId,
+                                          ActionListener<Metadata> listener) {
+
     }
 
     @Override
-    public IndexMetadata getSnapshotIndexMetadata(SnapshotId snapshotId, IndexId index) {
-        return null;
+    public void getSnapshotIndexMetadata(SnapshotId snapshotId,
+                                         IndexId indexId,
+                                         ActionListener<IndexMetadata> listener) throws IOException {
+
+    }
+
+    @Override
+    public void getSnapshotIndexMetadata(SnapshotId snapshotId,
+                                         Collection<IndexId> indexIds,
+                                         ActionListener<Collection<IndexMetadata>> listener) {
+
+    }
+
+    @Override
+    public void getShardSnapshotStatus(SnapshotId snapshotId,
+                                       Map<ShardId, IndexId> shardIndexIds,
+                                       ActionListener<Map<ShardId, IndexShardSnapshotStatus>> listener) {
+
     }
 
     @Override
@@ -146,12 +165,6 @@ public abstract class RestoreOnlyRepository implements Repository {
                              RecoveryState recoveryState,
                              ActionListener<Void> listener) {
 
-    }
-
-    @Override
-    public IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId,
-                                                           IndexId indexId, ShardId shardId) {
-        return null;
     }
 
     @Override

--- a/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -198,7 +198,7 @@ public final class BlobStoreTestUtil {
                 final BlobContainer indexContainer = indices.get(indexId.getId());
                 assertThat(indexContainer.listBlobs(),
                            hasKey(String.format(Locale.ROOT, BlobStoreRepository.METADATA_NAME_FORMAT, snapshotId.getUUID())));
-                final IndexMetadata indexMetadata = repository.getSnapshotIndexMetadata(snapshotId, indexId);
+                final IndexMetadata indexMetadata = PlainActionFuture.get(x -> repository.getSnapshotIndexMetadata(snapshotId, indexId, x));
                 for (Map.Entry<String, BlobContainer> entry : indexContainer.children().entrySet()) {
                     // Skip Lucene MockFS extraN directory
                     if (entry.getKey().startsWith("extra")) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `Repository` interface is adapted to make async and batched operations for the implementation possible.
Pre-requisite for a non-blocking `LogicalReplicationRepository`.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
