### PR TITLE
Add replication state for each subscribed table

### DIFF
--- a/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
@@ -21,6 +21,8 @@
 
 package io.crate.exceptions;
 
+import java.util.concurrent.CompletionException;
+
 public final class Exceptions {
 
     private Exceptions() {
@@ -48,6 +50,9 @@ public final class Exceptions {
     }
 
     public static RuntimeException toRuntimeException(Throwable t) {
+        if (t instanceof CompletionException) {
+            t = t.getCause();
+        }
         if (t instanceof RuntimeException) {
             return (RuntimeException) t;
         } else {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -182,13 +182,13 @@ public class PgCatalogTableDefinitions {
                 .iterator();
         tableDefinitions.put(PgSubscriptionTable.IDENT, new StaticTableDefinition<>(
             () -> subscriptionRows,
-            (user, s) -> s.owner().equals(user.name()),
+            (user, s) -> s.subscription().owner().equals(user.name()),
             PgSubscriptionTable.create().expressions()
         ));
 
         // pg_subscription_rel
         tableDefinitions.put(PgSubscriptionRelTable.IDENT, new StaticTableDefinition<>(
-            () -> PgSubscriptionRelTable.rows(logicalReplicationService, schemas),
+            () -> PgSubscriptionRelTable.rows(logicalReplicationService),
             (user, p) -> p.owner().equals(user.name()),
             PgSubscriptionRelTable.create().expressions()
         ));

--- a/server/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/server/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -21,46 +21,6 @@
 
 package io.crate.plugin;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.UnaryOperator;
-
-import javax.annotation.Nullable;
-
-import org.elasticsearch.action.bulk.BulkModule;
-import org.elasticsearch.cluster.NamedDiff;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.metadata.Metadata.Custom;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
-import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.component.LifecycleComponent;
-import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.index.IndexModule;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.engine.EngineFactory;
-import org.elasticsearch.index.mapper.ArrayMapper;
-import org.elasticsearch.index.mapper.ArrayTypeParser;
-import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.seqno.RetentionLeaseActions;
-import org.elasticsearch.plugins.ActionPlugin;
-import org.elasticsearch.plugins.ClusterPlugin;
-import org.elasticsearch.plugins.EnginePlugin;
-import org.elasticsearch.plugins.MapperPlugin;
-import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.transport.TransportResponse;
-
 import io.crate.action.sql.SQLOperations;
 import io.crate.auth.AuthSettings;
 import io.crate.auth.AuthenticationModule;
@@ -104,12 +64,51 @@ import io.crate.replication.logical.action.PublicationsStateAction;
 import io.crate.replication.logical.action.ReleasePublisherResourcesAction;
 import io.crate.replication.logical.action.ReplayChangesAction;
 import io.crate.replication.logical.action.ShardChangesAction;
+import io.crate.replication.logical.action.UpdateSubscriptionAction;
 import io.crate.replication.logical.engine.SubscriberEngine;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.user.UserManagementModule;
 import io.crate.user.metadata.UsersMetadata;
 import io.crate.user.metadata.UsersPrivilegesMetadata;
+import org.elasticsearch.action.bulk.BulkModule;
+import org.elasticsearch.cluster.NamedDiff;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.Metadata.Custom;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.mapper.ArrayMapper;
+import org.elasticsearch.index.mapper.ArrayTypeParser;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.seqno.RetentionLeaseActions;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.ClusterPlugin;
+import org.elasticsearch.plugins.EnginePlugin;
+import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportResponse;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 
 public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, ClusterPlugin, EnginePlugin {
@@ -346,7 +345,8 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             new ActionHandler<>(GetStoreMetadataAction.INSTANCE, GetStoreMetadataAction.TransportAction.class),
             new ActionHandler<>(ReleasePublisherResourcesAction.INSTANCE, ReleasePublisherResourcesAction.TransportAction.class),
             new ActionHandler<>(ShardChangesAction.INSTANCE, ShardChangesAction.TransportAction.class),
-            new ActionHandler<>(ReplayChangesAction.INSTANCE, ReplayChangesAction.TransportAction.class)
+            new ActionHandler<>(ReplayChangesAction.INSTANCE, ReplayChangesAction.TransportAction.class),
+            new ActionHandler<>(UpdateSubscriptionAction.INSTANCE, UpdateSubscriptionAction.TransportAction.class)
         );
     }
 

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -22,12 +22,13 @@
 package io.crate.replication.logical;
 
 import io.crate.action.FutureActionListener;
-import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.RelationAlreadyExists;
+import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.support.RetryRunnable;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.replication.logical.action.PublicationsStateAction;
+import io.crate.replication.logical.action.UpdateSubscriptionAction;
 import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
@@ -36,17 +37,19 @@ import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.replication.logical.repository.LogicalReplicationRepository;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreClusterStateListener;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.snapshots.RestoreInfo;
 import org.elasticsearch.snapshots.RestoreService;
@@ -57,10 +60,14 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static io.crate.replication.logical.repository.LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX;
 import static io.crate.replication.logical.repository.LogicalReplicationRepository.TYPE;
@@ -73,6 +80,7 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
     private final RemoteClusters remoteClusters;
+    private final Client client;
     private RepositoriesService repositoriesService;
     private RestoreService restoreService;
 
@@ -84,15 +92,17 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
                                      Settings settings,
                                      ClusterService clusterService,
                                      RemoteClusters remoteClusters,
-                                     ThreadPool threadPool) {
+                                     ThreadPool threadPool,
+                                     Client client) {
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.remoteClusters = remoteClusters;
+        this.client = client;
         this.metadataTracker = new MetadataTracker(
             indexScopedSettings,
             settings,
             threadPool,
-            subscriptionName -> remoteClusters.getClient(subscriptionName),
+            remoteClusters::getClient,
             clusterService
         );
         clusterService.addListener(this);
@@ -161,7 +171,7 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
         LOGGER.debug("Adding new logical replication repository for subscription '{}'", subscriptionName);
         repositoriesService.registerInternalRepository(REMOTE_REPOSITORY_PREFIX + subscriptionName, TYPE);
 
-        if (clusterService.localNode().isMasterNode()) {
+        if (clusterService.state().nodes().isLocalNodeElectedMaster()) {
             withRetry(
                 () -> {
                     // The startReplication will initiate the remote connection upfront
@@ -170,10 +180,24 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
                         .whenComplete(
                             (success, e) -> {
                                 if (e != null) {
+                                    e = SQLExceptions.unwrap(e);
                                     LOGGER.debug("Failure for logical replication for subscription", e);
+                                    // Set a generic error reason if state is not already "FAILED" (same states won't be overridden)
+                                    updateSubscriptionState(
+                                        subscriptionName,
+                                        Subscription.State.FAILED,
+                                        e.getMessage()
+                                    );
                                 } else if (success) {
-                                    LOGGER.debug("Acknowledged logical replication for subscription '{}'", subscriptionName);
-                                    metadataTracker.startTracking(subscriptionName);
+                                    LOGGER.debug("Acknowledged logical replication for subscription '{}'",
+                                                 subscriptionName);
+                                    updateSubscriptionState(
+                                        subscriptionName,
+                                        Subscription.State.MONITORING,
+                                        null
+                                    ).thenAccept(
+                                        ignored -> metadataTracker.startTracking(subscriptionName)
+                                    );
                                 }
                             }
                         );
@@ -217,36 +241,53 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
     }
 
     public CompletableFuture<Boolean> startReplication(String subscriptionName, Subscription subscription) {
-        return getPublicationState(subscriptionName, subscription)
+        return getPublicationState(subscriptionName, subscription.publications(), subscription.connectionInfo())
             .thenCompose(
                 stateResponse -> {
                     verifyTablesDoNotExist(subscriptionName, stateResponse);
                     return initiateReplication(subscriptionName, subscription, stateResponse);
-                }
-            )
-            .thenCompose(this::afterReplicationStarted);
+                })
+            .thenCompose(response -> afterReplicationStarted(subscriptionName, response));
     }
 
     public CompletableFuture<PublicationsStateAction.Response> getPublicationState(String subscriptionName,
-                                                                                   Subscription subscription) {
-        FutureActionListener<PublicationsStateAction.Response, PublicationsStateAction.Response> future =
+                                                                                   List<String> publications,
+                                                                                   ConnectionInfo connectionInfo) {
+        FutureActionListener<PublicationsStateAction.Response, PublicationsStateAction.Response> finalFuture =
             FutureActionListener.newInstance();
-        remoteClusters.connect(subscriptionName, subscription.connectionInfo())
-            .whenComplete((client, err) -> {
-                if (err == null) {
-                    client.execute(
-                        PublicationsStateAction.INSTANCE,
-                        new PublicationsStateAction.Request(
-                            subscription.publications(),
-                            subscription.connectionInfo().settings().get(ConnectionInfo.USERNAME.getKey())
-                        ),
-                        future
-                    );
-                } else {
-                    future.onFailure(Exceptions.toRuntimeException(err));
+        BiConsumer<String, Throwable> onError = (message, err) -> {
+            var subscriptionStateFuture = updateSubscriptionState(
+                subscriptionName,
+                Subscription.State.FAILED,
+                message
+            );
+            subscriptionStateFuture.whenComplete(
+                (stateResponse, ignoredErr) -> finalFuture.completeExceptionally(err)
+            );
+        };
+
+        remoteClusters.connect(subscriptionName, connectionInfo)
+            .whenComplete(
+                (client, err) -> {
+                    if (err == null) {
+                        client.execute(
+                            PublicationsStateAction.INSTANCE,
+                            new PublicationsStateAction.Request(
+                                publications,
+                                connectionInfo.settings().get(ConnectionInfo.USERNAME.getKey())
+                            ),
+                            ActionListener.delegateResponse(
+                                finalFuture,
+                                (d, stateError) -> onError.accept("Failed to request the publications state",
+                                                                  stateError)
+                            )
+                        );
+                    } else {
+                        onError.accept("Failed to connect to the remote cluster", err);
+                    }
                 }
-            });
-        return future;
+            );
+        return finalFuture;
     }
 
     public void verifyTablesDoNotExist(String subscriptionName,
@@ -301,44 +342,125 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
                 Strings.EMPTY_ARRAY
             );
 
-        FutureActionListener<RestoreService.RestoreCompletionResponse, RestoreService.RestoreCompletionResponse> future =
+        var finalFuture = new CompletableFuture<RestoreService.RestoreCompletionResponse>();
+        FutureActionListener<RestoreService.RestoreCompletionResponse, RestoreService.RestoreCompletionResponse> restoreFuture =
             FutureActionListener.newInstance();
-        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
-            @Override
-            public void onFailure(Exception e) {
-                future.onFailure(e);
+        restoreFuture.whenComplete(
+            (response, err) -> {
+                if (err == null) {
+                    updateSubscriptionState(
+                        subscriptionName,
+                        Subscription.State.RESTORING,
+                        null
+                    ).thenAccept(ignored -> finalFuture.complete(response));
+                } else {
+                    updateSubscriptionState(
+                        subscriptionName,
+                        Subscription.State.FAILED,
+                        "Failed restoring subscription, error=" + err.getMessage()
+                    ).whenComplete((ignored, ignoredErr) -> finalFuture.completeExceptionally(err));
+                }
             }
+        );
 
-            @Override
-            protected void doRun() {
-                restoreService.restoreSnapshot(restoreRequest, future);
+        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(
+            () -> {
+                try {
+                    restoreService.restoreSnapshot(restoreRequest, restoreFuture);
+                } catch (Exception e) {
+                    restoreFuture.onFailure(e);
+                }
             }
-        });
+        );
+
+        return finalFuture;
+    }
+
+    private CompletableFuture<Boolean> afterReplicationStarted(String subscriptionName,
+                                                               RestoreService.RestoreCompletionResponse response) {
+        var future = new CompletableFuture<Boolean>();
+        var restoreFuture = new FutureActionListener<RestoreSnapshotResponse, RestoreSnapshotResponse>(
+            Function.identity());
+        restoreFuture.whenComplete(
+            (restoreSnapshotResponse, err) -> {
+                if (err == null) {
+                    RestoreInfo restoreInfo = restoreSnapshotResponse.getRestoreInfo();
+                    if (restoreInfo == null) {
+                        LOGGER.error(
+                            "Restore failed, restoreInfo = NULL, seems like a master failure happened while restoring");
+                        updateSubscriptionState(
+                            subscriptionName,
+                            Subscription.State.FAILED,
+                            "Error while initial restoring the subscription relations"
+                        ).whenComplete(
+                            (ignore, ignoredErr) -> future.complete(false)
+                        );
+                    } else if (restoreInfo.failedShards() == 0) {
+                        LOGGER.debug("Restore success, following will start once shards are active");
+                        updateSubscriptionState(
+                            subscriptionName,
+                            Subscription.State.SYNCHRONIZED,
+                            null
+                        ).whenComplete(
+                            (ignore, ignoredErr) -> future.complete(true)
+                        );
+                    } else {
+                        assert restoreInfo.failedShards() > 0 : "Some failed shards are expected";
+                        LOGGER.error("Failed to restore {}/{} shards",
+                                     restoreInfo.failedShards(),
+                                     restoreInfo.totalShards());
+                        var msg = "Error while initial restoring the subscription relations";
+                        if (restoreInfo.failedShards() != restoreInfo.totalShards()) {
+                            msg = String.format(Locale.ENGLISH,
+                                                "Restoring the subscription relations failed partially. Failed to restore %d/%d shards",
+                                                restoreInfo.failedShards(),
+                                                restoreInfo.totalShards());
+                        }
+                        updateSubscriptionState(
+                            subscriptionName,
+                            Subscription.State.FAILED,
+                            msg
+                        ).whenComplete(
+                            (ignore, ignoredErr) -> future.complete(false)
+                        );
+                    }
+                } else {
+                    updateSubscriptionState(
+                        subscriptionName,
+                        Subscription.State.FAILED,
+                        "Error while initial restoring the subscription relations"
+                    ).whenComplete(
+                        (ignore, ignoredErr) -> future.completeExceptionally(err)
+                    );
+                }
+            }
+        );
+        clusterService.addListener(new RestoreClusterStateListener(clusterService, response, restoreFuture));
         return future;
     }
 
-    private CompletableFuture<Boolean> afterReplicationStarted(RestoreService.RestoreCompletionResponse response) {
-        var future = new FutureActionListener<RestoreSnapshotResponse, Boolean>(
-            restoreSnapshotResponse -> {
-                RestoreInfo restoreInfo = restoreSnapshotResponse.getRestoreInfo();
-                if (restoreInfo == null) {
-                    LOGGER.error(
-                        "Restore failed, restoreInfo = NULL, seems like a master failure happened while restoring");
-                    return false;
-                } else if (restoreInfo.failedShards() == 0) {
-                    LOGGER.debug("Restore success, following will start once shards are active");
-                    return true;
-                } else {
-                    assert restoreInfo.failedShards() > 0 : "Some failed shards are expected";
-                    LOGGER.error("Failed to restore {}/{} shards",
-                                 restoreInfo.failedShards(),
-                                 restoreInfo.totalShards());
-                    return false;
-                }
-
-            }
+    private CompletableFuture<Boolean> updateSubscriptionState(
+        final String subscriptionName,
+        final Subscription.State newState,
+        @Nullable final String failureReason) {
+        var oldSubscription = subscriptions().get(subscriptionName);
+        if (oldSubscription == null) {
+            return CompletableFuture.completedFuture(false);
+        }
+        HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>();
+        for (var entry : oldSubscription.relations().entrySet()) {
+            relations.put(entry.getKey(), new Subscription.RelationState(newState, failureReason));
+        }
+        var newSubscription = new Subscription(
+            oldSubscription.owner(),
+            oldSubscription.connectionInfo(),
+            oldSubscription.publications(),
+            oldSubscription.settings(),
+            relations
         );
-        clusterService.addListener(new RestoreClusterStateListener(clusterService, response, future));
+        var request = new UpdateSubscriptionAction.Request(subscriptionName, newSubscription);
+        var future = new FutureActionListener<>(AcknowledgedResponse::isAcknowledged);
+        client.execute(UpdateSubscriptionAction.INSTANCE, request, future);
         return future;
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/action/UpdateSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/UpdateSubscriptionAction.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
+import io.crate.replication.logical.metadata.Subscription;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class UpdateSubscriptionAction extends ActionType<AcknowledgedResponse> {
+
+    public static final String NAME = "internal:crate:replication/logical/subscription/update";
+    public static final UpdateSubscriptionAction INSTANCE = new UpdateSubscriptionAction();
+
+    public UpdateSubscriptionAction() {
+        super(NAME);
+    }
+
+    @Override
+    public Writeable.Reader<AcknowledgedResponse> getResponseReader() {
+        return AcknowledgedResponse::new;
+    }
+
+    @VisibleForTesting
+    static Subscription updateSubscription(Subscription oldSubscription, Subscription newSubscription) {
+        HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>();
+        for (var entry : newSubscription.relations().entrySet()) {
+            var relationName = entry.getKey();
+            relations.put(
+                relationName,
+                Subscription.updateRelationState(
+                    oldSubscription.relations().get(relationName),
+                    entry.getValue()
+                )
+            );
+        }
+        return new Subscription(
+            newSubscription.owner(),
+            newSubscription.connectionInfo(),
+            newSubscription.publications(),
+            newSubscription.settings(),
+            relations
+        );
+    }
+
+    @Singleton
+    public static class TransportAction extends TransportMasterNodeAction<Request, AcknowledgedResponse> {
+
+        @Inject
+        public TransportAction(TransportService transportService,
+                               ClusterService clusterService,
+                               ThreadPool threadPool,
+                               IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(NAME,
+                  transportService,
+                  clusterService,
+                  threadPool,
+                  Request::new,
+                  indexNameExpressionResolver);
+            TransportActionProxy.registerProxyAction(transportService, NAME, AcknowledgedResponse::new);
+        }
+
+        @Override
+        protected String executor() {
+            return ThreadPool.Names.SAME;
+        }
+
+        @Override
+        protected AcknowledgedResponse read(StreamInput in) throws IOException {
+            return new AcknowledgedResponse(in);
+        }
+
+        @Override
+        protected void masterOperation(Request request,
+                                       ClusterState state,
+                                       ActionListener<AcknowledgedResponse> listener) throws Exception {
+            clusterService.submitStateUpdateTask(
+                "update-subscription",
+                new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) throws Exception {
+                        final String subscriptionName = request.subscriptionName;
+
+                        Metadata currentMetadata = currentState.metadata();
+                        Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
+
+                        var oldMetadata = (SubscriptionsMetadata) mdBuilder.getCustom(SubscriptionsMetadata.TYPE);
+                        if (oldMetadata == null || oldMetadata.subscription().containsKey(subscriptionName) == false) {
+                            throw new SubscriptionUnknownException(subscriptionName);
+                        }
+
+                        var oldSubscription = oldMetadata.subscription().get(subscriptionName);
+                        var newSubscription = updateSubscription(oldSubscription, request.subscription);
+
+                        if (oldSubscription.equals(newSubscription)) {
+                            return currentState;
+                        }
+
+                        var newMetadata = SubscriptionsMetadata.newInstance(oldMetadata);
+                        newMetadata.subscription().put(subscriptionName, newSubscription);
+                        assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
+                        mdBuilder.putCustom(SubscriptionsMetadata.TYPE, newMetadata);
+
+                        return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                    }
+
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        listener.onFailure(e);
+                    }
+
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        listener.onResponse(new AcknowledgedResponse(true));
+                    }
+                }
+            );
+
+        }
+
+        @Override
+        protected ClusterBlockException checkBlock(Request request,
+                                                   ClusterState state) {
+            return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        }
+    }
+
+
+    public static class Request extends MasterNodeReadRequest<Request> {
+
+        private final String subscriptionName;
+        private final Subscription subscription;
+
+        public Request(String subscriptionName, Subscription subscription) {
+            this.subscriptionName = subscriptionName;
+            this.subscription = subscription;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            subscriptionName = in.readString();
+            subscription = new Subscription(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(subscriptionName);
+            subscription.writeTo(out);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/metadata/pgcatalog/PgSubscriptionTable.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/pgcatalog/PgSubscriptionTable.java
@@ -53,8 +53,5 @@ public class PgSubscriptionTable {
     }
 
     public record SubscriptionRow(String name, Subscription subscription) {
-        public String owner() {
-            return subscription.owner();
-        }
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -216,7 +216,6 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
     @Override
     public void getRepositoryData(ActionListener<RepositoryData> listener) {
         StepListener<PublicationsStateAction.Response> responseStepListener = new StepListener<>();
-        getPublicationsState(responseStepListener);
         responseStepListener.whenComplete(stateResponse -> {
             StepListener<ClusterState> clusterStateStepListener = new StepListener<>();
             getRemoteClusterState(clusterStateStepListener, stateResponse.concreteIndices().toArray(new String[0]));
@@ -237,6 +236,7 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                 listener.onResponse(repositoryData);
             }, listener::onFailure);
         }, listener::onFailure);
+        getPublicationsState(responseStepListener);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -19,37 +19,25 @@
 
 package org.elasticsearch.node;
 
-import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.cluster.node.DiscoveryNode.getRolesFromSettings;
-
-import java.io.BufferedWriter;
-import java.io.Closeable;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.annotation.Nullable;
-import javax.net.ssl.SNIHostName;
-
+import io.crate.auth.AlwaysOKAuthentication;
+import io.crate.auth.AuthSettings;
+import io.crate.auth.Authentication;
+import io.crate.auth.HostBasedAuthentication;
+import io.crate.common.io.IOUtils;
+import io.crate.common.unit.TimeValue;
+import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
+import io.crate.execution.engine.collect.files.CopyModule;
+import io.crate.execution.engine.window.WindowFunctionModule;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.tablefunctions.TableFunctionModule;
+import io.crate.metadata.settings.session.SessionSettingModule;
+import io.crate.netty.NettyBootstrap;
+import io.crate.plugin.CopyPlugin;
+import io.crate.protocols.ssl.SslContextProvider;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.types.DataTypes;
+import io.crate.user.UserLookup;
+import io.crate.user.UserLookupService;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -167,25 +155,35 @@ import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.netty4.Netty4Transport;
 
-import io.crate.auth.AlwaysOKAuthentication;
-import io.crate.auth.AuthSettings;
-import io.crate.auth.Authentication;
-import io.crate.auth.HostBasedAuthentication;
-import io.crate.common.io.IOUtils;
-import io.crate.common.unit.TimeValue;
-import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
-import io.crate.execution.engine.collect.files.CopyModule;
-import io.crate.execution.engine.window.WindowFunctionModule;
-import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.expression.tablefunctions.TableFunctionModule;
-import io.crate.metadata.settings.session.SessionSettingModule;
-import io.crate.netty.NettyBootstrap;
-import io.crate.plugin.CopyPlugin;
-import io.crate.protocols.ssl.SslContextProvider;
-import io.crate.replication.logical.LogicalReplicationService;
-import io.crate.types.DataTypes;
-import io.crate.user.UserLookup;
-import io.crate.user.UserLookupService;
+import javax.annotation.Nullable;
+import javax.net.ssl.SNIHostName;
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.cluster.node.DiscoveryNode.getRolesFromSettings;
 
 /**
  * A node represent a node within a cluster ({@code cluster.name}). The {@link #client()} can be used
@@ -537,7 +535,8 @@ public class Node implements Closeable {
                 settings,
                 clusterService,
                 remoteClusters,
-                threadPool
+                threadPool,
+                client
             );
             resourcesToClose.add(logicalReplicationService);
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -535,7 +535,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(895, response.rowCount());
+        assertEquals(897, response.rowCount());
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
@@ -44,10 +44,14 @@ import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.transport.TransportService;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -65,10 +69,10 @@ import static org.hamcrest.Matchers.is;
 
 public abstract class LogicalReplicationITestCase extends ESTestCase {
 
-    InternalTestCluster publisherCluster;
+    protected InternalTestCluster publisherCluster;
     SQLTransportExecutor publisherSqlExecutor;
 
-    InternalTestCluster subscriberCluster;
+    public InternalTestCluster subscriberCluster;
     SQLTransportExecutor subscriberSqlExecutor;
 
     protected static final String SUBSCRIBING_USER = "subscriber";
@@ -92,10 +96,10 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
         publisherCluster = new InternalTestCluster(
             randomLong(),
             createTempDir(),
-            true,
-            true,
-            2,
-            2,
+            getPublisherSupportsDedicatedMasters(),
+            getPublisherAutoManageMasterNodes(),
+            getPublisherNumberOfNodes(),
+            getPublisherNumberOfNodes(),
             "publishing_cluster",
             createNodeConfigurationSource(),
             0,
@@ -105,16 +109,16 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
             true
         );
         publisherCluster.beforeTest(random());
-        publisherCluster.ensureAtLeastNumDataNodes(2);
+        publisherCluster.ensureAtLeastNumDataNodes(getPublisherNumberOfNodes());
         publisherSqlExecutor = sqlExecutor(publisherCluster);
 
         subscriberCluster = new InternalTestCluster(
             randomLong(),
             createTempDir(),
-            false,
-            true,
-            1,
-            1,
+            getSubscriberSupportsDedicatedMasters(),
+            getSubscriberAutoManageMasterNodes(),
+            getSubscriberNumberOfNodes(),
+            getSubscriberNumberOfNodes(),
             "subscribing_cluster",
             createNodeConfigurationSource(),
             0,
@@ -124,7 +128,7 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
             true
         );
         subscriberCluster.beforeTest(random());
-        subscriberCluster.ensureAtLeastNumDataNodes(1);
+        subscriberCluster.ensureAtLeastNumDataNodes(getSubscriberNumberOfNodes());
         subscriberSqlExecutor = sqlExecutor(subscriberCluster);
     }
 
@@ -148,7 +152,7 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
         }
     }
 
-    SQLResponse executeOnPublisher(String sql) {
+    public SQLResponse executeOnPublisher(String sql) {
         return publisherSqlExecutor.exec(sql);
     }
 
@@ -160,7 +164,7 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
         return publisherSqlExecutor.execBulk(sql, bulkArgs);
     }
 
-    SQLResponse executeOnSubscriber(String sql) {
+    public SQLResponse executeOnSubscriber(String sql) {
         return subscriberSqlExecutor.exec(sql);
     }
 
@@ -226,7 +230,7 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
         );
     }
 
-    private String publisherConnectionUrl() {
+    public String publisherConnectionUrl() {
         var transportService = publisherCluster.getInstance(TransportService.class);
         InetSocketAddress address = transportService.boundAddress().publishAddress().address();
         return String.format(
@@ -277,5 +281,66 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
             " CONNECTION '" + publisherConnectionUrl() + "' publication " + pubName, user);
         ensureGreenOnSubscriber();
 
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE})
+    public @interface PublisherClusterScope {
+        int numberOfNodes() default 2;
+
+        boolean supportsDedicatedMasters() default true;
+
+        boolean autoManageMasterNodes() default true;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE})
+    public @interface SubscriberClusterScope {
+        int numberOfNodes() default 2;
+
+        boolean supportsDedicatedMasters() default true;
+
+        boolean autoManageMasterNodes() default true;
+    }
+
+    private int getPublisherNumberOfNodes() {
+        PublisherClusterScope annotation = getAnnotation(this.getClass(), PublisherClusterScope.class);
+        return annotation == null ? 2 : annotation.numberOfNodes();
+    }
+
+    private boolean getPublisherSupportsDedicatedMasters() {
+        PublisherClusterScope annotation = getAnnotation(this.getClass(), PublisherClusterScope.class);
+        return annotation == null || annotation.supportsDedicatedMasters();
+    }
+
+    private boolean getPublisherAutoManageMasterNodes() {
+        PublisherClusterScope annotation = getAnnotation(this.getClass(), PublisherClusterScope.class);
+        return annotation == null || annotation.autoManageMasterNodes();
+    }
+
+    private int getSubscriberNumberOfNodes() {
+        PublisherClusterScope annotation = getAnnotation(this.getClass(), PublisherClusterScope.class);
+        return annotation == null ? 2 : annotation.numberOfNodes();
+    }
+
+    private boolean getSubscriberSupportsDedicatedMasters() {
+        PublisherClusterScope annotation = getAnnotation(this.getClass(), PublisherClusterScope.class);
+        return annotation == null || annotation.supportsDedicatedMasters();
+    }
+
+    private boolean getSubscriberAutoManageMasterNodes() {
+        PublisherClusterScope annotation = getAnnotation(this.getClass(), PublisherClusterScope.class);
+        return annotation == null || annotation.autoManageMasterNodes();
+    }
+
+    private static <A extends Annotation> A getAnnotation(Class<?> clazz, Class<A> annotationClass) {
+        if (clazz == Object.class || clazz == LogicalReplicationITestCase.class) {
+            return null;
+        }
+        A annotation = clazz.getAnnotation(annotationClass);
+        if (annotation != null) {
+            return annotation;
+        }
+        return getAnnotation(clazz.getSuperclass(), annotationClass);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -584,7 +584,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     public void testAccessesToPgAttributeEntriesWithRespectToPrivileges() throws Exception {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession());
-        assertThat(response.rowCount(), is(459L));
+        assertThat(response.rowCount(), is(461L));
 
         //create a table with an attribute that a new user is not privileged to access
         executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests.disruption.replication.logical;
+
+import io.crate.integrationtests.LogicalReplicationITestCase;
+import io.crate.replication.logical.action.PublicationsStateAction;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.Matchers.is;
+
+@LogicalReplicationITestCase.PublisherClusterScope(numberOfNodes = 1, supportsDedicatedMasters = false)
+@LogicalReplicationITestCase.SubscriberClusterScope(numberOfNodes = 1, supportsDedicatedMasters = false)
+public class SubscriptionDisruptionIT extends LogicalReplicationITestCase {
+
+    @Test
+    public void test_subscription_state_on_restore_failure() throws Exception {
+        String subscriptionName = "sub1";
+        var requestCnt = new AtomicInteger(0);
+        List<MockTransportService> transportServices = new ArrayList<>();
+        for (TransportService transportService : publisherCluster.getDataOrMasterNodeInstances(TransportService.class)) {
+            MockTransportService mockTransportService = (MockTransportService) transportService;
+            transportServices.add(mockTransportService);
+            mockTransportService.addRequestHandlingBehavior(PublicationsStateAction.NAME, (handler, request, channel) -> {
+                // First request is sent on subscription creation while we want to fail on the asynchronous
+                // restore afterwards -> fail on 2nd request
+                if (request instanceof PublicationsStateAction.Request && requestCnt.getAndIncrement() == 1) {
+                    channel.sendResponse(new ElasticsearchException("fail on logical replication repository restore"));
+                } else {
+                    handler.messageReceived(request, channel);
+                }
+            });
+        }
+
+        try {
+            executeOnPublisher("CREATE TABLE doc.t1 (id INT) CLUSTERED INTO 1 SHARDS WITH (number_of_replicas=0)");
+            createPublication("pub1", false, List.of("doc.t1"));
+            executeOnSubscriber("CREATE SUBSCRIPTION " + subscriptionName +
+                                " CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
+
+            assertBusy(
+                () -> {
+                    var res = executeOnSubscriber(
+                        "SELECT s.subname, s.subpublications, sr.srrelid::text, sr.srsubstate, sr.srsubstate_reason" +
+                        " FROM pg_subscription s" +
+                        " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
+                        " ORDER BY s.subname");
+                    assertThat(printedTable(res.rows()),
+                               is("sub1| [pub1]| doc.t1| e| Failed to request the publications state\n"));
+                }
+            );
+        } finally {
+            transportServices.forEach(MockTransportService::clearAllRules);
+        }
+    }
+}

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -41,6 +41,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -74,11 +75,13 @@ public class MetadataTrackerTest extends ESTestCase {
 
     ClusterState buildSubscriberClusterState(IndexMetadata indexMetadata) {
         var subscriptionsMetadata = new SubscriptionsMetadata(
-            Map.of("sub1", new Subscription(
+            Map.of("sub1",
+                   new Subscription(
                        "user1",
                        ConnectionInfo.fromURL("crate://example.com:4310?user=valid_user&password=123"),
                        List.of("pub1"),
-                       Settings.EMPTY
+                       Settings.EMPTY,
+                       Collections.emptyMap()
                    )
             )
         );

--- a/server/src/test/java/io/crate/replication/logical/action/UpdateSubscriptionActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/UpdateSubscriptionActionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.metadata.ConnectionInfo;
+import io.crate.replication.logical.metadata.Subscription;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class UpdateSubscriptionActionTest {
+
+    @Test
+    public void test_existing_same_state_is_not_overridden() throws Exception {
+        var oldSubscription = new Subscription(
+            "user1",
+            ConnectionInfo.fromURL("crate://localhost"),
+            List.of("some_publication", "another_publication"),
+            Settings.builder().put("enable", "true").build(),
+            Map.of(
+                RelationName.fromIndexName("doc.t1"),
+                new Subscription.RelationState(Subscription.State.FAILED, "Subscription failed on restore")
+            )
+        );
+        var newSubscription = new Subscription(
+            oldSubscription.owner(),
+            oldSubscription.connectionInfo(),
+            oldSubscription.publications(),
+            oldSubscription.settings(),
+            Map.of(
+                RelationName.fromIndexName("doc.t1"),
+                new Subscription.RelationState(Subscription.State.FAILED, "Some other reason")
+            )
+        );
+
+        assertThat(UpdateSubscriptionAction.updateSubscription(oldSubscription, newSubscription), is(oldSubscription));
+    }
+}

--- a/server/src/test/java/io/crate/replication/logical/metadata/SubscriptionsMetadataTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/SubscriptionsMetadataTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.replication.logical.metadata;
 
+import io.crate.metadata.RelationName;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,14 +51,22 @@ public class SubscriptionsMetadataTest extends ESTestCase {
                 "user1",
                 ConnectionInfo.fromURL("crate://example.com:4310?user=valid_user&password=123"),
                 List.of("pub1"),
-                Settings.EMPTY
+                Settings.EMPTY,
+                Map.of(
+                    RelationName.fromIndexName("doc.t1"),
+                    new Subscription.RelationState(Subscription.State.INITIALIZING, null)
+                )
             ),
             "my_subscription",
             new Subscription(
                 "user2",
                 ConnectionInfo.fromURL("crate://localhost"),
                 List.of("some_publication", "another_publication"),
-                Settings.builder().put("enable", "true").build()
+                Settings.builder().put("enable", "true").build(),
+                Map.of(
+                    RelationName.fromIndexName("doc.t1"),
+                    new Subscription.RelationState(Subscription.State.FAILED, "Subscription failed on restore")
+                )
             )
         );
         return new SubscriptionsMetadata(map);


### PR DESCRIPTION
Add state information and possible failure reason for each relation inside the subscription.
It is exposed via the `pg_subscription_rel` system table.

Supersede #11944. 