### PR TITLE
Standardize Admin UI usage in docs

### DIFF
--- a/.github/styles/CrateDB/Terminology.yml
+++ b/.github/styles/CrateDB/Terminology.yml
@@ -3,6 +3,10 @@ message: Prefer '%s' over '%s'
 ignorecase: false
 level: warning
 swap:
+  AdminUI: Admin UI
+  admin UI: Admin UI
+  admin-ui: Admin UI
+  Admin-UI: Admin UI
   sql: SQL
   postgres: PostgreSQL
   Postgres: PostgreSQL

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Screenshots
 CrateDB provides an `Admin UI`_:
 
 .. image:: crate-admin.gif
-    :alt: Screenshots of the CrateDB admin UI
+    :alt: Screenshots of the CrateDB Admin UI
 
 
 Try CrateDB
@@ -84,7 +84,7 @@ Visit the `installation documentation`_ to see all the available download and
 install options.
 
 Once you're up and running, head over to the `introductory docs`_. To interact
-with CrateDB, you can use the Admin UI `web console`_ or the `CrateDB shell`_
+with CrateDB, you can use the Admin UI `sql console`_ or the `CrateDB shell`_
 CLI tool. Alternatively, review the list of recommended `clients and tools`_
 that work with CrateDB.
 
@@ -151,4 +151,4 @@ Looking for more help?
 .. _standard SQL: https://crate.io/docs/crate/reference/en/latest/sql/index.html
 .. _support channels: https://crate.io/support/
 .. _time-series data: https://crate.io/docs/crate/tutorials/en/latest/normalize-intervals.html
-.. _web console: https://crate.io/docs/crate/admin-ui/en/latest/console.html#sql-console
+.. _sql console: https://crate.io/docs/crate/admin-ui/en/latest/console.html#sql-console

--- a/docs/admin/auth/hba.rst
+++ b/docs/admin/auth/hba.rst
@@ -178,7 +178,7 @@ Authenticating to Admin UI
     cr> CREATE USER admin;
     CREATE OK, 1 row affected (... sec)
 
-When trying to access the CrateDB admin UI, authentication with the user
+When trying to access the CrateDB Admin UI, authentication with the user
 defined with the :ref:`auth.trust.http_default_user
 <auth_trust_http_default_user>` setting (defaults to ``crate``) will be
 attempted initially. If this authentication attempt fails, the browser will
@@ -186,7 +186,7 @@ open the standard popup window where the user is asked to fill in credentials.
 Depending on the HBA configuration, it may be necessary to a username and
 password, or, alternatively, a username only.
 
-Users that log in to the admin UI must be granted `DQL`` privileges at the
+Users that log in to the Admin UI must be granted `DQL`` privileges at the
 ``CLUSTER`` level in order to be able to access the various monitoring
 sections. For example::
 

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -789,7 +789,7 @@ Acknowledge failed checks
 -------------------------
 
 It is possible to acknowledge every check by updating the ``acknowledged``
-column. By doing this, specially CrateDB's built-in Admin-UI won't complain
+column. By doing this, specially CrateDB's built-in Admin UI won't complain
 anymore about failing checks.
 
 Imagine we've added a new node to our cluster, but as the
@@ -799,7 +799,7 @@ setting will not pass on the already running nodes until the config-file or
 command-line argument on these nodes is updated and the nodes are restarted
 (which is not what we want on a healthy well running cluster).
 
-In order to make the Admin-UI accept a failing check (so the checks label goes
+In order to make the Admin UI accept a failing check (so the checks label goes
 green again), we must acknowledge this check by updating it's ``acknowledged``
 flag::
 

--- a/docs/appendices/release-notes/1.0.0.rst
+++ b/docs/appendices/release-notes/1.0.0.rst
@@ -114,7 +114,7 @@ Changes
 
   - Fixed an issue that caused incorrect URL paths if the project gets built.
 
-    Implemented new layout for the admin-ui.
+    Implemented new layout for the Admin UI.
 
   - Local development: do not store ``base_uri`` permanently in localStorage
     but keep it in URL.

--- a/docs/appendices/release-notes/1.0.1.rst
+++ b/docs/appendices/release-notes/1.0.1.rst
@@ -49,7 +49,7 @@ Changes
    - Lowered opacity of placeholder query in the console.
 
    - Fix intercom support that disappeared during the implementation of the new
-     admin-ui layout.
+     Admin UI layout.
 
    - Fix Radio button position in load overview.
 

--- a/docs/appendices/release-notes/1.0.2.rst
+++ b/docs/appendices/release-notes/1.0.2.rst
@@ -46,7 +46,7 @@ Changes
 - Updated crate-admin to 1.0.3 which includes the following change:
 
   - Added compatibility with future CrateDB versions which will serve the
-    admin-ui from ``/admin/`` instead of ``/_plugins/crate-admin/``.
+    Admin UI from ``/admin/`` instead of ``/_plugins/crate-admin/``.
 
 
 Fixes

--- a/docs/appendices/release-notes/1.0.4.rst
+++ b/docs/appendices/release-notes/1.0.4.rst
@@ -44,7 +44,7 @@ Changes
     - Fixed a console results issue that caused the results table not to be
       displayed after horizontal scrolling.
 
-    - Fixed an issue that caused the admin-ui to load only one plugin.
+    - Fixed an issue that caused the Admin UI to load only one plugin.
 
     - Display warning in the console view when the query result contains an
       unsafe integer.

--- a/docs/appendices/release-notes/1.1.0.rst
+++ b/docs/appendices/release-notes/1.1.0.rst
@@ -45,7 +45,7 @@ Breaking Changes
 Changes
 -------
 
- - Serve admin UI from ``/``. Previously used URIs will direct to ``/``.
+ - Serve Admin UI from ``/``. Previously used URIs will direct to ``/``.
 
  - Added the subscript function support for object literals.
 
@@ -97,7 +97,7 @@ Changes
 
  - Upgraded the parser from ANTLR3 to ANTLR4.
 
- - Added monitoring plugin for the Enterprise edition in the admin UI.
+ - Added monitoring plugin for the Enterprise edition in the Admin UI.
 
  - Added Lazy loading of the stylesheet and plugins depending on the Enterprise
    settings.
@@ -150,7 +150,7 @@ Fixes
  - Fixed a console results issue that caused the results table not to be
    displayed after horizontal scrolling.
 
- - Fixed an issue that caused the admin UI to load only one plugin.
+ - Fixed an issue that caused the Admin UI to load only one plugin.
 
  - Display warning in the console view when the query result contains an unsafe
    integer.

--- a/docs/appendices/release-notes/1.1.1.rst
+++ b/docs/appendices/release-notes/1.1.1.rst
@@ -34,7 +34,7 @@ Changelog
 Changes
 -------
 
- - Querying the admin UI from ``/_plugin/crate-admin/`` will now redirect to
+ - Querying the Admin UI from ``/_plugin/crate-admin/`` will now redirect to
    ``/``.
 
  - Added possible data type conversion to a timestamp array. e.g.
@@ -52,7 +52,7 @@ Changes
 
  - Display notification warning only when a new CrateDB version is released.
 
- - Added ``lineWrapping`` option to console editor in the admin UI.
+ - Added ``lineWrapping`` option to console editor in the Admin UI.
 
 
 Fixes

--- a/docs/appendices/release-notes/2.0.0.rst
+++ b/docs/appendices/release-notes/2.0.0.rst
@@ -190,7 +190,7 @@ Changes
  - Implemented hash sum :ref:`scalar functions <scalar-functions>` (MD5, SHA1).
    Please see :ref:`sha1 <scalar-sha1>`.
 
- - Various admin UI improvements.
+ - Various Admin UI improvements.
 
  - Added support for ``GROUP BY`` on joins.
 

--- a/docs/appendices/release-notes/2.2.3.rst
+++ b/docs/appendices/release-notes/2.2.3.rst
@@ -35,7 +35,7 @@ Changelog
 Fixes
 -----
 
-- The download URL, in the notifications section of the admin UI, now links to
+- The download URL, in the notifications section of the Admin UI, now links to
   the stable CrateDB version.
 
 - Replica shards in the ``UNASSIGNED`` row of the *Shards* view of the Admin UI

--- a/docs/appendices/release-notes/2.3.3.rst
+++ b/docs/appendices/release-notes/2.3.3.rst
@@ -44,7 +44,7 @@ Fixes
   node start that could cause other custom meta data (such as users) to
   disappear from cluster state.
 
-- Fixed an Admin-UI issue that caused the translation strings to not be loaded
+- Fixed an Admin UI issue that caused the translation strings to not be loaded
   correctly.
 
 - Fixed an issue that only occurred in Enterprise Edition, when privileges are

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -283,7 +283,7 @@ Altered Settings
   data.
 
   Data paths that are incompatible with 3.0.0 will be indicated visually in the
-  `admin UI`_ if you are running the latest 2.2.x or 2.3.x release.
+  `Admin UI`_ if you are running the latest 2.2.x or 2.3.x release.
 
 
 Other Changes
@@ -312,7 +312,7 @@ Other Changes
   ``sys.nodes`` table.
 
 
-.. _admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
+.. _Admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
 .. _backup: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _full cluster restart: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
 .. _HTTP Authorization header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization

--- a/docs/appendices/release-notes/3.0.1.rst
+++ b/docs/appendices/release-notes/3.0.1.rst
@@ -52,7 +52,7 @@ Fixes
 -----
 
 - Fixed an issue that caused the CrateDB process CPU calculation in the
-  Admin-UI to be false.
+  Admin UI to be false.
 
 - Fixed the default log file name to ``crate.log`` if no cluster name was
   explicitly specified in the settings.

--- a/docs/appendices/release-notes/4.0.2.rst
+++ b/docs/appendices/release-notes/4.0.2.rst
@@ -44,7 +44,7 @@ See the :ref:`version_4.0.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue in the admin UI that prevented partitions from showing up in
+- Fixed an issue in the Admin UI that prevented partitions from showing up in
   the table detail view.
 
 - Fixed an issue in the version handling that would prevent rolling upgrades to

--- a/docs/appendices/release-notes/4.0.3.rst
+++ b/docs/appendices/release-notes/4.0.3.rst
@@ -59,7 +59,7 @@ Fixes
 
 - Fixed an issue with the version payload returned by HTTP, which resulted in
   falsely displaying CrateDB's version as a ``-SNAPSHOT`` version at the
-  AdminUI.
+  Admin UI.
 
 - Fixed parsing of timestamps with a time zone offset of ``+0000``.
 

--- a/docs/appendices/release-notes/4.0.5.rst
+++ b/docs/appendices/release-notes/4.0.5.rst
@@ -50,9 +50,9 @@ See the :ref:`version_4.0.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Improved the help section of the admin-ui including the Spanish translations.
+- Improved the help section of the Admin UI including the Spanish translations.
 
-- Fixed an issue in the admin-ui to no longer display all columns as being
+- Fixed an issue in the Admin UI to no longer display all columns as being
   generated columns in the table/column view section.
 
 - Fixed an issue introduced in CrateDB 4.0 resulting in dysfunctional

--- a/docs/appendices/release-notes/4.3.2.rst
+++ b/docs/appendices/release-notes/4.3.2.rst
@@ -51,7 +51,7 @@ Fixes
   ``regexp_matches()`` wrapped inside a :ref:`subscript expression
   <sql-subscripts>` from being used as a ``GROUP BY`` expression.
 
-  This fixed the broken AdminUI -> Monitoring tab as it uses such a statement.
+  This fixed the broken Admin UI -> Monitoring tab as it uses such a statement.
 
 - Fixed validation of ``GROUP BY`` :ref:`expressions <gloss-expression>` if an
   alias is used. The validation was by passed and resulted in an execution

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -14,7 +14,7 @@ CrateDB has two primary client interfaces:
 
 .. SEEALSO::
 
-   `Connecting to CrateDB`_ — Includes an introduction to the web admin UI, the
+   `Connecting to CrateDB`_ — Includes an introduction to the web Admin UI, the
    CrateDB shell, and the CrateDB HTTP endpoint
 
    `Client Libraries`_ — Officially supported clients and community supported


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- plus update vale suggestions
- ~example undetected vale edge cases~ (commit dropped as this should not need to be merged)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
