### PR TITLE
Improve outer join to inner join optimizer rule

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -175,6 +175,14 @@ New Types
 - Added the :ref:`JSON type <data-type-json>`.
 
 
+Performance
+-----------
+
+- Improved optimizer rewrite rules for outer join to inner joins rewrites.
+  Previously using aliases could prevent the rewrite from working.
+
+
+
 Fixes
 =====
 

--- a/server/src/main/java/io/crate/analyze/WhereClause.java
+++ b/server/src/main/java/io/crate/analyze/WhereClause.java
@@ -44,18 +44,23 @@ public class WhereClause {
     public static final WhereClause NO_MATCH = new WhereClause(Literal.BOOLEAN_FALSE);
 
     public static boolean canMatch(Symbol query) {
-        if (query instanceof Input) {
-            Object value = ((Input<?>) query).value();
-            if (value == null) {
-                return false;
-            }
-            if (value instanceof Boolean) {
-                return (Boolean) value;
-            } else {
-                throw new IllegalArgumentException("Expected query value to be of type `Boolean`, but got: " + value);
-            }
+        if (query instanceof Input<?> input) {
+            return canMatch(input);
         }
         return true;
+    }
+
+    public static boolean canMatch(Input<?> input) {
+        Object value = input.value();
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof Boolean bool) {
+            return bool;
+        } else {
+            throw new IllegalArgumentException(
+                "Expected query value to be of type `Boolean`, but got: " + value);
+        }
     }
 
     @Nullable


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

~Discards aliases over literals in the normalizer. This ensures the "can
match with NULL" logic in `RewriteFilterOnOuterJoinToInnerJoin` works.~

Use `SymbolEvaluator` instead of `Normalizer`, otherwise something like `NULL
AS foo` blocks the full normalization and the "query can match" detection
doesn't work.

Closes https://github.com/crate/crate/issues/12067

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
