### PR TITLE
Remove `valueForDisplay` from MappedFieldType

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -237,7 +237,6 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             SourceFieldMapper.NAME;
         final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
         leaf.reader().document(segmentDocID, fields);
-        fields.postProcess(mapperService);
 
         final Translog.Operation op;
         final boolean isTombstone = parallelArray.isTombStone[docIndex];

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -24,9 +24,8 @@ import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.IdFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
@@ -76,20 +75,6 @@ public class FieldsVisitor extends StoredFieldVisitor {
         return requiredFields.isEmpty()
                 ? Status.STOP
                 : Status.NO;
-    }
-
-    public void postProcess(MapperService mapperService) {
-        for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
-            MappedFieldType fieldType = mapperService.fullName(entry.getKey());
-            if (fieldType == null) {
-                throw new IllegalStateException("Field [" + entry.getKey()
-                    + "] exists in the index but not in mappings");
-            }
-            List<Object> fieldValues = entry.getValue();
-            for (int i = 0; i < fieldValues.size(); i++) {
-                fieldValues.set(i, fieldType.valueForDisplay(fieldValues.get(i)));
-            }
-        }
     }
 
     @Override
@@ -146,7 +131,7 @@ public class FieldsVisitor extends StoredFieldVisitor {
             return null;
         }
         assert values.size() == 1;
-        return values.get(0).toString();
+        return BytesRefs.toString(values.get(0));
     }
 
     public Map<String, List<Object>> fields() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -152,21 +152,6 @@ public class BooleanFieldMapper extends FieldMapper {
                                     sValue + "], expected [true] or [false]");
             }
         }
-
-        @Override
-        public Boolean valueForDisplay(Object value) {
-            if (value == null) {
-                return null;
-            }
-            switch (value.toString()) {
-                case "F":
-                    return false;
-                case "T":
-                    return true;
-                default:
-                    throw new IllegalArgumentException("Expected [T] or [F] but got [" + value + "]");
-            }
-        }
     }
 
     private final Boolean nullValue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -191,14 +191,6 @@ public class DateFieldMapper extends FieldMapper {
             return dateTimeFormatter().parser().parseMillis(value);
         }
 
-        @Override
-        public Object valueForDisplay(Object value) {
-            Long val = (Long) value;
-            if (val == null) {
-                return null;
-            }
-            return dateTimeFormatter().printer().print(val);
-        }
     }
 
     private final Boolean ignoreTimezone;

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.search.DocValueFormat;
 
 
 /** A {@link FieldMapper} for ip addresses. */
@@ -135,13 +134,6 @@ public class IpFieldMapper extends FieldMapper {
         }
 
 
-        @Override
-        public Object valueForDisplay(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return DocValueFormat.IP.format((BytesRef) value);
-        }
     }
 
     private final InetAddress nullValue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -191,16 +191,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Object valueForDisplay(Object value) {
-            if (value == null) {
-                return null;
-            }
-            // keywords are internally stored as utf8 bytes
-            BytesRef binaryValue = (BytesRef) value;
-            return binaryValue.utf8ToString();
-        }
-
-        @Override
         protected BytesRef indexedValueForSearch(Object value) {
             if (searchAnalyzer() == Lucene.KEYWORD_ANALYZER) {
                 // keyword analyzer with the default attribute source which encodes terms using UTF8

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -81,14 +81,6 @@ public abstract class MappedFieldType {
         this.searchQuoteAnalyzer = analyzer;
     }
 
-
-    /** Given a value that comes from the stored fields API, convert it to the
-     *  expected type. For instance a date field would store dates as longs and
-     *  format it back to a string in this method. */
-    public Object valueForDisplay(Object value) {
-        return value;
-    }
-
     /**
      * Returns true if the field is searchable.
      */

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -450,14 +450,6 @@ public class NumberFieldMapper extends FieldMapper {
             return type.name;
         }
 
-        @Override
-        public Object valueForDisplay(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return type.valueForSearch((Number) value);
-        }
-
     }
 
     private NumberFieldMapper(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There was a single use within FieldVisitor.postProcess.

`FieldVisitor.postProcess` itself can be removed. In the one call-site
only `id`, `routing` and `source` get accessed. Of the three only
`routing` was affected by the `postProcess` and we can handle that case
directly.

This is motivated by https://github.com/crate/crate/issues/10025
We already got several methods on `DataType` with a similar purpose.
(implicitCast, explicitCast, valueForInsert, sanitizeValue).


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
