### PR TITLE
Fix handling of queries after suspended fetch with pgwire

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -163,6 +163,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could lead to errors like ``Received resultset tuples,
+  but no field structure for them`` when fetching a subset of rows from one
+  query, and then intermediately triggering a different query before finishing
+  the first query.
+
 - Fixed an issue that could cause clients using the PostgreSQL wire protocol to
   receive row counts in incorrect orders when using APIs that allow to execute
   multiple statements in a batch.

--- a/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
@@ -116,6 +116,7 @@ public class RowConsumerToResultReceiver implements RowConsumer {
     }
 
     public void replaceResultReceiver(ResultReceiver resultReceiver, int maxRows) {
+        assert this.resultReceiver.completionFuture().isDone() : "Previous resultReceiver must be finished";
         this.resultReceiver = resultReceiver;
         this.maxRows = maxRows;
     }

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -128,7 +128,7 @@ public class Messages {
      * block; or 'E' if in a failed transaction block (queries will be
      * rejected until block is ended).
      */
-    static void sendReadyForQuery(Channel channel, TransactionState transactionState) {
+    static ChannelFuture sendReadyForQuery(Channel channel, TransactionState transactionState) {
         ByteBuf buffer = channel.alloc().buffer(6);
         buffer.writeByte('Z');
         buffer.writeInt(5);
@@ -137,6 +137,7 @@ public class Messages {
         if (LOGGER.isTraceEnabled()) {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace("sentReadyForQuery"));
         }
+        return channelFuture;
     }
 
     /**

--- a/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -72,6 +72,7 @@ class ResultSetReceiver extends BaseResultReceiver {
     public void batchFinished() {
         Messages.sendPortalSuspended(channel);
         Messages.sendReadyForQuery(channel, transactionState);
+        super.allFinished(true);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -504,6 +504,38 @@ public class PostgresITest extends SQLIntegrationTestCase {
     }
 
     @Test
+    public void test_query_inbetween_suspended_fetch_operation() throws Exception {
+        try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
+            conn.createStatement().executeUpdate("create table t (x int) with (number_of_replicas = 0)");
+            PreparedStatement preparedStatement = conn.prepareStatement("insert into t (x) values (?)");
+            for (int i = 0; i < 6; i++) {
+                preparedStatement.setInt(1, i);
+                preparedStatement.addBatch();
+            }
+            preparedStatement.executeBatch();
+
+            conn.createStatement().executeUpdate("refresh table t");
+            conn.setAutoCommit(false);
+            try (Statement st = conn.createStatement()) {
+                st.setFetchSize(2);
+                try (ResultSet xResults = st.executeQuery("select x from t")) {
+                    List<Integer> result = new ArrayList<>();
+                    while (xResults.next()) {
+                        if (result.size() == 3) {
+                            var select30Result = conn.createStatement().executeQuery("select 30");
+                            assertThat(select30Result.next(), is(true));
+                            assertThat(select30Result.getInt(1), is(30));
+                        }
+                        result.add(xResults.getInt(1));
+                    }
+                    Collections.sort(result);
+                    assertThat(result, Matchers.contains(0, 1, 2, 3, 4, 5));
+                }
+            }
+        }
+    }
+
+    @Test
     public void testCloseConnectionWithUnfinishedResultSetDoesNotLeaveAnyPendingOperations() throws Exception {
         try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
             conn.setAutoCommit(false);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Queries inbetween another query that uses fetch weren't processed
correctly. Leading to errors like `Received resultset tuples, but no
field structure for them`.

When the client fetches a subset of rows, we suspended the execution but
didn't trigger the `ResultReceiver.completionFuture()`, this caused the
`DelayableWriteChannel` to continue deferring messages and could
potentially also have led to ByteBuf leaks.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
