### PR TITLE
Set smaller quietPeriod for shutting down client group

### DIFF
--- a/server/src/testFixtures/java/io/crate/test/utils/ConnectionTest.java
+++ b/server/src/testFixtures/java/io/crate/test/utils/ConnectionTest.java
@@ -36,7 +36,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import java.net.InetSocketAddress;
 import java.util.List;
-
+import java.util.concurrent.TimeUnit;
 
 public final class ConnectionTest {
 
@@ -114,7 +114,7 @@ public final class ConnectionTest {
             return ProbeResult.SSL_MISSING;
         }
         finally {
-            group.shutdownGracefully().sync();
+            group.shutdownGracefully(0, 5, TimeUnit.SECONDS).sync();
         }
     }
 


### PR DESCRIPTION
To address timeouts of the [test_switch_to_plaintext_enabled_downgrades_to_plaintext](https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.SSLTrustedZoneITest/test_switch_to_plaintext_enabled_downgrades_to_plaintext) 

Very basic measure (commit 1) shows that it's `shutdownGracefully` being the main problem (we do 2 probes with 2 clientBoostarps & shutdowns and each shutdown takes roughly 2 seconds - in total it's 4 seconds out of 5 total timeout for the test suite.

Found [same issue](https://stackoverflow.com/questions/34522574/netty-client-side-connection-close-too-slow)  - will try out the mitigation

https://stackoverflow.com/a/29116343/2104560

`static final long DEFAULT_SHUTDOWN_QUIET_PERIOD = 2;` default value is too big, 2 seconds. - reduced to 100ms


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
