### PR TITLE
Fix cgroup v2 detection on older kernels

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -150,5 +150,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Improved the detection of the cgroup version to support kernels where the
+  `cpu.stat` and `memory.stat` files weren't available at the cgroup root
+  level.
+
 - Fixed an issue that could cause a deadlock, leading to an unavailable cluster
   if using blob tables and uploading multiple files in parallel.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://www.kernel.org/doc/html/v5.4/admin-guide/cgroup-v2.html?highlight=cgroup#controllers

The `cpu.stat` file didn't exist for root cgroups:

> A read-only flat-keyed file which exists on non-root cgroups. This file exists whether the controller is enabled or not.

In newer versions it changed:

> A read-only flat-keyed file. This file exists whether the controller is enabled or not.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
