### PR TITLE
CI/GHA: When uploading to wacklig, always use `bash`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,9 @@ jobs:
           WACKLIG_TOKEN: ${{ secrets.WACKLIG_TOKEN }}
         shell: bash
         run: |
-          curl -s https://raw.githubusercontent.com/pipifein/wacklig-uploader/master/wacklig.py | python - --token $WACKLIG_TOKEN || echo "Upload to wacklig failed"
+          curl -s https://raw.githubusercontent.com/pipifein/wacklig-uploader/master/wacklig.py | python - --token $WACKLIG_TOKEN \
+            && echo "Upload to wacklig succeeded" \
+            || errcode=$?; echo "Upload to wacklig failed"; exit $errcode
 
 
   forbiddenApis:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         if: always()
         env:
           WACKLIG_TOKEN: ${{ secrets.WACKLIG_TOKEN }}
+        shell: bash
         run: |
           curl -s https://raw.githubusercontent.com/pipifein/wacklig-uploader/master/wacklig.py | python - --token $WACKLIG_TOKEN || echo "Upload to wacklig failed"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           arguments: :server:test -Dtests.crate.run-windows-incompatible=${{ matrix.os == 'ubuntu-latest' }}
 
+      - name: Upload results to wacklig
+        if: always()
+        env:
+          WACKLIG_TOKEN: ${{ secrets.WACKLIG_TOKEN }}
+        run: |
+          curl -s https://raw.githubusercontent.com/pipifein/wacklig-uploader/master/wacklig.py | python - --token $WACKLIG_TOKEN || echo "Upload to wacklig failed"
+
+
   forbiddenApis:
     name: forbiddenApisMain
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi,

this patch could make #11924 succeed on Windows. The error at [build #4301579129](https://github.com/crate/crate/runs/4301579129) said:

```
usage: wacklig [-h] [--server SERVER] --token TOKEN
wacklig: error: argument --token: expected one argument
Upload to wacklig failed
```

This is probably because the command was executed by PowerShell (`C:\Program Files\PowerShell\7\pwsh.EXE`), where environment variables (`$WACKLIG_TOKEN`) would have to be expanded differently, like`$Env:WACKLIG_TOKEN` [1].

With kind regards,
Andreas.

[1] https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables