### PR TITLE
Avoid creating argument data types per row in unnest

### DIFF
--- a/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -113,12 +113,14 @@ public class UnnestFunction {
         private final RowType returnType;
         private final Signature signature;
         private final Signature boundSignature;
+        private final List<DataType<?>> argumentTypes;
 
         private UnnestTableFunctionImplementation(Signature signature,
                                                   Signature boundSignature,
                                                   RowType returnType) {
             this.signature = signature;
             this.boundSignature = boundSignature;
+            this.argumentTypes = boundSignature.getArgumentDataTypes();
             this.returnType = returnType;
         }
 
@@ -158,14 +160,14 @@ public class UnnestFunction {
             return new ColumnOrientedRowsIterator(() -> createIterators(valuesPerColumn));
         }
 
+        @SuppressWarnings({"unchecked", "rawtypes"})
         private Iterator<Object>[] createIterators(ArrayList<List<Object>> valuesPerColumn) {
             Iterator[] iterators = new Iterator[valuesPerColumn.size()];
             for (int i = 0; i < valuesPerColumn.size(); i++) {
-                DataType<?> dataType = boundSignature.getArgumentDataTypes().get(i);
+                DataType<?> dataType = argumentTypes.get(i);
                 assert dataType instanceof ArrayType : "Argument to unnest must be an array";
                 iterators[i] = createIterator(valuesPerColumn.get(i), (ArrayType<?>) dataType);
             }
-            //noinspection unchecked
             return iterators;
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Minor optimization.
`getArgumentDataTypes` calls `TypeSignature.createType` per argument.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
