### PR TITLE
Run checkstyle as a dedicated github action job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,19 @@ jobs:
         run: |
           ./gradlew forbiddenApisMain
 
+  checkstyle:
+    name: checkstyle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Gradle Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Run checkstyleMain
+        run: |
+          ./gradlew checkstyleMain
+
   linkcheck:
     name: Sphinx linkcheck
     runs-on: ubuntu-latest

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
       - status-success~=^Test CrateDB SQL on ubuntu
       - status-success~=^Test CrateDB SQL on windows
       - status-success=docs/readthedocs.org:crate
+      - status-success~=^CrateDB SQL / checkstyle
     name: default
   - actions:
       backport:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           steps {
             sh 'git clean -xdff'
             checkout scm
-            sh './gradlew --no-daemon --parallel -Dtests.crate.slow=true -PtestForks=8 test checkstyleMain jacocoReport'
+            sh './gradlew --no-daemon --parallel -Dtests.crate.slow=true -PtestForks=8 test jacocoReport'
 
             // Upload coverage report to Codecov.
             // https://about.codecov.io/blog/introducing-codecovs-new-uploader/


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Will help see checkstyle failures earlier, while still showing the test
failures if one chooses to wait for the tests to complete.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
