### PR TITLE
Don't log error in ShardChangesAction globalCheckpointListener

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
@@ -197,7 +197,6 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
                                 );
                                 listener.onResponse(response);
                             } else {
-                                LOGGER.error("Error occurred while waiting for advanced globalCheckpoint", e);
                                 listener.onFailure(e);
                             }
                         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The error gets propagated to the listener and whoever provides the listener
can decide how to deal with it.

Logging all errors can be misleading - for example when stopping a node,
shards will get closed which can fail already pending requests.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
