### PR TITLE
Remove unused `dynamic_date_formats` support

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -362,8 +362,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
             custom.toXContent(builder, params);
         }
 
-        doXContent(builder, params);
-
         // sort the mappers so we get consistent serialization format
         Mapper[] sortedMappers = mappers.values().stream().toArray(size -> new Mapper[size]);
         Arrays.sort(sortedMappers, new Comparator<Mapper>() {
@@ -387,9 +385,4 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
         builder.endObject();
     }
-
-    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -19,47 +19,20 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.Explicit;
-import javax.annotation.Nullable;
-import org.elasticsearch.common.joda.FormatDateTimeFormatter;
-import org.elasticsearch.common.joda.Joda;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.index.mapper.TypeParsers.parseDateTimeFormatter;
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.settings.Settings;
 
 public class RootObjectMapper extends ObjectMapper {
 
-    public static class Defaults {
-        public static final FormatDateTimeFormatter[] DYNAMIC_DATE_TIME_FORMATTERS =
-            new FormatDateTimeFormatter[] {
-                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
-                Joda.getStrictStandardDateFormatter()
-            };
-    }
-
     public static class Builder extends ObjectMapper.Builder<Builder> {
-
-        protected Explicit<FormatDateTimeFormatter[]> dynamicDateTimeFormatters = new Explicit<>(Defaults.DYNAMIC_DATE_TIME_FORMATTERS, false);
 
         public Builder(String name) {
             super(name);
             this.builder = this;
-        }
-
-        public Builder dynamicDateTimeFormatter(Collection<FormatDateTimeFormatter> dateTimeFormatters) {
-            this.dynamicDateTimeFormatters = new Explicit<>(dateTimeFormatters.toArray(new FormatDateTimeFormatter[0]), true);
-            return this;
         }
 
         @Override
@@ -74,7 +47,6 @@ public class RootObjectMapper extends ObjectMapper {
                 name,
                 dynamic,
                 mappers,
-                dynamicDateTimeFormatters,
                 settings
             );
         }
@@ -92,88 +64,23 @@ public class RootObjectMapper extends ObjectMapper {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
                 Object fieldNode = entry.getValue();
-                if (parseObjectOrDocumentTypeProperties(fieldName, fieldNode, parserContext, builder)
-                        || processField(builder, fieldName, fieldNode, parserContext.indexVersionCreated())) {
+                if (parseObjectOrDocumentTypeProperties(fieldName, fieldNode, parserContext, builder)) {
                     iterator.remove();
                 }
             }
             return builder;
         }
-
-        @SuppressWarnings("unchecked")
-        protected boolean processField(RootObjectMapper.Builder builder, String fieldName, Object fieldNode,
-                                       Version indexVersionCreated) {
-            if (fieldName.equals("date_formats") || fieldName.equals("dynamic_date_formats")) {
-                if (fieldNode instanceof List) {
-                    List<FormatDateTimeFormatter> formatters = new ArrayList<>();
-                    for (Object formatter : (List<?>) fieldNode) {
-                        if (formatter.toString().startsWith("epoch_")) {
-                            throw new MapperParsingException(
-                                "Epoch [" + formatter + "] is not supported as dynamic date format");
-                        }
-                        formatters.add(parseDateTimeFormatter(formatter));
-                    }
-                    builder.dynamicDateTimeFormatter(formatters);
-                } else if ("none".equals(fieldNode.toString())) {
-                    builder.dynamicDateTimeFormatter(Collections.emptyList());
-                } else {
-                    builder.dynamicDateTimeFormatter(Collections.singleton(parseDateTimeFormatter(fieldNode)));
-                }
-                return true;
-            }
-            return false;
-        }
     }
-
-    private Explicit<FormatDateTimeFormatter[]> dynamicDateTimeFormatters;
 
     RootObjectMapper(String name,
                      Dynamic dynamic,
                      Map<String, Mapper> mappers,
-                     Explicit<FormatDateTimeFormatter[]> dynamicDateTimeFormatters,
                      Settings settings) {
         super(name, null, name, dynamic, mappers, settings);
-        this.dynamicDateTimeFormatters = dynamicDateTimeFormatters;
-    }
-
-    @Override
-    public ObjectMapper mappingUpdate(Mapper mapper) {
-        RootObjectMapper update = (RootObjectMapper) super.mappingUpdate(mapper);
-        // for dynamic updates, no need to carry root-specific options, we just
-        // set everything to they implicit default value so that they are not
-        // applied at merge time
-        update.dynamicDateTimeFormatters = new Explicit<FormatDateTimeFormatter[]>(Defaults.DYNAMIC_DATE_TIME_FORMATTERS, false);
-        return update;
-    }
-
-    public FormatDateTimeFormatter[] dynamicDateTimeFormatters() {
-        return dynamicDateTimeFormatters.value();
     }
 
     @Override
     public RootObjectMapper merge(Mapper mergeWith) {
         return (RootObjectMapper) super.merge(mergeWith);
-    }
-
-    @Override
-    protected void doMerge(ObjectMapper mergeWith) {
-        super.doMerge(mergeWith);
-        RootObjectMapper mergeWithObject = (RootObjectMapper) mergeWith;
-        if (mergeWithObject.dynamicDateTimeFormatters.explicit()) {
-            this.dynamicDateTimeFormatters = mergeWithObject.dynamicDateTimeFormatters;
-        }
-    }
-
-    @Override
-    protected void doXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-        final boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
-
-        if (dynamicDateTimeFormatters.explicit() || includeDefaults) {
-            builder.startArray("dynamic_date_formats");
-            for (FormatDateTimeFormatter dateTimeFormatter : dynamicDateTimeFormatters.value()) {
-                builder.value(dateTimeFormatter.format());
-            }
-            builder.endArray();
-        }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Remove unused `dynamic_date_formats` support

`dynamic_date_formats` would allow to detect date time formats within
dynamic strings, but the feature is not exposed via SQL.

Removing it is motivated by https://github.com/crate/crate/issues/10025

If we want to skip parsing the source, we need to handle dynamic schema
updates differently and removing unused/unnecessary logic will make that
easier.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
