### PR TITLE
Speed up jobId generation

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.UUIDs;
 
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedCommit;
@@ -182,7 +183,7 @@ public class Session implements AutoCloseable {
         Statement parsedStmt = parse.apply(statement);
         AnalyzedStatement analyzedStatement = analyzer.analyze(parsedStmt, sessionContext, ParamTypeHints.EMPTY);
         RoutingProvider routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
-        UUID jobId = UUID.randomUUID();
+        UUID jobId = UUIDs.dirtyUUID();
         ClusterState clusterState = planner.currentClusterState();
         PlannerContext plannerContext = new PlannerContext(
             clusterState,
@@ -272,7 +273,7 @@ public class Session implements AutoCloseable {
             if ("".equals(query)) {
                 statement = EMPTY_STMT;
             } else {
-                jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t), sessionContext.sessionUser());
+                jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), query, SQLExceptions.messageOf(t), sessionContext.sessionUser());
                 throw t;
             }
         }
@@ -296,7 +297,7 @@ public class Session implements AutoCloseable {
             );
         } catch (Throwable t) {
             jobsLogs.logPreExecutionFailure(
-                UUID.randomUUID(),
+                UUIDs.dirtyUUID(),
                 query == null ? statementName : query,
                 SQLExceptions.messageOf(t),
                 sessionContext.sessionUser());
@@ -318,7 +319,7 @@ public class Session implements AutoCloseable {
         try {
             preparedStmt = getSafeStmt(statementName);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(UUID.randomUUID(), null, SQLExceptions.messageOf(t), sessionContext.sessionUser());
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), null, SQLExceptions.messageOf(t), sessionContext.sessionUser());
             throw t;
         }
 
@@ -531,7 +532,7 @@ public class Session implements AutoCloseable {
 
     private CompletableFuture<?> bulkExec(Statement statement, List<DeferredExecution> toExec) {
         assert toExec.size() >= 1 : "Must have at least 1 deferred execution for bulk exec";
-        var jobId = UUID.randomUUID();
+        var jobId = UUIDs.dirtyUUID();
         var routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
         var clusterState = executor.clusterService().state();
         var txnCtx = new CoordinatorTxnCtx(sessionContext);
@@ -612,7 +613,7 @@ public class Session implements AutoCloseable {
             return resultReceiver.completionFuture();
         }
 
-        var jobId = UUID.randomUUID();
+        var jobId = UUIDs.dirtyUUID();
         var routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
         var clusterState = executor.clusterService().state();
         var txnCtx = new CoordinatorTxnCtx(sessionContext);

--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -42,6 +42,8 @@ import io.crate.sql.tree.CheckConstraint;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -55,7 +57,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -598,7 +599,7 @@ public class AnalyzedTableElements<T> {
             sb.append("_").append(columnName);
         }
         sb.append("_check_");
-        String uuid = UUID.randomUUID().toString();
+        String uuid = UUIDs.dirtyUUID().toString();
         int idx = uuid.lastIndexOf("-");
         sb.append(idx > 0 ? uuid.substring(idx + 1) : uuid);
         return sb.toString();

--- a/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -34,12 +34,13 @@ import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
+
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 
 class CreateSnapshotAnalyzer {
 
@@ -63,7 +64,7 @@ class CreateSnapshotAnalyzer {
                 "Snapshot must be specified by \"<repository_name>\".\"<snapshot_name>\""));
 
         String snapshotName = createSnapshot.name().getSuffix();
-        Snapshot snapshot = new Snapshot(repositoryName, new SnapshotId(snapshotName, UUID.randomUUID().toString()));
+        Snapshot snapshot = new Snapshot(repositoryName, new SnapshotId(snapshotName, UUIDs.dirtyUUID().toString()));
 
         var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionContext());
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(

--- a/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -21,6 +21,13 @@
 
 package io.crate.analyze.relations;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.elasticsearch.common.UUIDs;
+
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
@@ -29,11 +36,6 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
-import org.elasticsearch.common.UUIDs;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
 
 public class UnionSelect implements AnalyzedRelation {
 
@@ -47,7 +49,7 @@ public class UnionSelect implements AnalyzedRelation {
             : "Both the left side and the right side of UNION must have the same number of outputs";
         this.left = left;
         this.right = right;
-        this.name = new RelationName(null, UUIDs.randomBase64UUID());
+        this.name = new RelationName(null, UUIDs.dirtyUUID().toString());
         // SQL semantics dictate that UNION uses the column names from the first relation (top or left side)
         List<Symbol> fieldsFromLeft = left.outputs();
         ArrayList<ScopedSymbol> outputs = new ArrayList<>(fieldsFromLeft.size());

--- a/server/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -41,6 +41,7 @@ import io.crate.metadata.Routing;
 import io.crate.planner.distribution.DistributionInfo;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.index.shard.ShardId;
@@ -132,7 +133,7 @@ public class RemoteCollectorFactory {
             }
             it.whenComplete(consumer);
         } else {
-            UUID childJobId = UUID.randomUUID();
+            UUID childJobId = UUIDs.dirtyUUID();
             RemoteCollector remoteCollector = new RemoteCollector(
                 childJobId,
                 collectTask.txnCtx().sessionSettings(),

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/RamAccountingQueue.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/RamAccountingQueue.java
@@ -27,11 +27,10 @@ import io.crate.breaker.RamAccounting;
 import io.crate.breaker.SizeEstimator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 
-import java.util.Locale;
 import java.util.Queue;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RamAccountingQueue<T> extends ForwardingQueue<T> {
@@ -57,7 +56,7 @@ public class RamAccountingQueue<T> extends ForwardingQueue<T> {
     }
 
     private static String contextId() {
-        return String.format(Locale.ENGLISH, "RamAccountingQueue[%s]", UUID.randomUUID().toString());
+        return "RamAccountingQueue[" + UUIDs.dirtyUUID() + ']';
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.UUIDs;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
@@ -47,7 +48,7 @@ public class PlannerContext {
         return new PlannerContext(
             context.clusterState,
             context.routingProvider,
-            UUID.randomUUID(),
+            UUIDs.dirtyUUID(),
             context.coordinatorTxnCtx,
             context.nodeCtx,
             fetchSize,

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -30,10 +30,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
+
+import org.elasticsearch.common.UUIDs;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
@@ -183,7 +184,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
                 source.outputs().indexOf(windowDefinition.partitions().iterator().next()))
             );
             MergePhase distWindowAgg = new MergePhase(
-                UUID.randomUUID(),
+                UUIDs.dirtyUUID(),
                 plannerContext.nextExecutionPhaseId(),
                 "distWindowAgg",
                 resultDescription.nodeIds().size(),

--- a/server/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
 import org.apache.logging.log4j.LogManager;
 import io.crate.common.unit.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -120,7 +121,7 @@ public class RetryOnFailureResultReceiver implements ResultReceiver {
     }
 
     private void retry() {
-        UUID newJobId = UUID.randomUUID();
+        UUID newJobId = UUIDs.dirtyUUID();
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Retrying statement due to a shard failure, attempt={}, jobId={}->{}", attempt, jobId, newJobId);
         }

--- a/server/src/main/java/org/elasticsearch/common/UUIDs.java
+++ b/server/src/main/java/org/elasticsearch/common/UUIDs.java
@@ -20,11 +20,28 @@
 package org.elasticsearch.common;
 
 import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class UUIDs {
 
     private static final RandomBasedUUIDGenerator RANDOM_UUID_GENERATOR = new RandomBasedUUIDGenerator();
     private static final UUIDGenerator TIME_UUID_GENERATOR = new TimeBasedUUIDGenerator();
+
+    /**
+     * Similar to {@link UUID#randomUUID()} but:
+     *
+     * <ul>
+     *  <li>Uses ThreadLocalRandom instead of SecureRandom</li>
+     *  <li>Doesn't return a UUID4, in fact it doesn't follow the UUID structure at all.
+     *      It's just two random longs.
+     *  </li>
+     * </ul>
+     **/
+    public static UUID dirtyUUID() {
+        var random = ThreadLocalRandom.current();
+        return new UUID(random.nextLong(), random.nextLong());
+    }
 
     /** Generates a time-based UUID (similar to Flake IDs), which is preferred when generating an ID to be indexed into a Lucene index as
      *  primary key.  The id is opaque and the implementation is free to change at any time! */


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`UUID.randomUUID` utilizes `SecureRandom`
For our jobIds it should be good enough to go with statistically random
ids created using ThreadLocalRandom instead:

      UUIDBenchmark.secureRandomUUID  avgt   10  423.891 ± 6.087  ns/op
      UUIDBenchmark.randomBytesUUID4  avgt   10   27.081 ± 1.475  ns/op
    → UUIDBenchmark.randomLongs       avgt   10    4.552 ± 0.096  ns/op
      UUIDBenchmark.staticLongs       avgt   10    3.681 ± 0.105  ns/op

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
