### PR TITLE
Remove write queue from Netty4MessageChannelHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -19,12 +19,6 @@
 
 package org.elasticsearch.transport.netty4;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -36,9 +30,9 @@ import org.elasticsearch.transport.InboundPipeline;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.Transports;
 
-import java.nio.channels.ClosedChannelException;
-import java.util.ArrayDeque;
-import java.util.Queue;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  * A handler (must be the last one!) that does size based frame decoding and forwards the actual message
@@ -47,10 +41,6 @@ import java.util.Queue;
 final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
 
     private final Netty4Transport transport;
-
-    private final Queue<WriteOperation> queuedWrites = new ArrayDeque<>();
-
-    private WriteOperation currentWrite;
     private final InboundPipeline pipeline;
 
     Netty4MessageChannelHandler(PageCacheRecycler recycler, Netty4Transport transport) {
@@ -95,112 +85,8 @@ final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        assert msg instanceof ByteBuf;
-        final boolean queued = queuedWrites.offer(new WriteOperation((ByteBuf) msg, promise));
-        assert queued;
-    }
-
-    @Override
-    public void channelWritabilityChanged(ChannelHandlerContext ctx) {
-        if (ctx.channel().isWritable()) {
-            doFlush(ctx);
-        }
-        ctx.fireChannelWritabilityChanged();
-    }
-
-    @Override
-    public void flush(ChannelHandlerContext ctx) {
-        Channel channel = ctx.channel();
-        if (channel.isWritable() || channel.isActive() == false) {
-            doFlush(ctx);
-        }
-    }
-
-    @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        doFlush(ctx);
         Releasables.closeWhileHandlingException(pipeline);
         super.channelInactive(ctx);
-    }
-
-    private void doFlush(ChannelHandlerContext ctx) {
-        assert ctx.executor().inEventLoop();
-        final Channel channel = ctx.channel();
-        if (channel.isActive() == false) {
-            if (currentWrite != null) {
-                currentWrite.promise.tryFailure(new ClosedChannelException());
-            }
-            failQueuedWrites();
-            return;
-        }
-        while (channel.isWritable()) {
-            if (currentWrite == null) {
-                currentWrite = queuedWrites.poll();
-            }
-            if (currentWrite == null) {
-                break;
-            }
-            final WriteOperation write = currentWrite;
-            if (write.buf.readableBytes() == 0) {
-                write.promise.trySuccess();
-                currentWrite = null;
-                continue;
-            }
-            final int readableBytes = write.buf.readableBytes();
-            final int bufferSize = Math.min(readableBytes, 1 << 18);
-            final int readerIndex = write.buf.readerIndex();
-            final boolean sliced = readableBytes != bufferSize;
-            final ByteBuf writeBuffer;
-            if (sliced) {
-                writeBuffer = write.buf.retainedSlice(readerIndex, bufferSize);
-                write.buf.readerIndex(readerIndex + bufferSize);
-            } else {
-                writeBuffer = write.buf;
-            }
-            final ChannelFuture writeFuture = ctx.write(writeBuffer);
-            if (sliced == false || write.buf.readableBytes() == 0) {
-                currentWrite = null;
-                writeFuture.addListener(future -> {
-                    assert ctx.executor().inEventLoop();
-                    if (future.isSuccess()) {
-                        write.promise.trySuccess();
-                    } else {
-                        write.promise.tryFailure(future.cause());
-                    }
-                });
-            } else {
-                writeFuture.addListener(future -> {
-                    assert ctx.executor().inEventLoop();
-                    if (future.isSuccess() == false) {
-                        write.promise.tryFailure(future.cause());
-                    }
-                });
-            }
-            ctx.flush();
-            if (channel.isActive() == false) {
-                failQueuedWrites();
-                return;
-            }
-        }
-    }
-
-    private void failQueuedWrites() {
-        WriteOperation queuedWrite;
-        while ((queuedWrite = queuedWrites.poll()) != null) {
-            queuedWrite.promise.tryFailure(new ClosedChannelException());
-        }
-    }
-
-    private static final class WriteOperation {
-
-        private final ByteBuf buf;
-
-        private final ChannelPromise promise;
-
-        WriteOperation(ByteBuf buf, ChannelPromise promise) {
-            this.buf = buf;
-            this.promise = promise;
-        }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The queue was introduced in
https://github.com/crate/crate/commit/a7d80dfe9519abf21399416aab1ac9a5a6e21360
to chunk and throttle netty writes.

It looks as if the implementation has a bug and the flush is not always
triggered.

Instead of fixing the implementation this removes the queue altogether.
There have been some optimizations in netty since, and for us it would
likely make more sense to change the serialization and allocation
strategy in the `OutboundHandler` and serialize directly to a pooled
`ByteBuf` instead.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
