### PR TITLE
Move disableProcessorCheck for netty to EsTestCase

### DIFF
--- a/server/src/test/java/io/crate/execution/ddl/RepositoryServiceTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/RepositoryServiceTest.java
@@ -21,15 +21,7 @@
 
 package io.crate.execution.ddl;
 
-import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
@@ -50,17 +42,18 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
 public class RepositoryServiceTest extends CrateDummyClusterServiceUnitTest {
-
-    @BeforeClass
-    public static void disableProcessorCheck() {
-        System.setProperty("es.set.netty.runtime.available.processors", "false");
-    }
 
     @Test
     public void testConvertException() throws Throwable {

--- a/server/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
+++ b/server/src/test/java/io/crate/protocols/http/CrateHttpsTransportTest.java
@@ -21,16 +21,12 @@
 
 package io.crate.protocols.http;
 
-import static io.crate.protocols.ssl.SslContextProviderTest.getAbsoluteFilePathFromClassPath;
-import static org.elasticsearch.env.Environment.PATH_HOME_SETTING;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.mock;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.Collections;
-
+import io.crate.netty.NettyBootstrap;
+import io.crate.plugin.PipelineRegistry;
+import io.crate.protocols.ssl.SslContextProvider;
+import io.crate.protocols.ssl.SslSettings;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.ssl.SslHandler;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkService;
@@ -43,22 +39,20 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.crate.netty.NettyBootstrap;
-import io.crate.plugin.PipelineRegistry;
-import io.crate.protocols.ssl.SslSettings;
-import io.crate.protocols.ssl.SslContextProvider;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.ssl.SslHandler;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+
+import static io.crate.protocols.ssl.SslContextProviderTest.getAbsoluteFilePathFromClassPath;
+import static org.elasticsearch.env.Environment.PATH_HOME_SETTING;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
 
 public class CrateHttpsTransportTest extends ESTestCase {
 
     private static File trustStoreFile;
     private static File keyStoreFile;
-
-    @BeforeClass
-    public static void disableProcessorCheck() {
-        System.setProperty("es.set.netty.runtime.available.processors", "false");
-    }
 
     @BeforeClass
     public static void beforeTests() throws IOException {

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -24,7 +24,6 @@ package org.elasticsearch.test;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-
 import io.crate.common.collections.Lists2;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
@@ -82,7 +81,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.store.MockFSIndexStore;
-import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -179,11 +177,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
  */
 @LuceneTestCase.SuppressFileSystems("ExtrasFS") // doesn't work with potential multi data path from test cluster yet
 public abstract class ESIntegTestCase extends ESTestCase {
-
-    @BeforeClass
-    public static void disableProcessorCheck() {
-        System.setProperty("es.set.netty.runtime.available.processors", "false");
-    }
 
     /** node names of the corresponding clusters will start with these prefixes */
     public static final String SUITE_CLUSTER_NODE_PREFIX = "node_s";

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -302,6 +302,11 @@ public abstract class ESTestCase extends LuceneTestCase {
     protected void afterIfSuccessful() throws Exception {
     }
 
+    @BeforeClass
+    public static void disableProcessorCheck() {
+        System.setProperty("es.set.netty.runtime.available.processors", "false");
+    }
+
     // setup mock filesystems for this test run. we change PathUtils
     // so that all accesses are plumbed thru any mock wrappers
 


### PR DESCRIPTION
Since the MockTransport is removed in favour of the NettyTranport,
some non-integration tests are failing cause of the enabled
processor check.