### PR TITLE
array_position initial commit

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2788,6 +2788,46 @@ function supports arrays of any of the :ref:`primitive types
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-array_position:
+
+``array_position(anycompatiblearray, anycompatible [, integer ] ) → integer``
+-----------------------------------------------------------------------------
+
+The ``array_position`` function returns the subscript of the first
+occurrence of the second argument in the ``array``, or ``NULL`` if it's not
+present. If the third argument is given, the search begins at that subscript.
+The third argument is ignored if it's null or invalid value out of ``array``
+range. It is also possible to search for ``NULL`` values.
+
+::
+
+    cr> SELECT array_position([1,3,7,4], 7) as position;
+    +----------+
+    | position |
+    +----------+
+    |        3 |
+    +----------+
+    SELECT 1 row in set (... sec)
+
+Begin the search from given subscript (optional).
+
+::
+
+    cr> SELECT array_position([1,3,7,4], 7, 2) as position;
+    +----------+
+    | position |
+    +----------+
+    |        3 |
+    +----------+
+    SELECT 1 row in set (... sec)
+
+.. TIP::
+    When searching for the existence of an ``array`` element, using the
+    :ref:`ANY <sql_any_array_comparison>` operator inside the ``WHERE``
+    clause is much more efficient as it can utilize the index whereas
+    ``array_position`` won't even when used inside the ``WHERE`` clause.
+
+
 .. _scalar-array_max:
 
 ``array_max(array)``

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
@@ -1,0 +1,103 @@
+package io.crate.expression.scalar;
+
+import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
+
+    public static final String NAME = "array_position";
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    public ArrayPositionFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        ensureInnerTypeIsNotUndefined(boundSignature.getArgumentDataTypes(), signature.getName().name());
+    }
+
+    public static void register(ScalarFunctionModule scalarFunctionModule) {
+        scalarFunctionModule.register(
+            Signature.scalar(NAME,
+                parseTypeSignature("array(T)"),
+                parseTypeSignature("T"),
+                DataTypes.INTEGER.getTypeSignature()
+            ).withTypeVariableConstraints(typeVariable("T")),
+            ArrayPositionFunction::new);
+
+        scalarFunctionModule.register(
+            Signature.scalar(NAME,
+                parseTypeSignature("array(T)"),
+                parseTypeSignature("T"),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            ).withTypeVariableConstraints(typeVariable("T")),
+            ArrayPositionFunction::new);
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+
+    @Override
+    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input[] args) {
+
+        List<Object> elements = (List<Object>) args[0].value();
+        if (elements == null || elements.isEmpty()) {
+            return null;
+        }
+
+        Object targetValue = args[1].value();
+
+        //Start iteration with 0 if optional parameter not supplied
+        Integer beginIndex = 0;
+        if (args.length > 2) {
+            beginIndex = getBeginPosition(args[2].value(), elements.size());
+        }
+
+        if (beginIndex == null) {
+            return null;
+        }
+
+        Object element = null;
+        for (int i = beginIndex; i < elements.size(); i++) {
+            element = elements.get(i);
+            if (Objects.equals(targetValue, element)) {
+                return i + 1; //Return position.
+            }
+        }
+
+        return null;
+    }
+
+    private Integer getBeginPosition(Object position, int elementsSize) {
+
+        if (position == null) {
+            return 0;
+        }
+
+        Integer beginPosition = (Integer) position;
+        if (beginPosition < 1 || beginPosition > elementsSize) {
+            return null;
+        }
+
+        return beginPosition - 1;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -187,6 +187,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         ArraySumFunction.register(this);
         ArrayAvgFunction.register(this);
         ArraySliceFunction.register(this);
+        ArrayPositionFunction.register(this);
 
         CoalesceFunction.register(this);
         GreatestFunction.register(this);

--- a/server/src/test/java/io/crate/expression/scalar/ArrayPositionFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayPositionFunctionTest.java
@@ -1,0 +1,74 @@
+package io.crate.expression.scalar;
+
+import static io.crate.testing.Asserts.assertThrowsMatches;
+
+import org.junit.Test;
+
+import io.crate.exceptions.ConversionException;
+
+public class ArrayPositionFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_array_position_find_from_given_position() {
+        assertEvaluate(
+            "array_position([null, 'array','position','function','test','crate','db'], 'crate', 3)",
+            6);
+    }
+
+    @Test
+    public void test_array_position_find_text_in_int_array_with_value_effectively_equal() {
+        assertEvaluate("array_position([3,4,1,4,6], '3')", 1);
+    }
+
+    @Test
+    public void test_array_position_find_null() {
+        assertEvaluate("array_position([3,2,null,4,6], null)", 3);
+    }
+
+    @Test
+    public void test_array_position_find_array_of_objects() {
+        assertEvaluate("array_position([[{id=101 ,name='John'}, {id=102 ,name='Harry'}], [{id=103 ,name='San'}]], [{id=103 , name='San'}])",
+            2);
+    }
+
+    @Test
+    public void test_array_position_find_element_when_begin_position_given_beyond_target_index() {
+        assertEvaluate("array_position([3,2,1,5,4,6,2], 2, 3)", 7);
+    }
+
+    @Test
+    public void test_array_position_find_element_when_begin_position_null_does_not_fail() {
+        assertEvaluate("array_position([3,2,1,5,4,6], 5, null)", 4);
+    }
+
+    @Test
+    public void test_array_position_find_element_when_begin_position_given_cast_compatible_returns_success() {
+        assertEvaluate("array_position([3,2,1,5,4,6], 2, 1.4)", 2);
+    }
+
+    @Test
+    public void test_array_position_with_empty_array() {
+        assertEvaluate("array_position(cast([] as array(integer)), 14)", null);
+    }
+
+    @Test
+    public void test_array_position_with_null_array() {
+        assertEvaluate("array_position(null, 1)", null);
+    }
+
+    @Test
+    public void test_array_position_find_element_when_begin_position_given_zero_or_negative_then_ignored() {
+        assertEvaluate("array_position([3,2,1,5,4,6], 4, 0)", null);
+    }
+
+    @Test
+    public void test_array_position_find_element_when_begin_position_given_greater_than_array_size_then_ignored() {
+        assertEvaluate("array_position([3,2,1,5,4], 4, 6)", null);
+    }
+
+    @Test
+    public void test_array_position_find_text_in_int_array_with_start_position_provided_throws_error() {
+        assertThrowsMatches(() -> assertEvaluate("array_position([3,4,1,4,6], 'a', 3)", null),
+            ConversionException.class, "Cannot cast `'a'` of type `text` to type `integer`");
+    }
+}


### PR DESCRIPTION
This pull request adds a new scalar function to search the position of an element in array. All data types (including null) are possible to search that are supported by arrays as in Crate DB documentation.

Appropriate tests have been added and boundary conditions have been taken care of.  