### PR TITLE
Add age function to support PostgreSQL wire protocol

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -137,8 +137,7 @@ Changes
 - Added the `column_details` column to the `information_schema.columns` table
   including the top level column name and path information of object elements.
 
-- Registered the scalar function :ref:`age <scalar-age>`
-  under the `pg_catalog` schema.
+- Registered the scalar function :ref:`age <scalar-age>`.
 
 Fixes
 =====

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -137,6 +137,9 @@ Changes
 - Added the `column_details` column to the `information_schema.columns` table
   including the top level column name and path information of object elements.
 
+- Registered the scalar function :ref:`age <scalar-age>`
+  under the `pg_catalog` schema.
+
 Fixes
 =====
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1464,27 +1464,20 @@ specified interval added to the timestamp of ``0000/01/01 00:00:00``::
 
 .. _scalar-age:
 
-``age(['timezone',][timestamp,]timestamp)``
+``age([timestamp,]timestamp)``
 -------------------------------------------
 
 Returns: ``bigint``
 
 The ``age`` function can be used to calculate the difference between timestamp inputs
-or timestamp input and today at midnight if is called with one timestamp parameter.
+or today at midnight and timestamp input.
 
 The return value is the age in milliseconds.
 
-It is implemented to improve compatibility with
-clients that use the PostgreSQL wire protocol.
-
 If at least one argument is ``NULL``, the return value is ``NULL``.
 
-Valid values for ``timezone`` are either the name of a time zone (for example
-'Europe/Vienna') or the UTC offset of a time zone (for example '+01:00'). To
-get a complete overview of all possible values take a look at the `available
-time zones`_ supported by `Joda-Time`_.
 
- ``age`` function  example from today at 00:00 till 2021-11-5 ::
+Example with ``age`` between  today at 00:00 and 2021-11-5: ::
 
 
     cr> select
@@ -1496,6 +1489,16 @@ time zones`_ supported by `Joda-Time`_.
     +--------------+
     SELECT 1 row in set (... sec)
 
+Example with ``age`` between 2021-11-03 and 2020-09-01: ::
+
+    cr> select
+    ...     pg_catalog.age(timestamp '2021-11-03', timestamp '2020-09-01') as age;
+    +--------------+
+    |          age |
+    +--------------+
+    |  36979200000 |
+    +--------------+
+    SELECT 1 row in set (... sec)
 
 
 .. _scalar-geo:
@@ -3655,7 +3658,7 @@ Example:
     SELECT 1 row in set (... sec)
 
 
-If the given ``OID`` is not k(now, ``???`` is returned::
+If the given ``OID`` is not know, ``???`` is returned::
 
 
     cr> SELECT pg_catalog.format_type(3, null) AS name;
@@ -3663,7 +3666,7 @@ If the given ``OID`` is not k(now, ``???`` is returned::
     | name |
     +------+
     |  ??? |
-    +------+)
+    +------+
     SELECT 1 row in set (... sec)
 
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1462,6 +1462,42 @@ specified interval added to the timestamp of ``0000/01/01 00:00:00``::
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-age:
+
+``age(['timezone',][timestamp,]timestamp)``
+-------------------------------------------
+
+Returns: ``bigint``
+
+The ``age`` function can be used to calculate the difference between timestamp inputs
+or timestamp input and today at midnight if is called with one timestamp parameter.
+
+The return value is the age in milliseconds.
+
+It is implemented to improve compatibility with
+clients that use the PostgreSQL wire protocol.
+
+If at least one argument is ``NULL``, the return value is ``NULL``.
+
+Valid values for ``timezone`` are either the name of a time zone (for example
+'Europe/Vienna') or the UTC offset of a time zone (for example '+01:00'). To
+get a complete overview of all possible values take a look at the `available
+time zones`_ supported by `Joda-Time`_.
+
+ ``age`` function  example from today at 00:00 till 2021-11-5 ::
+
+
+    cr> select
+    ...     pg_catalog.age(timestamp '2021-11-05') as age;
+    +--------------+
+    |          age |
+    +--------------+
+    |    345600000 |
+    +--------------+
+    SELECT 1 row in set (... sec)
+
+
+
 .. _scalar-geo:
 
 Geo functions
@@ -3619,7 +3655,7 @@ Example:
     SELECT 1 row in set (... sec)
 
 
-If the given ``OID`` is not know, ``???`` is returned::
+If the given ``OID`` is not k(now, ``???`` is returned::
 
 
     cr> SELECT pg_catalog.format_type(3, null) AS name;
@@ -3627,7 +3663,7 @@ If the given ``OID`` is not know, ``???`` is returned::
     | name |
     +------+
     |  ??? |
-    +------+
+    +------+)
     SELECT 1 row in set (... sec)
 
 

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -100,7 +100,7 @@ public class AgeFunction extends Scalar<Long, Object> {
             return null;
 
         Object earliestValue = args[args.length - 1].value();
-        Long timestampEarliest = DataTypes.LONG.sanitizeValue(earliestValue);
+        Long timestampEarliest = DataTypes.TIMESTAMP.implicitCast(earliestValue);
         Long timestampNewest = getNewestDateValue(txnCtx, args);
         Long duration = timestampNewest.longValue() - timestampEarliest.longValue();
 
@@ -127,7 +127,7 @@ public class AgeFunction extends Scalar<Long, Object> {
 
         if (args.length == 2) {
             Object newestValue = args[0].value();
-            timestampNewest = DataTypes.LONG.sanitizeValue(newestValue);
+            timestampNewest =  DataTypes.TIMESTAMP.implicitCast(newestValue);
         } else {
             timestampNewest = getTodayMidnightAtUTC(txnCtx);
         }

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -1,0 +1,226 @@
+package io.crate.expression.scalar;
+
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.StringType;
+import org.apache.commons.math3.util.Pair;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * This class implements the pg_catalog.age function
+ * Usage example:
+ * <pre>
+ *    SELECT pg_catalog.age(timestamp '2021-11-06')
+ *
+ * </pre>
+ *
+ */
+public class AgeFunction extends Scalar<Long, Object>
+{
+
+    public static final FunctionName NAME = new FunctionName(PgCatalogSchemaInfo.NAME, "age");
+    private final Signature signature;
+    private final Signature boundSignature;
+
+
+    /**
+     * Registers the pg_catalog function in the {@link ScalarFunctionModule}.
+     * It takes as input a TIMESTAMP  or two TIMESTAMP and optionally TIMEZONE
+     * and produces a LONG
+     * @param module the {@link ScalarFunctionModule}
+     */
+    public static void register(ScalarFunctionModule module)
+    {
+        List<DataType<?>> supportedTimestampTypes = List.of(
+            DataTypes.TIMESTAMPZ, DataTypes.TIMESTAMP, DataTypes.LONG);
+        for (DataType<?> dataType : supportedTimestampTypes)
+        {
+
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    dataType.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                ), AgeFunction::new
+            );
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    dataType.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                ), AgeFunction::new
+            );
+
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    dataType.getTypeSignature(),
+                    dataType.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                ),
+                AgeFunction::new
+            );
+            module.register(
+                Signature.scalar(
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    dataType.getTypeSignature(),
+                    dataType.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                ),
+                AgeFunction::new
+            );
+
+        }
+    }
+
+
+    public AgeFunction(Signature signature, Signature boundSignature)
+    {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+
+    @Override
+    public Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args)
+    {
+
+        assert args.length >= 1 &&  args.length <= 4 :
+            "Signature must ensure that there are  one,two ,three or four arguments";
+
+        if (checkNullInput(args))
+            return null;
+
+        Object earliestValue = args[args.length - 1].value();
+        Long timestampEarliest = DataTypes.TIMESTAMPZ.sanitizeValue(earliestValue);
+
+
+        Pair<String,Long> pair =   getTimezoneAndNewestDateValue(txnCtx, args);
+        Long timestampNewest= pair.getSecond();
+        String timeZoneString = pair.getFirst();
+        DateTimeZone timeZone = TimeZoneParser.parseTimeZone(timeZoneString);
+        DateTime dateNewest = new DateTime(timestampNewest.longValue(),timeZone);
+        DateTime dateEarliest = new DateTime(timestampEarliest.longValue(),timeZone);
+
+
+        Long duration = dateNewest.getMillis() - dateEarliest.getMillis();
+        return duration;
+    }
+
+
+    private boolean checkNullInput(Input<Object>[] args)
+    {
+        if(args.length==1)
+        {
+            if (args[0] == null)
+            {
+                return true;
+            }
+        }
+        else  if(args.length==2){
+            if (args[0] == null || args[1]==null)
+            {
+                return true;
+            }
+        }
+        else if(args.length==3){
+            if (args[0] == null || args[1]==null || args[2] ==null)
+            {
+                return true;
+            }
+        }
+        else  if(args.length==4 || args[1]==null || args[2]==null || args[3]==null){
+            if (args[0] == null)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private Pair<String,Long> getTimezoneAndNewestDateValue(TransactionContext txnCtx, Input<Object>... args){
+
+
+    Long timestampNewest;
+    String timeZoneString = TimeZoneParser.DEFAULT_TZ_LITERAL.value();
+        if (args.length == 3)
+            {   timeZoneString = (String) args[0].value();
+                Object newestValue = args[1].value();
+                timestampNewest = DataTypes.TIMESTAMPZ.sanitizeValue(newestValue);
+            }
+        else if (args.length == 2)
+            {
+                if (args[0] instanceof Literal && ((Literal)args[0]).valueType().equals(DataTypes.STRING)){
+                         timeZoneString = (String) args[0].value();
+                         timestampNewest = getTodayMidnightAtUTC(txnCtx);
+                }else{
+                    Object newestValue = args[0].value();
+                    timestampNewest = DataTypes.TIMESTAMPZ.sanitizeValue(newestValue);
+
+                }
+           }
+        else
+        {
+            timestampNewest = getTodayMidnightAtUTC(txnCtx);
+        }
+    Pair<String,Long > pair = new Pair<String, Long>(timeZoneString,timestampNewest );
+    return pair;
+}
+
+    private Long getTodayMidnightAtUTC(TransactionContext txnCtx)
+    {
+
+        return ChronoUnit.MILLIS.between(Instant.EPOCH, txnCtx.currentInstant().now().truncatedTo(ChronoUnit.DAYS));
+    }
+
+
+    @Override
+    public Signature signature()
+    {
+        return signature;
+    }
+
+
+    @Override
+    public Signature boundSignature()
+    {
+        return boundSignature;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -207,5 +207,6 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         PgFunctionIsVisibleFunction.register(this);
         PgGetFunctionResultFunction.register(this);
         PgPostmasterStartTime.register(this);
+        AgeFunction.register(this);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
@@ -1,0 +1,181 @@
+package io.crate.expression.scalar;
+
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+
+
+import org.junit.Test;
+import java.time.*;
+import java.time.temporal.ChronoUnit;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.Matchers.*;
+
+public class AgeFunctionTest extends ScalarTestCase
+{
+
+    @Test
+    public void testAgeCanBeAddressed() throws Exception
+    {
+        assertEvaluate("age(1401777485000)", is(notNullValue()));
+        assertEvaluate("age('2021-09-03'::timestamp without time zone)", is(notNullValue()));
+        assertEvaluate("age('2021-09-03'::timestamp)",  is(notNullValue()));
+        assertEvaluate("age(timestamp '2021-09-03',timestamp '2021-08-03')",  is(notNullValue()));
+        assertEvaluate("pg_catalog.age(1401777485000)", is(notNullValue()));
+        assertEvaluate("pg_catalog.age('2021-09-03'::timestamp without time zone)", is(notNullValue()));
+        assertEvaluate("pg_catalog.age('2021-09-03'::timestamp)",  is(notNullValue()));
+        assertEvaluate("pg_catalog.age(timestamp '2021-09-03',timestamp '2021-08-03')",  is(notNullValue()));
+
+    }
+
+
+    @Test
+    public void testAgeDateTimeZoneAware() throws Exception {
+
+        long midnightMoscow = LocalDate.now( ZoneOffset.UTC ).atTime(3,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        long midnightVienna = LocalDate.now( ZoneOffset.UTC ).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        long midnightUTC = LocalDate.now( ZoneOffset.UTC ).atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli();
+        Long expected3 =midnightMoscow-LocalDate.of(2021, Month.NOVEMBER, 8).atTime(3,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected1 =midnightVienna-LocalDate.of(2021, Month.NOVEMBER, 8).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected0 =midnightUTC-LocalDate.of(2021, Month.NOVEMBER, 8).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        assertEvaluate("age('2021-11-08')", expected0);
+        assertEvaluate("age('Europe/Vienna', '2021-11-08')", expected1);  // +0100
+        assertEvaluate("age('+01:00', '2021-11-08')",expected1);         // +0100
+        assertEvaluate("age('CET', '2021-11-08')", expected1);           // +0100
+        assertEvaluate("age('Europe/Moscow', '2021-11-08')", expected3); // +0300
+        assertEvaluate("age('+03:00', '2021-11-08')",expected3);         // +0300
+
+
+    }
+    @Test
+    public void testAgeDateTimeTimeZoneAware() throws Exception {
+
+        long midnightMoscow = LocalDate.now( ZoneOffset.UTC ).atTime(3,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        long midnightVienna = LocalDate.now( ZoneOffset.UTC ).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        long midnightUTC = LocalDate.now( ZoneOffset.UTC ).atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli();
+        Long expected4 = midnightMoscow - LocalDate.of(2021, Month.NOVEMBER, 8).atTime(4,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected2 = midnightVienna - LocalDate.of(2021, Month.NOVEMBER, 8).atTime(2,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected1 = midnightUTC - LocalDate.of(2021, Month.NOVEMBER, 8).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
+        assertEvaluate("age('2021-11-08 01:00')", expected1);
+        assertEvaluate("age('Europe/Vienna', '2021-11-08 01:00')", expected2);  // +0100
+        assertEvaluate("age('+01:00', '2021-11-08 01:00')",expected2);         // +0100
+        assertEvaluate("age('CET', '2021-11-08 01:00')", expected2);           // +0100
+        assertEvaluate("age('Europe/Moscow', '2021-11-08 01:00')", expected4); // +0300
+        assertEvaluate("age('+03:00', '2021-11-08 01:00')",expected4);         // +0300
+
+    }
+
+
+    @Test
+    public void testAgeWithTruncatedTimeToMidnight() throws Exception
+    {
+        long at5Nov = LocalDate.of(2021, Month.NOVEMBER, 5).atTime(3,43).toEpochSecond(ZoneOffset.UTC) * 1000;
+        long midnight = LocalDate.now( ZoneOffset.UTC ).atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli();
+        Long expected = midnight - at5Nov;
+
+        assertEvaluate("pg_catalog.age(timestamp '2021-11-05 03:43')", expected);
+
+
+    }
+
+
+    @Test
+    public void testAgeDiffWithYearsMonthsAndDays() throws Exception
+    {
+        long expected1 = LocalDate.of(2020, Month.SEPTEMBER, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        long expected2 = LocalDate.of(2021, Month.NOVEMBER, 3).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected = expected2 - expected1;
+        assertEvaluate("age( timestamp '2021-11-03', timestamp '2020-09-01')", expected);
+        assertEvaluate("age( '2021-11-03'::timestamp without time zone, '2020-09-01'::timestamp without time zone)", expected);
+        assertEvaluate("age( "+expected2+", "+expected1+")", expected);
+
+
+    }
+
+    @Test
+    public void testAgeDiffWithYears() throws Exception
+    {
+        long expected1 = LocalDate.of(2020, Month.NOVEMBER, 3).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        long expected2 = LocalDate.of(2021, Month.NOVEMBER, 3).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected = expected2 - expected1;
+        assertEvaluate("age( timestamp '2021-11-03', timestamp '2020-11-03')", expected);
+        assertEvaluate("age( "+expected2+", "+expected1+")", expected);
+
+
+    }
+
+    @Test
+    public void testAgeDiffWithMonths() throws Exception
+    {
+        long expected1 = LocalDate.of(2021, Month.SEPTEMBER, 3).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        long expected2 = LocalDate.of(2021, Month.NOVEMBER, 3).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected = expected2 - expected1;
+        assertEvaluate("age( timestamp '2021-11-03', timestamp '2021-09-03')", expected);
+        assertEvaluate("age( "+expected2+", "+expected1+")", expected);
+
+
+    }
+
+    @Test
+    public void testAgeDiffWithDays() throws Exception
+    {
+        long expected1 = LocalDate.of(2021, Month.NOVEMBER, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        long expected2 = LocalDate.of(2021, Month.NOVEMBER, 3).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected = expected2 - expected1;
+        assertEvaluate("age( timestamp '2021-11-03', timestamp '2021-11-01')", expected);
+        assertEvaluate("age( "+expected2+", "+expected1+")", expected);
+
+
+    }
+
+    @Test
+    public void testAgeWithIdenticalDates() throws Exception
+    {
+
+        Long expected = 0l;
+        assertEvaluate("age(timestamp '2021-09-01', timestamp '2021-09-01')", expected);
+
+
+    }
+
+
+    @Test
+    public void testCallTwiceSameResult() throws Exception{
+
+        assertEvaluate("age(timestamp '2021-09-01', timestamp '2021-08-01') = age(timestamp '2021-09-01', timestamp '2021-08-01')", true);
+
+    }
+
+    @Test
+    public void testNegativeAge() throws Exception
+    {
+        long expected1 = LocalDate.of(2020, Month.SEPTEMBER, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        long expected2 = LocalDate.of(2021, Month.NOVEMBER, 3).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        Long expected = expected1 - expected2;
+        // ("age('2020-09-01', '2021-11-03') -> "-1 years -2 mons -2 days"
+        assertEvaluate("age( timestamp '2020-09-01',timestamp '2021-11-03')", expected);
+    }
+
+
+}
+

--- a/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
@@ -50,38 +50,13 @@ public class AgeFunctionTest extends ScalarTestCase
 
 
     @Test
-    public void testAgeDateTimeZoneAware() throws Exception {
+    public void testAgeDate() throws Exception {
 
-        long midnightMoscow = LocalDate.now( ZoneOffset.UTC ).atTime(3,0).toEpochSecond(ZoneOffset.UTC) * 1000;
-        long midnightVienna = LocalDate.now( ZoneOffset.UTC ).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
         long midnightUTC = LocalDate.now( ZoneOffset.UTC ).atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli();
-        Long expected3 =midnightMoscow-LocalDate.of(2021, Month.NOVEMBER, 8).atTime(3,0).toEpochSecond(ZoneOffset.UTC) * 1000;
-        Long expected1 =midnightVienna-LocalDate.of(2021, Month.NOVEMBER, 8).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
         Long expected0 =midnightUTC-LocalDate.of(2021, Month.NOVEMBER, 8).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
         assertEvaluate("age('2021-11-08')", expected0);
-        assertEvaluate("age('Europe/Vienna', '2021-11-08')", expected1);  // +0100
-        assertEvaluate("age('+01:00', '2021-11-08')",expected1);         // +0100
-        assertEvaluate("age('CET', '2021-11-08')", expected1);           // +0100
-        assertEvaluate("age('Europe/Moscow', '2021-11-08')", expected3); // +0300
-        assertEvaluate("age('+03:00', '2021-11-08')",expected3);         // +0300
 
 
-    }
-    @Test
-    public void testAgeDateTimeTimeZoneAware() throws Exception {
-
-        long midnightMoscow = LocalDate.now( ZoneOffset.UTC ).atTime(3,0).toEpochSecond(ZoneOffset.UTC) * 1000;
-        long midnightVienna = LocalDate.now( ZoneOffset.UTC ).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
-        long midnightUTC = LocalDate.now( ZoneOffset.UTC ).atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli();
-        Long expected4 = midnightMoscow - LocalDate.of(2021, Month.NOVEMBER, 8).atTime(4,0).toEpochSecond(ZoneOffset.UTC) * 1000;
-        Long expected2 = midnightVienna - LocalDate.of(2021, Month.NOVEMBER, 8).atTime(2,0).toEpochSecond(ZoneOffset.UTC) * 1000;
-        Long expected1 = midnightUTC - LocalDate.of(2021, Month.NOVEMBER, 8).atTime(1,0).toEpochSecond(ZoneOffset.UTC) * 1000;
-        assertEvaluate("age('2021-11-08 01:00')", expected1);
-        assertEvaluate("age('Europe/Vienna', '2021-11-08 01:00')", expected2);  // +0100
-        assertEvaluate("age('+01:00', '2021-11-08 01:00')",expected2);         // +0100
-        assertEvaluate("age('CET', '2021-11-08 01:00')", expected2);           // +0100
-        assertEvaluate("age('Europe/Moscow', '2021-11-08 01:00')", expected4); // +0300
-        assertEvaluate("age('+03:00', '2021-11-08 01:00')",expected4);         // +0300
 
     }
 

--- a/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
@@ -21,22 +21,25 @@
 
 package io.crate.integrationtests;
 
+
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 import io.crate.types.DataTypes;
 import org.junit.Test;
-
+import java.util.Objects;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 
 @UseJdbc(0) // data types needed
-public class ScalarIntegrationTest extends SQLIntegrationTestCase {
+public class ScalarIntegrationTest extends SQLIntegrationTestCase
+{
 
     @Test
-    public void testExtractFunctionReturnTypes() {
+    public void testExtractFunctionReturnTypes()
+    {
         execute("SELECT EXTRACT(DAY FROM CURRENT_TIMESTAMP)");
         assertThat(response.columnTypes()[0], is(DataTypes.INTEGER));
 
@@ -44,8 +47,10 @@ public class ScalarIntegrationTest extends SQLIntegrationTestCase {
         assertThat(response.columnTypes()[0], is(DataTypes.DOUBLE));
     }
 
+
     @Test
-    public void testSubscriptFunctionFromUnnest() {
+    public void testSubscriptFunctionFromUnnest()
+    {
         var session = sqlExecutor.newSession();
         session.sessionContext().setErrorOnUnknownObjectKey(true);
         Asserts.assertThrowsMatches(
@@ -69,5 +74,40 @@ public class ScalarIntegrationTest extends SQLIntegrationTestCase {
         response = sqlExecutor.exec("SELECT [col1]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
                                         session2);
         assertThat(TestingHelpers.printedTable(response.rows()), is("[1]\n[null]\n"));
+    }
+
+
+    @Test
+    public void testAgeFunctionWithOrderBy()
+    {
+
+        Object[][] ar = {
+            {"2021-10-01, 00:00"}, {"2021-10-02, 00:00"},
+            {"2021-10-03, 00:00"}, {"2021-10-04, 00:00"},
+            {"2021-10-05, 00:00"}, {"2021-10-06, 00:00"},
+            {"2021-10-07, 00:00"}, {"2021-10-08, 00:00"},
+            {"2021-10-09, 00:00"}, {"2021-10-10, 00:00"},
+            {"2021-10-11, 00:00"}, {"2021-10-12, 00:00"},
+            {"2021-10-13, 00:00"}, {"2021-10-14, 00:00"},
+            {"2021-10-15, 00:00"}, {"2021-10-16, 00:00"},
+            {"2021-10-17, 00:00"}, {"2021-10-18, 00:00"},
+            {"2021-10-19, 00:00"}, {"2021-10-20, 00:00"},
+            {"2021-10-21, 00:00"}, {"2021-10-22, 00:00"},
+            {"2021-10-23, 00:00"}, {"2021-10-24, 00:00"},
+            {"2021-10-25, 00:00"}, {"2021-10-26, 00:00"},
+            {"2021-10-27, 00:00"}, {"2021-10-28, 00:00"},
+            {"2021-10-29, 00:00"}, {"2021-10-30, 00:00"},
+            {"2021-10-31, 00:00"}, {"2021-11-01, 00:00"},
+            {"2021-11-02, 00:00"}
+
+        };
+        execute(
+            "SELECT   date_format('%Y-%m-%d, %H:%i', x)  FROM generate_series('2021-10-01'::timestamp, '2021-11-02'::timestamp, '1 days'::interval) AS t(x) order by pg_catalog.age(x) desc");
+
+
+        assertThat(Objects.deepEquals(response.rows(), ar), is(true));
+
+
+
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Introduce pg_catalog.age scalar function related with

https://github.com/crate/crate/issues/11758



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
