### PR TITLE
Don't use shared event loop group for HTTP

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -150,3 +150,5 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could cause a deadlock, leading to an unavailable cluster
+  if using blob tables and uploading multiple files in parallel.

--- a/server/src/main/java/io/crate/netty/NettyBootstrap.java
+++ b/server/src/main/java/io/crate/netty/NettyBootstrap.java
@@ -57,15 +57,9 @@ public class NettyBootstrap {
     private int refs = 0;
     private EventLoopGroup worker;
 
-    public synchronized BorrowedItem<EventLoopGroup> getEventLoopGroup(Settings settings) {
+    public synchronized BorrowedItem<EventLoopGroup> getSharedEventLoopGroup(Settings settings) {
         if (worker == null) {
-            ThreadFactory workerThreads = daemonThreadFactory(settings, WORKER_THREAD_PREFIX);
-            int workerCount = Netty4Transport.WORKER_COUNT.get(settings);
-            if (Epoll.isAvailable()) {
-                worker = new EpollEventLoopGroup(workerCount, workerThreads);
-            } else {
-                worker = new NioEventLoopGroup(workerCount, workerThreads);
-            }
+            worker = newEventLoopGroup(settings);
         }
         refs++;
         return new BorrowedItem<>(worker, () -> {
@@ -81,6 +75,16 @@ public class NettyBootstrap {
                 }
             }
         });
+    }
+
+    public static EventLoopGroup newEventLoopGroup(Settings settings) {
+        ThreadFactory workerThreads = daemonThreadFactory(settings, WORKER_THREAD_PREFIX);
+        int workerCount = Netty4Transport.WORKER_COUNT.get(settings);
+        if (Epoll.isAvailable()) {
+            return new EpollEventLoopGroup(workerCount, workerThreads);
+        } else {
+            return new NioEventLoopGroup(workerCount, workerThreads);
+        }
     }
 
     public static Class<? extends Channel> clientChannel() {

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
@@ -149,7 +149,7 @@ public class PostgresNetty extends AbstractLifecycleComponent {
         if (!enabled) {
             return;
         }
-        eventLoopGroup = nettyBootstrap.getEventLoopGroup(settings);
+        eventLoopGroup = nettyBootstrap.getSharedEventLoopGroup(settings);
         bootstrap = NettyBootstrap.newServerBootstrap(settings, eventLoopGroup.item());
         this.openChannels = new Netty4OpenChannelsHandler(LOGGER);
 

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -149,7 +149,7 @@ public class Netty4Transport extends TcpTransport {
     protected void doStart() {
         boolean success = false;
         try {
-            eventLoopGroup = nettyBootstrap.getEventLoopGroup(settings);
+            eventLoopGroup = nettyBootstrap.getSharedEventLoopGroup(settings);
             clientBootstrap = createClientBootstrap(eventLoopGroup.item());
             if (NetworkService.NETWORK_SERVER.get(settings)) {
                 for (ProfileSettings profileSettings : profileSettings) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The blob layer blocks on the netty thread. If we use shared workers
between HTTP and transport that can lead to deadlocks if blob uploads
block enough threads to starve the transport layer, which in turn can
break coordination and lead to the blob uploads blocking the threads
forever.

Discovered this by disabling the mocked transport in the test layer.

Should we add changes + backport this?


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
