### PR TITLE
Add an empty pg_catalog.pg_locks table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,9 @@ Changes
 - Added support for the :ref:`END <ref-end>` statement for improved PostgreSQL
   compatibility.
 
+- Added an empty ``pg_catalog.pg_locks`` table for improved PostgreSQL
+  compatibility.
+
 - Registered the scalar function :ref:`array_to_string
   <scalar-array_to_string>` under the `pg_catalog` schema.
 

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -91,6 +91,7 @@ number of replicas.
     | pg_catalog         | pg_enum                 | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_index                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_indexes              | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_locks                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_namespace            | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_proc                 | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_range                | BASE TABLE |             NULL | NULL               |
@@ -119,7 +120,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 52 rows in set (... sec)
+    SELECT 53 rows in set (... sec)
 
 The table also contains additional information such as the specified
 :ref:`routing column <gloss-routing-column>` and :ref:`partition columns

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -167,6 +167,7 @@ following tables:
  - `pg_enum`_
  - `pg_index <pgsql_pg_index_>`__
  - `pg_indexes <pgsql_pg_indexes_>`__
+ - `pg_locks <pgsql_pg_locks_>`__
  - `pg_namespace <pgsql_pg_namespace_>`__
  - `pg_proc <pgsql_pg_proc_>`__
  - `pg_range`_
@@ -552,6 +553,7 @@ CrateDB and we love to hear feedback.
 .. _pgsql_pg_database: https://www.postgresql.org/docs/10/static/catalog-pg-database.html
 .. _pgsql_pg_index: https://www.postgresql.org/docs/10/static/catalog-pg-index.html
 .. _pgsql_pg_indexes: https://www.postgresql.org/docs/current/view-pg-indexes.html
+.. _pgsql_pg_locks: https://www.postgresql.org/docs/current/view-pg-locks.html
 .. _pgsql_pg_namespace: https://www.postgresql.org/docs/10/static/catalog-pg-namespace.html
 .. _pgsql_pg_proc: https://www.postgresql.org/docs/10/static/catalog-pg-proc.html
 .. _pgsql_pg_settings: https://www.postgresql.org/docs/10/view-pg-settings.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -70,7 +70,8 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgRolesTable.IDENT.name(), PgRolesTable.create()),
             Map.entry(PgAmTable.IDENT.name(), PgAmTable.create()),
             Map.entry(PgTablespaceTable.IDENT.name(), PgTablespaceTable.create()),
-            Map.entry(PgIndexesTable.IDENT.name(), PgIndexesTable.create())
+            Map.entry(PgIndexesTable.IDENT.name(), PgIndexesTable.create()),
+            Map.entry(PgLocksTable.IDENT.name(), PgLocksTable.create())
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -151,6 +151,11 @@ public class PgCatalogTableDefinitions {
             PgIndexesTable.create().expressions(),
             false
         ));
+        tableDefinitions.put(PgLocksTable.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgLocksTable.create().expressions(),
+            false
+        ));
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgLocksTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgLocksTable.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.types.DataTypes;
+
+public class PgLocksTable {
+
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_locks");
+
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(IDENT)
+            .add("locktype", DataTypes.STRING, x -> null)
+            .add("database", DataTypes.INTEGER, x -> null)
+            .add("relation", DataTypes.INTEGER, x -> null)
+            .add("page", DataTypes.INTEGER, x -> null)
+            .add("tuple", DataTypes.SHORT, x -> null)
+            .add("virtualxid", DataTypes.STRING, x -> null)
+            .add("transactionid", DataTypes.INTEGER, x -> null)
+            .add("classid", DataTypes.INTEGER, x -> null)
+            .add("objid", DataTypes.STRING, x -> null)
+            .add("objsubid", DataTypes.SHORT, x -> null)
+            .add("virtualtransaction", DataTypes.STRING, x -> null)
+            .add("pid", DataTypes.INTEGER, x -> null)
+            .add("mode", DataTypes.STRING, x -> null)
+            .add("granted", DataTypes.BOOLEAN, x -> null)
+            .add("fastpath", DataTypes.BOOLEAN, x -> null)
+            .add("waitstart", DataTypes.TIMESTAMPZ, x -> null)
+            .build();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -61,7 +61,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(48L, response.rowCount());
+        assertEquals(49L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| character_sets| information_schema| BASE TABLE| NULL\n" +
@@ -85,6 +85,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_enum| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_index| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_indexes| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_locks| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_namespace| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_proc| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_range| pg_catalog| BASE TABLE| NULL\n" +
@@ -193,13 +194,13 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(48L, response.rowCount());
+        assertEquals(49L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(49L, response.rowCount());
+        assertEquals(50L, response.rowCount());
     }
 
     @Test
@@ -531,7 +532,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(867, response.rowCount());
+        assertEquals(883, response.rowCount());
     }
 
     @Test
@@ -783,7 +784,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(51L, response.rows()[0][0]);
+        assertEquals(52L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -450,7 +450,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     public void testAccessesToPgClassEntriesWithRespectToPrivileges() throws Exception {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         execute("select relname from pg_catalog.pg_class order by relname", null, testUserSession());
-        assertThat(response.rowCount(), is(38L));
+        assertThat(response.rowCount(), is(39L));
         assertThat(printedTable(response.rows()), is(
             """
                 character_sets
@@ -468,6 +468,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
                 pg_enum
                 pg_index
                 pg_indexes
+                pg_locks
                 pg_namespace
                 pg_proc
                 pg_range
@@ -581,7 +582,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     public void testAccessesToPgAttributeEntriesWithRespectToPrivileges() throws Exception {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession());
-        assertThat(response.rowCount(), is(435L));
+        assertThat(response.rowCount(), is(451L));
 
         //create a table with an attribute that a new user is not privileged to access
         executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -99,7 +99,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(48L, response.rowCount());
+        assertEquals(49L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/11726


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
