### PR TITLE
Ensure pg clients receive response messages in order on inserts

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -163,6 +163,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused the ``npgsql`` PostgreSQL client to fail with an
+  ``System.Exception: Received unexpected backend message ParseComplete`` error
+  if using the ``EntityFramework.Core`` framework to insert records.
+
 - Fixed an issue that could lead to errors like ``Received resultset tuples,
   but no field structure for them`` when fetching a subset of rows from one
   query, and then intermediately triggering a different query before finishing

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -464,6 +464,7 @@ public class Session implements AutoCloseable {
                     }
                 }
             );
+            return resultReceiver.completionFuture();
         } else {
             if (!deferredExecutionsByStmt.isEmpty()) {
                 throw new UnsupportedOperationException(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits, especially the last one:

Clients like npgsql who do not wait for a `commandComplete` message
before sending further messages could have received messages out of
order when batching up inserts:

    parse         -> sendParseComplete    -> buffered
    bind          -> sendBindComplete     -> buffered
    describe      -> sendDescribeComplete -> buffered
    execute       -> deferred

    parse         -> sendParseComplete    -> buffered
    bind          -> sendBindComplete     -> buffered
    describe      -> sendDescribeComplete -> buffered
    execute       -> deferred

    sync -> triggers execution
              -> first execution finishes
              -> triggers sendCommandComplete which flushes buffered messages

    client receives:
      sendParseComplete
      sendBindComplete
      sendDescribeComplete
      sendParseComplete
      sendBindComplete
      sendDescribeComplete
      sendCommandComplete  <- this here must arrive before the second parseComplete
      sendCommandComplete

To solve this, inserts now also activate the `DelayableWriteChannel`.
It uses the `CompletionFuture` of the ResultReceiver, this works because
we complete them in the right order within `Session#bulkExec`.

There are a few cases where the `ResultReceiver` future never complete.
For example if we don't trigger the execution at all, because a
subsequent bind fails with an analyzer error. For these cases this now
discards or writes all pending messages on the next sync.

Closes https://github.com/crate/crate/issues/12003

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
