### PR TITLE
Remove unused blocking getPublicationsState

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -449,13 +449,6 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
             });
     }
 
-    private PublicationsStateAction.Response getPublicationsState() {
-        return getRemoteClusterClient().execute(
-            PublicationsStateAction.INSTANCE,
-            new PublicationsStateAction.Request(logicalReplicationService.subscriptions().get(subscriptionName).publications())
-        ).actionGet(REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC);
-    }
-
     private void getPublicationsState(ActionListener<PublicationsStateAction.Response> listener) {
         getRemoteClusterClient().execute(
             PublicationsStateAction.INSTANCE,


### PR DESCRIPTION


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
