### PR TITLE
Update log4j to 2.15.0

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -150,6 +150,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Updated ``log4j`` to 2.15.0 to fix a security vulnerability. See `Log4Shell
+  <https://www.lunasec.io/docs/blog/log4j-zero-day/>`_ for details.
+
 - Fixed an issue that could result in an error if a client sent multiple
   statements in a single string using the PostgreSQL simple protocol mode.
 

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -35,7 +35,7 @@ hadoop2=2.8.1
 spatial4j=0.8
 jts=1.18.0
 log4j=1.2.7
-log4j2=2.11.1
+log4j2=2.15.0
 slf4j=1.6.2
 jna=5.6.0
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://www.lunasec.io/docs/blog/log4j-zero-day/

For CrateDB versions >= 3.2.0 it is possible to mitigate the issue setting `-Dlog4j2.formatMsgNoLookups=true` via `CRATE_JAVA_OPTS`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
