### PR TITLE
Add privilege check for pub sub creation (no ownership check)

### DIFF
--- a/docs/admin/logical-replication.rst
+++ b/docs/admin/logical-replication.rst
@@ -85,3 +85,20 @@ you can't replicate a view.
 The tables are matched between the publisher and the subscriber using the fully
 qualified table name. Replication to differently-named tables on the subscriber
 is not supported.
+
+Security
+--------
+
+To create a publication, a user must have the ``AL`` privilege on the cluster.
+To add tables to a publication, the user must have all privileges on the
+table (``AL``, ``DQL``, ``DML``, ``DDL``). When user creates a publication that
+publishes all tables automatically, only those tables where user has all
+privileges will be published.
+
+To create a subscription, a user must have the ``AL`` privilege in the cluster.
+
+.. CAUTION::
+
+   A network setup that allows the two clusters to communicate is a
+   pre-requisite for a working publication/subscription setup.
+   See :ref:`HBA <admin_hba_node>`.

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -53,6 +53,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import static io.crate.user.Privilege.Type.VALUES;
 import static io.crate.user.User.CRATE_USER;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
@@ -616,5 +617,21 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_show_transaction_isolation_does_not_require_privileges() throws Exception {
         analyze("show transaction_isolation");
         assertThat(validationCallArguments, Matchers.empty());
+    }
+
+    @Test
+    public void test_create_publication_for_specific_tables_asks_clusterAL_and_all_for_each_table() {
+        analyze("create publication pub1 FOR TABLE t1, t2", user);
+        assertAskedForCluster(Privilege.Type.AL);
+        for (Privilege.Type type: VALUES) {
+            assertAskedForTable(type, "doc.t1");
+            assertAskedForTable(type, "doc.t2");
+        }
+    }
+
+    @Test
+    public void test_create_subscription_asks_cluster_AL() {
+        analyze("create subscription sub1 CONNECTION 'postgresql://user@localhost/crate:5432' PUBLICATION pub1", user);
+        assertAskedForCluster(Privilege.Type.AL);
     }
 }


### PR DESCRIPTION
User + privileges awareness of publication and subscription

https://www.postgresql.org/docs/14/logical-replication-security.html

intra-zone communication must be protected by [node 2 node encryption](https://crate.io/docs/crate/reference/en/master/admin/auth/hba.html#node-to-node-communication) (mentioned in docs)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
