### PR TITLE
Config client certificate authentication per-protocol

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -155,3 +155,7 @@ Fixes
 - Fixed a performance regression introduced in 4.2 which caused queries with
   ``WHERE`` clause on aliased column on top of views or virtual tables to be
   slow.
+
+- Fixed an issue in ``HBA`` which caused entries with method ``cert`` for one
+  protocol affect entries of other protocols in the way that client certificate
+  is requested for ``trust`` or ``password`` entries of other protocols.

--- a/server/src/main/java/io/crate/auth/AuthSettings.java
+++ b/server/src/main/java/io/crate/auth/AuthSettings.java
@@ -29,9 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.function.Function;
 
-import javax.annotation.Nullable;
-
-
 public final class AuthSettings {
 
     private AuthSettings() {
@@ -58,14 +55,17 @@ public final class AuthSettings {
 
     public static final String HTTP_HEADER_REAL_IP = "X-Real-Ip";
 
-    public static ClientAuth resolveClientAuth(Settings settings, @Nullable Protocol protocol) {
+    public static ClientAuth resolveClientAuth(Settings settings, Protocol protocol) {
         Settings hbaSettings = AUTH_HOST_BASED_CONFIG_SETTING.get(settings);
         int numMethods = 0;
         int numCertMethods = 0;
         for (var entry : hbaSettings.getAsGroups().entrySet()) {
             Settings entrySettings = entry.getValue();
             String protocolEntry = entrySettings.get("protocol");
-            if (protocol != null && !protocol.name().equalsIgnoreCase(protocolEntry)) {
+            if (protocolEntry != null && !protocol.name().equalsIgnoreCase(protocolEntry)) {
+                // We need null check for protocolEntry since we want entry without protocol be matched with any protocol
+                // Without it !equalsIgnoreCase returns true and HBA with only 'cert' entries but all without protocol
+                // might end up with NONE while correct value is 'REQUIRED'.
                 continue;
             }
             String method = entrySettings.get("method", "trust");

--- a/server/src/main/java/io/crate/plugin/PipelineRegistry.java
+++ b/server/src/main/java/io/crate/plugin/PipelineRegistry.java
@@ -21,6 +21,7 @@
 
 package io.crate.plugin;
 
+import io.crate.auth.Protocol;
 import io.crate.protocols.ssl.SslSettings;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.netty.channel.ChannelHandler;
@@ -111,7 +112,7 @@ public class PipelineRegistry {
         }
 
         if (sslContextProvider != null) {
-            SslContext sslContext = sslContextProvider.getServerContext();
+            SslContext sslContext = sslContextProvider.getServerContext(Protocol.HTTP);
             if (sslContext != null) {
                 SslHandler sslHandler = sslContext.newHandler(pipeline.channel().alloc());
                 pipeline.addFirst(sslHandler);

--- a/server/src/main/java/io/crate/protocols/postgres/SslReqHandler.java
+++ b/server/src/main/java/io/crate/protocols/postgres/SslReqHandler.java
@@ -21,6 +21,7 @@
 
 package io.crate.protocols.postgres;
 
+import io.crate.auth.Protocol;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -81,7 +82,7 @@ public final class SslReqHandler {
         if (buffer.readInt() == SSL_REQUEST_BYTE_LENGTH && buffer.readInt() == SSL_REQUEST_CODE) {
             final SslContext sslContext;
             if (sslContextProvider != null) {
-                sslContext = sslContextProvider.getServerContext();
+                sslContext = sslContextProvider.getServerContext(Protocol.POSTGRES);
             } else {
                 sslContext = null;
             }

--- a/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
@@ -24,6 +24,7 @@ package io.crate.protocols.postgres;
 import io.crate.action.sql.SQLOperations;
 import io.crate.auth.AccessControl;
 import io.crate.auth.AlwaysOKAuthentication;
+import io.crate.auth.Protocol;
 import io.crate.protocols.ssl.SslContextProvider;
 
 import org.elasticsearch.common.settings.Settings;
@@ -105,7 +106,7 @@ public class SslReqHandlerTest extends ESTestCase {
         return new SslContextProvider(Settings.EMPTY) {
 
             @Override
-            public SslContext getServerContext() {
+            public SslContext getServerContext(Protocol protocol) {
                 try {
                     SelfSignedCertificate ssc = new SelfSignedCertificate();
                     return SslContextBuilder

--- a/server/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
+++ b/server/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
@@ -43,6 +43,7 @@ import java.security.cert.X509Certificate;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 
+import io.crate.auth.Protocol;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
@@ -78,7 +79,7 @@ public class SslContextProviderTest extends ESTestCase {
         expectedException.expect(SslConfigurationException.class);
         expectedException.expectMessage("Failed to build SSL configuration");
         var sslContextProvider = new SslContextProvider(settings);
-        sslContextProvider.getServerContext();
+        sslContextProvider.getServerContext(Protocol.TRANSPORT);
     }
 
     @Test
@@ -93,7 +94,7 @@ public class SslContextProviderTest extends ESTestCase {
             .put(SslSettings.SSL_KEYSTORE_KEY_PASSWORD.getKey(), "keystorePassword")
             .build();
         var sslContextProvider = new SslContextProvider(settings);
-        SslContext sslContext = sslContextProvider.getServerContext();
+        SslContext sslContext = sslContextProvider.getServerContext(Protocol.TRANSPORT);
         assertThat(sslContext, instanceOf(SslContext.class));
         assertThat(sslContext.isServer(), is(true));
         assertThat(sslContext.cipherSuites(), not(empty()));
@@ -109,7 +110,7 @@ public class SslContextProviderTest extends ESTestCase {
             .put(SslSettings.SSL_KEYSTORE_PASSWORD_SETTING_NAME, KEYSTORE_PASSWORD)
             .put(SslSettings.SSL_KEYSTORE_KEY_PASSWORD_SETTING_NAME, KEYSTORE_KEY_PASSWORD)
         .build();
-        SslContext sslContext = new SslContextProvider(settings).getServerContext();
+        SslContext sslContext = new SslContextProvider(settings).getServerContext(Protocol.TRANSPORT);
         assertThat(sslContext.isServer(), is(true));
         assertThat(sslContext.cipherSuites(), not(empty()));
         // check that we don't offer NULL ciphers which do not encrypt


### PR DESCRIPTION
Resolves [#11856](https://github.com/crate/crate/issues/11856) which is similar to https://github.com/crate/crate/issues/10736 - but in order no prevent "transport" entries to affect others we have different contexts (with different clientauth) per protocol.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
