### PR TITLE
Close replication service and remote clusters earlier on node stop

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -951,6 +951,10 @@ public class Node implements Closeable {
         toClose.add(nodeService);
         toClose.add(() -> stopWatch.stop().start("http"));
         toClose.add(injector.getInstance(HttpServerTransport.class));
+
+        toClose.add(() -> stopWatch.stop().start("logical_replication_service"));
+        toClose.add(injector.getInstance(LogicalReplicationService.class));
+
         toClose.add(() -> stopWatch.stop().start("snapshot_service"));
         toClose.add(injector.getInstance(SnapshotsService.class));
         toClose.add(injector.getInstance(SnapshotShardsService.class));
@@ -963,6 +967,10 @@ public class Node implements Closeable {
         // close filter/fielddata caches after indices
         toClose.add(injector.getInstance(IndicesStore.class));
         toClose.add(injector.getInstance(PeerRecoverySourceService.class));
+
+        toClose.add(() -> stopWatch.stop().start("remote_clusters"));
+        toClose.add(injector.getInstance(RemoteClusters.class));
+
         toClose.add(() -> stopWatch.stop().start("routing"));
         toClose.add(() -> stopWatch.stop().start("cluster"));
         toClose.add(injector.getInstance(ClusterService.class));
@@ -976,11 +984,6 @@ public class Node implements Closeable {
         toClose.add(injector.getInstance(GatewayService.class));
         toClose.add(() -> stopWatch.stop().start("transport"));
         toClose.add(injector.getInstance(TransportService.class));
-
-        toClose.add(() -> stopWatch.stop().start("remote_clusters"));
-        toClose.add(injector.getInstance(RemoteClusters.class));
-        toClose.add(() -> stopWatch.stop().start("logical_replication_service"));
-        toClose.add(injector.getInstance(LogicalReplicationService.class));
 
         toClose.add(() -> stopWatch.stop().start("gateway_meta_state"));
         toClose.add(injector.getInstance(GatewayMetaState.class));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This changes the order to avoid error messages in logs caused by
something getting closed that was still in use by another component.

LogicalReplicationService uses RemoteClusters and RemoteClusters depends
on TransportService (among others)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
