### PR TITLE
Ensure row counts are sent in correct order to pg clients

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -160,6 +160,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could cause clients using the PostgreSQL wire protocol to
+  receive row counts in incorrect orders when using APIs that allow to execute
+  multiple statements in a batch.
+
 - Fixed an issue that could cause inserts into partitioned tables to fail with
   a ``IndexNotFoundException`` if concurrently deleting partitions.
 

--- a/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
+++ b/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
@@ -294,12 +294,7 @@ public class DelayableWriteChannel implements Channel {
     }
 
     public void delayWritesUntil(CompletableFuture<?> future) {
-        DelayedWrites delayedWrites;
-        if (delay == null) {
-            delayedWrites = new DelayedWrites(future);
-        } else {
-            delayedWrites = new DelayedWrites(delay.future.thenCompose(ignored -> future));
-        }
+        DelayedWrites delayedWrites = new DelayedWrites();
         this.delay = delayedWrites;
         future.whenComplete((res, err) -> {
             delayedWrites.runDelayed();
@@ -322,10 +317,8 @@ public class DelayableWriteChannel implements Channel {
     static class DelayedWrites {
 
         private final ArrayDeque<DelayedMsg> delayed = new ArrayDeque<>();
-        private final CompletableFuture<?> future;
 
-        public DelayedWrites(CompletableFuture<?> future) {
-            this.future = future;
+        public DelayedWrites() {
         }
 
         public void releaseAll() {

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -36,8 +36,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.util.ReferenceCountUtil;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -472,14 +470,9 @@ public class Messages {
         buffer.writeByte(msgType);
         buffer.writeInt(4);
 
-        try {
-            ChannelFuture channelFuture = channel.write(buffer);
-            if (LOGGER.isTraceEnabled()) {
-                channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace(traceLogMsg));
-            }
-        } catch (Exception ex) {
-            LOGGER.warn("Error during channel.write msg={} err={}", traceLogMsg, ex);
-            ReferenceCountUtil.safeRelease(buffer);
+        ChannelFuture channelFuture = channel.write(buffer);
+        if (LOGGER.isTraceEnabled()) {
+            channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace(traceLogMsg));
         }
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -663,10 +663,10 @@ public class PostgresITest extends SQLIntegrationTestCase {
 
             Statement statement = conn.createStatement();
             statement.addBatch("insert into t (x) values (1)");
-            statement.addBatch("insert into t (x) values (2)");
+            statement.addBatch("insert into t (x) values (2), (3)");
 
             int[] results = statement.executeBatch();
-            assertThat(results, is(new int[]{1, 1}));
+            assertThat(results, is(new int[]{1, 2}));
 
             statement.executeUpdate("refresh table t");
             ResultSet resultSet = statement.executeQuery("select * from t order by x");


### PR DESCRIPTION


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
