### PR TITLE
bp: Fix Leaking Listener When Closing NodeClient

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -404,7 +404,7 @@ should be crossed out as well.
 - [x] 06b33457878 Avoid double-recovery when state recovery delayed
 - [x] cd228095dfe Retry failed peer recovery due to transient errors (#55883)
 - [ ] cab7bcc1562 Disk decider respect watermarks for single data node (#55805) (#55847)
-- [ ] f38385ee257 Fix Leaking Listener When Closing NodeClient (#55676) (#55864)
+- [x] f38385ee257 Fix Leaking Listener When Closing NodeClient (#55676) (#55864)
 - [x] 80662f31a1c Introduce mechanism to stub request handling (#55832)
 - [ ] 4bfd65a3750 Remove TODO around aggregating on _index.
 - [ ] b5916ac455c Ignore closed exception on refresh pending location listener (#55799)

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -619,10 +619,11 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
                     timeoutHandler.cancel();
                 }
                 // callback that an exception happened, but on a different thread since we don't
-                // want handlers to worry about stack overflows
+                // want handlers to worry about stack overflows. In the special case of running into a closing node we run on the current
+                // thread on a best effort basis though.
                 final SendRequestTransportException sendRequestException = new SendRequestTransportException(node, action, e);
-                threadPool.executor(ThreadPool.Names.GENERIC).execute(new AbstractRunnable() {
-
+                final String executor = lifecycle.stoppedOrClosed() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC;
+                threadPool.executor(executor).execute(new AbstractRunnable() {
                     @Override
                     public void onRejection(Exception e) {
                         // if we get rejected during node shutdown we don't wanna bubble it up


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Spotted this while looking into flaky test failures.
I doubt it is related, but just to rule it out.

https://github.com/elastic/elasticsearch/commit/f38385ee25725e8ca7631eb852ca16b5b1508da1


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
