### PR TITLE
disable flaky test temprarily: test_copy_from_with_fail_fast_property_can_kill_all_nodes_with_failure_from_single_node

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -954,6 +954,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         return null;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/crate/crate/issues/11956")
     @Test
     public void test_copy_from_with_fail_fast_property_can_kill_all_nodes_with_failure_from_single_node() throws Exception {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
