### PR TITLE
Unwrap alias object on Lucene query build

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -147,3 +147,7 @@ Fixes
 - Fixed an issue that caused ``date_format()`` to return wrong values when used
   with the ``%D`` specifier (day of month as ordinal number) for 11th, 12th and
   13th.
+
+- Fixed a performance regression introduced in 4.2 which caused queries with
+  ``WHERE`` clause on aliased column on top of views or virtual tables to be
+  slow.

--- a/server/src/main/java/io/crate/expression/symbol/AliasResolver.java
+++ b/server/src/main/java/io/crate/expression/symbol/AliasResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.symbol;
+
+public class AliasResolver extends FunctionCopyVisitor<Void> {
+
+    public static AliasResolver INSTANCE = new AliasResolver();
+
+    @Override
+    public Symbol visitAlias(AliasSymbol aliasSymbol, Void context) {
+        return aliasSymbol.symbol().accept(this, context);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import io.crate.expression.symbol.AliasResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
@@ -143,6 +144,7 @@ public class Optimizer {
 
         @Override
         public Symbol visitFunction(io.crate.expression.symbol.Function symbol, Void context) {
+            symbol = (io.crate.expression.symbol.Function) symbol.accept(AliasResolver.INSTANCE, null);
             visitedFunctions.push(symbol);
             var maybeTransformedSymbol = tryApplyRules(symbol);
             if (symbol.equals(maybeTransformedSymbol) == false) {

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -39,7 +39,7 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
     @Rule
     public TestName testName = new TestName();
 
-    private QueryTester queryTester;
+    protected QueryTester queryTester;
 
     @Before
     public void prepare() throws Exception {

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -195,7 +195,7 @@ public final class QueryTester implements AutoCloseable {
                     return Optimizer.optimizeCasts(expressions.normalize(boundSymbol), plannerContext);
                 },
                 symbol -> queryBuilder.convert(
-                    symbol,
+                    Optimizer.optimizeCasts(symbol,plannerContext),
                     systemTxnCtx,
                     indexEnv.mapperService(),
                     indexEnv.indexService().index().getName(),


### PR DESCRIPTION
Resolves [#11846](https://github.com/crate/crate/issues/11846)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
