### PR TITLE
Don't dispatch to different thread in TcpTransport.doStop

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/network/CloseableChannel.java
+++ b/server/src/main/java/org/elasticsearch/common/network/CloseableChannel.java
@@ -19,18 +19,19 @@
 
 package org.elasticsearch.common.network;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 
 import io.crate.common.io.IOUtils;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 public interface CloseableChannel extends Closeable {
 
@@ -85,7 +86,7 @@ public interface CloseableChannel extends Closeable {
      * @param channels to close
      * @param blocking indicates if we should block on channel close
      */
-    static <C extends CloseableChannel> void closeChannels(List<C> channels, boolean blocking) {
+    static <C extends CloseableChannel> void closeChannels(Collection<C> channels, boolean blocking) {
         try {
             IOUtils.close(channels);
         } catch (IOException e) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It used a latch to block the caller thread anyway - we can run the logic
directly without additional dispatching.

Spotted this while investigating connection errors in the logs after
node teardown in tests.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
