### PR TITLE
Remove unused `ConnectionProfile` parameter from connectToNode

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -102,10 +102,9 @@ public class ClusterConnectionManager implements ConnectionManager {
      * The ActionListener will be called on the calling thread or the generic thread pool.
      */
     @Override
-    public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
+    public void connectToNode(DiscoveryNode node,
                               ConnectionValidator connectionValidator,
                               ActionListener<Void> listener) throws ConnectTransportException {
-        final ConnectionProfile resolvedProfile = ConnectionProfile.resolveConnectionProfile(connectionProfile, defaultProfile);
         if (node == null) {
             listener.onFailure(new ConnectTransportException(null, "can't connect to a null node"));
             return;
@@ -137,8 +136,8 @@ public class ClusterConnectionManager implements ConnectionManager {
         currentListener.addListener(listener, EsExecutors.directExecutor());
 
         final RunOnce releaseOnce = new RunOnce(connectingRefCounter::decRef);
-        internalOpenConnection(node, resolvedProfile, ActionListener.wrap(conn -> {
-            connectionValidator.validate(conn, resolvedProfile, ActionListener.wrap(
+        internalOpenConnection(node, defaultProfile, ActionListener.wrap(conn -> {
+            connectionValidator.validate(conn, defaultProfile, ActionListener.wrap(
                 ignored -> {
                     assert Transports.assertNotTransportThread("connection validator success");
                     try {

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
@@ -34,7 +34,7 @@ public interface ConnectionManager extends Closeable {
 
     void openConnection(DiscoveryNode node, ConnectionProfile connectionProfile, ActionListener<Transport.Connection> listener);
 
-    void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
+    void connectToNode(DiscoveryNode node,
                        ConnectionValidator connectionValidator,
                        ActionListener<Void> listener) throws ConnectTransportException;
 

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -189,7 +189,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
                 DiscoveryNode node = new DiscoveryNode(id, resolved, attributes, DiscoveryNodeRole.BUILT_IN_ROLES,
                                                        Version.CURRENT.minimumCompatibilityVersion());
 
-                connectionManager.connectToNode(node, null, clusterNameValidator, new ActionListener<Void>() {
+                connectionManager.connectToNode(node, clusterNameValidator, new ActionListener<Void>() {
                     @Override
                     public void onResponse(Void v) {
                         compositeListener.onResponse(v);

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -54,10 +54,10 @@ public class RemoteConnectionManager implements ConnectionManager {
     }
 
     @Override
-    public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
+    public void connectToNode(DiscoveryNode node,
                               ConnectionManager.ConnectionValidator connectionValidator,
                               ActionListener<Void> listener) throws ConnectTransportException {
-        delegate.connectToNode(node, connectionProfile, connectionValidator, listener);
+        delegate.connectToNode(node, connectionValidator, listener);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -249,7 +249,6 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                                  proxyAddress);
                     final DiscoveryNode handshakeNodeWithProxy = maybeAddProxyAddress(proxyAddress, handshakeNode);
                     connectionManager.connectToNode(handshakeNodeWithProxy,
-                                                    null,
                                                     transportService.connectionValidator(handshakeNodeWithProxy),
                                                     fullConnectionStep);
                 } else {
@@ -334,7 +333,6 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                     final DiscoveryNode nodeWithProxy = maybeAddProxyAddress(proxyAddress, node);
                     connectionManager.connectToNode(
                         nodeWithProxy,
-                        null,
                         transportService.connectionValidator(node),
                         new ActionListener<>() {
                             @Override

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -304,23 +304,11 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
      * @param listener the action listener to notify
      */
     public void connectToNode(DiscoveryNode node, ActionListener<Void> listener) throws ConnectTransportException {
-        connectToNode(node, null, listener);
-    }
-
-    /**
-     * Connect to the specified node with the given connection profile.
-     * The ActionListener will be called on the calling thread or the generic thread pool.
-     *
-     * @param node the node to connect to
-     * @param connectionProfile the connection profile to use when connecting to this node
-     * @param listener the action listener to notify
-     */
-    public void connectToNode(final DiscoveryNode node, ConnectionProfile connectionProfile, ActionListener<Void> listener) {
         if (isLocalNode(node)) {
             listener.onResponse(null);
             return;
         }
-        connectionManager.connectToNode(node, connectionProfile, connectionValidator(node), listener);
+        connectionManager.connectToNode(node, connectionValidator(node), listener);
     }
 
     public ConnectionManager.ConnectionValidator connectionValidator(DiscoveryNode node) {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -64,15 +64,15 @@ public class RemoteConnectionManagerTests extends ESTestCase {
 
         DiscoveryNode node1 = new DiscoveryNode("node-1", address, Version.CURRENT);
         PlainActionFuture<Void> future1 = PlainActionFuture.newFuture();
-        remoteConnectionManager.connectToNode(node1, null, validator, future1);
+        remoteConnectionManager.connectToNode(node1, validator, future1);
         assertTrue(future1.isDone());
 
         // Add duplicate connect attempt to ensure that we do not get duplicate connections in the round robin
-        remoteConnectionManager.connectToNode(node1, null, validator, PlainActionFuture.newFuture());
+        remoteConnectionManager.connectToNode(node1, validator, PlainActionFuture.newFuture());
 
         DiscoveryNode node2 = new DiscoveryNode("node-2", address, Version.CURRENT.minimumCompatibilityVersion());
         PlainActionFuture<Void> future2 = PlainActionFuture.newFuture();
-        remoteConnectionManager.connectToNode(node2, null, validator, future2);
+        remoteConnectionManager.connectToNode(node2, validator, future2);
         assertTrue(future2.isDone());
 
         assertEquals(node1, remoteConnectionManager.getConnection(node1).getNode());

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -180,7 +180,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             emptySet(),
             handleB.discoveryNode.getVersion());
         ConnectTransportException ex = expectThrows(ConnectTransportException.class, () -> {
-            AbstractSimpleTransportTestCase.connectToNode(handleA.transportService, discoveryNode, TestProfiles.LIGHT_PROFILE);
+            AbstractSimpleTransportTestCase.connectToNode(handleA.transportService, discoveryNode);
         });
         assertThat(ex.getMessage(), containsString("unexpected remote node"));
         assertFalse(handleA.transportService.nodeConnected(discoveryNode));

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
@@ -96,10 +96,10 @@ public class StubbableConnectionManager implements ConnectionManager {
     }
 
     @Override
-    public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
-                              ConnectionValidator connectionValidator, ActionListener<Void> listener)
-        throws ConnectTransportException {
-        delegate.connectToNode(node, connectionProfile, connectionValidator, listener);
+    public void connectToNode(DiscoveryNode node,
+                              ConnectionValidator connectionValidator,
+                              ActionListener<Void> listener) throws ConnectTransportException {
+        delegate.connectToNode(node, connectionValidator, listener);
     }
 
     @Override

--- a/server/src/testFixtures/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -33,18 +33,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
      * @param node the node to connect to
      */
     public static void connectToNode(TransportService service, DiscoveryNode node) throws ConnectTransportException {
-        connectToNode(service, node, null);
-    }
-
-    /**
-     * Connect to the specified node with the given connection profile
-     *
-     * @param service service to connect from
-     * @param node the node to connect to
-     * @param connectionProfile the connection profile to use when connecting to this node
-     */
-    public static void connectToNode(TransportService service, DiscoveryNode node, ConnectionProfile connectionProfile) {
-        PlainActionFuture.get(fut -> service.connectToNode(node, connectionProfile, ActionListener.map(fut, x -> null)));
+        PlainActionFuture.get(fut -> service.connectToNode(node, ActionListener.map(fut, x -> null)));
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The only call-site which provided a non-null value was within a test
case. Everywhere else the `ConnectionProfile` was always `null`.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
