### PR TITLE
Add tracking of metadata for logical replication

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -89,6 +89,7 @@ public class LogicalReplicationService extends RemoteClusterAware implements Clu
     private final Map<String, RemoteClusterConnection> remoteClusters = ConcurrentCollections.newConcurrentMap();
     private volatile SubscriptionsMetadata currentSubscriptionsMetadata = new SubscriptionsMetadata();
     private volatile PublicationsMetadata currentPublicationsMetadata = new PublicationsMetadata();
+    private final MetadataTracker metadataTracker;
 
     public LogicalReplicationService(Settings settings,
                                      ClusterService clusterService,
@@ -98,6 +99,12 @@ public class LogicalReplicationService extends RemoteClusterAware implements Clu
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
+        this.metadataTracker = new MetadataTracker(
+            settings,
+            threadPool,
+            subscriptionName -> getRemoteClusterClient(threadPool, subscriptionName),
+            clusterService
+        );
         clusterService.addListener(this);
     }
 
@@ -144,54 +151,62 @@ public class LogicalReplicationService extends RemoteClusterAware implements Clu
 
         for (var entry : newSubscriptions.entrySet()) {
             var subscriptionName = entry.getKey();
-            if (oldSubscriptions.get(subscriptionName) == null) {
-                assert repositoriesService != null
-                    : "RepositoriesService must be set immediately after LogicalReplicationService construction";
-
-                LOGGER.debug("Adding new logical replication repository for subscription '{}'", subscriptionName);
-                repositoriesService.registerInternalRepository(REMOTE_REPOSITORY_PREFIX + subscriptionName, TYPE);
-
-                if (clusterService.localNode().isMasterNode()) {
-                    withRetry(
-                        () -> {
-                            // The startReplication will initiate the remote connection upfront
-                            LOGGER.debug("Start logical replication for subscription '{}'", subscriptionName);
-                            startReplication(subscriptionName, entry.getValue(), new ActionListener<>() {
-
-                                @Override
-                                public void onResponse(AcknowledgedResponse acknowledgedResponse) {
-                                    LOGGER.debug("Acknowledged logical replication for subscription '{}'",
-                                                 subscriptionName);
-                                }
-
-                                @Override
-                                public void onFailure(Exception e) {
-                                    LOGGER.debug("Failure for logical replication for subscription", e);
-                                }
-                            });
-                        }
-                    ).run();
-                } else {
-                    // Initiate the remote connection for the subscription, needed on all nodes to restore the
-                    // repository and for following remote shard changes.
-                    // Must run inside a transport thread
-                    withRetry(() -> updateRemoteConnection(subscriptionName)).run();
-                }
+            boolean subscriptionAdded = oldSubscriptions.get(subscriptionName) == null;
+            if (subscriptionAdded) {
+                addSubscription(subscriptionName, entry.getValue());
             }
         }
         for (var entry : oldSubscriptions.entrySet()) {
             var subscriptionName = entry.getKey();
-            if (newSubscriptions.get(subscriptionName) == null) {
-                assert repositoriesService != null
-                    : "RepositoriesService must be set immediately after LogicalReplicationService construction";
-                LOGGER.debug("Removing logical replication repository for dropped subscription '{}'",
-                             subscriptionName);
-                repositoriesService.unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + subscriptionName);
+            boolean subscriptionRemoved = newSubscriptions.get(subscriptionName) == null;
+            if (subscriptionRemoved) {
+                removeSubscription(subscriptionName);
             }
-
             // Close connection for removed subscription (must not run inside a transport thread)
             withRetry(() -> updateRemoteConnection(subscriptionName, Settings.EMPTY));
         }
+    }
+
+    private void addSubscription(String subscriptionName, Subscription subscription) {
+        assert repositoriesService != null
+            : "RepositoriesService must be set immediately after LogicalReplicationService construction";
+        LOGGER.debug("Adding new logical replication repository for subscription '{}'", subscriptionName);
+        repositoriesService.registerInternalRepository(REMOTE_REPOSITORY_PREFIX + subscriptionName, TYPE);
+
+        if (clusterService.localNode().isMasterNode()) {
+            withRetry(
+                () -> {
+                    // The startReplication will initiate the remote connection upfront
+                    LOGGER.debug("Start logical replication for subscription '{}'", subscriptionName);
+                    startReplication(subscriptionName, subscription, new ActionListener<>() {
+                        @Override
+                        public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                            LOGGER.debug("Acknowledged logical replication for subscription '{}'", subscriptionName);
+                            metadataTracker.startTracking(subscriptionName);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            LOGGER.debug("Failure for logical replication for subscription", e);
+                        }
+                    });
+                }
+            ).run();
+        } else {
+            // Initiate the remote connection for the subscription, needed on all nodes to restore the
+            // repository and for following remote shard changes.
+            // Must run inside a transport thread
+            withRetry(() -> updateRemoteConnection(subscriptionName)).run();
+        }
+    }
+
+    private void removeSubscription(String subscriptionName) {
+        assert repositoriesService != null
+            : "RepositoriesService must be set immediately after LogicalReplicationService construction";
+        LOGGER.debug("Removing logical replication repository for dropped subscription '{}'",
+                     subscriptionName);
+        repositoriesService.unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + subscriptionName);
+        metadataTracker.stopTracking(subscriptionName);
     }
 
     private Runnable withRetry(Runnable runnable) {
@@ -213,6 +228,7 @@ public class LogicalReplicationService extends RemoteClusterAware implements Clu
 
     @Override
     public void close() throws IOException {
+        metadataTracker.close();
         IOUtils.close(remoteClusters.values());
     }
 

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical;
+
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.common.unit.TimeValue;
+import io.crate.execution.support.RetryRunnable;
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.metadata.PublicationsMetadata;
+import io.crate.replication.logical.metadata.Subscription;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static io.crate.replication.logical.repository.LogicalReplicationRepository.REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC;
+
+public final class MetadataTracker implements Closeable {
+
+    private static final Logger LOGGER = Loggers.getLogger(MetadataTracker.class);
+
+    private final ThreadPool threadPool;
+    private final Function<String, Client> remoteClient;
+    private final ClusterService clusterService;
+    private final TimeValue pollDelay;
+
+    // Using a copy-on-write approach. The assumption is that subscription changes are rare and reads happen more frequently
+    private volatile Set<String> subscriptionsToTrack = new HashSet<>();
+    private volatile Scheduler.Cancellable cancellable;
+    private volatile boolean isActive = false;
+
+    public MetadataTracker(Settings settings, ThreadPool threadPool, Function<String, Client> remoteClient, ClusterService clusterService) {
+        this.threadPool = threadPool;
+        this.remoteClient = remoteClient;
+        this.clusterService = clusterService;
+        this.pollDelay = LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION.get(settings);
+    }
+
+    private void start() {
+        assert isActive == false : "MetadataTracker is already started";
+        assert clusterService.state().getNodes().getLocalNode().isMasterNode() : "MetadataTracker must only be run on the master node";
+        var runnable = new RetryRunnable(
+            threadPool.executor(ThreadPool.Names.LOGICAL_REPLICATION),
+            threadPool.scheduler(),
+            this::run,
+            BackoffPolicy.exponentialBackoff(pollDelay, 8)
+        );
+        runnable.run();
+        isActive = true;
+    }
+
+    private void stop() {
+        if (cancellable != null) {
+            cancellable.cancel();
+        }
+        isActive = false;
+    }
+
+    private void schedule() {
+        cancellable = threadPool.schedule(
+            this::run,
+            pollDelay,
+            ThreadPool.Names.LOGICAL_REPLICATION
+        );
+        isActive = true;
+    }
+
+    public boolean startTracking(String subscriptionName) {
+        synchronized (this) {
+            var copy = new HashSet<>(subscriptionsToTrack);
+            var updated = copy.add(subscriptionName);
+            if (updated && !isActive) {
+                start();
+            }
+            subscriptionsToTrack = copy;
+            return updated;
+        }
+    }
+
+    public boolean stopTracking(String subscriptionName) {
+        synchronized (this) {
+            var copy = new HashSet<>(subscriptionsToTrack);
+            var updated = copy.remove(subscriptionName);
+            if (isActive && copy.isEmpty()) {
+                stop();
+            }
+            subscriptionsToTrack = copy;
+            return updated;
+        }
+    }
+
+    private void run() {
+        for (String subscriptionName : subscriptionsToTrack) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Start tracking metadata for subscription {}", subscriptionName);
+            }
+            getRemoteClusterState(subscriptionName, remoteClusterState -> {
+                clusterService.submitStateUpdateTask("track-metadata", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState localClusterState) throws Exception {
+                        return updateMetadata(subscriptionName, localClusterState, remoteClusterState);
+                    }
+
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        LOGGER.error(e);
+                    }
+                });
+            });
+        }
+        if (isActive) {
+            schedule();
+        }
+    }
+
+    @VisibleForTesting
+    static ClusterState updateMetadata(String subscriptionName, ClusterState subscriberClusterState, ClusterState publisherClusterState) {
+        PublicationsMetadata publicationsMetadata = publisherClusterState.metadata().custom(PublicationsMetadata.TYPE);
+        SubscriptionsMetadata subscriptionsMetadata = subscriberClusterState.metadata().custom(SubscriptionsMetadata.TYPE);
+        if (publicationsMetadata == null || subscriptionsMetadata == null) {
+            return subscriberClusterState;
+        }
+        var subscribedTables = new HashSet<RelationName>();
+        Subscription subscription = subscriptionsMetadata.subscription().get(subscriptionName);
+        if (subscription != null) {
+            for (var publicationName : subscription.publications()) {
+                var publications = publicationsMetadata.publications();
+                if (publications != null) {
+                    var publication = publications.get(publicationName);
+                    subscribedTables.addAll(publication.tables());
+                }
+            }
+        }
+        // Check for all the subscribed tables if the index metadata changed and apply
+        // the changes from the publisher cluster state to the subscriber cluster state
+        var metadataBuilder = Metadata.builder(subscriberClusterState.metadata());
+        var isUpdated = false;
+        for (var followedTable : subscribedTables) {
+            var publisherIndexMetadata = publisherClusterState.metadata().index(followedTable.indexNameOrAlias());
+            var subscriberIndexMetadata = subscriberClusterState.metadata().index(followedTable.indexNameOrAlias());
+            if (publisherIndexMetadata != null && subscriberIndexMetadata != null) {
+                var publisherMapping = publisherIndexMetadata.mapping();
+                var subscriberMapping = subscriberIndexMetadata.mapping();
+                if (publisherMapping != null && subscriberMapping != null) {
+                    if (publisherIndexMetadata.getMappingVersion() > subscriberIndexMetadata.getMappingVersion()) {
+                        var indexMetadataBuilder = IndexMetadata.builder(subscriberIndexMetadata).putMapping(
+                            publisherMapping).mappingVersion(publisherIndexMetadata.getMappingVersion());
+                        metadataBuilder.put(indexMetadataBuilder.build(), true);
+                        isUpdated = true;
+                    }
+                }
+            }
+        }
+        if (isUpdated) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Updated index metadata for subscription {}", subscriptionName);
+            }
+            return ClusterState.builder(subscriberClusterState).metadata(metadataBuilder).build();
+        } else {
+            return subscriberClusterState;
+        }
+    }
+
+    private void getRemoteClusterState(String subscriptionName, Consumer<ClusterState> consumer) {
+        var client = remoteClient.apply(subscriptionName);
+
+        var clusterStateRequest = client.admin().cluster().prepareState()
+            .setWaitForTimeOut(new TimeValue(REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC))
+            .request();
+
+        client.admin().cluster().execute(
+            ClusterStateAction.INSTANCE, clusterStateRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(ClusterStateResponse clusterStateResponse) {
+                    consumer.accept(clusterStateResponse.getState());
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    LOGGER.error(e);
+                }
+            });
+    }
+
+    @Override
+    public void close() throws IOException {
+        stop();
+    }
+
+}

--- a/server/src/main/java/io/crate/replication/logical/metadata/PublicationsMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/PublicationsMetadata.java
@@ -79,7 +79,7 @@ public class PublicationsMetadata extends AbstractNamedDiffable<Metadata.Custom>
 
     @Override
     public EnumSet<Metadata.XContentContext> context() {
-        return EnumSet.of(Metadata.XContentContext.GATEWAY, Metadata.XContentContext.SNAPSHOT);
+        return EnumSet.of(Metadata.XContentContext.GATEWAY, Metadata.XContentContext.SNAPSHOT, Metadata.XContentContext.API);
     }
 
     @Override

--- a/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
@@ -82,7 +82,7 @@ public class SubscriptionsMetadata extends AbstractNamedDiffable<Metadata.Custom
 
     @Override
     public EnumSet<Metadata.XContentContext> context() {
-        return EnumSet.of(Metadata.XContentContext.GATEWAY, Metadata.XContentContext.SNAPSHOT);
+        return EnumSet.of(Metadata.XContentContext.GATEWAY, Metadata.XContentContext.SNAPSHOT, Metadata.XContentContext.API);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -21,221 +21,20 @@
 
 package io.crate.integrationtests;
 
-import io.crate.action.sql.SQLOperations;
 import io.crate.exceptions.RelationAlreadyExists;
-import io.crate.plugin.SQLPlugin;
-import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.replication.logical.LogicalReplicationService;
-import io.crate.replication.logical.LogicalReplicationSettings;
-import io.crate.testing.SQLResponse;
-import io.crate.testing.SQLTransportExecutor;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.common.network.NetworkModule;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.BoundTransportAddress;
-import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.InternalSettingsPlugin;
-import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.MockHttpTransport;
-import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
-import org.elasticsearch.transport.Netty4Plugin;
-import org.elasticsearch.transport.TransportService;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
 import java.util.StringJoiner;
+
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static io.crate.testing.TestingHelpers.printedTable;
-import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
-import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.hamcrest.Matchers.is;
 
-public class LogicalReplicationITest extends ESTestCase {
 
-    InternalTestCluster publisherCluster;
-    SQLTransportExecutor publisherSqlExecutor;
-
-    InternalTestCluster subscriberCluster;
-    SQLTransportExecutor subscriberSqlExecutor;
-
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(
-            SQLPlugin.class,
-            Netty4Plugin.class
-        );
-    }
-
-    @Before
-    public void setupClusters() throws IOException, InterruptedException {
-        Collection<Class<? extends Plugin>> mockPlugins = List.of(
-            ESIntegTestCase.TestSeedPlugin.class,
-            MockHttpTransport.TestPlugin.class,
-            MockTransportService.TestPlugin.class,
-            MockTcpTransportPlugin.class,
-            InternalSettingsPlugin.class
-        );
-
-        publisherCluster = new InternalTestCluster(
-            randomLong(),
-            createTempDir(),
-            true,
-            true,
-            2,
-            6,
-            "publishing_cluster",
-            createNodeConfigurationSource(),
-            0,
-            "publisher",
-            Stream.concat(nodePlugins().stream(), mockPlugins.stream())
-                .collect(Collectors.toList()),
-            true
-        );
-        publisherCluster.beforeTest(random());
-        publisherCluster.ensureAtLeastNumDataNodes(2);
-        publisherSqlExecutor = sqlExecutor(publisherCluster);
-
-        subscriberCluster = new InternalTestCluster(
-            randomLong(),
-            createTempDir(),
-            true,
-            true,
-            2,
-            6,
-            "subscribing_cluster",
-            createNodeConfigurationSource(),
-            0,
-            "subscriber",
-            Stream.concat(nodePlugins().stream(), mockPlugins.stream())
-                .collect(Collectors.toList()),
-            true
-        );
-        subscriberCluster.beforeTest(random());
-        subscriberCluster.ensureAtLeastNumDataNodes(1);
-        subscriberSqlExecutor = sqlExecutor(subscriberCluster);
-    }
-
-    @After
-    public void clearCluster() throws Exception {
-        try {
-            publisherCluster.beforeIndexDeletion();
-            publisherCluster.assertSeqNos();
-            publisherCluster.assertSameDocIdsOnShards();
-            publisherCluster.assertConsistentHistoryBetweenTranslogAndLuceneIndex();
-
-            subscriberCluster.beforeIndexDeletion();
-            subscriberCluster.assertSeqNos();
-            subscriberCluster.assertSameDocIdsOnShards();
-            subscriberCluster.assertConsistentHistoryBetweenTranslogAndLuceneIndex();
-        } finally {
-            publisherCluster.wipe(Collections.emptySet());
-            publisherCluster.close();
-            subscriberCluster.wipe(Collections.emptySet());
-            subscriberCluster.close();
-        }
-    }
-
-    private SQLResponse executeOnPublisher(String sql) {
-        return publisherSqlExecutor.exec(sql);
-    }
-
-    private long[] executeBulkOnPublisher(String sql, @Nullable Object[][] bulkArgs) {
-        return publisherSqlExecutor.execBulk(sql, bulkArgs);
-    }
-
-    private SQLResponse executeOnSubscriber(String sql) {
-        return subscriberSqlExecutor.exec(sql);
-    }
-
-    private static NodeConfigurationSource createNodeConfigurationSource() {
-        Settings.Builder builder = Settings.builder();
-        // disables a port scan for other nodes by setting seeds to an empty list
-        builder.putList(DISCOVERY_SEED_HOSTS_SETTING.getKey());
-        builder.putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file");
-        builder.put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType());
-        // reduce time waiting for changes and rather poll faster
-        builder.put(LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION.getKey(), "10ms");
-        // reduce batch size to test repeated polling of changes
-        builder.put(LogicalReplicationSettings.REPLICATION_CHANGE_BATCH_SIZE.getKey(), "20");
-        return new NodeConfigurationSource() {
-            @Override
-            public Settings nodeSettings(int nodeOrdinal) {
-                return builder.build();
-            }
-
-            @Override
-            public Path nodeConfigPath(int nodeOrdinal) {
-                return null;
-            }
-
-            @Override
-            public Settings transportClientSettings() {
-                return super.transportClientSettings();
-            }
-
-            @Override
-            public Collection<Class<? extends Plugin>> transportClientPlugins() {
-                return List.of(getTestTransportPlugin());
-            }
-        };
-    }
-
-    private static SQLTransportExecutor sqlExecutor(InternalTestCluster cluster) {
-        return new SQLTransportExecutor(
-            new SQLTransportExecutor.ClientProvider() {
-                @Override
-                public Client client() {
-                    return ESIntegTestCase.client();
-                }
-
-                @Override
-                public String pgUrl() {
-                    PostgresNetty postgresNetty = cluster.getInstance(PostgresNetty.class);
-                    BoundTransportAddress boundTransportAddress = postgresNetty.boundAddress();
-                    if (boundTransportAddress != null) {
-                        InetSocketAddress address = boundTransportAddress.publishAddress().address();
-                        return String.format(Locale.ENGLISH, "jdbc:postgresql://%s:%d/?ssl=%s&sslmode=%s",
-                                             address.getHostName(), address.getPort(), false, "disable");
-                    }
-                    return null;
-                }
-
-                @Override
-                public SQLOperations sqlOperations() {
-                    return cluster.getInstance(SQLOperations.class);
-                }
-            }
-        );
-    }
-
-    private String publisherConnectionUrl() {
-        var transportService = publisherCluster.getInstance(TransportService.class);
-        InetSocketAddress address = transportService.boundAddress().publishAddress().address();
-        return String.format(
-            Locale.ENGLISH,
-            "crate://%s:%d?mode=sniff&seeds=%s:%d",
-            address.getHostName(),
-            address.getPort(),
-            address.getHostName(),
-            address.getPort()
-        );
-    }
+public class LogicalReplicationITest extends LogicalReplicationIntegrationTest {
 
     private String defaultTableSettings() {
         var joiner = new StringJoiner(",");
@@ -439,19 +238,5 @@ public class LogicalReplicationITest extends ESTestCase {
             var res = executeOnSubscriber("SELECT * FROM doc.t1");
             assertThat(res.rowCount(), is((long) (numDocs + 2)));
         }, 10, TimeUnit.SECONDS);
-    }
-
-    private void ensureGreenOnSubscriber() throws Exception {
-        assertBusy(() -> {
-            try {
-                var response = executeOnSubscriber(
-                    "SELECT health, count(*) FROM sys.health GROUP BY 1");
-                assertThat(response.rowCount(), is(1L));
-                assertThat(response.rows()[0][0], is("GREEN"));
-            } catch (Exception e) {
-                fail();
-            }
-        }, 10, TimeUnit.SECONDS);
-
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationIntegrationTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.action.sql.SQLOperations;
+import io.crate.plugin.SQLPlugin;
+import io.crate.protocols.postgres.PostgresNetty;
+import io.crate.replication.logical.LogicalReplicationSettings;
+import io.crate.testing.SQLResponse;
+import io.crate.testing.SQLTransportExecutor;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.MockHttpTransport;
+import org.elasticsearch.test.NodeConfigurationSource;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.MockTcpTransportPlugin;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.Before;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION;
+import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.hamcrest.Matchers.is;
+
+public abstract class LogicalReplicationIntegrationTest extends ESTestCase {
+
+    InternalTestCluster publisherCluster;
+    SQLTransportExecutor publisherSqlExecutor;
+
+    InternalTestCluster subscriberCluster;
+    SQLTransportExecutor subscriberSqlExecutor;
+
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(
+            SQLPlugin.class,
+            Netty4Plugin.class
+        );
+    }
+
+    @Before
+    public void setupClusters() throws IOException, InterruptedException {
+        Collection<Class<? extends Plugin>> mockPlugins = List.of(
+            ESIntegTestCase.TestSeedPlugin.class,
+            MockHttpTransport.TestPlugin.class,
+            MockTransportService.TestPlugin.class,
+            MockTcpTransportPlugin.class,
+            InternalSettingsPlugin.class
+        );
+
+        publisherCluster = new InternalTestCluster(
+            randomLong(),
+            createTempDir(),
+            true,
+            true,
+            2,
+            2,
+            "publishing_cluster",
+            createNodeConfigurationSource(),
+            0,
+            "publisher",
+            Stream.concat(nodePlugins().stream(), mockPlugins.stream())
+                .collect(Collectors.toList()),
+            true
+        );
+        publisherCluster.beforeTest(random());
+        publisherCluster.ensureAtLeastNumDataNodes(2);
+        publisherSqlExecutor = sqlExecutor(publisherCluster);
+
+        subscriberCluster = new InternalTestCluster(
+            randomLong(),
+            createTempDir(),
+            false,
+            true,
+            1,
+            1,
+            "subscribing_cluster",
+            createNodeConfigurationSource(),
+            0,
+            "subscriber",
+            Stream.concat(nodePlugins().stream(), mockPlugins.stream())
+                .collect(Collectors.toList()),
+            true
+        );
+        subscriberCluster.beforeTest(random());
+        subscriberCluster.ensureAtLeastNumDataNodes(1);
+        subscriberSqlExecutor = sqlExecutor(subscriberCluster);
+    }
+
+    @After
+    public void clearCluster() throws Exception {
+        try {
+            publisherCluster.beforeIndexDeletion();
+            publisherCluster.assertSeqNos();
+            publisherCluster.assertSameDocIdsOnShards();
+            publisherCluster.assertConsistentHistoryBetweenTranslogAndLuceneIndex();
+
+            subscriberCluster.beforeIndexDeletion();
+            subscriberCluster.assertSeqNos();
+            subscriberCluster.assertSameDocIdsOnShards();
+            subscriberCluster.assertConsistentHistoryBetweenTranslogAndLuceneIndex();
+        } finally {
+            publisherCluster.wipe(Collections.emptySet());
+            publisherCluster.close();
+            subscriberCluster.wipe(Collections.emptySet());
+            subscriberCluster.close();
+        }
+    }
+
+    SQLResponse executeOnPublisher(String sql) {
+        return publisherSqlExecutor.exec(sql);
+    }
+
+    long[] executeBulkOnPublisher(String sql, @Nullable Object[][] bulkArgs) {
+        return publisherSqlExecutor.execBulk(sql, bulkArgs);
+    }
+
+    SQLResponse executeOnSubscriber(String sql) {
+        return subscriberSqlExecutor.exec(sql);
+    }
+
+    Settings logicalReplicationSettings() {
+        Settings.Builder builder = Settings.builder();
+        // reduce time waiting for changes and rather poll faster
+        builder.put(REPLICATION_READ_POLL_DURATION.getKey(), "10ms");
+        // reduce batch size to test repeated polling of changes
+        builder.put(LogicalReplicationSettings.REPLICATION_CHANGE_BATCH_SIZE.getKey(), "20");
+        return builder.build();
+    }
+
+    NodeConfigurationSource createNodeConfigurationSource() {
+        Settings.Builder builder = Settings.builder();
+        builder.put(logicalReplicationSettings());
+        // disables a port scan for other nodes by setting seeds to an empty list
+        builder.putList(DISCOVERY_SEED_HOSTS_SETTING.getKey());
+        builder.putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file");
+        builder.put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType());
+        return new NodeConfigurationSource() {
+            @Override
+            public Settings nodeSettings(int nodeOrdinal) {
+                return builder.build();
+            }
+
+            @Override
+            public Path nodeConfigPath(int nodeOrdinal) {
+                return null;
+            }
+
+            @Override
+            public Settings transportClientSettings() {
+                return super.transportClientSettings();
+            }
+
+            @Override
+            public Collection<Class<? extends Plugin>> transportClientPlugins() {
+                return List.of(getTestTransportPlugin());
+            }
+        };
+    }
+
+    SQLTransportExecutor sqlExecutor(InternalTestCluster cluster) {
+        return new SQLTransportExecutor(
+            new SQLTransportExecutor.ClientProvider() {
+                @Override
+                public Client client() {
+                    return ESIntegTestCase.client();
+                }
+
+                @Override
+                public String pgUrl() {
+                    PostgresNetty postgresNetty = cluster.getInstance(PostgresNetty.class);
+                    BoundTransportAddress boundTransportAddress = postgresNetty.boundAddress();
+                    if (boundTransportAddress != null) {
+                        InetSocketAddress address = boundTransportAddress.publishAddress().address();
+                        return String.format(Locale.ENGLISH, "jdbc:postgresql://%s:%d/?ssl=%s&sslmode=%s",
+                                             address.getHostName(), address.getPort(), false, "disable");
+                    }
+                    return null;
+                }
+
+                @Override
+                public SQLOperations sqlOperations() {
+                    return cluster.getInstance(SQLOperations.class);
+                }
+            }
+        );
+    }
+
+    String publisherConnectionUrl() {
+        var transportService = publisherCluster.getInstance(TransportService.class);
+        InetSocketAddress address = transportService.boundAddress().publishAddress().address();
+        return String.format(
+            Locale.ENGLISH,
+            "crate://%s:%d?mode=sniff&seeds=%s:%d",
+            address.getHostName(),
+            address.getPort(),
+            address.getHostName(),
+            address.getPort()
+        );
+    }
+
+    void ensureGreenOnSubscriber() throws Exception {
+        assertBusy(() -> {
+            try {
+                var response = executeOnSubscriber(
+                    "SELECT health, count(*) FROM sys.health GROUP BY 1");
+                assertThat(response.rowCount(), is(1L));
+                assertThat(response.rows()[0][0], is("GREEN"));
+            } catch (Exception e) {
+                fail();
+            }
+        }, 10, TimeUnit.SECONDS);
+
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION;
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.Matchers.is;
+
+public class MetadataTrackerITest extends LogicalReplicationIntegrationTest {
+
+    @Override
+    Settings logicalReplicationSettings() {
+        Settings.Builder builder = Settings.builder();
+        builder.put(super.logicalReplicationSettings());
+        // Increase poll duration to 1s to make sure there is an out-of-sync situation
+        // when the mapping changes on the subscriber cluster
+        builder.put(REPLICATION_READ_POLL_DURATION.getKey(), "1s");
+        return builder.build();
+    }
+
+    @Test
+    @TestLogging("_root:INFO,io.crate.replication.logical:DEBUG")
+    public void test_subscribed_tables_are_followed_when_schema_changed() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        assertBusy(() -> {
+            var response = executeOnSubscriber("SELECT * FROM doc.t1");
+            assertThat(printedTable(response.rows()), is("1\n" +
+                                                         "2\n"));
+        }, 10, TimeUnit.SECONDS);
+
+        executeOnPublisher("ALTER TABLE doc.t1 ADD COLUMN value string");
+        executeOnPublisher("REFRESH TABLE doc.t1");
+
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE doc.t1");
+            var r = executeOnSubscriber("SELECT * FROM doc.t1");
+            assertThat(printedTable(r.rows()), is("1| NULL\n" +
+                                                  "2| NULL\n"));
+
+        }, 10, TimeUnit.SECONDS);
+    }
+
+
+    @Test
+    @TestLogging("_root:INFO,io.crate.replication.logical:DEBUG")
+    public void test_subscribed_tables_are_followed_when_schema_changed_and_new_data_is_synced() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                           " number_of_replicas=0," +
+                           " \"translog.flush_threshold_size\"='64b'" +
+                           ")");
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.t1");
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        executeOnPublisher("ALTER TABLE doc.t1 ADD COLUMN name varchar");
+        //This insert is synced to the subscriber and the mapping might not be updated yet
+        executeOnPublisher("INSERT INTO doc.t1 (id, name) VALUES (3, 'chewbacca')");
+        executeOnPublisher("INSERT INTO doc.t1 (id, name) VALUES (4, 'r2d2')");
+        executeOnPublisher("REFRESH TABLE doc.t1");
+        //Lets alter the table again
+        executeOnPublisher("ALTER TABLE doc.t1 ADD COLUMN age integer");
+        executeOnPublisher("INSERT INTO doc.t1 (id, name, age) VALUES (5, 'luke', 37)");
+        executeOnPublisher("INSERT INTO doc.t1 (id, name, age) VALUES (6, 'yoda', 900)");
+        executeOnPublisher("REFRESH TABLE doc.t1");
+
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE doc.t1");
+            var r = executeOnSubscriber("SELECT * FROM doc.t1");
+            assertThat(printedTable(r.rows()), is("1| NULL| NULL\n" +
+                                                  "2| NULL| NULL\n" +
+                                                  "3| chewbacca| NULL\n"+
+                                                  "4| r2d2| NULL\n" +
+                                                  "5| luke| 37\n" +
+                                                  "6| yoda| 900\n"));
+
+        }, 10, TimeUnit.SECONDS);
+
+    }
+
+    @Test
+    @TestLogging("_root:INFO,io.crate.replication.logical:DEBUG")
+    public void test_add_multiple_tables() throws Exception {
+        int numberOfTables = randomIntBetween(1,10);
+        var tableNames = new ArrayList<String>();
+        for (int i = 1; i <= numberOfTables; i++) {
+            tableNames.add("doc.t" + i);
+        }
+
+        for (String tableName : tableNames) {
+            executeOnPublisher("CREATE TABLE " + tableName + " (id INT) CLUSTERED INTO 1 SHARDS WITH(" +
+                               " number_of_replicas=0," +
+                               " \"translog.flush_threshold_size\"='64b'" +
+                               ")");
+            executeOnPublisher("INSERT INTO " + tableName + " (id) VALUES (1), (2)");
+        }
+
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE " + String.join(",", tableNames));
+
+        executeOnSubscriber("CREATE SUBSCRIPTION sub1 CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+        ensureGreenOnSubscriber();
+
+        for (String tableName : tableNames) {
+            executeOnPublisher("ALTER TABLE " + tableName + " ADD COLUMN name varchar");
+            executeOnPublisher("INSERT INTO " + tableName + " (id, name) VALUES (3, 'chewbacca'), (4, 'r2d2')");
+        }
+
+        executeOnPublisher("REFRESH TABLE " + String.join(",", tableNames));
+
+        for (String tableName : tableNames) {
+            executeOnPublisher("ALTER TABLE " + tableName + " ADD COLUMN age integer");
+        }
+
+        for (String tableName : tableNames) {
+            executeOnPublisher("INSERT INTO " + tableName + "(id, name, age) VALUES (5, 'luke', 37), (6, 'yoda', 900)");
+        }
+
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE " + String.join(",", tableNames));
+            for (String tableName : tableNames) {
+                var r = executeOnSubscriber("SELECT * FROM " + tableName);
+                assertThat(printedTable(r.rows()), is("1| NULL| NULL\n" +
+                                                      "2| NULL| NULL\n" +
+                                                      "3| chewbacca| NULL\n" +
+                                                      "4| r2d2| NULL\n" +
+                                                      "5| luke| 37\n" +
+                                                      "6| yoda| 900\n"));
+            }
+        }, 10, TimeUnit.SECONDS);
+    }
+}

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical;
+
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.metadata.ConnectionInfo;
+import io.crate.replication.logical.metadata.Publication;
+import io.crate.replication.logical.metadata.PublicationsMetadata;
+import io.crate.replication.logical.metadata.Subscription;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class MetadataTrackerTest extends ESTestCase {
+
+    @Test
+    public void test_index_mappings_is_transfered_between_two_clusterstates() throws Exception {
+        var mappingMetadata = new MappingMetadata("test", Map.of("1", "one"));
+        var indexMetadata = IndexMetadata.builder("test").putMapping(mappingMetadata)
+            .settings(settings(Version.CURRENT))
+            .version(1)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        PublicationsMetadata publicationsMetadata = new PublicationsMetadata(
+            Map.of("pub1", new Publication("user", false, List.of(new RelationName("doc", "test"))))
+        );
+
+        var publisherClusterState = ClusterState.builder(new ClusterName("publisher"))
+            .version(1L)
+            .metadata(Metadata.builder().put(indexMetadata, true).putCustom(PublicationsMetadata.TYPE, publicationsMetadata).build())
+            .build();
+
+        var subscriptionsMetadata = new SubscriptionsMetadata(
+            Map.of("sub1", new Subscription(
+                       "user1",
+                       ConnectionInfo.fromURL("crate://example.com:4310?user=valid_user&password=123"),
+                       List.of("pub1"),
+                       Settings.EMPTY
+                   )
+            )
+        );
+
+        var subscriberClusterState = ClusterState.builder(new ClusterName("subscriber"))
+            .version(1L)
+            .metadata(Metadata.builder().put(indexMetadata, true).putCustom(SubscriptionsMetadata.TYPE, subscriptionsMetadata).build())
+            .build();
+
+        var syncedSubriberClusterState = MetadataTracker.updateMetadata("sub1", subscriberClusterState, publisherClusterState);
+        // Nothing in the indexMetadata changed, so the clusterstate must be equal
+        assertThat(subscriberClusterState, is(syncedSubriberClusterState));
+
+
+        //Now lets change the mapping on the publisher publisherClusterState
+        var updatedMappingMetadata = new MappingMetadata("test", Map.of("1", "one", "2", "two"));
+        var updatedIndexMetadata = IndexMetadata.builder(indexMetadata).putMapping(updatedMappingMetadata).mappingVersion(2L).build();
+        var updatedPublisherClusterState = ClusterState.builder(publisherClusterState).metadata(Metadata.builder().put(
+            updatedIndexMetadata,
+            true).putCustom(PublicationsMetadata.TYPE, publicationsMetadata).build()).build();
+
+        syncedSubriberClusterState = MetadataTracker.updateMetadata("sub1", subscriberClusterState, updatedPublisherClusterState);
+
+        assertThat(subscriberClusterState, is(not(syncedSubriberClusterState)));
+
+        var syncedIndexMetadata = syncedSubriberClusterState.metadata().index("test");
+        // Verify that mappings are in-sync between updated publisher cluster and new subscriber clusterstate
+        assertThat(syncedIndexMetadata.mapping(), is(updatedIndexMetadata.mapping()));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds a polling task which tracks index metadata from the Publisher to the Subscriber cluster. It also handles the special case when data is replicated and the index metadata is not updated yet. See `MetadataTrackerITest` for the usecases.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
