### PR TITLE
Do not unwrap TransportException by default

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -21,10 +21,16 @@
 
 package io.crate.exceptions;
 
+import java.util.Locale;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import io.crate.auth.AccessControl;
-import io.crate.metadata.PartitionName;
-import io.crate.sql.parser.ParsingException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchWrapperException;
@@ -41,21 +47,18 @@ import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.snapshots.InvalidSnapshotNameException;
 import org.elasticsearch.snapshots.SnapshotCreationException;
 import org.elasticsearch.snapshots.SnapshotMissingException;
-import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.RemoteTransportException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Locale;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Predicate;
+import io.crate.auth.AccessControl;
+import io.crate.metadata.PartitionName;
+import io.crate.sql.parser.ParsingException;
 
 public class SQLExceptions {
 
     private static final Logger LOGGER = LogManager.getLogger(SQLExceptions.class);
 
     private static final Predicate<Throwable> EXCEPTIONS_TO_UNWRAP = throwable ->
-        throwable instanceof TransportException ||
+        throwable instanceof RemoteTransportException ||
         throwable instanceof UncheckedExecutionException ||
         throwable instanceof CompletionException ||
         throwable instanceof UncategorizedExecutionException ||

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -154,8 +154,8 @@ public class TransportHandshakerTests extends ESTestCase {
         handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), versionFuture);
 
         assertTrue(versionFuture.isDone());
-        RuntimeException cte = expectThrows(RuntimeException.class, versionFuture::actionGet);
-        assertThat(cte.getMessage(), containsString("boom"));
+        ConnectTransportException cte = expectThrows(ConnectTransportException.class, versionFuture::actionGet);
+        assertThat(cte.getMessage(), containsString("failure to send internal:tcp/handshake"));
         assertNull(handshaker.removeHandlerForHandshake(reqId));
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There are several places where we check exceptions for instances of
`ConnectTransportException`. If we unwrap any `TransportException` by
default, the checks for `ConnectTransportException` no longer work.

This changes it to instead unwrap only `RemoteTransportException` -
which is the only `TransportException` used as a generic wrapper.

I suspect this may have caused some flakyness.

Follow up to https://github.com/crate/crate/pull/11988

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
