### PR TITLE
Fix flaky testRepeatedFetchDoesNotLeakSysJobsLog

### DIFF
--- a/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
@@ -116,7 +116,10 @@ public class RowConsumerToResultReceiver implements RowConsumer {
     }
 
     public void replaceResultReceiver(ResultReceiver resultReceiver, int maxRows) {
-        assert this.resultReceiver.completionFuture().isDone() : "Previous resultReceiver must be finished";
+        if (!this.resultReceiver.completionFuture().isDone()) {
+            // interrupt previous resultReceiver before replacing it, to ensure future triggers
+            this.resultReceiver.allFinished(true);
+        }
         this.resultReceiver = resultReceiver;
         this.maxRows = maxRows;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

    org.postgresql.util.PSQLException: ERROR: java.lang.AssertionError: Previous resultReceiver must be finished
    	at __randomizedtesting.SeedInfo.seed([CA8B61AE5F09E570:8F064BB0D7D0517D]:0)
    	at app//org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2674)
    	at app//org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2364)
    	at app//org.postgresql.core.v3.QueryExecutorImpl.fetch(QueryExecutorImpl.java:2560)
    	at app//org.postgresql.jdbc.PgResultSet.next(PgResultSet.java:2077)
    	at app//io.crate.integrationtests.PostgresITest.testRepeatedFetchDoesNotLeakSysJobsLog(PostgresITest.java:925)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
