### PR TITLE
Minor documentation edits

### DIFF
--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -200,14 +200,6 @@ Behavior of ``GRANT``, ``DENY`` and ``REVOKE``
     must :ref:`create a user <administration_user_management>` and then
     configure privileges.
 
-.. CAUTION::
-
-    Stale permissions might be introduced if ``DDL`` statements were invoked
-    while the Enterprise Edition is temporarily disabled. To allow clients
-    to remove such stale permissions even, if the table does not exist anymore,
-    the ``REVOKE`` statement does not perform any validation checks on the
-    table ident.
-
 ``GRANT``
 .........
 

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1779,7 +1779,7 @@ License check
 .. NOTE::
 
    This check was removed in version 4.5 because CrateDB no longer requires an
-   enterprise license
+   enterprise license, see also `Farewell to the CrateDB Enterprise License`_.
 
 
 This check warns you when your license is close to expiration, is already
@@ -2296,3 +2296,6 @@ been analyzed.
 
     Not all data types support creating statistics. So some columns may not
     show up in the table.
+
+
+.. _Farewell to the CrateDB Enterprise License: https://crate.io/blog/farewell-to-the-cratedb-enterprise-license-faq

--- a/docs/admin/udc.rst
+++ b/docs/admin/udc.rst
@@ -77,10 +77,6 @@ Below are two ways you can disable UDC. However we hope you support us offering
 the open source edition, and leave UDC on, so we learn how many people use
 CrateDB.
 
-.. NOTE::
-
-   If UDC is disabled on the CrateDB server the Intercom service is
-   deactivated.
 
 .. highlight:: yaml
 

--- a/docs/admin/udc.rst
+++ b/docs/admin/udc.rst
@@ -47,7 +47,7 @@ Hardware Address  MAC address to uniquely identify instances behind
                   firewalls.
 Processor count   Number of available CPUs as reported by
                   ``Runtime.availableProcessors``
-Enterprise        Identifies whether the Enterprise Edition is used.
+Enterprise        Identifies whether the Enterprise Edition is used. [#f1]_
 ================  =========================================================
 
 After startup, UDC waits for 10 minutes before sending the first ping. It does
@@ -95,3 +95,10 @@ a system property setting like this will also make sure that UDC is never
 activated::
 
     -Cudc.enabled=false
+
+
+.. [#f1] The "CrateDB Enterprise Edition" has been dissolved starting with
+         CrateDB 4.5.0, see also `Farewell to the CrateDB Enterprise License`_.
+
+
+.. _Farewell to the CrateDB Enterprise License: https://crate.io/blog/farewell-to-the-cratedb-enterprise-license-faq


### PR DESCRIPTION
Hi there,

because we have been working on the UDC backend recently, I found that the corresponding documentation here still contained a reference to "Intercom", which has been phased out already (see also https://github.com/crate/crate-admin/pull/725).

The other updates are related to the former "CrateDB Enterprise Edition", because I also found a reference to it within the UDC documentation, where I decided not to remove it but add a footnote instead.

With kind regards,
Andreas.
