### PR TITLE
Use table UUID instead of table name to identify tables in metadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -503,6 +503,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return indices.containsKey(index);
     }
 
+    public boolean hasIndex(Index index) {
+        return indicesByUUID.containsKey(index.getUUID());
+    }
+
     public boolean hasConcreteIndex(String index) {
         return getAliasAndIndexLookup().containsKey(index);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -99,7 +99,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
 
     boolean validate(Metadata metadata) {
         // check index exists
-        if (!metadata.hasIndex(index.getName())) {
+        if (!metadata.hasIndex(index)) {
             throw new IllegalStateException(index + " exists in routing does not exists in metadata");
         }
         IndexMetadata indexMetadata = metadata.index(index.getName());

--- a/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -153,7 +153,7 @@ public class DanglingIndicesState implements ClusterStateListener {
             Map<Index, IndexMetadata> newIndices = new HashMap<>(indexMetadataList.size());
             final IndexGraveyard graveyard = metadata.indexGraveyard();
             for (IndexMetadata indexMetadata : indexMetadataList) {
-                if (metadata.hasIndex(indexMetadata.getIndex().getName())) {
+                if (metadata.hasIndex(indexMetadata.getIndex())) {
                     LOGGER.warn("[{}] can not be imported as a dangling index, as index with same name already exists in cluster metadata",
                         indexMetadata.getIndex());
                 } else if (graveyard.containsIndex(indexMetadata.getIndex())) {

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -127,7 +127,7 @@ public class LocalAllocateDangledIndices {
                                 minIndexCompatibilityVersion);
                             continue;
                         }
-                        if (currentState.metadata().hasIndex(indexMetadata.getIndex().getName())) {
+                        if (currentState.metadata().hasIndex(indexMetadata.getIndex())) {
                             continue;
                         }
                         if (currentState.metadata().hasAlias(indexMetadata.getIndex().getName())) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -586,12 +586,12 @@ public class IndicesService extends AbstractLifecycleComponent
     @Override
     public void deleteUnassignedIndex(String reason, IndexMetadata metadata, ClusterState clusterState) {
         if (nodeEnv.hasNodeFile()) {
-            String indexName = metadata.getIndex().getName();
+            Index index = metadata.getIndex();
             try {
-                if (clusterState.metadata().hasIndex(indexName)) {
-                    final IndexMetadata index = clusterState.metadata().index(indexName);
-                    throw new IllegalStateException("Can't delete unassigned index store for [" + indexName + "] - it's still part of " +
-                                                    "the cluster state [" + index.getIndexUUID() + "] [" + metadata.getIndexUUID() + "]");
+                if (clusterState.metadata().hasIndex(index)) {
+                    final IndexMetadata indexMetadata = clusterState.metadata().index(index);
+                    throw new IllegalStateException("Can't delete unassigned index store for [" + indexMetadata.getIndex().getName() + "] - it's still part of " +
+                                                    "the cluster state [" + indexMetadata.getIndexUUID() + "] [" + metadata.getIndexUUID() + "]");
                 }
                 deleteIndexStore(reason, metadata);
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -329,7 +329,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             if (indexService != null) {
                 indexSettings = indexService.getIndexSettings();
                 indicesService.removeIndex(index, DELETED, "index no longer part of the metadata");
-            } else if (previousState.metadata().hasIndex(index.getName())) {
+            } else if (previousState.metadata().hasIndex(index)) {
                 // The deleted index was part of the previous cluster state, but not loaded on the local node
                 final IndexMetadata metadata = previousState.metadata().index(index);
                 indexSettings = new IndexSettings(metadata, settings);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1014,7 +1014,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         Set<String> closed = new HashSet<>();
         for (ObjectObjectCursor<ShardId, SnapshotsInProgress.ShardSnapshotStatus> entry : shards) {
             if (entry.value.state() == ShardState.MISSING) {
-                if (metadata.hasIndex(entry.key.getIndex().getName()) &&
+                if (metadata.hasIndex(entry.key.getIndex()) &&
                     metadata.getIndexSafe(entry.key.getIndex()).getState() == IndexMetadata.State.CLOSE) {
                     closed.add(entry.key.getIndex().getName());
                 } else {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

A table name is allowed to be changed by e.g. swapping or renaming. Thus resolving tables must be done by the immutable UUID instead of a mutable name. This should fix a rare edge-case on table swapping were tables are wrongly resolved by their old name.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
