### PR TITLE
prevent nodeActions from executing if the corresponding Task is killed

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -25,6 +25,7 @@ import io.crate.exceptions.JobKilledException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.TransportShardAction;
+import io.crate.execution.jobs.TasksService;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -54,6 +55,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
     public TransportShardDeleteAction(TransportService transportService,
                                       ClusterService clusterService,
                                       IndicesService indicesService,
+                                      TasksService tasksService,
                                       ThreadPool threadPool,
                                       ShardStateAction shardStateAction,
                                       SchemaUpdateClient schemaUpdateClient) {
@@ -62,6 +64,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
             transportService,
             clusterService,
             indicesService,
+            tasksService,
             threadPool,
             shardStateAction,
             ShardDeleteRequest::new,

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -110,6 +110,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             transportService,
             clusterService,
             indicesService,
+            tasksService,
             threadPool,
             shardStateAction,
             ShardUpsertRequest::new,

--- a/server/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.dml.delete;
 
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
+import io.crate.execution.jobs.TasksService;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -77,6 +78,7 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
                 Settings.EMPTY, Version.CURRENT, THREAD_POOL, clusterService.getClusterSettings()),
             mock(ClusterService.class),
             indicesService,
+            mock(TasksService.class),
             mock(ThreadPool.class),
             mock(ShardStateAction.class),
             mock(SchemaUpdateClient.class)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This should help prevent lingering upsert actions after copy-from failed, leading to satisfying the consistency faster.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
