### PR TITLE
Handle parse errors in `handleSimpleQuery`

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -733,7 +733,14 @@ public class PostgresWireProtocol {
             return;
         }
 
-        List<Statement> statements = SqlParser.createStatements(queryString);
+        List<Statement> statements;
+        try {
+            statements = SqlParser.createStatements(queryString);
+        } catch (Exception ex) {
+            Messages.sendErrorResponse(channel, getAccessControl.apply(session.sessionContext()), ex);
+            Messages.sendReadyForQuery(channel, TransactionState.IDLE);
+            return;
+        }
         CompletableFuture<?> composedFuture = CompletableFuture.completedFuture(null);
         for (var statement : statements) {
             composedFuture = composedFuture.thenCompose(result -> handleSingleQuery(statement, channel));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/11953

If `createStatements` failed to parse the statement the
`ReadyForQueryCallback` never triggered. This prevented the client from
receiving a ready for query message and it became stuck

Discovered via the crate-qa sqllogic tests


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
