### PR TITLE
Deduplicate parts of SQLExceptions/ExceptionsHelper/Exceptions

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -27,6 +27,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.sql.parser.ParsingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchWrapperException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -58,6 +59,7 @@ public class SQLExceptions {
         throwable instanceof UncheckedExecutionException ||
         throwable instanceof CompletionException ||
         throwable instanceof UncategorizedExecutionException ||
+        throwable instanceof ElasticsearchWrapperException ||
         throwable instanceof ExecutionException;
 
     public static Throwable unwrap(@Nonnull Throwable t, @Nullable Predicate<Throwable> additionalUnwrapCondition) {

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -25,6 +25,7 @@ import static io.crate.exceptions.SQLExceptions.userFriendlyCrateExceptionTopOnl
 import static io.crate.execution.dml.upsert.InsertSourceGen.SOURCE_WRITERS;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,7 +36,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nullable;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -324,7 +324,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 rawSource = BytesReference.bytes(XContentFactory.jsonBuilder().map(source, SOURCE_WRITERS));
             }
         } catch (IOException e) {
-            throw ExceptionsHelper.convertToElastic(e);
+            throw new UncheckedIOException(e);
         }
         item.source(rawSource);
 

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -26,6 +26,7 @@ import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_
 import static org.elasticsearch.index.IndexSettings.same;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,7 +39,6 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingClusterStateUpdateRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsClusterStateUpdateRequest;
@@ -460,7 +460,7 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
                 indicesService.verifyIndexMetadata(updatedMetadata, updatedMetadata);
             }
         } catch (IOException ex) {
-            throw ExceptionsHelper.convertToElastic(ex);
+            throw new UncheckedIOException(ex);
         }
         return updatedState;
     }

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -20,6 +20,8 @@
 package org.elasticsearch;
 
 import io.crate.common.CheckedFunction;
+import io.crate.exceptions.SQLExceptions;
+
 import org.elasticsearch.action.admin.indices.alias.AliasesNotFoundException;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
@@ -227,7 +229,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * @see ExceptionsHelper#unwrapCause(Throwable)
      */
     public Throwable unwrapCause() {
-        return ExceptionsHelper.unwrapCause(this);
+        return SQLExceptions.unwrap(this);
     }
 
     /**
@@ -299,7 +301,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        Throwable ex = ExceptionsHelper.unwrapCause(this);
+        Throwable ex = SQLExceptions.unwrap(this);
         if (ex != this) {
             generateThrowableXContent(builder, params, this);
         } else {
@@ -509,7 +511,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * be parsed back using the {@link #fromXContent(XContentParser)} method.
      */
     public static void generateThrowableXContent(XContentBuilder builder, Params params, Throwable t) throws IOException {
-        t = ExceptionsHelper.unwrapCause(t);
+        t = SQLExceptions.unwrap(t);
 
         if (t instanceof ElasticsearchException) {
             ((ElasticsearchException) t).toXContent(builder, params);
@@ -602,7 +604,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * is returned.
      */
     public static ElasticsearchException[] guessRootCauses(Throwable t) {
-        Throwable ex = ExceptionsHelper.unwrapCause(t);
+        Throwable ex = SQLExceptions.unwrap(t);
         if (ex instanceof ElasticsearchException) {
             // ElasticsearchException knows how to guess its own root cause
             return ((ElasticsearchException) ex).guessRootCauses();

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.rest.RestStatus;
 
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -45,13 +46,6 @@ import java.util.stream.Collectors;
 public final class ExceptionsHelper {
 
     private static final Logger LOGGER = LogManager.getLogger(ExceptionsHelper.class);
-
-    public static RuntimeException convertToRuntime(Exception e) {
-        if (e instanceof RuntimeException) {
-            return (RuntimeException) e;
-        }
-        return new ElasticsearchException(e);
-    }
 
     public static ElasticsearchException convertToElastic(Exception e) {
         if (e instanceof ElasticsearchException) {

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.rest.RestStatus;
 
@@ -153,20 +152,6 @@ public final class ExceptionsHelper {
             } while ((t = t.getCause()) != null);
         }
         return null;
-    }
-
-    /**
-     * Throws the specified exception. If null if specified then <code>true</code> is returned.
-     */
-    public static boolean reThrowIfNotNull(@Nullable Throwable e) {
-        if (e != null) {
-            if (e instanceof RuntimeException) {
-                throw (RuntimeException) e;
-            } else {
-                throw new RuntimeException(e);
-            }
-        }
-        return true;
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -47,13 +47,6 @@ public final class ExceptionsHelper {
 
     private static final Logger LOGGER = LogManager.getLogger(ExceptionsHelper.class);
 
-    public static ElasticsearchException convertToElastic(Exception e) {
-        if (e instanceof ElasticsearchException) {
-            return (ElasticsearchException) e;
-        }
-        return new ElasticsearchException(e);
-    }
-
     public static RestStatus status(Throwable t) {
         if (t != null) {
             if (t instanceof ElasticsearchException) {

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -60,26 +60,6 @@ public final class ExceptionsHelper {
         return RestStatus.INTERNAL_SERVER_ERROR;
     }
 
-    public static Throwable unwrapCause(Throwable t) {
-        int counter = 0;
-        Throwable result = t;
-        while (result instanceof ElasticsearchWrapperException) {
-            if (result.getCause() == null) {
-                return result;
-            }
-            if (result.getCause() == result) {
-                return result;
-            }
-            if (counter++ > 10) {
-                // dear god, if we got more than 10 levels down, WTF? just bail
-                LOGGER.warn("Exception cause unwrapping ran for 10 levels...", t);
-                return result;
-            }
-            result = result.getCause();
-        }
-        return result;
-    }
-
     public static String stackTrace(Throwable e) {
         StringWriter stackTraceStringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter(stackTraceStringWriter);

--- a/server/src/main/java/org/elasticsearch/action/support/TransportActions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/TransportActions.java
@@ -20,17 +20,18 @@
 package org.elasticsearch.action.support;
 
 import org.apache.lucene.store.AlreadyClosedException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 
+import io.crate.exceptions.SQLExceptions;
+
 public class TransportActions {
 
     public static boolean isShardNotAvailableException(final Throwable e) {
-        final Throwable actual = ExceptionsHelper.unwrapCause(e);
+        final Throwable actual = SQLExceptions.unwrap(e);
         return (actual instanceof ShardNotFoundException ||
                 actual instanceof IndexNotFoundException ||
                 actual instanceof IllegalIndexShardStateException ||

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -40,6 +40,8 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
 
+import io.crate.exceptions.SQLExceptions;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -237,7 +239,7 @@ public class ReplicationOperation<
     }
 
     private void onNoLongerPrimary(Exception failure) {
-        final Throwable cause = ExceptionsHelper.unwrapCause(failure);
+        final Throwable cause = SQLExceptions.unwrap(failure);
         final boolean nodeIsClosing = cause instanceof NodeClosedException;
         final String message;
         if (nodeIsClosing) {

--- a/server/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.action.index;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
@@ -29,12 +28,13 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.Mapping;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.Exceptions;
+import io.crate.exceptions.SQLExceptions;
 
 /**
  * Called by shards in the cluster when their mapping was dynamically updated and it needs to be updated
@@ -80,12 +80,8 @@ public class MappingUpdatedAction {
 
                 @Override
                 public void onFailure(Exception e) {
-                    listener.onFailure(unwrapException(e));
+                    listener.onFailure(Exceptions.toException(SQLExceptions.unwrap(e)));
                 }
             });
-    }
-
-    private static Exception unwrapException(Exception cause) {
-        return cause instanceof ElasticsearchException ? FutureUtils.unwrapEsException((ElasticsearchException) cause) : cause;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -21,7 +21,6 @@ package org.elasticsearch.cluster.metadata;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsClusterStateUpdateRequest;
@@ -48,6 +47,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.ShardLimitValidator;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
@@ -245,7 +245,7 @@ public class MetadataUpdateSettingsService {
                                 indicesService.verifyIndexMetadata(updatedMetadata, updatedMetadata);
                             }
                         } catch (IOException ex) {
-                            throw ExceptionsHelper.convertToElastic(ex);
+                            throw new UncheckedIOException(ex);
                         }
                         return updatedState;
                     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -27,6 +27,7 @@ import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
@@ -996,6 +997,8 @@ public abstract class StreamInput extends InputStream {
                 case 18:
                     final boolean isExecutorShutdown = readBoolean();
                     return (T) readStackTrace(new EsRejectedExecutionException(readOptionalString(), isExecutorShutdown), this);
+                case 19:
+                    return (T) readStackTrace(new UncheckedIOException(readOptionalString(), readException()), this);
                 default:
                     throw new IOException("no such exception for id: " + key);
             }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -24,6 +24,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -942,6 +943,13 @@ public abstract class StreamOutput extends OutputStream {
                 writeVInt(18);
                 writeBoolean(((EsRejectedExecutionException) throwable).isExecutorShutdown());
                 writeCause = false;
+            } else if (throwable instanceof UncheckedIOException) {
+                if (version.onOrAfter(Version.V_4_7_0)) {
+                    writeVInt(19);
+                } else {
+                    // Fallback to implicit IOException, it should have the same semantics
+                    writeVInt(17);
+                }
             } else {
                 final ElasticsearchException ex;
                 if (throwable instanceof ElasticsearchException && ElasticsearchException.isRegistered(throwable.getClass(), version)) {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
@@ -19,15 +19,18 @@
 
 package org.elasticsearch.common.util.concurrent;
 
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchTimeoutException;
-import javax.annotation.Nullable;
-import io.crate.common.SuppressForbidden;
-
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.ElasticsearchTimeoutException;
+
+import io.crate.common.SuppressForbidden;
+import io.crate.exceptions.Exceptions;
+import io.crate.exceptions.SQLExceptions;
 
 public class FutureUtils {
 
@@ -86,21 +89,6 @@ public class FutureUtils {
     }
 
     public static RuntimeException rethrowExecutionException(ExecutionException e) {
-        if (e.getCause() instanceof ElasticsearchException) {
-            ElasticsearchException esEx = (ElasticsearchException) e.getCause();
-            return unwrapEsException(esEx);
-        } else if (e.getCause() instanceof RuntimeException) {
-            return (RuntimeException) e.getCause();
-        } else {
-            return new UncategorizedExecutionException("Failed execution", e);
-        }
-    }
-
-    public static RuntimeException unwrapEsException(ElasticsearchException esEx) {
-        Throwable root = esEx.unwrapCause();
-        if (root instanceof ElasticsearchException || root instanceof RuntimeException) {
-            return (RuntimeException) root;
-        }
-        return new UncategorizedExecutionException("Failed execution", root);
+        return Exceptions.toRuntimeException(SQLExceptions.unwrap(e));
     }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -23,7 +23,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchTimeoutException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
@@ -36,6 +35,8 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.transport.ReceiveTimeoutTransportException;
+
+import io.crate.exceptions.SQLExceptions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -212,7 +213,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
                             shardId, nodeEntry.getNodeId(), type, nodeEntry.getFetchingRound(), fetchingRound);
                     } else if (nodeEntry.isFailed() == false) {
                         // if the entry is there, for the right fetching round and not marked as failed already, process it
-                        Throwable unwrappedCause = ExceptionsHelper.unwrapCause(failure.getCause());
+                        Throwable unwrappedCause = SQLExceptions.unwrap(failure.getCause());
                         // if the request got rejected or timed out, we need to try it again next time...
                         if (unwrappedCause instanceof EsRejectedExecutionException ||
                             unwrappedCause instanceof ReceiveTimeoutTransportException ||

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -21,12 +21,13 @@ package org.elasticsearch.gateway;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import io.crate.common.io.IOUtils;
+import io.crate.exceptions.Exceptions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -497,14 +498,14 @@ public class GatewayMetaState implements Closeable {
                         throw new AlreadyClosedException("persisted state has been closed");
                     }
                 } catch (Exception e) {
-                    throw ExceptionsHelper.convertToRuntime(e);
+                    throw Exceptions.toRuntimeException(e);
                 }
             }
         }
 
         private void handleExceptionOnWrite(Exception e) {
             writeNextStateFully = true;
-            throw ExceptionsHelper.convertToRuntime(e);
+            throw Exceptions.toRuntimeException(e);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -155,6 +155,8 @@ import io.crate.common.Booleans;
 import io.crate.common.collections.Tuple;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.Exceptions;
+
 import java.util.HashSet;
 
 public class IndexShard extends AbstractIndexShardComponent implements IndicesClusterStateService.Shard {
@@ -1432,7 +1434,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     // mainly for MapperParsingException and Failure to detect xcontent
                     logger.info("ignoring recovery of a corrupt translog entry", e);
                 } else {
-                    throw ExceptionsHelper.convertToRuntime(e);
+                    throw Exceptions.toRuntimeException(e);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.indices.recovery;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.SQLExceptions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -27,7 +29,6 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.RateLimiter;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.cluster.ClusterState;
@@ -227,7 +228,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     "[{}][{}] Got exception on recovery", request.shardId().getIndex().getName(),
                     request.shardId().id()), e);
             }
-            Throwable cause = ExceptionsHelper.unwrapCause(e);
+            Throwable cause = SQLExceptions.unwrap(e);
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {
                 // this can also come from the source wrapped in a RemoteTransportException
                 onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request,
@@ -240,7 +241,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                 cause = cause.getCause();
             }
             // do it twice, in case we have double transport exception
-            cause = ExceptionsHelper.unwrapCause(cause);
+            cause = SQLExceptions.unwrap(cause);
             if (cause instanceof RecoveryEngineException) {
                 // unwrap an exception that was thrown as part of the recovery
                 cause = cause.getCause();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -55,6 +55,8 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.index.translog.Translog;
 
+import io.crate.exceptions.Exceptions;
+
 /**
  * Represents a recovery where the current node is the target node of the recovery. To track recoveries in a central place, instances of
  * this class are created through {@link RecoveriesCollection}.
@@ -372,11 +374,12 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                 if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
                     throw new MapperException("mapping updates are not allowed [" + operation + "]");
                 }
-                if (result.getFailure() != null) {
+                Exception failure = result.getFailure();
+                if (failure != null) {
                     if (Assertions.ENABLED && result.getFailure() instanceof MapperException == false) {
                         throw new AssertionError("unexpected failure while replicating translog entry", result.getFailure());
                     }
-                    ExceptionsHelper.reThrowIfNotNull(result.getFailure());
+                    Exceptions.rethrowRuntimeException(failure);
                 }
             }
             // update stats only after all operations completed (to ensure that mapping updates don't mess with stats)

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -20,11 +20,12 @@
 package org.elasticsearch.indices.recovery;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.SQLExceptions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.RateLimiter;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.RetryableAction;
@@ -267,7 +268,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
 
     private static boolean retryableException(Exception e) {
         if (e instanceof RemoteTransportException) {
-            final Throwable cause = ExceptionsHelper.unwrapCause(e);
+            final Throwable cause = SQLExceptions.unwrap(e);
             return cause instanceof CircuitBreakingException ||
                 cause instanceof EsRejectedExecutionException;
         }

--- a/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
@@ -21,7 +21,8 @@ package org.elasticsearch.threadpool;
 
 import io.crate.common.SuppressForbidden;
 import io.crate.common.unit.TimeValue;
-import org.elasticsearch.ExceptionsHelper;
+import io.crate.exceptions.Exceptions;
+
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
@@ -260,7 +261,10 @@ public interface Scheduler {
             if (t != null) return;
             // Scheduler only allows Runnable's so we expect no checked exceptions here. If anyone uses submit directly on `this`, we
             // accept the wrapped exception in the output.
-            ExceptionsHelper.reThrowIfNotNull(EsExecutors.rethrowErrors(r));
+            Throwable error = EsExecutors.rethrowErrors(r);
+            if (error != null) {
+                Exceptions.rethrowRuntimeException(error);
+            }
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -154,8 +154,8 @@ public class TransportHandshakerTests extends ESTestCase {
         handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), versionFuture);
 
         assertTrue(versionFuture.isDone());
-        ConnectTransportException cte = expectThrows(ConnectTransportException.class, versionFuture::actionGet);
-        assertThat(cte.getMessage(), containsString("failure to send internal:tcp/handshake"));
+        RuntimeException cte = expectThrows(RuntimeException.class, versionFuture::actionGet);
+        assertThat(cte.getMessage(), containsString("boom"));
         assertNull(handshaker.removeHandlerForHandshake(reqId));
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
@@ -18,10 +18,11 @@
  */
 package org.elasticsearch.test.disruption;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.Exceptions;
+
 import org.elasticsearch.test.InternalTestCluster;
 
 import java.util.Random;
@@ -114,7 +115,7 @@ public class SlowClusterStateProcessing extends SingleNodeDisruption {
                     }
                     countDownLatch.countDown();
                 } catch (InterruptedException e) {
-                    ExceptionsHelper.reThrowIfNotNull(e);
+                    Exceptions.rethrowRuntimeException(e);
                 }
             }, (source, e) -> countDownLatch.countDown(),
             Priority.IMMEDIATE);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits.
Main motivation was to have a simpler answer to "should I use ExceptionsHelper.unwrapCause or SQLExceptions.unwrap".

A potential next step would be to merge everything from `ExceptionsHelper` & `SQLExceptions` into a single class.

(`Exceptions` is in the libs/shared module and therefore doesn't have access to some of the exception the other two classes use)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
