### PR TITLE
Implement scalar function pg_catalog.age

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,6 +74,9 @@ Changes
   <scalar-pg_encoding_to_char>` which converts an PostgreSQL encoding's internal
   identifier to a human-readable name.
 
+- Added the scalar function :ref:`age <scalar-pg-age>` which returns
+  :ref:`interval <type-interval>` between 2 timestamps.
+
 - Added a :ref:`sys node check for max shards per node
   <sys-node_checks_max_shards_per_node>` to verify that the amount of shards on the
   current node is less than 90 % of  :ref:`cluster.max_shards_per_node

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1461,6 +1461,34 @@ specified interval added to the timestamp of ``0000/01/01 00:00:00``::
     +---------------------+
     SELECT 1 row in set (... sec)
 
+.. _scalar-pg-age:
+
+``age([timestamp,] timestamp)``
+---------------------------------------------------
+
+Returns: :ref:`interval <type-interval>` between 2 timestamps. Second argument
+is subtracted from the first one. If at least one argument is ``NULL``, the
+return value is ``NULL``. If only one timestamp is given, the return value is
+interval between current_date (at midnight) and the given timestamp.
+
+Example::
+
+    cr> select pg_catalog.age('2021-10-21'::timestamp, '2021-10-20'::timestamp)
+    ... as age;
+    +----------------+
+    | age            |
+    +----------------+
+    | 1 day 00:00:00 |
+    +----------------+
+    SELECT 1 row in set (... sec)
+
+    cr> select pg_catalog.age(date_trunc('day', CURRENT_DATE)) as age;
+    +----------+
+    | age      |
+    +----------+
+    | 00:00:00 |
+    +----------+
+    SELECT 1 row in set (... sec)
 
 .. _scalar-geo:
 

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.data.Input;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.types.DataTypes;
+import org.joda.time.Interval;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
+
+import static io.crate.metadata.functions.Signature.scalar;
+
+public class AgeFunction extends Scalar<Period, Object> {
+
+    private static final FunctionName NAME = new FunctionName(PgCatalogSchemaInfo.NAME, "age");
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            scalar(
+                NAME,
+                DataTypes.TIMESTAMP.getTypeSignature(),
+                DataTypes.INTERVAL.getTypeSignature()
+            ).withFeatures(NO_FEATURES),
+            AgeFunction::new
+        );
+
+        module.register(
+            scalar(
+                NAME,
+                DataTypes.TIMESTAMP.getTypeSignature(),
+                DataTypes.TIMESTAMP.getTypeSignature(),
+                DataTypes.INTERVAL.getTypeSignature()
+            ).withFeatures(NO_FEATURES),
+            AgeFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    public AgeFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public Period evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>... args) {
+        /*
+         We cannot create Period from millis difference
+         since sometimes we need to treat different millis range as same interval.
+         Postgres treats age between first days of the sequential months as
+         '1 month' despite on possibly different 28, 30, 31 days/millis range.
+         */
+        assert args.length > 0 && args.length < 3 : "Invalid number of arguments";
+
+        var arg1 = args[0].value();
+        if (arg1 == null) {
+            return null;
+        }
+        if (args.length == 1) {
+            long curDateMillis = txnCtx.currentInstant().toEpochMilli();
+            curDateMillis = curDateMillis - curDateMillis % 86400000; // current_date at midnight, similar to CurrentDateFunction implementation.
+            return getPeriod(curDateMillis, (long) arg1);
+        } else {
+            var arg2 = args[1].value();
+            if (arg2 == null) {
+                return null;
+            }
+            return getPeriod((long) arg1, (long) arg2);
+        }
+    }
+
+    /**
+     * returns Period in yearMonthDayTime which corresponds to Postgres default Interval output format.
+     * See https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-INTERVAL-OUTPUT
+     */
+    private static Period getPeriod(long timestamp1, long timestamp2) {
+        /*
+         Normalize is important as it affects the internal representation of the Period object.
+         PeriodType.yearMonthDayTime() is needed to return 8 days but not 1 week 1 day.
+         Streamer of the IntervalType will simply put 0 in 'out.writeVInt(p.getWeeks())' as getWeeks() returns zero for unused fields.
+         */
+        if (timestamp1 < timestamp2) {
+            // In Postgres second argument is subtracted from the first.
+            // Interval's first argument must be smaller than second and thus we swap params and negate.
+            return new Interval(timestamp1, timestamp2).toPeriod(PeriodType.yearMonthDayTime()).negated();
+        } else {
+            return new Interval(timestamp2, timestamp1).toPeriod(PeriodType.yearMonthDayTime());
+        }
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -142,6 +142,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         DateFormatFunction.register(this);
         CurrentDateFunction.register(this);
         DateBinFunction.register(this);
+        AgeFunction.register(this);
 
         ToCharFunction.register(this);
 

--- a/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+package io.crate.expression.scalar;
+
+import io.crate.metadata.SystemClock;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneOffset;
+
+import static io.crate.testing.Asserts.assertThrowsMatches;
+
+public class AgeFunctionTest extends ScalarTestCase {
+
+    private static final long FIRST_JAN_2021_MIDNIGHT_UTC_AS_MILLIS =
+        LocalDate.of(2021, Month.JANUARY, 1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
+
+    @Before
+    public void prepare() {
+        SystemClock.setCurrentMillisFixedUTC(FIRST_JAN_2021_MIDNIGHT_UTC_AS_MILLIS);
+    }
+
+    @After
+    public void cleanUp() {
+        SystemClock.setCurrentMillisSystemUTC();
+    }
+
+    @Test
+    public void test_calls_within_statement_are_idempotent() {
+        assertEvaluate("age('2019-01-01' :: TIMESTAMP) = age('2019-01-01' :: TIMESTAMP)", true);
+    }
+
+    @Test
+    public void test_1_argument_before_curdate_age_is_positive() {
+        // 1 second before the current_date (manually set 2021.01.01 midnight)
+        assertEvaluate("pg_catalog.age('2020-12-31T23:59:59'::timestamp)",  Period.seconds(1).normalizedStandard(PeriodType.yearMonthDayTime()));
+    }
+
+    @Test
+    public void test_1_argument_after_curdate_age_is_negative() {
+        // 1 second before the current_date (manually set 2021.01.01 midnight)
+        assertEvaluate("pg_catalog.age('2021-01-01T00:00:01'::timestamp)",  Period.seconds(1).normalizedStandard(PeriodType.yearMonthDayTime()).negated());
+    }
+
+    @Test
+    public void test_floating_point_arguments() {
+        // We treat float and double values as seconds with milliseconds as fractions.
+        assertEvaluate("pg_catalog.age(1.2, 1.1) ", Period.millis(100).normalizedStandard(PeriodType.yearMonthDayTime()));
+        assertEvaluate("pg_catalog.age(1.1, 1.2) ", Period.millis(100).normalizedStandard(PeriodType.yearMonthDayTime()).negated());
+    }
+
+    @Test
+    public void test_2_arguments_more_than_7_days_no_weeks() {
+        // Postgres returns 8 days.
+        // If we remove PeriodType.yearMonthDayTime() normalization in the implementation, age returns 1 week 1 day.
+        var expectedInterval= Period.days(8).normalizedStandard(PeriodType.yearMonthDayTime());
+        assertEvaluate("pg_catalog.age('2021-01-09T00:00:00'::timestamp, '2021-01-01T00:00:00'::timestamp)", expectedInterval);
+    }
+
+    @Test
+    public void test_age_is_1_month_regardless_of_days_in_month() {
+        var expectedInterval= Period.months(1).normalizedStandard(PeriodType.yearMonthDayTime());
+        assertEvaluate("pg_catalog.age('2021-02-01T00:00:00'::timestamp, '2021-01-01T00:00:00'::timestamp)", expectedInterval); // 31 days but 1 month
+        assertEvaluate("pg_catalog.age('2021-03-01T00:00:00'::timestamp, '2021-02-01T00:00:00'::timestamp)", expectedInterval); // 28 days but 1 month
+        assertEvaluate("pg_catalog.age('2021-05-01T00:00:00'::timestamp, '2021-04-01T00:00:00'::timestamp)", expectedInterval); // 30 days but 1 month
+    }
+
+    @Test
+    public void test_2_arguments_positive() {
+        // 1 year 2 months 3 days 4 hours 5 minutes 6 seconds 7 milliseconds before the current_date (manually set 2021.01.01 midnight)
+        var expectedInterval= Period.years(1).plusMonths(2).plusDays(3).plusHours(4).plusMinutes(5).plusSeconds(6)
+            .plusMillis(7).normalizedStandard(PeriodType.yearMonthDayTime());
+        assertEvaluate("pg_catalog.age('2021-01-01T00:00:00'::timestamp, '2019-10-28T19:54:53.993'::timestamp)", expectedInterval);
+    }
+
+    @Test
+    public void test_2_arguments_negative() {
+        // 1 year 2 months 3 days 4 hours 5 minutes 6 seconds 7 milliseconds after the current_date (manually set 2021.01.01 midnight)
+        var expectedInterval= Period.years(1).plusMonths(2).plusDays(3).plusHours(4).plusMinutes(5).plusSeconds(6)
+            .plusMillis(7).normalizedStandard(PeriodType.yearMonthDayTime()).negated();
+        assertEvaluate("pg_catalog.age('2021-01-01T00:00:00'::timestamp, '2022-03-04T04:05:06.007'::timestamp)", expectedInterval);
+    }
+
+    @Test
+    public void test_at_least_one_arg_is_null_returns_null() {
+        assertEvaluate("age(null)", null);
+        assertEvaluate("age(null, '2019-01-02'::TIMESTAMP)", null);
+        assertEvaluate("age('2019-01-02'::TIMESTAMP, null)", null);
+        assertEvaluate("age(null, null)", null);
+    }
+
+    @Test
+    public void test_2_arguments_with_timezone() throws Exception {
+        assertEvaluate("pg_catalog.age(CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", Period.seconds(0).normalizedStandard(PeriodType.yearMonthDayTime()));
+    }
+
+    @Test
+    public void test_3_args_throws_exception() {
+        assertThrowsMatches(() -> assertEvaluate("pg_catalog.age(null, null, null)", null),
+            UnsupportedOperationException.class,
+            "Unknown function: pg_catalog.age(NULL, NULL, NULL), no overload found for matching argument types: (undefined, undefined, undefined). " +
+                "Possible candidates: pg_catalog.age(timestamp without time zone):interval, " +
+                "pg_catalog.age(timestamp without time zone, timestamp without time zone):interval"
+        );
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/11758


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
