### PR TITLE
Add END statement as synonym for COMMIT

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -64,6 +64,9 @@ Deprecations
 Changes
 =======
 
+- Added support for the :ref:`END <ref-end>` statement for improved PostgreSQL
+  compatibility.
+
 - Registered the scalar function :ref:`array_to_string
   <scalar-array_to_string>` under the `pg_catalog` schema.
 

--- a/docs/sql/statements/end.rst
+++ b/docs/sql/statements/end.rst
@@ -1,11 +1,11 @@
 .. highlight:: psql
-.. _ref-commit:
+.. _ref-end:
 
-==========
-``COMMIT``
-==========
+=======
+``END``
+=======
 
-Commit the current transaction
+A synonym for :ref:`ref-commit`.
 
 .. rubric:: Table of contents
 
@@ -17,7 +17,7 @@ Synopsis
 
 ::
 
-   COMMIT [ WORK | TRANSACTION ]
+   END [ WORK | TRANSACTION ]
 
 
 Parameters
@@ -27,7 +27,6 @@ Parameters
 `TRANSACTION`
 
 Optional keywords. They have no effect.
-
 
 Description
 ===========

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -38,6 +38,7 @@ SQL Statements
     drop-table
     drop-user
     drop-view
+    end
     explain
     grant
     insert

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -33,7 +33,8 @@ statement
     : query                                                                          #default
     | BEGIN (WORK | TRANSACTION)? (transactionMode (',' transactionMode)*)?          #begin
     | START TRANSACTION (transactionMode (',' transactionMode)*)?                    #startTransaction
-    | COMMIT                                                                         #commit
+    | COMMIT (WORK | TRANSACTION)?                                                   #commit
+    | END (WORK | TRANSACTION)?                                                      #commit
     | EXPLAIN (ANALYZE)? statement                                                   #explain
     | OPTIMIZE TABLE tableWithPartitions withProperties?                             #optimize
     | REFRESH TABLE tableWithPartitions                                              #refreshTable

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -215,6 +215,15 @@ public class TestStatementBuilder {
     @Test
     public void testCommit() {
         printStatement("COMMIT");
+        printStatement("COMMIT WORK");
+        printStatement("COMMIT TRANSACTION");
+    }
+
+    @Test
+    public void testEnd() {
+        printStatement("END");
+        printStatement("END WORK");
+        printStatement("END TRANSACTION");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
@@ -121,6 +121,12 @@ public class PostgresCompatIntegrationTest extends SQLIntegrationTestCase {
         assertNoErrorResponse(response);
     }
 
+    @Test
+    public void testEndStatement() {
+        execute("END");
+        assertNoErrorResponse(response);
+    }
+
     /**
      * In CrateDB -1 means row-count unknown, and -2 means error.
      * In JDBC -2 means row-count unknown and -3 means error.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/11899
See https://www.postgresql.org/docs/current/sql-end.html


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
