### PR TITLE
Fix syncGlobalCheckpointAfterOperation flag in TransportWriteAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -73,7 +73,7 @@ public abstract class TransportWriteAction<
             reader,
             replicaReader,
             executor,
-            false,
+            true,
             forceExecutionOnPrimary);
     }
 


### PR DESCRIPTION
This corrects the syncGlobalCheckpointAfterOperation flag to true in
TransportWriteAction. This was caused by mistake in the backport
https://github.com/crate/crate/commit/206ee29e167c3cb01695af77b1207d086177e871.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
