### PR TITLE
Rename LogicalReplicationIntegrationTest -> LogicalReplicationITestCase

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -39,7 +39,7 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
 
-public class LogicalReplicationITest extends LogicalReplicationIntegrationTest {
+public class LogicalReplicationITest extends LogicalReplicationITestCase {
 
     private String defaultTableSettings() {
         var joiner = new StringJoiner(",");

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
@@ -50,7 +50,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +63,7 @@ import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDE
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.hamcrest.Matchers.is;
 
-public abstract class LogicalReplicationIntegrationTest extends ESTestCase {
+public abstract class LogicalReplicationITestCase extends ESTestCase {
 
     InternalTestCluster publisherCluster;
     SQLTransportExecutor publisherSqlExecutor;

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -33,7 +33,7 @@ import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATIO
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-public class MetadataTrackerITest extends LogicalReplicationIntegrationTest {
+public class MetadataTrackerITest extends LogicalReplicationITestCase {
 
     @Override
     Settings logicalReplicationSettings() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Having a `LogicalReplicationITest` that extends
`LogicalReplicationIntegrationTest` is confusing.

The latter is a base test case class and the name should reflect that.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
