### PR TITLE
The array slice implementation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -143,6 +143,10 @@ Changes
 - Enabled the setting of most prototype methods for JavaScript Objects (e.g.
   Array.prototype, Object.prototype) in :ref:`user-defined functions <user-defined-functions>`
 
+- Added support for the array slice access expression ``anyarray[from:to]``.
+
+- Added the :ref:`scalar-array_slice` scalar function.
+
 Fixes
 =====
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2547,6 +2547,36 @@ Returns: ``integer``
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-array_slice:
+
+``array_slice(anyarray, from, to)``
+-----------------------------------
+
+The ``array_slice`` function returns a slice of the given array using the given
+lower and upper bound.
+
+Returns: ``array``
+
+.. SEEALSO::
+
+    :ref:`Accessing arrays<sql_dql_arrays>`
+
+::
+
+    cr> select array_slice(['a', 'b', 'c', 'd'], 2, 3) AS arr;
+    +------------+
+    | arr        |
+    +------------+
+    | ["b", "c"] |
+    +------------+
+    SELECT 1 row in set (... sec)
+
+.. NOTE::
+
+    The first index value is ``1``. The maximum array index is ``2147483647``.
+    Both the ``from`` and ``to`` index values are inclusive.
+    Using an index greater than the array size results in an empty array.
+
 .. _scalar-array_to_string:
 
 ``array_to_string(anyarray, separator, [ null_string ])``

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -691,6 +691,46 @@ When using the ``=`` :ref:`operator <gloss-operator>`, as above, the value of
 the array element at index ``n`` is compared. To compare against *any* array
 element, see :ref:`sql_dql_any_array`.
 
+The slice of array elements can be selected from the ``landmarks`` column
+with ``landmarks[from:to]``, where ``from`` and ``to`` are the integer array indices, like so::
+
+    cr> select name, landmarks[1:2] from locations
+    ... where name = 'Frogstar';
+    +----------+-------------------------------------------+
+    | name     | array_slice(landmarks, 1, 2)              |
+    +----------+-------------------------------------------+
+    | Frogstar | ["Total Perspective Vortex", "Milliways"] |
+    +----------+-------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+When the ``from`` index is omitted, then the slice starts from the first element::
+
+    cr> select name, landmarks[:2] from locations
+    ... where name = 'Frogstar';
+    +----------+-------------------------------------------+
+    | name     | array_slice(landmarks, NULL, 2)           |
+    +----------+-------------------------------------------+
+    | Frogstar | ["Total Perspective Vortex", "Milliways"] |
+    +----------+-------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+When the ``to`` index is omitted, then the slice uses the size of the array as
+an upper-bound::
+
+    cr> select name, landmarks[1:] from locations
+    ... where name = 'Frogstar';
+    +----------+-------------------------------------------+
+    | name     | array_slice(landmarks, 1, NULL)           |
+    +----------+-------------------------------------------+
+    | Frogstar | ["Total Perspective Vortex", "Milliways"] |
+    +----------+-------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+.. NOTE::
+
+    The first index value is ``1``. The maximum array index is ``2147483647``.
+    Both the ``from`` and ``to`` index values are inclusive.
+    Using an index greater than the array size results in an empty array.
 
 .. _sql_dql_objects:
 

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -259,6 +259,8 @@ primaryExpression
     // This is an extension to ANSI SQL, which considers EXISTS to be a <boolean expression>
     | EXISTS '(' query ')'                                                           #exists
     | value=primaryExpression '[' index=valueExpression ']'                          #subscript
+    | base=primaryExpression '[' (from=valueExpression)? ':'
+                                 (to=valueExpression)? ']'                           #arraySlice
     | ident ('.' ident)*                                                             #dereference
     | primaryExpression CAST_OPERATOR dataType                                       #doubleColonCast
     | timestamp=primaryExpression AT TIME ZONE zone=primaryExpression                #atTimezone
@@ -413,7 +415,6 @@ unquotedIdent
     : IDENTIFIER                        #unquotedIdentifier
     | nonReserved                       #unquotedIdentifier
     | DIGIT_IDENTIFIER                  #digitIdentifier        // not supported
-    | COLON_IDENT                       #colonIdentifier        // not supported
     ;
 
 quotedIdent
@@ -1026,10 +1027,6 @@ QUOTED_IDENTIFIER
 
 BACKQUOTED_IDENTIFIER
     : '`' ( ~'`' | '``' )* '`'
-    ;
-
-COLON_IDENT
-    : (LETTER | DIGIT | '_' )+ ':' (LETTER | DIGIT | '_' )+
     ;
 
 fragment EXPONENT

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -26,6 +26,7 @@ import io.crate.sql.tree.ArithmeticExpression;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.ArrayLikePredicate;
 import io.crate.sql.tree.ArrayLiteral;
+import io.crate.sql.tree.ArraySliceExpression;
 import io.crate.sql.tree.ArraySubQueryExpression;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.BetweenPredicate;
@@ -216,6 +217,14 @@ public final class ExpressionFormatter {
         @Override
         protected String visitSubscriptExpression(SubscriptExpression node, @Nullable List<Expression> parameters) {
             return node.base() + "[" + node.index() + "]";
+        }
+
+        @Override
+        protected String visitArraySliceExpression(ArraySliceExpression node,
+                                                   List<Expression> context) {
+            return node.getBase() +
+                   "[" + node.getFrom().map(Expression::toString).orElse("") + ":" +
+                   node.getTo().map(Expression::toString).orElse("") + "]";
         }
 
         @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -175,6 +175,7 @@ import io.crate.sql.tree.ShowTables;
 import io.crate.sql.tree.ShowTransaction;
 import io.crate.sql.tree.SimpleCaseExpression;
 import io.crate.sql.tree.SingleColumn;
+import io.crate.sql.tree.ArraySliceExpression;
 import io.crate.sql.tree.SortItem;
 import io.crate.sql.tree.Statement;
 import io.crate.sql.tree.StringLiteral;
@@ -1704,6 +1705,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitSubqueryExpression(SqlBaseParser.SubqueryExpressionContext context) {
         return new SubqueryExpression((Query) visit(context.query()));
+    }
+
+    @Override
+    public Node visitArraySlice(SqlBaseParser.ArraySliceContext ctx) {
+        return new ArraySliceExpression((Expression) visit(ctx.base),
+                                        visitIfPresent(ctx.from, Expression.class),
+                                        visitIfPresent(ctx.to, Expression.class));
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
@@ -163,16 +163,6 @@ public class SqlParser {
         }
 
         @Override
-        public void exitColonIdentifier(SqlBaseParser.ColonIdentifierContext context) {
-            Token token = context.COLON_IDENT().getSymbol();
-            throw new ParsingException(
-                "identifiers must not contain ':'",
-                null,
-                token.getLine(),
-                token.getCharPositionInLine());
-        }
-
-        @Override
         public void exitNonReserved(SqlBaseParser.NonReservedContext context) {
             // replace nonReserved words with IDENT tokens
             context.getParent().removeLastChild();

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ArraySliceExpression.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ArraySliceExpression.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * <pre>
+ * {@code
+ *      <array>[<index>:<index>]
+ *
+ *  Examples:
+ *
+ *      [1,2,3][1:2]
+ *      [1,2,3][1:]
+ *      [1,2,3][:2]
+ *      [1,2,3][:]
+ * }
+ * </pre>
+ */
+public class ArraySliceExpression extends Expression {
+
+    private Expression base;
+    private Optional<Expression> from;
+    private Optional<Expression> to;
+
+    public ArraySliceExpression(Expression base, Optional<Expression> from, Optional<Expression> to) {
+        this.base = base;
+        this.from = from;
+        this.to = to;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitArraySliceExpression(this, context);
+    }
+
+    public Expression getBase() {
+        return base;
+    }
+
+    public Optional<Expression> getFrom() {
+        return from;
+    }
+
+    public Optional<Expression> getTo() {
+        return to;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ArraySliceExpression that)) {
+            return false;
+        }
+        return Objects.equals(from, that.from) && Objects.equals(to, that.to);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from, to);
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -248,6 +248,10 @@ public abstract class AstVisitor<R, C> {
         return visitExpression(node, context);
     }
 
+    protected R visitArraySliceExpression(ArraySliceExpression node, C context) {
+        return visitExpression(node, context);
+    }
+
     public R visitParameterExpression(ParameterExpression node, C context) {
         return visitExpression(node, context);
     }

--- a/server/src/main/java/io/crate/analyze/ArraySliceContext.java
+++ b/server/src/main/java/io/crate/analyze/ArraySliceContext.java
@@ -19,18 +19,52 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.sql.parser;
+package io.crate.analyze;
 
-enum IdentifierSymbol {
-    AT_SIGN('@');
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.QualifiedName;
 
-    private final char symbol;
+import java.util.Optional;
 
-    IdentifierSymbol(char symbol) {
-        this.symbol = symbol;
+public class ArraySliceContext {
+
+    private QualifiedName qualifiedName;
+    private Expression base;
+    private Optional<Expression> from = Optional.empty();
+    private Optional<Expression> to = Optional.empty();
+
+    public ArraySliceContext() {
     }
 
-    public char getSymbol() {
-        return symbol;
+    public QualifiedName getQualifiedName() {
+        return qualifiedName;
+    }
+
+    public void setQualifiedName(QualifiedName qualifiedName) {
+        this.qualifiedName = qualifiedName;
+    }
+
+    public Expression getBase() {
+        return base;
+    }
+
+    public void setBase(Expression base) {
+        this.base = base;
+    }
+
+    public Optional<Expression> getFrom() {
+        return from;
+    }
+
+    public void setFrom(Optional<Expression> from) {
+        this.from = from;
+    }
+
+    public Optional<Expression> getTo() {
+        return to;
+    }
+
+    public void setTo(Optional<Expression> to) {
+        this.to = to;
     }
 }

--- a/server/src/main/java/io/crate/analyze/ArraySliceValidator.java
+++ b/server/src/main/java/io/crate/analyze/ArraySliceValidator.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.sql.tree.ArrayLiteral;
+import io.crate.sql.tree.ArraySliceExpression;
+import io.crate.sql.tree.AstVisitor;
+import io.crate.sql.tree.Cast;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.IntegerLiteral;
+import io.crate.sql.tree.LongLiteral;
+import io.crate.sql.tree.NegativeExpression;
+import io.crate.sql.tree.ParameterExpression;
+import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.TryCast;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public final class ArraySliceValidator {
+
+    private static final long MAX_VALUE = Integer.MAX_VALUE;
+
+    private ArraySliceValidator() {
+    }
+
+    public static void validate(ArraySliceExpression node, ArraySliceContext arraySliceContext) {
+        node.accept(ArraySliceNameVisitor.INSTANCE, arraySliceContext);
+    }
+
+    private static class ArraySliceNameVisitor extends AstVisitor<Void, ArraySliceContext> {
+
+        private static final ArraySliceNameVisitor INSTANCE = new ArraySliceNameVisitor();
+
+        @Override
+        protected Void visitArraySliceExpression(ArraySliceExpression node, ArraySliceContext context) {
+            node.getFrom().ifPresent(from -> from.accept(ArraySliceIndexVisitor.FROM_INSTANCE, context));
+            node.getTo().ifPresent(to -> to.accept(ArraySliceIndexVisitor.TO_INSTANCE, context));
+            node.getBase().accept(this, context);
+            return null;
+        }
+
+        @Override
+        protected Void visitQualifiedNameReference(QualifiedNameReference node, ArraySliceContext context) {
+            context.setQualifiedName(node.getName());
+            return null;
+        }
+
+        @Override
+        protected Void visitCast(Cast node, ArraySliceContext context) {
+            context.setBase(node);
+            return null;
+        }
+
+        @Override
+        protected Void visitTryCast(TryCast node, ArraySliceContext context) {
+            context.setBase(node);
+            return null;
+        }
+
+        @Override
+        public Void visitArrayLiteral(ArrayLiteral node, ArraySliceContext context) {
+            context.setBase(node);
+            return null;
+        }
+
+        @Override
+        protected Void visitExpression(Expression node, ArraySliceContext context) {
+            throw new UnsupportedOperationException(
+                String.format(Locale.ENGLISH,
+                              "An expression of type %s cannot have an array slice ([<from>:<to>])",
+                              node.getClass().getSimpleName())
+            );
+        }
+    }
+
+    private static class ArraySliceIndexVisitor extends AstVisitor<Void, ArraySliceContext> {
+
+        private static final ArraySliceIndexVisitor FROM_INSTANCE = new ArraySliceIndexVisitor(
+            ArraySliceContext::setFrom,
+            ArraySliceContext::getFrom
+        );
+        private static final ArraySliceIndexVisitor TO_INSTANCE = new ArraySliceIndexVisitor(
+            ArraySliceContext::setTo,
+            ArraySliceContext::getTo
+        );
+
+        private final BiConsumer<ArraySliceContext, Optional<Expression>> setter;
+        private final Function<ArraySliceContext, Optional<Expression>> getter;
+
+        public ArraySliceIndexVisitor(BiConsumer<ArraySliceContext, Optional<Expression>> setter,
+                                      Function<ArraySliceContext, Optional<Expression>> getter) {
+            this.setter = setter;
+            this.getter = getter;
+        }
+
+        private void validateNestedArraySlice(ArraySliceContext context) {
+            if (getter.apply(context).isPresent()) {
+                throw new UnsupportedOperationException("Nested array slice is not supported");
+            }
+        }
+
+        @Override
+        public Void visitParameterExpression(ParameterExpression node, ArraySliceContext context) {
+            throw new UnsupportedOperationException("Parameter substitution is not supported in an array slice");
+        }
+
+        @Override
+        protected Void visitLongLiteral(LongLiteral node, ArraySliceContext context) {
+            validateNestedArraySlice(context);
+            long value = node.getValue();
+
+            if (value < 1 || value > MAX_VALUE) {
+                raiseInvalidIndexValue();
+            }
+            setter.accept(context, Optional.of(new IntegerLiteral((int) value)));
+            return null;
+        }
+
+        @Override
+        protected Void visitIntegerLiteral(IntegerLiteral node, ArraySliceContext context) {
+            validateNestedArraySlice(context);
+            setter.accept(context, Optional.of(node));
+            return null;
+        }
+
+        @Override
+        protected Void visitExpression(Expression node, ArraySliceContext context) {
+            validateNestedArraySlice(context);
+            setter.accept(context, Optional.of(node));
+            return null;
+        }
+
+        @Override
+        protected Void visitNegativeExpression(NegativeExpression node, ArraySliceContext context) {
+            raiseInvalidIndexValue();
+            return null;
+        }
+    }
+
+    public static void raiseInvalidIndexValue() {
+        throw new UnsupportedOperationException(
+            String.format(Locale.ENGLISH, "Array index must be in range 1 to %s", Integer.MAX_VALUE)
+        );
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static io.crate.analyze.ArraySliceValidator.raiseInvalidIndexValue;
+import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public class ArraySliceFunction extends Scalar<List<Object>, Object> {
+
+    public static final String NAME = "array_slice";
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                parseTypeSignature("array(E)"),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                parseTypeSignature("array(E)")
+            ).withTypeVariableConstraints(typeVariable("E")),
+            ArraySliceFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    private ArraySliceFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), signature.getName().name());
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public List<Object> evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>[] args) {
+        List<Object> listInput = (List<Object>) args[0].value();
+        if (listInput == null || listInput.isEmpty()) {
+            return List.of();
+        }
+
+        int from = 1;
+        if (args.length >= 2) {
+            from = intValueOrDefault(args[1], 1);
+        }
+        validateIndex(from);
+
+        int to = listInput.size();
+        if (args.length == 3) {
+            to = Math.min(
+                to,
+                intValueOrDefault(args[2], listInput.size())
+            );
+        }
+        validateIndex(to);
+
+        return to >= from ? new ArrayList<>(listInput.subList(from - 1, to)) : List.of();
+    }
+
+    private static int intValueOrDefault(Input<Object> arg, int defaultValue) {
+        try {
+            Object value = arg.value();
+            if (value != null) {
+                return ((Number) value).intValue();
+            } else {
+                return defaultValue;
+            }
+        } catch (IllegalArgumentException e) {
+            raiseInvalidIndexValue();
+            return 0;
+        }
+    }
+
+    private static void validateIndex(int value) {
+        if (value < 1) {
+            raiseInvalidIndexValue();
+        }
+    }
+
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -184,6 +184,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         ArrayMaxFunction.register(this);
         ArraySumFunction.register(this);
         ArrayAvgFunction.register(this);
+        ArraySliceFunction.register(this);
 
         CoalesceFunction.register(this);
         GreatestFunction.register(this);

--- a/server/src/test/java/io/crate/analyze/ArraySliceValidatorTest.java
+++ b/server/src/test/java/io/crate/analyze/ArraySliceValidatorTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.ArrayLiteral;
+import io.crate.sql.tree.ArraySliceExpression;
+import io.crate.sql.tree.Cast;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.IntegerLiteral;
+import io.crate.sql.tree.TryCast;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ArraySliceValidatorTest extends ESTestCase {
+
+    private ArraySliceContext analyzeArraySlice(String expressionString) {
+        ArraySliceContext context = new ArraySliceContext();
+        Expression expression = SqlParser.createExpression(expressionString);
+        ArraySliceValidator.validate((ArraySliceExpression) expression, context);
+        return context;
+    }
+
+    @Test
+    public void testVisitSubscriptExpression() {
+        ArraySliceContext context = analyzeArraySlice("a.b[1:3]");
+        assertThat("a", context.getQualifiedName().toString(), is("a.b"));
+        assertThat(context.getFrom().get(), is(new IntegerLiteral(1)));
+        assertThat(context.getTo().get(), is(new IntegerLiteral(3)));
+    }
+
+    @Test
+    public void testSliceOnArrayLiteral() {
+        ArraySliceContext context = analyzeArraySlice("[1,2,3][1:3]");
+        assertThat(context.getBase(), is(notNullValue()));
+        assertThat(context.getBase(), instanceOf(ArrayLiteral.class));
+        assertThat(context.getFrom().get(), is(new IntegerLiteral(1)));
+        assertThat(context.getTo().get(), is(new IntegerLiteral(3)));
+    }
+
+    @Test
+    public void testSliceWithoutTo() {
+        ArraySliceContext context = analyzeArraySlice("[1,2,3][1:]");
+        assertThat(context.getBase(), is(notNullValue()));
+        assertThat(context.getBase(), instanceOf(ArrayLiteral.class));
+        assertThat(context.getFrom().get(), is(new IntegerLiteral(1)));
+        assertThat(context.getTo(), is(Optional.empty()));
+    }
+
+    @Test
+    public void testSliceWithoutFrom() {
+        ArraySliceContext context = analyzeArraySlice("[1,2,3][:3]");
+        assertThat(context.getBase(), is(notNullValue()));
+        assertThat(context.getBase(), instanceOf(ArrayLiteral.class));
+        assertThat(context.getFrom(), is(Optional.empty()));
+        assertThat(context.getTo().get(), is(new IntegerLiteral(3)));
+    }
+
+    @Test
+    public void testSliceWithoutFromAndTo() {
+        ArraySliceContext context = analyzeArraySlice("[1,2,3][:]");
+        assertThat(context.getBase(), is(notNullValue()));
+        assertThat(context.getBase(), instanceOf(ArrayLiteral.class));
+        assertThat(context.getFrom(), is(Optional.empty()));
+        assertThat(context.getTo(), is(Optional.empty()));
+    }
+
+    @Test
+    public void testSliceOnCast() {
+        ArraySliceContext context = analyzeArraySlice("cast([1.1,2.1] as array(integer))[1:3]");
+        assertThat(context.getBase(), is(notNullValue()));
+        assertThat(context.getBase(), instanceOf(Cast.class));
+        assertThat(context.getFrom().get(), is(new IntegerLiteral(1)));
+        assertThat(context.getTo().get(), is(new IntegerLiteral(3)));
+    }
+
+    @Test
+    public void testSliceOnTryCast() {
+        ArraySliceContext context = analyzeArraySlice("try_cast([1, 2] as array(double))[1:3]");
+        assertThat(context.getBase(), is(notNullValue()));
+        assertThat(context.getBase(), instanceOf(TryCast.class));
+        assertThat(context.getFrom().get(), is(new IntegerLiteral(1)));
+        assertThat(context.getTo().get(), is(new IntegerLiteral(3)));
+    }
+
+    @Test
+    public void testVisitArraySliceWithFromExpression() {
+        ArraySliceContext context = analyzeArraySlice("a[1+2:]");
+        assertThat(context.getQualifiedName().getSuffix(), is("a"));
+        assertThat(context.getFrom().get(), isSQL("1 + 2"));
+    }
+
+    @Test
+    public void testVisitArraySliceWithToExpression() {
+        ArraySliceContext context = analyzeArraySlice("a[:1+2]");
+        assertThat(context.getQualifiedName().getSuffix(), is("a"));
+        assertThat(context.getTo().get(), isSQL("1 + 2"));
+    }
+
+    @Test
+    public void testVisitArraySliceWithNestedFromExpression() throws Exception {
+        ArraySliceContext context = analyzeArraySlice("a[b[1]:]");
+        assertThat(context.getQualifiedName().getSuffix(), is("a"));
+        assertThat(context.getFrom().get(), isSQL("\"b\"[1]"));
+    }
+
+    @Test
+    public void testVisitArraySliceWithNestedToExpression() throws Exception {
+        ArraySliceContext context = analyzeArraySlice("a[:b[1]]");
+        assertThat(context.getQualifiedName().getSuffix(), is("a"));
+        assertThat(context.getTo().get(), isSQL("\"b\"[1]"));
+    }
+
+    @Test
+    public void testNestedArraySlice() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Nested array slice is not supported");
+        analyzeArraySlice("a[1:2][3:4]");
+    }
+
+    @Test
+    public void testInvalidArraySliceExpressionName() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("An expression of type StringLiteral cannot have an array slice ([<from>:<to>])");
+        analyzeArraySlice("'a'[1:3]");
+    }
+
+    @Test
+    public void testArraySliceBigTo() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        analyzeArraySlice("a[1:214748364700]");
+    }
+
+    @Test
+    public void testArraySliceBigFrom() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        analyzeArraySlice("a[214748364700:5]");
+    }
+
+    @Test
+    public void testArraySliceNegativeFrom() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        analyzeArraySlice("a[-1:5]");
+    }
+
+    @Test
+    public void testArraySliceNegativeTo() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        analyzeArraySlice("a[1:-5]");
+    }
+
+    @Test
+    public void testArraySliceFromParameter() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Parameter substitution is not supported in an array slice");
+        analyzeArraySlice("a[?:5]");
+    }
+
+    @Test
+    public void testArraySliceToParameter() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Parameter substitution is not supported in an array slice");
+        analyzeArraySlice("a[1:?]");
+    }
+
+}

--- a/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.exceptions.ConversionException;
+
+public class ArraySliceFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void testFromAndTo() {
+        assertEvaluate("[1, 2, 3, 4, 5][1:3]", List.of(1, 2, 3));
+    }
+
+    @Test
+    public void testSliceAll() {
+        assertEvaluate("[1, 2, 3, 4, 5][1:5]", List.of(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void testSameFromAndTo() {
+        assertEvaluate("[1, 2, 3, 4, 5][2: 2 ]", List.of(2));
+    }
+
+    @Test
+    public void testFromOnly() {
+        assertEvaluate("[1, 2, 3, 4, 5][2:]", List.of(2, 3, 4, 5));
+    }
+
+    @Test
+    public void testFromIsMoreThanSizeOfArray() {
+        assertEvaluate("[1, 2, 3, 4, 5][6:]", List.of());
+    }
+
+    @Test
+    public void testFromIsEqualToSizeOfArray() {
+        assertEvaluate("[1, 2, 3, 4, 5][5:]", List.of(5));
+    }
+
+    @Test
+    public void testNoFromAndTo() {
+        assertEvaluate("[1, 2, 3, 4, 5][:]", List.of(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void testToIsMoreThanSizeOfArray() {
+        assertEvaluate("[1, 2, 3, 4, 5][ 3 :100]", List.of(3, 4, 5));
+    }
+
+    @Test
+    public void testFromAndToIsMoreThanSizeOfArray() {
+        assertEvaluate("[1, 2, 3, 4, 5][ 20:100 ]", List.of());
+    }
+
+    @Test
+    public void testFromIsBiggerThanTo() {
+        assertEvaluate("[1, 2, 3, 4, 5][ 3 : 1 ]", List.of());
+    }
+
+    @Test
+    public void testEmptyArray() {
+        assertEvaluate("([]::array(integer))[1 :10]", List.of());
+    }
+
+    @Test
+    public void testNullArray() {
+        assertEvaluate("(null::array(integer))[1 :10]", List.of());
+    }
+
+    @Test
+    public void testFromIsNull() {
+        assertEvaluate("[1,2,3,4,5][null:3]", List.of(1, 2, 3));
+    }
+
+    @Test
+    public void testToIsNull() {
+        assertEvaluate("[1,2,3,4,5][3:null]", List.of(3, 4, 5));
+    }
+
+    @Test
+    public void test_array_slice_qualified_name_usage() {
+        assertEvaluate("array_slice([1, 2, 3, 4, 5], 3, 5)", List.of(3, 4, 5));
+    }
+
+    @Test
+    public void testFromIsNotAnInteger() {
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("Cannot cast `'three'` of type `text` to type `integer`");
+        assertEvaluate("[1,2,3,4,5]['three':]", null);
+    }
+
+    @Test
+    public void testToIsNotAnInteger() {
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("Cannot cast `'three'` of type `text` to type `integer`");
+        assertEvaluate("[1,2,3,4,5][:'three']", null);
+    }
+
+    @Test
+    public void testBaseIsNotAnArray() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("An expression of type StringLiteral cannot have " +
+                                        "an array slice ([<from>:<to>])");
+        assertEvaluate("'not an array'[1:3]", null);
+    }
+
+    @Test
+    public void testFromIsNegative() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][-1:]", null);
+    }
+
+    @Test
+    public void testToIsNegative() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][:-1]", null);
+    }
+
+    @Test
+    public void testFromIsBig() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][2147483648:]", List.of());
+    }
+
+    @Test
+    public void testToIsBig() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][:2147483648]", List.of(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void testFromIsBigExpression() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][2147483647+20:]", List.of());
+    }
+
+    @Test
+    public void testToIsBigExpression() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][:2147483647+20]", List.of(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void testFromIsZero() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][0:]", List.of());
+    }
+
+    @Test
+    public void testToIsZero() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][:0]", List.of());
+    }
+
+    @Test
+    public void testFromIsZeroExpression() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][10-10:]", List.of());
+    }
+
+    @Test
+    public void testToIsZeroExpression() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
+        assertEvaluate("[1,2,3,4,5][:10-10]", List.of());
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/11910

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)

## Comments regarding the implementation
1) The problem with having an explicit `array_slice` function is that the solutions like [CosmosDB](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/sql-query-array-slice) or [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/array_slice.html) implement this function with the indices starting from `0`. Crate on the other hand indexes arrays starting with `1`. It could be confusing to both start from `1`, because it differs from other solutions; and from `0` because it is different from the array indexing in Crate.

2) The pr implements array slices in the Postgres syntax https://www.postgresql.org/docs/current/arrays.html#ARRAYS-ACCESSING. However, it doesn't implement the multi-dimensional slices. Here it follows the array subscript logic to reject the nested array access.


