### PR TITLE
Upload GHA test results to wacklig

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,15 @@ jobs:
         with:
           arguments: :server:test -Dtests.crate.run-windows-incompatible=${{ matrix.os == 'ubuntu-latest' }}
 
+      - name: Upload results to wacklig
+        if: always()
+        shell: bash
+        env:
+          WACKLIG_TOKEN: ${{ secrets.WACKLIG_TOKEN }}
+        run: |
+          curl -s https://raw.githubusercontent.com/pipifein/wacklig-uploader/master/wacklig.py | python - --token $WACKLIG_TOKEN || echo "Upload to wacklig failed"
+
+
   forbiddenApis:
     name: forbiddenApisMain
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Should help give us a better overview over whether there are some tests
that exclusively fail on Windows.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
