### PR TITLE
WIP remove the REPLICATION_SUBSCRIPTION_NAME index setting

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -144,7 +144,8 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
                                    ActionListener<AcknowledgedResponse> listener) throws Exception {
         assert state.nodes().getMinNodeVersion().onOrAfter(Version.V_4_3_0)
             : "All nodes must be on 4.3 to use the new dedicated close action";
-        closeTables(listener, List.of(new OpenCloseTable(request.table(), request.partition())), request.ackTimeout());
+        clusterService.submitStateUpdateTask("add-block-close-table",
+            new AddCloseBlocksTask(listener, List.of(new OpenCloseTable(request.table(), request.partition())), request.ackTimeout()));
 
     }
 
@@ -352,14 +353,14 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
             .build();
     }
 
-    private final class AddCloseBlocksTask extends ClusterStateUpdateTask {
+    public final class AddCloseBlocksTask extends ClusterStateUpdateTask {
 
         private final ActionListener<AcknowledgedResponse> listener;
         private final List<OpenCloseTable> tablesToClose;
         private final TimeValue requestAckTimeout;
         private final Map<Index, ClusterBlock> blockedIndices = new HashMap<>();
 
-        private AddCloseBlocksTask(ActionListener<AcknowledgedResponse> listener,
+        public AddCloseBlocksTask(ActionListener<AcknowledgedResponse> listener,
                                    List<OpenCloseTable> tablesToClose,
                                    TimeValue requestAckTimeout) {
             this.listener = listener;

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -144,8 +144,7 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
                                    ActionListener<AcknowledgedResponse> listener) throws Exception {
         assert state.nodes().getMinNodeVersion().onOrAfter(Version.V_4_3_0)
             : "All nodes must be on 4.3 to use the new dedicated close action";
-        clusterService.submitStateUpdateTask("add-block-close-table",
-            new AddCloseBlocksTask(listener, List.of(new OpenCloseTable(request.table(), request.partition())), request.ackTimeout()));
+        closeTables(listener, List.of(new OpenCloseTable(request.table(), request.partition())), request.ackTimeout());
 
     }
 
@@ -353,14 +352,14 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
             .build();
     }
 
-    public final class AddCloseBlocksTask extends ClusterStateUpdateTask {
+    private final class AddCloseBlocksTask extends ClusterStateUpdateTask {
 
         private final ActionListener<AcknowledgedResponse> listener;
         private final List<OpenCloseTable> tablesToClose;
         private final TimeValue requestAckTimeout;
         private final Map<Index, ClusterBlock> blockedIndices = new HashMap<>();
 
-        public AddCloseBlocksTask(ActionListener<AcknowledgedResponse> listener,
+        private AddCloseBlocksTask(ActionListener<AcknowledgedResponse> listener,
                                    List<OpenCloseTable> tablesToClose,
                                    TimeValue requestAckTimeout) {
             this.listener = listener;

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -32,12 +32,10 @@ import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -57,8 +55,7 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
                                                     IndexNameExpressionResolver indexNameExpressionResolver,
                                                     AllocationService allocationService,
                                                     DDLClusterStateService ddlClusterStateService,
-                                                    MetadataIndexUpgradeService metadataIndexUpgradeService,
-                                                    IndicesService indexServices) {
+                                                    OpenTableClusterStateTaskExecutor openExecutor) {
         super(ACTION_NAME,
             transportService,
             clusterService,
@@ -68,8 +65,7 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
             AcknowledgedResponse::new,
             AcknowledgedResponse::new,
             "open-table-or-partition");
-        openExecutor = new OpenTableClusterStateTaskExecutor(indexNameExpressionResolver, allocationService,
-            ddlClusterStateService, metadataIndexUpgradeService, indexServices);
+        this.openExecutor = openExecutor;
         closeExecutor = new CloseTableClusterStateTaskExecutor(indexNameExpressionResolver, allocationService,
             ddlClusterStateService);
     }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -32,10 +32,12 @@ import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -55,7 +57,8 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
                                                     IndexNameExpressionResolver indexNameExpressionResolver,
                                                     AllocationService allocationService,
                                                     DDLClusterStateService ddlClusterStateService,
-                                                    OpenTableClusterStateTaskExecutor openExecutor) {
+                                                    MetadataIndexUpgradeService metadataIndexUpgradeService,
+                                                    IndicesService indexServices) {
         super(ACTION_NAME,
             transportService,
             clusterService,
@@ -65,7 +68,8 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
             AcknowledgedResponse::new,
             AcknowledgedResponse::new,
             "open-table-or-partition");
-        this.openExecutor = openExecutor;
+        openExecutor = new OpenTableClusterStateTaskExecutor(indexNameExpressionResolver, allocationService,
+            ddlClusterStateService, metadataIndexUpgradeService, indexServices);
         closeExecutor = new CloseTableClusterStateTaskExecutor(indexNameExpressionResolver, allocationService,
             ddlClusterStateService);
     }

--- a/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
@@ -35,14 +35,12 @@ import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDLClusterStateTaskExecutor<OpenCloseTableOrPartitionRequest> {
 
-     public static class Context {
+    protected static class Context {
 
         private final Set<IndexMetadata> indicesMetadata;
         @Nullable
@@ -92,15 +90,9 @@ public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDL
         this.ddlClusterStateService = ddlClusterStateService;
     }
 
-    /**
-     * Returns Context for the case when relevant indices are known and no need to specify partition.
-     * Such behavior is the case in DROP SUBSCRIPTION when we close/open tables as intermediate steps.
-     */
-    protected Context prepare(List<IndexMetadata> indexMetadata) {
-        return new Context(new HashSet<>(indexMetadata), null, null);
-    }
-
-    protected Context prepare(ClusterState currentState, RelationName relationName, String partitionIndexName) {
+    protected Context prepare(ClusterState currentState, OpenCloseTableOrPartitionRequest request) {
+        RelationName relationName = request.tableIdent();
+        String partitionIndexName = request.partitionIndexName();
         Metadata metadata = currentState.metadata();
         String indexToResolve = partitionIndexName != null ? partitionIndexName : relationName.indexNameOrAlias();
         PartitionName partitionName = partitionIndexName != null ? PartitionName.fromIndexOrTemplate(partitionIndexName) : null;

--- a/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
@@ -35,12 +35,14 @@ import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDLClusterStateTaskExecutor<OpenCloseTableOrPartitionRequest> {
 
-    protected static class Context {
+     public static class Context {
 
         private final Set<IndexMetadata> indicesMetadata;
         @Nullable
@@ -90,9 +92,15 @@ public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDL
         this.ddlClusterStateService = ddlClusterStateService;
     }
 
-    protected Context prepare(ClusterState currentState, OpenCloseTableOrPartitionRequest request) {
-        RelationName relationName = request.tableIdent();
-        String partitionIndexName = request.partitionIndexName();
+    /**
+     * Returns Context for the case when relevant indices are known and no need to specify partition.
+     * Such behavior is the case in DROP SUBSCRIPTION when we close/open tables as intermediate steps.
+     */
+    protected Context prepare(List<IndexMetadata> indexMetadata) {
+        return new Context(new HashSet<>(indexMetadata), null, null);
+    }
+
+    protected Context prepare(ClusterState currentState, RelationName relationName, String partitionIndexName) {
         Metadata metadata = currentState.metadata();
         String indexToResolve = partitionIndexName != null ? partitionIndexName : relationName.indexNameOrAlias();
         PartitionName partitionName = partitionIndexName != null ? PartitionName.fromIndexOrTemplate(partitionIndexName) : null;

--- a/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
@@ -35,12 +35,14 @@ import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDLClusterStateTaskExecutor<OpenCloseTableOrPartitionRequest> {
 
-    protected static class Context {
+     public static class Context {
 
         private final Set<IndexMetadata> indicesMetadata;
         @Nullable
@@ -69,6 +71,14 @@ public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDL
         }
     }
 
+    public record OpenCloseTable(RelationName relationName,
+                                 @Nullable String partitionIndexName) {
+
+        public OpenCloseTable(RelationName relationName, @Nullable String partitionIndexName) {
+            this.relationName = relationName;
+            this.partitionIndexName = partitionIndexName;
+        }
+    }
 
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     final AllocationService allocationService;
@@ -82,9 +92,15 @@ public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDL
         this.ddlClusterStateService = ddlClusterStateService;
     }
 
-    protected Context prepare(ClusterState currentState, OpenCloseTableOrPartitionRequest request) {
-        RelationName relationName = request.tableIdent();
-        String partitionIndexName = request.partitionIndexName();
+    /**
+     * Returns Context for the case when relevant indices are known and no need to specify partition.
+     * Such behavior is the case in DROP SUBSCRIPTION when we close/open tables as intermediate steps.
+     */
+    protected Context prepare(List<IndexMetadata> indexMetadata) {
+        return new Context(new HashSet<>(indexMetadata), null, null);
+    }
+
+    protected Context prepare(ClusterState currentState, RelationName relationName, String partitionIndexName) {
         Metadata metadata = currentState.metadata();
         String indexToResolve = partitionIndexName != null ? partitionIndexName : relationName.indexNameOrAlias();
         PartitionName partitionName = partitionIndexName != null ? PartitionName.fromIndexOrTemplate(partitionIndexName) : null;

--- a/server/src/main/java/io/crate/metadata/cluster/CloseTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/CloseTableClusterStateTaskExecutor.java
@@ -56,7 +56,7 @@ public class CloseTableClusterStateTaskExecutor extends AbstractOpenCloseTableCl
 
     @Override
     protected ClusterState execute(ClusterState currentState, OpenCloseTableOrPartitionRequest request) throws Exception {
-        Context context = prepare(currentState, request);
+        Context context = prepare(currentState, request.tableIdent(), request.partitionIndexName());
 
         Set<Index> indicesToClose = context.indicesMetadata().stream()
             .map(IndexMetadata::getIndex)

--- a/server/src/main/java/io/crate/metadata/cluster/CloseTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/CloseTableClusterStateTaskExecutor.java
@@ -56,7 +56,7 @@ public class CloseTableClusterStateTaskExecutor extends AbstractOpenCloseTableCl
 
     @Override
     protected ClusterState execute(ClusterState currentState, OpenCloseTableOrPartitionRequest request) throws Exception {
-        Context context = prepare(currentState, request.tableIdent(), request.partitionIndexName());
+        Context context = prepare(currentState, request);
 
         Set<Index> indicesToClose = context.indicesMetadata().stream()
             .map(IndexMetadata::getIndex)

--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -21,8 +21,10 @@
 
 package io.crate.metadata.cluster;
 
+import java.util.List;
 import java.util.Set;
 
+import io.crate.metadata.RelationName;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
@@ -34,18 +36,24 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndicesService;
 
 import io.crate.execution.ddl.tables.OpenCloseTableOrPartitionRequest;
 import io.crate.execution.ddl.tables.TransportCloseTable;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+@Singleton
 public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClusterStateTaskExecutor {
 
     private final MetadataIndexUpgradeService metadataIndexUpgradeService;
     private final IndicesService indicesService;
 
+    @Inject
     public OpenTableClusterStateTaskExecutor(IndexNameExpressionResolver indexNameExpressionResolver,
                                       AllocationService allocationService,
                                       DDLClusterStateService ddlClusterStateService,
@@ -63,7 +71,21 @@ public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClu
 
     @Override
     protected ClusterState execute(ClusterState currentState, OpenCloseTableOrPartitionRequest request) throws Exception {
-        Context context = prepare(currentState, request);
+        return openTables(List.of(new OpenCloseTable(request.tableIdent(), request.partitionIndexName())), null, currentState);
+    }
+
+    public ClusterState openTables(@Nonnull List<OpenCloseTable> openCloseTables,
+                                   @Nullable List<IndexMetadata> relevantIndices,
+                                   ClusterState currentState) {
+        Context context;
+        if (relevantIndices != null) {
+            // DROP SUBSCRIPTION step, indices are already known.
+            context = prepare(relevantIndices);
+        } else {
+            // ALTER TABLE, context is created from single RelationName and optionally partitionIndexName
+            context = prepare(currentState, openCloseTables.get(0).relationName(), openCloseTables.get(0).partitionIndexName());
+        }
+
         Set<IndexMetadata> indicesToOpen = context.indicesMetadata();
         IndexTemplateMetadata templateMetadata = context.templateMetadata();
 
@@ -116,9 +138,12 @@ public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClu
 
         // call possible registered modifiers
         if (context.partitionName() != null) {
+            // only ALTER TABLE
             updatedState = ddlClusterStateService.onOpenTablePartition(updatedState, context.partitionName());
         } else {
-            updatedState = ddlClusterStateService.onOpenTable(updatedState, request.tableIdent());
+            for(OpenCloseTable tableToOpen: openCloseTables) {
+                updatedState = ddlClusterStateService.onOpenTable(updatedState, tableToOpen.relationName());
+            }
         }
 
         RoutingTable.Builder rtBuilder = RoutingTable.builder(updatedState.routingTable());
@@ -131,4 +156,5 @@ public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClu
             ClusterState.builder(updatedState).routingTable(rtBuilder.build()).build(),
             "indices opened " + indicesToOpen);
     }
+
 }

--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -21,10 +21,8 @@
 
 package io.crate.metadata.cluster;
 
-import java.util.List;
 import java.util.Set;
 
-import io.crate.metadata.RelationName;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
@@ -36,24 +34,18 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndicesService;
 
 import io.crate.execution.ddl.tables.OpenCloseTableOrPartitionRequest;
 import io.crate.execution.ddl.tables.TransportCloseTable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-@Singleton
 public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClusterStateTaskExecutor {
 
     private final MetadataIndexUpgradeService metadataIndexUpgradeService;
     private final IndicesService indicesService;
 
-    @Inject
     public OpenTableClusterStateTaskExecutor(IndexNameExpressionResolver indexNameExpressionResolver,
                                       AllocationService allocationService,
                                       DDLClusterStateService ddlClusterStateService,
@@ -71,21 +63,7 @@ public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClu
 
     @Override
     protected ClusterState execute(ClusterState currentState, OpenCloseTableOrPartitionRequest request) throws Exception {
-        return openTables(List.of(new OpenCloseTable(request.tableIdent(), request.partitionIndexName())), null, currentState);
-    }
-
-    public ClusterState openTables(@Nonnull List<OpenCloseTable> openCloseTables,
-                                   @Nullable List<IndexMetadata> relevantIndices,
-                                   ClusterState currentState) {
-        Context context;
-        if (relevantIndices != null) {
-            // DROP SUBSCRIPTION step, indices are already known.
-            context = prepare(relevantIndices);
-        } else {
-            // ALTER TABLE, context is created from single RelationName and optionally partitionIndexName
-            context = prepare(currentState, openCloseTables.get(0).relationName(), openCloseTables.get(0).partitionIndexName());
-        }
-
+        Context context = prepare(currentState, request);
         Set<IndexMetadata> indicesToOpen = context.indicesMetadata();
         IndexTemplateMetadata templateMetadata = context.templateMetadata();
 
@@ -138,12 +116,9 @@ public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClu
 
         // call possible registered modifiers
         if (context.partitionName() != null) {
-            // only ALTER TABLE
             updatedState = ddlClusterStateService.onOpenTablePartition(updatedState, context.partitionName());
         } else {
-            for(OpenCloseTable tableToOpen: openCloseTables) {
-                updatedState = ddlClusterStateService.onOpenTable(updatedState, tableToOpen.relationName());
-            }
+            updatedState = ddlClusterStateService.onOpenTable(updatedState, request.tableIdent());
         }
 
         RoutingTable.Builder rtBuilder = RoutingTable.builder(updatedState.routingTable());
@@ -156,5 +131,4 @@ public class OpenTableClusterStateTaskExecutor extends AbstractOpenCloseTableClu
             ClusterState.builder(updatedState).routingTable(rtBuilder.build()).build(),
             "indices opened " + indicesToOpen);
     }
-
 }

--- a/server/src/main/java/io/crate/metadata/table/Operation.java
+++ b/server/src/main/java/io/crate/metadata/table/Operation.java
@@ -64,7 +64,7 @@ public enum Operation {
     public static final EnumSet<Operation> METADATA_DISABLED_OPERATIONS = EnumSet.of(READ, UPDATE, INSERT, DELETE,
         ALTER_BLOCKS, ALTER_OPEN_CLOSE, ALTER_REROUTE, REFRESH, SHOW_CREATE, OPTIMIZE);
     public static final EnumSet<Operation> LOGICAL_REPLICATED = EnumSet.of(
-        READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE);
+        READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE, ALTER_OPEN_CLOSE);
 
     private final String representation;
 

--- a/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
@@ -138,7 +138,7 @@ public class TransportDropSubscriptionAction extends TransportMasterNodeAction<D
     private CompletableFuture<Void> submitCloseSubscriptionsTablesTask(DropSubscriptionRequest request,
                                                                        List<OpenCloseTable> openCloseTables) {
         FutureActionListener<AcknowledgedResponse, Void> future = new FutureActionListener<>(r -> null);
-        transportCloseTable.closeTables(future, openCloseTables, request.ackTimeout());
+        clusterService.submitStateUpdateTask("add-block-close-table", transportCloseTable. new AddCloseBlocksTask(future, openCloseTables, request.ackTimeout()));
         return future;
     }
 

--- a/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
@@ -138,7 +138,7 @@ public class TransportDropSubscriptionAction extends TransportMasterNodeAction<D
     private CompletableFuture<Void> submitCloseSubscriptionsTablesTask(DropSubscriptionRequest request,
                                                                        List<OpenCloseTable> openCloseTables) {
         FutureActionListener<AcknowledgedResponse, Void> future = new FutureActionListener<>(r -> null);
-        clusterService.submitStateUpdateTask("add-block-close-table", transportCloseTable. new AddCloseBlocksTask(future, openCloseTables, request.ackTimeout()));
+        transportCloseTable.closeTables(future, openCloseTables, request.ackTimeout());
         return future;
     }
 

--- a/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
@@ -21,73 +21,320 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.execution.ddl.AbstractDDLTransportAction;
-import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.action.FutureActionListener;
+import io.crate.exceptions.Exceptions;
+import io.crate.execution.ddl.tables.TransportCloseTable;
+import io.crate.execution.engine.collect.sources.InformationSchemaIterables;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.cluster.OpenTableClusterStateTaskExecutor;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+import static io.crate.metadata.cluster.AbstractOpenCloseTableClusterStateTaskExecutor.OpenCloseTable;
+
 @Singleton
-public class TransportDropSubscriptionAction extends AbstractDDLTransportAction<DropSubscriptionRequest, AcknowledgedResponse> {
+public class TransportDropSubscriptionAction extends TransportMasterNodeAction<DropSubscriptionRequest, AcknowledgedResponse> {
 
     public static final String ACTION_NAME = "internal:crate:replication/logical/subscription/drop";
+
+    private final OpenTableClusterStateTaskExecutor openTableClusterStateTaskExecutor;
+
+    private final Schemas schemas;
+
+    private final TransportCloseTable transportCloseTable;
 
     @Inject
     public TransportDropSubscriptionAction(TransportService transportService,
                                            ClusterService clusterService,
                                            ThreadPool threadPool,
-                                           IndexNameExpressionResolver indexNameExpressionResolver) {
+                                           IndexNameExpressionResolver indexNameExpressionResolver,
+                                           OpenTableClusterStateTaskExecutor openTableClusterStateTaskExecutor,
+                                           Schemas schemas,
+                                           TransportCloseTable transportCloseTable) {
         super(ACTION_NAME,
             transportService,
             clusterService,
             threadPool,
-            indexNameExpressionResolver,
             DropSubscriptionRequest::new,
-            AcknowledgedResponse::new,
-            AcknowledgedResponse::new,
-            "drop-subscription");
+            indexNameExpressionResolver);
+        this.openTableClusterStateTaskExecutor = openTableClusterStateTaskExecutor;
+        this.schemas = schemas;
+        this.transportCloseTable = transportCloseTable;
+    }
+
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
     }
 
     @Override
-    public ClusterStateTaskExecutor<DropSubscriptionRequest> clusterStateTaskExecutor(DropSubscriptionRequest request) {
-        return new DDLClusterStateTaskExecutor<>() {
-            @Override
-            protected ClusterState execute(ClusterState currentState, DropSubscriptionRequest dropSubscriptionRequest) throws Exception {
-                Metadata currentMetadata = currentState.metadata();
-                Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
+    protected AcknowledgedResponse read(StreamInput in) throws IOException {
+        return new AcknowledgedResponse(in);
+    }
 
-                SubscriptionsMetadata oldMetadata = (SubscriptionsMetadata) mdBuilder.getCustom(SubscriptionsMetadata.TYPE);
-                if (oldMetadata != null && oldMetadata.subscription().containsKey(request.name())) {
+    @Override
+    protected void masterOperation(DropSubscriptionRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) throws Exception {
+        List<IndexMetadata> subscriptionIndices = getSubscriptionIndices(request.name(), state.metadata().indices());
 
-                    // LogicalReplicationService will react to cluster change events and will stop the replication.
-                    SubscriptionsMetadata newMetadata = SubscriptionsMetadata.newInstance(oldMetadata);
-                    newMetadata.subscription().remove(request.name());
-                    assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
-                    mdBuilder.putCustom(SubscriptionsMetadata.TYPE, newMetadata);
+        //TODO: Replace it, all relations which are replicated by a subscription have been added into the subscription metadata.
+        List<OpenCloseTable> openCloseTables = getSubscriptionTables(request.name(), schemas);
 
-                    return ClusterState.builder(currentState).metadata(mdBuilder).build();
-                } else if (request.ifExists() == false) {
-                    throw new SubscriptionUnknownException(request.name());
+        submitCloseSubscriptionsTablesTask(request, openCloseTables)
+            .thenCompose(ignore -> submitDropSubscriptionTask(request, subscriptionIndices))
+            .thenCompose(ignore -> submitOpenSubscriptionsTablesTask(request, openCloseTables, subscriptionIndices))
+            .whenComplete(
+                (ignore, err) -> {
+                    if (err == null) {
+                        listener.onResponse(new AcknowledgedResponse(true));
+                    } else {
+                        listener.onFailure(Exceptions.toRuntimeException(err));
+                    }
                 }
-
-                return currentState;
-            }
-        };
+            );
     }
 
     @Override
     protected ClusterBlockException checkBlock(DropSubscriptionRequest request, ClusterState state) {
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
+
+    /**
+     * Closes tables and consequently closes all shards of the index
+     * which, in turn, stops trackers and removes retention lease on the remote cluster.
+     */
+    private CompletableFuture<Void> submitCloseSubscriptionsTablesTask(DropSubscriptionRequest request,
+                                                                       List<OpenCloseTable> openCloseTables) {
+        FutureActionListener<AcknowledgedResponse, Void> future = new FutureActionListener<>(r -> null);
+        transportCloseTable.closeTables(future, openCloseTables, request.ackTimeout());
+        return future;
+    }
+
+    /**
+     * Removes subscription from the cluster metadata and
+     * removes setting LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME from each relevant for subscription index.
+     */
+    private CompletableFuture<Void> submitDropSubscriptionTask(DropSubscriptionRequest request,
+                                                               List<IndexMetadata> subscriptionIndices) {
+
+        var future = new CompletableFuture<Void>();
+        // Check if we're still the elected master before sending second update task
+
+
+        clusterService.submitStateUpdateTask(
+            "drop-sub-remove-setting-and-metadata",
+            new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+
+                    if (!clusterService.state().nodes().isLocalNodeElectedMaster()) {
+                        logger.error("Couldn't execute task 'drop-sub-remove-setting-and-metadata'. Please run command DROP SUBSCRIPTION again.");
+                        future.completeExceptionally(new IllegalStateException("Master was re-elected, cannot execute 'drop-sub-remove-setting-and-metadata'"));
+                    }
+
+                    Metadata currentMetadata = currentState.metadata();
+                    Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
+
+                    SubscriptionsMetadata oldMetadata = (SubscriptionsMetadata) mdBuilder.getCustom(SubscriptionsMetadata.TYPE);
+                    if (oldMetadata != null && oldMetadata.subscription().containsKey(request.name())) {
+
+                        SubscriptionsMetadata newMetadata = SubscriptionsMetadata.newInstance(oldMetadata);
+                        newMetadata.subscription().remove(request.name());
+                        assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
+                        mdBuilder.putCustom(SubscriptionsMetadata.TYPE, newMetadata);
+
+                        // mdBuilder is mutated accordingly.
+                        removeSubscriptionSetting(subscriptionIndices, mdBuilder);
+
+                        return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                    } else if (request.ifExists() == false) {
+                        throw new SubscriptionUnknownException(request.name());
+                    }
+                    return currentState;
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    logger.error("Couldn't execute task 'drop-sub-remove-setting-and-metadata'. Please run command DROP SUBSCRIPTION again.");
+                    future.completeExceptionally(e);
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    future.complete(null);
+                }
+            }
+        );
+        return future;
+        /*
+        var future = new CompletableFuture<Void>();
+
+        clusterService.submitStateUpdateTask(
+            "drop-sub-remove-setting-and-metadata",
+            // Highest priority to reduce probability of master re-election and necessity to re-run some commands.
+            new ChainedAckedClusterStateUpdateTask(Priority.IMMEDIATE,
+                request,
+                future,
+                clusterService,
+                (currentState) ->  {
+                    Metadata currentMetadata = currentState.metadata();
+                    Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
+
+                    SubscriptionsMetadata oldMetadata = (SubscriptionsMetadata) mdBuilder.getCustom(SubscriptionsMetadata.TYPE);
+                    var subscription = oldMetadata.subscription().get(request.name());
+                    if (oldMetadata != null && subscription != null) {
+
+                        SubscriptionsMetadata newMetadata = SubscriptionsMetadata.newInstance(oldMetadata);
+                        newMetadata.subscription().remove(request.name());
+                        assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
+                        mdBuilder.putCustom(SubscriptionsMetadata.TYPE, newMetadata);
+
+                        // mdBuilder and subscriptionIndices is mutated accordingly.
+                        removeSubscriptionSetting(subscriptionIndices, mdBuilder);
+
+                        return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                    } else if (request.ifExists() == false) {
+                        future.completeExceptionally(new SubscriptionUnknownException(request.name()));
+                    }
+                    return currentState;
+                },
+                "Please run command DROP SUBSCRIPTION again."
+            )
+        );
+        return future;
+        */
+
+    }
+
+    /**
+     * Opens tables after removing replication setting
+     * and consequently updates DocTableInfo-s with the normal engine and makes tables writable.
+     */
+    private CompletableFuture<Void> submitOpenSubscriptionsTablesTask(DropSubscriptionRequest request,
+                                                                      List<OpenCloseTable> openCloseTables,
+                                                                      List<IndexMetadata> subscriptionIndices) {
+
+      var future = new CompletableFuture<Void>();
+
+        clusterService.submitStateUpdateTask(
+            "drop-sub-open-tables",
+            new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    if (!clusterService.state().nodes().isLocalNodeElectedMaster()) {
+                        logger.error("Couldn't execute task 'drop-sub-close-tables'. Please run command DROP SUBSCRIPTION again.");
+                        future.completeExceptionally(new IllegalStateException("Master was re-elected, cannot execute 'drop-sub-close-tables'"));
+                    }
+                    return openTableClusterStateTaskExecutor.openTables(openCloseTables, subscriptionIndices, currentState);
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    logger.error("Couldn't execute task 'drop-sub-open-tables'. Please run command DROP SUBSCRIPTION again.");
+                    future.completeExceptionally(e);
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    future.complete(null);
+                }
+            }
+        );
+        return future;
+
+         /*
+        var future = new CompletableFuture<Void>();
+
+        clusterService.submitStateUpdateTask(
+            "drop-sub-open-tables",
+            // Highest priority to reduce probability of master re-election and necessity to re-run some commands.
+            new ChainedAckedClusterStateUpdateTask(Priority.IMMEDIATE,
+                request,
+                future,
+                clusterService,
+                (currentState) -> openTableClusterStateTaskExecutor.openTables(openCloseTables, subscriptionIndices, currentState),
+                "Please run command DROP SUBSCRIPTION again."
+            )
+        );
+        return future;
+
+         */
+    }
+
+
+    private List<IndexMetadata> getSubscriptionIndices(@Nonnull String subscriptionToDrop, ImmutableOpenMap<String, IndexMetadata> indices) {
+        List<IndexMetadata> relevantIndices = new ArrayList<>();
+        Iterator<IndexMetadata> indicesIterator = indices.valuesIt();
+        while (indicesIterator.hasNext()) {
+            IndexMetadata indexMetadata = indicesIterator.next();
+            var settings = indexMetadata.getSettings();
+            var subscriptionName = REPLICATION_SUBSCRIPTION_NAME.get(settings); // Can be null.
+            if (subscriptionToDrop.equals(subscriptionName)) {
+                relevantIndices.add(indexMetadata);
+            }
+        }
+        return relevantIndices;
+    }
+
+    private List<OpenCloseTable> getSubscriptionTables(@Nonnull String subscriptionToDrop, Schemas schemas) {
+        return InformationSchemaIterables.tablesStream(schemas)
+            .filter(t -> {
+                if (t instanceof DocTableInfo dt) {
+                    return subscriptionToDrop.equals(REPLICATION_SUBSCRIPTION_NAME.get(dt.parameters()));
+                }
+                return false;
+            })
+            .map(dt -> new OpenCloseTable(dt.ident(), null))
+            .collect(Collectors.toList());
+    }
+
+    private void removeSubscriptionSetting(List<IndexMetadata> subscriptionIndices, Metadata.Builder mdBuilder) {
+        for (int i = 0;i < subscriptionIndices.size(); i++) {
+            var indexMetadata = subscriptionIndices.get(i);
+            var settingsBuilder = Settings.builder().put(indexMetadata.getSettings());
+            settingsBuilder.remove(REPLICATION_SUBSCRIPTION_NAME.getKey());
+            IndexMetadata.Builder builder = IndexMetadata
+                .builder(indexMetadata)
+                .settingsVersion(1 + indexMetadata.getSettingsVersion())
+                .settings(settingsBuilder);
+            subscriptionIndices.set(i, builder.build());
+            // Important, need to update subscriptionIndices so that setting removal is visible for the next step.
+            // Enhanced loop not used because it doesnt see reference update
+            mdBuilder.put(indexMetadata, true);
+
+        }
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/cluster/ChainedAckedClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ChainedAckedClusterStateUpdateTask.java
@@ -1,0 +1,72 @@
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ack.AckedRequest;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+
+import javax.annotation.Nullable;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+public class ChainedAckedClusterStateUpdateTask extends AckedClusterStateUpdateTask {
+
+    private final String hintOnError;
+    private final Function<ClusterState, ClusterState> task;
+    private final ClusterService clusterService;
+    private final CompletableFuture future;
+
+    public ChainedAckedClusterStateUpdateTask(Priority priority,
+                                              AckedRequest request,
+                                              CompletableFuture future,
+                                              ClusterService clusterService,
+                                              Function<ClusterState, ClusterState> task,
+                                              String hintOnError) {
+        // Parent class AckedClusterStateUpdateTask uses listener in onAllNodesAcked, onAckTimeout and onFailure methods
+        // and since we override those methods here and use future we don't need listener
+        super(priority, request, null);
+        this.clusterService = clusterService;
+        this.future = new CompletableFuture<>();
+        this.hintOnError = hintOnError;
+        this.task = task;
+    }
+
+    @Override
+    protected AcknowledgedResponse newResponse(boolean acknowledged) {
+        // Implemented since it's obligatory but not used
+        // as both consumers of this method (onAckTimeout and onAllNodesAcked) are overwritten.
+        return new AcknowledgedResponse(acknowledged);
+    }
+
+    @Override
+    public void onAckTimeout() {
+        future.completeExceptionally(new TimeoutException(hintOnError));
+    }
+
+    @Override
+    public ClusterState execute(ClusterState currentState) throws Exception {
+        // Check if we're still the elected master before sending the task.
+        if (!clusterService.state().nodes().isLocalNodeElectedMaster()) {
+            throw new IllegalStateException("Master was re-elected."); // Hint gets added in onFailure()
+        } else {
+            return task.apply(currentState);
+        }
+    }
+
+    @Override
+    public void onFailure(String source, Exception e) {
+        future.completeExceptionally(new IllegalStateException(hintOnError, e));
+    }
+
+    @Override
+    public void onAllNodesAcked(@Nullable Exception e) {
+        if (e == null) {
+            future.complete(null);
+        } else {
+            future.completeExceptionally(new IllegalStateException(hintOnError, e));
+        }
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -437,4 +437,37 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
             " JOIN pg_class r ON sr.srrelid = r.oid");
         assertThat(printedTable(res.rows()), is("sub1| t1| r| NULL\n"));
     }
+
+    @Test
+    public void test_write_to_subscribed_table_is_allowed_after_dropping_subscription() throws Exception {
+        executeOnPublisher("CREATE TABLE doc.t1 (id INT) WITH(" + defaultTableSettings() + ")");
+        executeOnPublisher("CREATE TABLE doc.t2 (id INT) WITH(" + defaultTableSettings() + ")");
+
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
+        executeOnPublisher("INSERT INTO doc.t2 (id) VALUES (1), (2)");
+
+        // It's important to subscribe to more than 1 table to check
+        // that re-used close/open table logic works with multiple tables
+        createPublication("pub1", false, List.of("doc.t1", "doc.t2"));
+        createSubscription("sub1", "pub1");
+
+        assertThrowsMatches(
+            () -> executeOnSubscriber("INSERT INTO doc.t1 (id) VALUES(3)"),
+            OperationOnInaccessibleRelationException.class,
+            "The relation \"doc.t1\" doesn't support or allow INSERT operations."
+        );
+        assertThrowsMatches(
+            () -> executeOnSubscriber("INSERT INTO doc.t2 (id) VALUES(3)"),
+            OperationOnInaccessibleRelationException.class,
+            "The relation \"doc.t2\" doesn't support or allow INSERT operations."
+        );
+
+       // executeOnSubscriber("ALTER TABLE doc.t1 CLOSE"); // TODO - make it part of DROP SUB
+      //  executeOnSubscriber("ALTER TABLE doc.t2 CLOSE"); // TODO - make it part of DROP SUB
+        executeOnSubscriber("DROP SUBSCRIPTION sub1 ");
+       //  executeOnSubscriber("ALTER TABLE doc.t1 OPEN");
+     //    executeOnSubscriber("ALTER TABLE doc.t2 OPEN");
+        var response = executeOnSubscriber("INSERT INTO doc.t1 (id) VALUES(3)");
+        assertThat(response.rowCount(), is(1L));
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -448,7 +448,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
 
         // It's important to subscribe to more than 1 table to check
         // that re-used close/open table logic works with multiple tables
-        createPublication("pub1", false, List.of("doc.t1", "doc.t2"));
+        createPublication("pub1", false, List.of("doc.t1"));
         createSubscription("sub1", "pub1");
 
         assertThrowsMatches(
@@ -456,11 +456,11 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
             OperationOnInaccessibleRelationException.class,
             "The relation \"doc.t1\" doesn't support or allow INSERT operations."
         );
-        assertThrowsMatches(
-            () -> executeOnSubscriber("INSERT INTO doc.t2 (id) VALUES(3)"),
-            OperationOnInaccessibleRelationException.class,
-            "The relation \"doc.t2\" doesn't support or allow INSERT operations."
-        );
+//        assertThrowsMatches(
+//            () -> executeOnSubscriber("INSERT INTO doc.t2 (id) VALUES(3)"),
+//            OperationOnInaccessibleRelationException.class,
+//            "The relation \"doc.t2\" doesn't support or allow INSERT operations."
+//        );
 
        // executeOnSubscriber("ALTER TABLE doc.t1 CLOSE"); // TODO - make it part of DROP SUB
       //  executeOnSubscriber("ALTER TABLE doc.t2 CLOSE"); // TODO - make it part of DROP SUB


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/11897#issuecomment-968953154

- [ ] stop tracking of remote shards (by CLOSE TABLE)
- [ ] remove retention leases on the remote cluster for each table/index (by CLOSE TABLE)
- [ ] remove the REPLICATION_SUBSCRIPTION_NAME index setting to turn the tables into normal tables
- [ ] update doc info for all subscription tables to make them normal after DROP SUBSCRIPTION (by OPEN TABLE)


