### PR TITLE
Remove unused method from Repository interface

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -41,7 +41,6 @@ import org.elasticsearch.snapshots.SnapshotShardFailure;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -52,8 +51,6 @@ import java.util.function.Function;
  * <p>
  * To perform a snapshot:
  * <ul>
- * <li>Master calls {@link #initializeSnapshot(SnapshotId, List, org.elasticsearch.cluster.metadata.Metadata)}
- * with list of indices that will be included into the snapshot</li>
  * <li>Data nodes call {@link Repository#snapshotShard}
  * for each shard</li>
  * <li>When all shard calls return master calls {@link #finalizeSnapshot} with possible list of failures</li>
@@ -228,15 +225,6 @@ public interface Repository extends LifecycleComponent {
      */
     void restoreShard(Store store, SnapshotId snapshotId, IndexId indexId, ShardId snapshotShardId, RecoveryState recoveryState,
                       ActionListener<Void> listener);
-
-    /**
-     * Retrieve multiple shard snapshot statuses for the stored snapshot
-     *
-     * @param snapshotId    snapshot id
-     * @param shardIndexIds Map containing the shardId and the corresponding snapshotted indexId
-     * @param listener      listener to invoke once done
-     */
-    void getShardSnapshotStatus(SnapshotId snapshotId, Map<ShardId, IndexId> shardIndexIds, ActionListener<Map<ShardId, IndexShardSnapshotStatus>> listener);
 
     /**
      * Update the repository with the incoming cluster state. This method is invoked from {@link RepositoriesService#applyClusterState} and

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -117,7 +117,6 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1761,30 +1760,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private static InputStream maybeRateLimit(InputStream stream, @Nullable RateLimiter rateLimiter, CounterMetric metric) {
         return rateLimiter == null ? stream : new RateLimitingInputStream(stream, rateLimiter, metric::inc);
-    }
-
-    @Override
-    public void getShardSnapshotStatus(SnapshotId snapshotId, Map<ShardId,IndexId> shardIndexIds, ActionListener<Map<ShardId, IndexShardSnapshotStatus>> listener) {
-        try {
-            var result = new HashMap<ShardId, IndexShardSnapshotStatus>();
-            for (var shardIndexId : shardIndexIds.entrySet()) {
-                var shardId = shardIndexId.getKey();
-                var indexId = shardIndexId.getValue();
-                BlobStoreIndexShardSnapshot snapshot = loadShardSnapshot(shardContainer(indexId, shardId), snapshotId);
-                result.put(shardId, IndexShardSnapshotStatus.newDone(
-                    snapshot.startTime(),
-                    snapshot.time(),
-                    snapshot.incrementalFileCount(),
-                    snapshot.totalFileCount(),
-                    snapshot.incrementalSize(),
-                    snapshot.totalSize(),
-                    null)
-                ); // Not adding a real generation here as it doesn't matter to callers
-            }
-            listener.onResponse(result);
-        } catch (SnapshotException e) {
-            listener.onFailure(e);
-        }
     }
 
     @Override

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -43,8 +43,6 @@ import org.elasticsearch.snapshots.SnapshotShardFailure;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,13 +84,6 @@ public abstract class RestoreOnlyRepository implements Repository {
     public void getSnapshotIndexMetadata(SnapshotId snapshotId,
                                          Collection<IndexId> indexIds,
                                          ActionListener<Collection<IndexMetadata>> listener) {
-
-    }
-
-    @Override
-    public void getShardSnapshotStatus(SnapshotId snapshotId,
-                                       Map<ShardId, IndexId> shardIndexIds,
-                                       ActionListener<Map<ShardId, IndexShardSnapshotStatus>> listener) {
 
     }
 


### PR DESCRIPTION
The `Repository.getShardSnapshotStatus()` method is not used inside CrateDB