### PR TITLE
Fix IndexNotFound errors during inserts on partitioned table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -157,6 +157,8 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could cause inserts into partitioned tables to fail with
+  a ``IndexNotFoundException`` if concurrently deleting partitions.
 
 - Fixed a BWC translog issue for indices created with CrateDB < 3.2.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

testDeletePartitionWhileInsertingData in
PartitionedTableConcurrentIntegrationTest was flaky:

    io.crate.exceptions.RelationUnknown: Relation 'yfjvblyelpwzy..partitioned.parted.04132' unknown
            ...
    Caused by: [yfjvblyelpwzy..partitioned.parted.04132/d-U30GdTQN-GukNosYvp8A] org.elasticsearch.index.IndexNotFoundException: no such index
            at app//org.elasticsearch.cluster.routing.RoutingTable.shardRoutingTable(RoutingTable.java:150)
            at app//io.crate.planner.operators.InsertFromValues.execute(InsertFromValues.java:647)
            at app//io.crate.planner.operators.InsertFromValues.lambda$execute$0(InsertFromValues.java:285)
            at java.base@17/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
            at java.base@17/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
            at app//io.crate.planner.operators.InsertFromValues.execute(InsertFromValues.java:281)
            at app//io.crate.action.sql.Session.singleExec(Session.java:664)
            at app//io.crate.action.sql.Session.exec(Session.java:527)
            at app//io.crate.action.sql.Session.triggerDeferredExecutions(Session.java:514)
            at app//io.crate.action.sql.Session.sync(Session.java:498)
            at app//io.crate.testing.SQLTransportExecutor.execute(SQLTransportExecutor.java:258)
            at app//io.crate.testing.SQLTransportExecutor.execute(SQLTransportExecutor.java:236)
            ... 5 more

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
