### PR TITLE
Fix is-node-master flag in UDC ping task

### DIFF
--- a/server/src/main/java/io/crate/metadata/RoutingProvider.java
+++ b/server/src/main/java/io/crate/metadata/RoutingProvider.java
@@ -84,7 +84,7 @@ public final class RoutingProvider {
 
     public Routing forRandomMasterOrDataNode(RelationName relationName, DiscoveryNodes nodes) {
         DiscoveryNode localNode = nodes.getLocalNode();
-        if (localNode.isMasterNode() || localNode.isDataNode()) {
+        if (localNode.isMasterEligibleNode() || localNode.isDataNode()) {
             return forTableOnSingleNode(relationName, localNode.getId());
         }
         ImmutableOpenMap<String, DiscoveryNode> masterAndDataNodes = nodes.getMasterAndDataNodes();

--- a/server/src/main/java/io/crate/udc/ping/PingTask.java
+++ b/server/src/main/java/io/crate/udc/ping/PingTask.java
@@ -21,16 +21,16 @@
 
 package io.crate.udc.ping;
 
+import io.crate.common.unit.TimeValue;
 import io.crate.monitor.ExtendedNodeInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.service.ClusterService;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.Strings;
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -77,7 +77,7 @@ public class PingTask extends TimerTask {
     }
 
     private Boolean isMasterNode() {
-        return clusterService.localNode().isMasterNode();
+        return clusterService.state().nodes().isLocalNodeElectedMaster();
     }
 
     private Map<String, Object> getCounters() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -73,7 +73,7 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
     Set<VotingConfigExclusion> resolveVotingConfigExclusions(ClusterState currentState) {
         final DiscoveryNodes allNodes = currentState.nodes();
         final Set<VotingConfigExclusion> resolvedNodes = Arrays.stream(allNodes.resolveNodes(nodeDescriptions))
-                .map(allNodes::get).filter(DiscoveryNode::isMasterNode).map(VotingConfigExclusion::new).collect(Collectors.toSet());
+                .map(allNodes::get).filter(DiscoveryNode::isMasterEligibleNode).map(VotingConfigExclusion::new).collect(Collectors.toSet());
 
         if (resolvedNodes.isEmpty()) {
             throw new IllegalArgumentException("add voting config exclusions request for " + Arrays.asList(nodeDescriptions)

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -87,7 +87,7 @@ public class ClusterBootstrapService {
                     "] is not allowed when [" + DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey() + "] is set to [" +
                     DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE + "]");
             }
-            if (DiscoveryNode.isMasterNode(settings) == false) {
+            if (DiscoveryNode.isMasterEligibleNode(settings) == false) {
                 throw new IllegalArgumentException("node with [" + DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey() + "] set to [" +
                     DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE + "] must be master-eligible");
             }
@@ -116,7 +116,7 @@ public class ClusterBootstrapService {
 
     void onFoundPeersUpdated() {
         final Set<DiscoveryNode> nodes = getDiscoveredNodes();
-        if (bootstrappingPermitted.get() && transportService.getLocalNode().isMasterNode() && bootstrapRequirements.isEmpty() == false
+        if (bootstrappingPermitted.get() && transportService.getLocalNode().isMasterEligibleNode() && bootstrapRequirements.isEmpty() == false
             && isBootstrappedSupplier.getAsBoolean() == false) {
 
             final Tuple<Set<DiscoveryNode>,List<String>> requirementMatchingResult;
@@ -151,7 +151,7 @@ public class ClusterBootstrapService {
             return;
         }
 
-        if (transportService.getLocalNode().isMasterNode() == false) {
+        if (transportService.getLocalNode().isMasterEligibleNode() == false) {
             return;
         }
 
@@ -179,7 +179,7 @@ public class ClusterBootstrapService {
     }
 
     private void startBootstrap(Set<DiscoveryNode> discoveryNodes, List<String> unsatisfiedRequirements) {
-        assert discoveryNodes.stream().allMatch(DiscoveryNode::isMasterNode) : discoveryNodes;
+        assert discoveryNodes.stream().allMatch(DiscoveryNode::isMasterEligibleNode) : discoveryNodes;
         assert unsatisfiedRequirements.size() < discoveryNodes.size() : discoveryNodes + " smaller than " + unsatisfiedRequirements;
         if (bootstrappingPermitted.compareAndSet(true, false)) {
             doBootstrap(new VotingConfiguration(Stream.concat(discoveryNodes.stream().map(DiscoveryNode::getId),
@@ -193,7 +193,7 @@ public class ClusterBootstrapService {
     }
 
     private void doBootstrap(VotingConfiguration votingConfiguration) {
-        assert transportService.getLocalNode().isMasterNode();
+        assert transportService.getLocalNode().isMasterEligibleNode();
 
         try {
             votingConfigurationConsumer.accept(votingConfiguration);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -146,7 +146,7 @@ public class ClusterFormationFailureHelper {
             final String discoveryStateIgnoringQuorum = String.format(Locale.ROOT, "have discovered %s; %s",
                 foundPeers, discoveryWillContinueDescription);
 
-            if (clusterState.nodes().getLocalNode().isMasterNode() == false) {
+            if (clusterState.nodes().getLocalNode().isMasterEligibleNode() == false) {
                 return String.format(Locale.ROOT, "master not discovered yet: %s", discoveryStateIgnoringQuorum);
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -506,7 +506,7 @@ public class CoordinationState {
         private final Map<String, DiscoveryNode> nodes;
 
         public boolean addVote(DiscoveryNode sourceNode) {
-            return sourceNode.isMasterNode() && nodes.put(sourceNode.getId(), sourceNode) == null;
+            return sourceNode.isMasterEligibleNode() && nodes.put(sourceNode.getId(), sourceNode) == null;
         }
 
         public VoteCollection() {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -239,7 +239,7 @@ public class JoinHelper {
     }
 
     public void sendJoinRequest(DiscoveryNode destination, Optional<Join> optionalJoin) {
-        assert destination.isMasterNode() : "trying to join master-ineligible " + destination;
+        assert destination.isMasterEligibleNode() : "trying to join master-ineligible " + destination;
         final JoinRequest joinRequest = new JoinRequest(transportService.getLocalNode(), optionalJoin);
         final Tuple<DiscoveryNode, JoinRequest> dedupKey = Tuple.tuple(destination, joinRequest);
         if (pendingOutgoingJoins.add(dedupKey)) {
@@ -278,7 +278,7 @@ public class JoinHelper {
     }
 
     void sendStartJoinRequest(final StartJoinRequest startJoinRequest, final DiscoveryNode destination) {
-        assert startJoinRequest.getSourceNode().isMasterNode()
+        assert startJoinRequest.getSourceNode().isMasterEligibleNode()
             : "sending start-join request for master-ineligible " + startJoinRequest.getSourceNode();
         transportService.sendRequest(destination, START_JOIN_ACTION_NAME,
             startJoinRequest, new TransportResponseHandler<Empty>() {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
@@ -98,12 +98,12 @@ public class Reconfigurator {
             this, currentConfig, liveNodes, retiredNodeIds, currentMaster);
 
         final Set<String> liveNodeIds = liveNodes.stream()
-            .filter(DiscoveryNode::isMasterNode).map(DiscoveryNode::getId).collect(Collectors.toSet());
+            .filter(DiscoveryNode::isMasterEligibleNode).map(DiscoveryNode::getId).collect(Collectors.toSet());
         final Set<String> currentConfigNodeIds = currentConfig.getNodeIds();
 
         final Set<VotingConfigNode> orderedCandidateNodes = new TreeSet<>();
         liveNodes.stream()
-            .filter(DiscoveryNode::isMasterNode)
+            .filter(DiscoveryNode::isMasterEligibleNode)
             .filter(n -> retiredNodeIds.contains(n.getId()) == false)
             .forEach(n -> orderedCandidateNodes.add(new VotingConfigNode(n.getId(), true,
                 n.getId().equals(currentMaster.getId()), currentConfigNodeIds.contains(n.getId()))));

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -61,7 +61,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return localStorageEnable;
     }
 
-    public static boolean isMasterNode(Settings settings) {
+    public static boolean isMasterEligibleNode(Settings settings) {
         return Node.NODE_MASTER_SETTING.get(settings);
     }
 
@@ -340,7 +340,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     /**
      * Can this node become master or not.
      */
-    public boolean isMasterNode() {
+    public boolean isMasterEligibleNode() {
         return roles.contains(DiscoveryNodeRole.MASTER_ROLE);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -162,7 +162,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
      */
     public Stream<DiscoveryNode> mastersFirstStream() {
         return Stream.concat(StreamSupport.stream(masterNodes.spliterator(), false).map(cur -> cur.value),
-            StreamSupport.stream(this.spliterator(), false).filter(n -> n.isMasterNode() == false));
+            StreamSupport.stream(this.spliterator(), false).filter(n -> n.isMasterEligibleNode() == false));
     }
 
     /**
@@ -670,11 +670,11 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                 if (nodeEntry.value.isDataNode()) {
                     dataNodesBuilder.put(nodeEntry.key, nodeEntry.value);
                 }
-                if (nodeEntry.value.isMasterNode()) {
+                if (nodeEntry.value.isMasterEligibleNode()) {
                     masterNodesBuilder.put(nodeEntry.key, nodeEntry.value);
                 }
                 final Version version = nodeEntry.value.getVersion();
-                if (nodeEntry.value.isDataNode() || nodeEntry.value.isMasterNode()) {
+                if (nodeEntry.value.isDataNode() || nodeEntry.value.isMasterEligibleNode()) {
                     if (minNonClientNodeVersion == null) {
                         minNonClientNodeVersion = version;
                         maxNonClientNodeVersion = version;

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -112,7 +112,7 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                                         if (remoteNode.equals(transportService.getLocalNode())) {
                                             // TODO cache this result for some time? forever?
                                             listener.onFailure(new ConnectTransportException(remoteNode, "local node found"));
-                                        } else if (remoteNode.isMasterNode() == false) {
+                                        } else if (remoteNode.isMasterEligibleNode() == false) {
                                             // TODO cache this result for some time?
                                             listener.onFailure(new ConnectTransportException(remoteNode, "non-master-eligible node found"));
                                         } else {

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -141,7 +141,7 @@ public abstract class PeerFinder {
             final List<DiscoveryNode> knownPeers;
             if (active) {
                 assert leader.isPresent() == false : leader;
-                if (peersRequest.getSourceNode().isMasterNode()) {
+                if (peersRequest.getSourceNode().isMasterEligibleNode()) {
                     startProbe(peersRequest.getSourceNode().getAddress());
                 }
                 peersRequest.getKnownPeers().stream().map(DiscoveryNode::getAddress).forEach(this::startProbe);
@@ -349,7 +349,7 @@ public abstract class PeerFinder {
             transportAddressConnector.connectToRemoteMasterNode(transportAddress, new ActionListener<DiscoveryNode>() {
                 @Override
                 public void onResponse(DiscoveryNode remoteNode) {
-                    assert remoteNode.isMasterNode() : remoteNode + " is not master-eligible";
+                    assert remoteNode.isMasterEligibleNode() : remoteNode + " is not master-eligible";
                     assert remoteNode.equals(getLocalNode()) == false : remoteNode + " is the local node";
                     synchronized (mutex) {
                         if (active == false) {

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -314,12 +314,12 @@ public final class NodeEnvironment implements Closeable {
             applySegmentInfosTrace(settings);
             assertCanWrite();
 
-            if (DiscoveryNode.isMasterNode(settings) || DiscoveryNode.isDataNode(settings)) {
+            if (DiscoveryNode.isMasterEligibleNode(settings) || DiscoveryNode.isDataNode(settings)) {
                 ensureAtomicMoveSupported(nodePaths);
             }
 
             if (DiscoveryNode.isDataNode(settings) == false) {
-                if (DiscoveryNode.isMasterNode(settings) == false) {
+                if (DiscoveryNode.isMasterEligibleNode(settings) == false) {
                     ensureNoIndexMetadata(nodePaths);
                 }
 

--- a/server/src/main/java/org/elasticsearch/env/NodeRepurposeCommand.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeRepurposeCommand.java
@@ -79,7 +79,7 @@ public class NodeRepurposeCommand extends ElasticsearchNodeCommand {
     protected void processNodePaths(Terminal terminal, Path[] dataPaths, OptionSet options, Environment env) throws IOException {
         assert DiscoveryNode.isDataNode(env.settings()) == false;
 
-        if (DiscoveryNode.isMasterNode(env.settings()) == false) {
+        if (DiscoveryNode.isMasterEligibleNode(env.settings()) == false) {
             processNoMasterNoDataNode(terminal, dataPaths, env);
         } else {
             processMasterNoDataNode(terminal, dataPaths, env);

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -95,7 +95,7 @@ public class GatewayMetaState implements Closeable {
                       MetadataUpgrader metadataUpgrader, PersistedClusterStateService persistedClusterStateService) {
         assert persistedState.get() == null : "should only start once, but already have " + persistedState.get();
 
-        if (DiscoveryNode.isMasterNode(settings) || DiscoveryNode.isDataNode(settings)) {
+        if (DiscoveryNode.isMasterEligibleNode(settings) || DiscoveryNode.isDataNode(settings)) {
             try {
                 final PersistedClusterStateService.OnDiskState onDiskState = persistedClusterStateService.loadBestOnDiskState();
 
@@ -120,7 +120,7 @@ public class GatewayMetaState implements Closeable {
                                                                                      .version(lastAcceptedVersion)
                                                                                      .metadata(upgradeMetadataForNode(metadata, metadataIndexUpgradeService, metadataUpgrader))
                                                                                      .build());
-                    if (DiscoveryNode.isMasterNode(settings)) {
+                    if (DiscoveryNode.isMasterEligibleNode(settings)) {
                         persistedState = new LucenePersistedState(persistedClusterStateService, currentTerm, clusterState);
                     } else {
                         persistedState = new AsyncLucenePersistedState(settings, transportService.getThreadPool(),

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -193,14 +193,14 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     @Override
     protected void doStart() {
         // Doesn't make sense to manage shards on non-master and non-data nodes
-        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterEligibleNode(settings)) {
             clusterService.addHighPriorityApplier(this);
         }
     }
 
     @Override
     protected void doStop() {
-        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterEligibleNode(settings)) {
             clusterService.removeApplier(this);
         }
     }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -77,7 +77,7 @@ public class RepositoriesService implements ClusterStateApplier {
         this.threadPool = threadPool;
         // Doesn't make sense to maintain repositories on non-master and non-data nodes
         // Nothing happens there anyway
-        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterEligibleNode(settings)) {
             clusterService.addStateApplier(this);
         }
         this.verifyAction = new VerifyNodeRepositoryAction(transportService, clusterService, this);
@@ -170,7 +170,7 @@ public class RepositoriesService implements ClusterStateApplier {
                 @Override
                 public boolean mustAck(DiscoveryNode discoveryNode) {
                     // repository is created on both master and data nodes
-                    return discoveryNode.isMasterNode() || discoveryNode.isDataNode();
+                    return discoveryNode.isMasterEligibleNode() || discoveryNode.isDataNode();
                 }
             });
     }
@@ -223,7 +223,7 @@ public class RepositoriesService implements ClusterStateApplier {
                 @Override
                 public boolean mustAck(DiscoveryNode discoveryNode) {
                     // repository was created on both master and data nodes
-                    return discoveryNode.isMasterNode() || discoveryNode.isDataNode();
+                    return discoveryNode.isMasterEligibleNode() || discoveryNode.isDataNode();
                 }
             });
     }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -146,7 +146,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         this.repositoriesService = repositoriesService;
         this.threadPool = threadPool;
 
-        if (DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.isMasterEligibleNode(settings)) {
             // addLowPriorityApplier to make sure that Repository will be created before snapshot
             clusterService.addLowPriorityApplier(this);
         }

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionProfile.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionProfile.java
@@ -87,7 +87,7 @@ public final class ConnectionProfile {
         builder.addConnections(connectionsPerNodeBulk, TransportRequestOptions.Type.BULK);
         builder.addConnections(connectionsPerNodePing, TransportRequestOptions.Type.PING);
         // if we are not master eligible we don't need a dedicated channel to publish the state
-        builder.addConnections(DiscoveryNode.isMasterNode(settings) ? connectionsPerNodeState : 0, TransportRequestOptions.Type.STATE);
+        builder.addConnections(DiscoveryNode.isMasterEligibleNode(settings) ? connectionsPerNodeState : 0, TransportRequestOptions.Type.STATE);
         // if we are not a data-node we don't need any dedicated channels for recovery
         builder.addConnections(DiscoveryNode.isDataNode(settings) ? connectionsPerNodeRecovery : 0, TransportRequestOptions.Type.RECOVERY);
         builder.addConnections(connectionsPerNodeReg, TransportRequestOptions.Type.REG);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -152,7 +152,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             cluster.stabilise();
 
             final ClusterNode leader = cluster.getAnyLeader();
-            assertTrue(leader.getLocalNode().isMasterNode());
+            assertTrue(leader.getLocalNode().isMasterEligibleNode());
         }
     }
 
@@ -1370,7 +1370,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             final ClusterNode leader = cluster.getAnyLeader();
             final long expectedTerm = leader.coordinator.getCurrentTerm();
 
-            if (cluster.clusterNodes.stream().filter(n -> n.getLocalNode().isMasterNode()).count() == 2) {
+            if (cluster.clusterNodes.stream().filter(n -> n.getLocalNode().isMasterEligibleNode()).count() == 2) {
                 // in the 2-node case, auto-shrinking the voting configuration is required to reduce the voting configuration down to just
                 // the leader, otherwise restarting the other master-eligible node triggers an election
                 leader.submitSetAutoShrinkVotingConfiguration(true);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -585,7 +585,7 @@ public class FollowersCheckerTests extends ESTestCase {
         List<DiscoveryNode> followerTargets = Stream.of(capturingTransport.getCapturedRequestsAndClear())
             .map(cr -> cr.node).collect(Collectors.toList());
         List<DiscoveryNode> sortedFollowerTargets = new ArrayList<>(followerTargets);
-        Collections.sort(sortedFollowerTargets, Comparator.comparing(n -> n.isMasterNode() == false));
+        Collections.sort(sortedFollowerTargets, Comparator.comparing(n -> n.isMasterEligibleNode() == false));
         assertEquals(sortedFollowerTargets, followerTargets);
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
@@ -397,7 +397,7 @@ public class PublicationTests extends ESTestCase {
 
         List<DiscoveryNode> publicationTargets = new ArrayList<>(publication.pendingPublications.keySet());
         List<DiscoveryNode> sortedPublicationTargets = new ArrayList<>(publicationTargets);
-        Collections.sort(sortedPublicationTargets, Comparator.comparing(n -> n.isMasterNode() == false));
+        Collections.sort(sortedPublicationTargets, Comparator.comparing(n -> n.isMasterEligibleNode() == false));
         assertEquals(sortedPublicationTargets, publicationTargets);
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -85,7 +85,7 @@ public class DiscoveryNodesTests extends ESTestCase {
         final String[] nonMasterNodes =
                 StreamSupport.stream(discoveryNodes.getNodes().values().spliterator(), false)
                         .map(n -> n.value)
-                        .filter(n -> n.isMasterNode() == false)
+                        .filter(n -> n.isMasterEligibleNode() == false)
                         .map(DiscoveryNode::getId)
                         .toArray(String[]::new);
         assertThat(discoveryNodes.resolveNodes("_all", "master:false"), arrayContainingInAnyOrder(nonMasterNodes));
@@ -99,14 +99,14 @@ public class DiscoveryNodesTests extends ESTestCase {
         final String[] coordinatorOnlyNodes =
                 StreamSupport.stream(discoveryNodes.getNodes().values().spliterator(), false)
                     .map(n -> n.value)
-                    .filter(n -> n.isDataNode() == false && n.isMasterNode() == false)
+                    .filter(n -> n.isDataNode() == false && n.isMasterEligibleNode() == false)
                     .map(DiscoveryNode::getId)
                     .toArray(String[]::new);
 
         final String[] nonCoordinatorOnlyNodes =
                 StreamSupport.stream(discoveryNodes.getNodes().values().spliterator(), false)
                     .map(n -> n.value)
-                    .filter(n -> n.isMasterNode() || n.isDataNode())
+                    .filter(n -> n.isMasterEligibleNode() || n.isDataNode())
                     .map(DiscoveryNode::getId)
                     .toArray(String[]::new);
 
@@ -158,7 +158,7 @@ public class DiscoveryNodesTests extends ESTestCase {
         assertEquals(returnedNodes.size(), inputNodes.size());
         assertEquals(new HashSet<>(returnedNodes), new HashSet<>(inputNodes));
         final List<DiscoveryNode> sortedNodes = new ArrayList<>(returnedNodes);
-        Collections.sort(sortedNodes, Comparator.comparing(n -> n.isMasterNode() == false));
+        Collections.sort(sortedNodes, Comparator.comparing(n -> n.isMasterEligibleNode() == false));
         assertEquals(sortedNodes, returnedNodes);
     }
 

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -126,7 +126,7 @@ public class PeerFinderTests extends ESTestCase {
                     for (final Map.Entry<TransportAddress, DiscoveryNode> addressAndNode : reachableNodes.entrySet()) {
                         if (addressAndNode.getKey().equals(transportAddress)) {
                             final DiscoveryNode discoveryNode = addressAndNode.getValue();
-                            if (discoveryNode.isMasterNode()) {
+                            if (discoveryNode.isMasterEligibleNode()) {
                                 disconnectedNodes.remove(discoveryNode);
                                 connectedNodes.add(discoveryNode);
                                 assertTrue(inFlightConnectionAttempts.remove(transportAddress));

--- a/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
@@ -168,11 +168,11 @@ public final class InternalTestCluster extends TestCluster {
         nodeAndClient -> DiscoveryNode.isDataNode(nodeAndClient.node.settings());
 
     private static final Predicate<NodeAndClient> NO_DATA_NO_MASTER_PREDICATE = nodeAndClient ->
-        DiscoveryNode.isMasterNode(nodeAndClient.node.settings()) == false
+        DiscoveryNode.isMasterEligibleNode(nodeAndClient.node.settings()) == false
             && DiscoveryNode.isDataNode(nodeAndClient.node.settings()) == false;
 
     private static final Predicate<NodeAndClient> MASTER_NODE_PREDICATE =
-        nodeAndClient -> DiscoveryNode.isMasterNode(nodeAndClient.node.settings());
+        nodeAndClient -> DiscoveryNode.isMasterEligibleNode(nodeAndClient.node.settings());
 
     public static final int DEFAULT_LOW_NUM_MASTER_NODES = 1;
     public static final int DEFAULT_HIGH_NUM_MASTER_NODES = 3;
@@ -1503,7 +1503,7 @@ public final class InternalTestCluster extends TestCluster {
                 List<String> discoveryFileContents = unicastHosts.map(
                     nac -> nac.node.injector().getInstance(TransportService.class)
                 ).filter(Objects::nonNull)
-                    .map(TransportService::getLocalNode).filter(Objects::nonNull).filter(DiscoveryNode::isMasterNode)
+                    .map(TransportService::getLocalNode).filter(Objects::nonNull).filter(DiscoveryNode::isMasterEligibleNode)
                     .map(n -> n.getAddress().toString())
                     .distinct().collect(Collectors.toList());
                 Set<Path> configPaths = Stream.concat(currentNodes.stream(), newNodes.stream())

--- a/server/src/testFixtures/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -371,7 +371,7 @@ public class InternalTestClusterTests extends ESTestCase {
             for (String name : cluster.getNodeNames()) {
                 DiscoveryNode node = cluster.getInstance(ClusterService.class, name).localNode();
                 List<String> paths = Arrays.stream(getNodePaths(cluster, name)).map(Path::toString).collect(Collectors.toList());
-                if (node.isMasterNode()) {
+                if (node.isMasterEligibleNode()) {
                     result.computeIfAbsent(DiscoveryNodeRole.MASTER_ROLE, k -> new HashSet<>()).addAll(paths);
                 } else {
                     result.computeIfAbsent(DiscoveryNodeRole.DATA_ROLE, k -> new HashSet<>()).addAll(paths);


### PR DESCRIPTION
`clusterService.localNode().isMasterNode()` tells if the current
node *can* be a master node (has the master node role), but not
if it *is* the current master node.
