### PR TITLE
Migrate mergify config to use new queue rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,10 +1,16 @@
 ---
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=ci/jenkins/pr_tests
+      - check-success~=^Test CrateDB SQL on ubuntu
+      - check-success~=^Test CrateDB SQL on windows
+      - check-success=docs/readthedocs.org:crate
+      - check-success~=^checkstyle
+
+
 pull_request_rules:
-  - actions:
-      merge:
-        method: rebase
-        rebase_fallback: null
-        strict: true
+  - name: automatic merge
     conditions:
       - label=ready-to-merge
       - '#approved-reviews-by>=1'
@@ -13,7 +19,12 @@ pull_request_rules:
       - status-success~=^Test CrateDB SQL on windows
       - status-success=docs/readthedocs.org:crate
       - status-success~=^checkstyle
-    name: default
+    actions:
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
+
   - actions:
       backport:
         ignore_conflicts: true


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`strict` mode is deprecated.
See https://blog.mergify.com/strict-mode-deprecation/

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
