### PR TITLE
fix CollectTask#kill to take effect right away

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
@@ -143,13 +144,14 @@ public class CollectTask implements Task {
     }
 
     @Override
-    public void kill(Throwable throwable) {
+    public void kill(@Nonnull Throwable throwable) {
         if (started.compareAndSet(false, true)) {
             consumer.accept(null, throwable);
         } else {
             batchIterator.whenComplete((it, err) -> {
                 if (err == null) {
                     it.kill(throwable);
+                    consumer.accept(null, throwable);
                 } // else: Consumer must have received a failure already
             });
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

to resolve situation like the following:

```
Task{
	id=befb5a76-9b25-44ec-9a1a-725f67b22cf4,
	tasks=[
		CollectTask{
			id=0,
			sharedContexts=SharedShardContexts{allocatedShards=[]},
			consumer=DistributingConsumer{
				jobId=befb5a76-9b25-44ec-9a1a-725f67b22cf4,
				targetPhaseId=1,
				inputId=0,
				bucketIdx=0,
				downstreams=[Downstream{T73WU0yCRLOWImILnk_JKw', needsMoreData=true}]
			},
			searchContexts=[],
			batchIterator=java.util.concurrent.CompletableFuture@25b5115f[Completed normally],   // --> batchIterator is finished,
			finished=false	                                                                      // --> but the consumer is not finished yet.
		}
	],
	closed=true                                                                                           // --> RootTask is closed
}
```
Until the consumer completes, it will be in this unwanted state where the `RootTask` is closed but `CollectTask` is not yet finished. 


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
