### PR TITLE
update note about default analyzer for the FULLTEXT index

### DIFF
--- a/docs/general/ddl/fulltext-indices.rst
+++ b/docs/general/ddl/fulltext-indices.rst
@@ -101,7 +101,7 @@ may not work anymore.  See :ref:`builtin-analyzer` for details about available
 builtin analyzer or :ref:`sql-ddl-custom-analyzer`.
 
 If no analyzer is specified when using a fulltext index, the
-:ref:`plain <plain-analyzer>` analyzer is used::
+:ref:`standard <standard-analyzer>` analyzer is used::
 
     cr> create table table_c (
     ...   first_column text INDEX using fulltext


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/9527/

Default analyzer for INDEX USING FULLTEXT is standard.

```
create table t1 (
    text_field TEXT,
    fulltext_text_field TEXT INDEX USING FULLTEXT,
    obj OBJECT(DYNAMIC) AS (
      date TEXT INDEX USING FULLTEXT
    )
);
```

```
show create table t1;
CREATE TABLE IF NOT EXISTS "doc"."t1" (                   |
|    "text_field" TEXT,                                     |
|    "fulltext_text_field" TEXT INDEX USING FULLTEXT WITH ( |
|       analyzer = 'standard'                               | // Not plain
|    ),                                                     |
|    "obj" OBJECT(DYNAMIC) AS (                             |
|       "date" TEXT INDEX USING FULLTEXT WITH (             |
|          analyzer = 'standard'                            | // For Object dynamic field also standard is default
|       )                                                   |
|    )                                                      |
| )
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
