### PR TITLE
Fix flaky ClusterDisruptionIT

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/ClusterDisruptionIT.java
@@ -204,7 +204,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                     semaphore.release(docsPerIndexer);
                 }
                 logger.info("waiting for indexing requests to complete");
-                assertTrue(countDownLatchRef.get().await(20, TimeUnit.SECONDS));
+                assertThat("indexing requests must complete", countDownLatchRef.get().await(20, TimeUnit.SECONDS), is(true));
 
                 logger.info("stopping disruption");
                 disruptionScheme.stopDisrupting();

--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
@@ -594,7 +594,7 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
     public SQLResponse execute(String stmt, Object[] args, String node, TimeValue timeout) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
         try (Session session = sqlOperations.createSession(sqlExecutor.getCurrentSchema(), User.CRATE_USER)) {
-            SQLResponse response = sqlExecutor.exec(stmt, args, session);
+            SQLResponse response = sqlExecutor.exec(stmt, args, session, timeout);
             this.response = response;
             return response;
         }

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -221,8 +221,12 @@ public class SQLTransportExecutor {
         );
     }
 
+    public SQLResponse exec(String statement, @Nullable Object[] args, Session session, TimeValue timeout) {
+        return FutureUtils.get(execute(statement, args, session), timeout.millis(), TimeUnit.MILLISECONDS);
+    }
+
     public SQLResponse exec(String statement, @Nullable Object[] args, Session session) {
-        return FutureUtils.get(execute(statement, args, session), REQUEST_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        return exec(statement, args, session, REQUEST_TIMEOUT);
     }
 
     public SQLResponse exec(String statement, Session session) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/12000

The timeout value wasn't passed along, causing
ClusterDisruptionIT.testAckedIndexing to fail


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
