### PR TITLE
mention UTC in current_timestamp() and now() docs

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1027,8 +1027,8 @@ Synopsis::
 ---------------------
 
 The ``CURRENT_TIMESTAMP`` expression returns the timestamp in milliseconds
-since epoch at the time the SQL statement was handled. Therefore, the same
-timestamp value is returned for every invocation of a single statement.
+since midnight UTC at the time the SQL statement was handled. Therefore, the
+same timestamp value is returned for every invocation of a single statement.
 
 Synopsis::
 
@@ -1054,9 +1054,6 @@ Synopsis::
     :ref:`ddl-generated-columns` it behaves slightly different in ``UPDATE``
     operations. In such a case the actual timestamp of each row update is
     returned.
-
-    The return value of expressions ``CURRENT_TIMESTAMP`` and ``CURRENT_TIME``
-    depends on the system clock and the JVM implementation.
 
 
 .. _scalar-curdate:
@@ -1094,7 +1091,7 @@ Synopsis::
 ``now()``
 ---------
 
-Returns the current date and time.
+Returns the current date and time in UTC.
 
 This is the same as ``current_timestamp``
 


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/12064

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
