### PR TITLE
Enable prototype methods for JavaScript objects in UDFs

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -138,7 +138,7 @@ Changes
   including the top level column name and path information of object elements.
 
 - Enabled the setting of most prototype methods for JavaScript Objects (e.g. 
-  Array.prototype, Object.prototype) in User Defined Functions 
+  Array.prototype, Object.prototype) in :ref:`user-defined functions <user-defined-functions>`
 
 Fixes
 =====

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -137,6 +137,9 @@ Changes
 - Added the `column_details` column to the `information_schema.columns` table
   including the top level column name and path information of object elements.
 
+- Enabled the setting of most prototype methods for JavaScript Objects (e.g. 
+  Array.prototype, Object.prototype) in User Defined Functions 
+
 Fixes
 =====
 

--- a/docs/general/user-defined-functions.rst
+++ b/docs/general/user-defined-functions.rst
@@ -242,6 +242,16 @@ Also, even though user-defined functions implemented with ECMA-compliant
 JavaScript, objects that are normally accessible with a web browser
 (e.g. ``window``, ``console``, and so on) are not available.
 
+.. NOTE::
+    
+    GraalVM treats objects provided to JavaScript user-defined functions as 
+    close as possible to their respective counterparts and therefore by default 
+    only a subset of prototype functions are available in user-defined 
+    functions. For CrateDB 4.6 and earlier the object prototype was disabled.
+    
+    Please refer to the `GraalVM JavaScript Compatibility FAQ`_ to learn more 
+    about the compatibility.
+
 
 .. _udf-js-supported-types:
 
@@ -394,6 +404,7 @@ is returned::
 
 .. _ECMAScript 2019: https://262.ecma-international.org/10.0/index.html
 .. _GraalVM JavaScript: https://www.graalvm.org/reference-manual/js/
+.. _GraalVM JavaScript Compatibility FAQ: https://www.graalvm.org/reference-manual/js/FAQ/#compatibility
 .. _GraalVM Polyglot API: https://www.graalvm.org/reference-manual/embed-languages/
 .. _GraalVM Security Guide: https://www.graalvm.org/security-guide/
 .. _stock host Java VM JIT compilers: https://www.graalvm.org/reference-manual/js/RunOnJDK/

--- a/docs/general/user-defined-functions.rst
+++ b/docs/general/user-defined-functions.rst
@@ -392,45 +392,8 @@ is returned::
     cr> DROP FUNCTION utc(bigint, bigint, bigint);
     DROP OK, 1 row affected  (... sec)
 
-
-.. _udf-js-array-methods:
-
-Working with ``Array`` methods
-..............................
-
-The JavaScript ``Array`` object has a number of prototype methods you can
-use, such as `join`_, `map`_, `sort`_, `slice`_, `reduce`_, and so on.
-
-Normally, you can call these methods directly from an ``Array`` object, like
-so:
-
-.. code-block:: js
-
-    function array_join(a, b) {
-        return a.join(b);
-    }
-
-However, when writing JavaScript for use with CrateDB, you must explicitly use
-the prototype method:
-
-.. code-block:: js
-
-    function array_join(a, b) {
-        return Array.prototype.join.call(a, b);
-    }
-
-You must do it like this because arguments are not passed as ``Array`` objects,
-and so do not have the associated prototype methods available. Arguments are instead
-passed as array-like objects.
-
-
 .. _ECMAScript 2019: https://262.ecma-international.org/10.0/index.html
 .. _GraalVM JavaScript: https://www.graalvm.org/reference-manual/js/
 .. _GraalVM Polyglot API: https://www.graalvm.org/reference-manual/embed-languages/
 .. _GraalVM Security Guide: https://www.graalvm.org/security-guide/
-.. _join: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join
-.. _map: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
-.. _reduce: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
-.. _slice: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
-.. _sort: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 .. _stock host Java VM JIT compilers: https://www.graalvm.org/reference-manual/js/RunOnJDK/

--- a/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
+++ b/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
@@ -46,6 +46,7 @@ public class JavaScriptLanguage implements UDFLanguage {
     static final String NAME = "javascript";
 
     private static final Engine ENGINE = Engine.newBuilder()
+        .option("js.foreign-object-prototype", "true")
         .build();
 
     private static final HostAccess HOST_ACCESS = HostAccess.newBuilder()

--- a/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -349,7 +349,7 @@ public class JavascriptUserDefinedFunctionTest extends ScalarTestCase {
             "f",
             DataTypes.STRING,
             List.of(DataTypes.STRING_ARRAY),
-            "function f(a) { return Array.prototype.join.call(a, '.'); }");
+            "function f(a) { return a.join('.'); }");
         assertEvaluate("f(['a', 'b'])", is("a.b"));
         assertEvaluate("f(['a', 'b'])", is("a.b"), Literal.of(List.of("a", "b"), DataTypes.STRING_ARRAY));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Enable prototype methods for JavaScript objects in UDFs

---

By default GraalVM does map Java arrays to shallow JavaScript arrays with an empty prototype objects [1]. This means, that if you want to call e.g. array methods like 

```js
myArray.sort((a,b) => b - a)
```

one needs to explicitly call them like

```js
Array.prototype.call.sort(myArray, (a,b) => b - a)
```

This behaviour can be changed by enabling the `js.foreign-object-prototype` option, which has been moved from the experimental stage in version 20.3.0. 

> When enabled, objects on the JavaScript side get the most prototype (e.g. Array.prototype, Function.prototype, Object.prototype) set and can thus behave more similarly to native JavaScript objects of the respective type. Normal JavaScript precedence rules apply here, e.g., own properties (of the Java object in that case) take precedence over and hide properties from the prototype.

This change should make the writing of JavaScript UDFs more straight forward for new users.

[1] https://www.graalvm.org/reference-manual/js/FAQ/#builtin-functions-like-arraymap-or-fnapply-are-not-available-on-non-javascript-objects-like-proxyarrays-from-java


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
