### PR TITLE
Forbid DDL and DML operations on replicating tables

### DIFF
--- a/server/src/main/java/io/crate/metadata/table/Operation.java
+++ b/server/src/main/java/io/crate/metadata/table/Operation.java
@@ -32,6 +32,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+
 public enum Operation {
     READ("READ"),
     UPDATE("UPDATE"),
@@ -61,6 +63,8 @@ public enum Operation {
         ALTER_BLOCKS, ALTER_REROUTE, SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO, CREATE_SNAPSHOT);
     public static final EnumSet<Operation> METADATA_DISABLED_OPERATIONS = EnumSet.of(READ, UPDATE, INSERT, DELETE,
         ALTER_BLOCKS, ALTER_OPEN_CLOSE, ALTER_REROUTE, REFRESH, SHOW_CREATE, OPTIMIZE);
+    public static final EnumSet<Operation> LOGICAL_REPLICATED = EnumSet.of(
+        READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE);
 
     private final String representation;
 
@@ -81,6 +85,10 @@ public enum Operation {
             return CLOSED_OPERATIONS;
         }
         Set<Operation> operations = ALL;
+        var subscriptionName = REPLICATION_SUBSCRIPTION_NAME.get(settings);
+        if (subscriptionName != null && subscriptionName.isEmpty() == false) {
+            operations = LOGICAL_REPLICATED;
+        }
         for (Map.Entry<String, EnumSet<Operation>> entry : BLOCK_SETTING_TO_OPERATIONS_MAP.entrySet()) {
             if (!settings.getAsBoolean(entry.getKey(), false)) {
                 continue;

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -25,13 +25,11 @@ import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.user.User;
 import io.crate.user.UserLookup;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
-
 import java.util.concurrent.TimeUnit;
 
 import static io.crate.testing.Asserts.assertThrowsMatches;
@@ -331,7 +329,6 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
                                                      "2\n"));
     }
 
-    @TestLogging("io.crate.replication.logical:TRACE,org.elasticsearch.index.seqno:TRACE")
     @Test
     public void test_subscribed_tables_are_followed_and_updated() throws Exception {
         executeOnPublisher("CREATE TABLE doc.t1 (id INT) WITH(" +

--- a/server/src/test/java/io/crate/replication/logical/engine/SubscriberEngineTest.java
+++ b/server/src/test/java/io/crate/replication/logical/engine/SubscriberEngineTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.engine;
+
+import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.InternalEngineTests;
+import org.junit.Test;
+
+import static io.crate.testing.Asserts.assertThrowsMatches;
+import static org.elasticsearch.index.engine.EngineTestCase.newUid;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+
+public class SubscriberEngineTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_operation_validation_with_unassigned_seqno_raises_exception() {
+        var op = new Engine.Index(newUid("0"), 0, InternalEngineTests.createParsedDoc("0", null));
+        assertThrowsMatches(
+            () -> SubscriberEngine.validate(op),
+            UnsupportedFeatureException.class,
+            "A subscriber engine does not accept operations without an assigned sequence number"
+        );
+    }
+
+    @Test
+    public void test_operation_validation_with_invalid_version_type_raises_exception() {
+        var op = new Engine.Index(newUid("0"),
+                                  InternalEngineTests.createParsedDoc("0", null),
+                                  0,
+                                  0,
+                                  Versions.MATCH_ANY,
+                                  VersionType.INTERNAL,
+                                  Engine.Operation.Origin.PRIMARY,
+                                  System.nanoTime(),
+                                  -1,
+                                  false,
+                                  UNASSIGNED_SEQ_NO,
+                                  0);
+        assertThrowsMatches(
+            () -> SubscriberEngine.validate(op),
+            IllegalStateException.class,
+            "Invalid version_type in a subscriber engine; version_type=INTERNAL origin=PRIMARY"
+        );
+    }
+}


### PR DESCRIPTION
Create dedicated list of supported `Operation`s when table is a replicating one.
Additionally ensure that the SubscriberEngine is only used by subscribed tables by throwing an exception if no valid
SeqNo is provided (fallback safeguard).

As a follow up we'd have to allow to alter some concrete table settings even for replicating tables, would do this once we've implemented filtered table setting replication.