### PR TITLE
Implement DROP SUBSCRIPTION in 3 requests

### DIFF
--- a/.github/styles/Vocab/CrateDB/accept.txt
+++ b/.github/styles/Vocab/CrateDB/accept.txt
@@ -16,6 +16,7 @@ cgroups
 charset
 cleartext
 concat
+conninfo
 deallocate
 Deallocate
 deallocating

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -124,7 +124,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 56 rows in set (... sec)
+    SELECT 57 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -129,7 +129,7 @@ class AlterTableAnalyzer {
             relationName = schemas.resolveRelation(table.getName(), txnCtx.sessionContext().searchPath());
         }
 
-        DocTableInfo tableInfo = schemas.getTableInfo(relationName, Operation.ALTER_OPEN_CLOSE);
+        DocTableInfo tableInfo = schemas.getTableInfo(relationName, node.openTable() ? Operation.ALTER_OPEN : Operation.ALTER_CLOSE);
         return new AnalyzedAlterTableOpenClose(tableInfo, table, node.openTable());
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -144,7 +144,7 @@ public class AlterTableOperation {
         return session;
     }
 
-    public CompletableFuture<Long> executeAlterTableOpenClose(DocTableInfo tableInfo,
+    public CompletableFuture<Long> executeAlterTableOpenClose(List<RelationName> tables,
                                                               boolean openTable,
                                                               @Nullable PartitionName partitionName) {
         String partitionIndexName = null;
@@ -153,12 +153,11 @@ public class AlterTableOperation {
         }
         FutureActionListener<AcknowledgedResponse, Long> listener = new FutureActionListener<>(r -> -1L);
         if (openTable || clusterService.state().getNodes().getMinNodeVersion().before(Version.V_4_3_0)) {
-            OpenCloseTableOrPartitionRequest request = new OpenCloseTableOrPartitionRequest(
-                tableInfo.ident(), partitionIndexName, openTable);
+            OpenCloseTableOrPartitionRequest request = new OpenCloseTableOrPartitionRequest(tables, partitionIndexName, openTable);
             transportOpenCloseTableOrPartitionAction.execute(request, listener);
         } else {
             transportCloseTable.execute(
-                new CloseTableRequest(tableInfo.ident(), partitionIndexName),
+                new CloseTableRequest(tables, partitionIndexName),
                 listener
             );
         }

--- a/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
@@ -23,40 +23,61 @@
 package io.crate.execution.ddl.tables;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.metadata.RelationName;
 
-public final class CloseTableRequest extends AcknowledgedRequest<CloseTableRequest> {
+public class CloseTableRequest extends AcknowledgedRequest<CloseTableRequest> {
 
-    private final RelationName table;
+    private final List<RelationName> tables;
     private final String partition;
 
-    public CloseTableRequest(RelationName table, @Nullable String partition) {
-        this.table = table;
+    public CloseTableRequest(List<RelationName> tables, @Nullable String partition) {
+        this.tables = tables;
         this.partition = partition;
     }
 
     public CloseTableRequest(StreamInput in) throws IOException {
         super(in);
-        this.table = new RelationName(in);
-        this.partition = in.readOptionalString();
+        if (in.getVersion().before(Version.fromString("4.8.0"))) {
+            tables = List.of(new RelationName(in));
+        } else {
+            int count = in.readVInt();
+            tables = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                tables.add(new RelationName(in));
+            }
+        }
+        partition = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        table.writeTo(out);
+        if (out.getVersion().before(Version.fromString("4.8.0"))) {
+            // Before 4.8.0 request was used only for closing table with non-null RelationName field.
+            // In this branch it's guaranteed that we are not passing empty list
+            assert tables.isEmpty() == false : "CloseTableRequest must have at least one table";
+            tables.get(0).writeTo(out);
+        } else {
+            out.writeVInt(tables.size());
+            for (int i = 0; i < tables.size(); i++) {
+                tables.get(i).writeTo(out);
+            }
+        }
         out.writeOptionalString(partition);
     }
 
-    public RelationName table() {
-        return table;
+    public List<RelationName> tables() {
+        return tables;
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/execution/ddl/tables/OpenCloseTableOrPartitionRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/OpenCloseTableOrPartitionRequest.java
@@ -22,29 +22,28 @@
 package io.crate.execution.ddl.tables;
 
 import io.crate.metadata.RelationName;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCloseTableOrPartitionRequest> {
 
-    private final RelationName relationName;
+    private final List<RelationName> tables;
     @Nullable
     private final String partitionIndexName;
     private final boolean openTable;
 
-    public OpenCloseTableOrPartitionRequest(RelationName relationName, @Nullable String partitionIndexName, boolean openTable) {
-        this.relationName = relationName;
+    public OpenCloseTableOrPartitionRequest(List<RelationName> tables, @Nullable String partitionIndexName, boolean openTable) {
+        this.tables = tables;
         this.partitionIndexName = partitionIndexName;
         this.openTable = openTable;
-    }
-
-    public RelationName tableIdent() {
-        return relationName;
     }
 
     @Nullable
@@ -58,7 +57,15 @@ public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCl
 
     public OpenCloseTableOrPartitionRequest(StreamInput in) throws IOException {
         super(in);
-        relationName = new RelationName(in);
+        if (in.getVersion().before(Version.fromString("4.8.0"))) {
+            tables = List.of(new RelationName(in));
+        } else {
+            int count = in.readVInt();
+            tables = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                tables.add(new RelationName(in));
+            }
+        }
         partitionIndexName = in.readOptionalString();
         openTable = in.readBoolean();
     }
@@ -66,8 +73,22 @@ public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCl
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        relationName.writeTo(out);
+        if (out.getVersion().before(Version.fromString("4.8.0"))) {
+            // Before 4.8.0 request was used only for closing table with non-null RelationName field.
+            // In this branch it's guaranteed that we are not passing empty list
+            assert tables.isEmpty() == false : "CloseTableRequest must have at least one table";
+            tables.get(0).writeTo(out);
+        } else {
+            out.writeVInt(tables.size());
+            for (int i = 0; i < tables.size(); i++) {
+                tables.get(i).writeTo(out);
+            }
+        }
         out.writeOptionalString(partitionIndexName);
         out.writeBoolean(openTable);
+    }
+
+    public List<RelationName> tables() {
+        return tables;
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -41,6 +41,9 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import static io.crate.execution.ddl.tables.TransportCloseTable.getIndices;
+
+
 @Singleton
 public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTransportAction<OpenCloseTableOrPartitionRequest, AcknowledgedResponse> {
 
@@ -86,6 +89,6 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
     @Override
     protected ClusterBlockException checkBlock(OpenCloseTableOrPartitionRequest request, ClusterState state) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.tableIdent().indexNameOrAlias()));
+            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, getIndices(request.tables(), request.partitionIndexName())));
     }
 }

--- a/server/src/main/java/io/crate/metadata/table/Operation.java
+++ b/server/src/main/java/io/crate/metadata/table/Operation.java
@@ -42,7 +42,8 @@ public enum Operation {
     DROP("DROP"),
     ALTER("ALTER"),
     ALTER_BLOCKS("ALTER"),
-    ALTER_OPEN_CLOSE("ALTER OPEN/CLOSE"),
+    ALTER_OPEN("ALTER OPEN"),
+    ALTER_CLOSE("ALTER CLOSE"),
     ALTER_TABLE_RENAME("ALTER RENAME"),
     ALTER_REROUTE("ALTER REROUTE"),
     REFRESH("REFRESH"),
@@ -55,16 +56,16 @@ public enum Operation {
     public static final EnumSet<Operation> ALL = EnumSet.allOf(Operation.class);
     public static final EnumSet<Operation> SYS_READ_ONLY = EnumSet.of(READ);
     public static final EnumSet<Operation> READ_ONLY = EnumSet.of(READ, ALTER_BLOCKS);
-    public static final EnumSet<Operation> CLOSED_OPERATIONS = EnumSet.of(ALTER_OPEN_CLOSE, ALTER_TABLE_RENAME);
+    public static final EnumSet<Operation> CLOSED_OPERATIONS = EnumSet.of(ALTER_OPEN, ALTER_CLOSE, ALTER_TABLE_RENAME);
     public static final EnumSet<Operation> BLOB_OPERATIONS = EnumSet.of(READ, OPTIMIZE, ALTER, ALTER_REROUTE, DROP);
     public static final EnumSet<Operation> READ_DISABLED_OPERATIONS = EnumSet.of(UPDATE, INSERT, DELETE, DROP, ALTER,
-        ALTER_OPEN_CLOSE, ALTER_REROUTE, ALTER_BLOCKS, REFRESH, OPTIMIZE);
-    public static final EnumSet<Operation> WRITE_DISABLED_OPERATIONS = EnumSet.of(READ, ALTER, ALTER_OPEN_CLOSE,
+        ALTER_OPEN, ALTER_CLOSE, ALTER_REROUTE, ALTER_BLOCKS, REFRESH, OPTIMIZE);
+    public static final EnumSet<Operation> WRITE_DISABLED_OPERATIONS = EnumSet.of(READ, ALTER, ALTER_OPEN, ALTER_CLOSE,
         ALTER_BLOCKS, ALTER_REROUTE, SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO, CREATE_SNAPSHOT);
     public static final EnumSet<Operation> METADATA_DISABLED_OPERATIONS = EnumSet.of(READ, UPDATE, INSERT, DELETE,
-        ALTER_BLOCKS, ALTER_OPEN_CLOSE, ALTER_REROUTE, REFRESH, SHOW_CREATE, OPTIMIZE);
+        ALTER_BLOCKS, ALTER_OPEN, ALTER_CLOSE, ALTER_REROUTE, REFRESH, SHOW_CREATE, OPTIMIZE);
     public static final EnumSet<Operation> LOGICAL_REPLICATED = EnumSet.of(
-        READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE);
+        READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE, ALTER_OPEN);
 
     private final String representation;
 

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
@@ -37,6 +37,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Table;
 
+import java.util.List;
 import java.util.function.Function;
 
 public class AlterTableOpenClosePlan implements Plan {
@@ -74,7 +75,7 @@ public class AlterTableOpenClosePlan implements Plan {
         }
 
         dependencies.alterTableOperation()
-            .executeAlterTableOpenClose(tableInfo, analyzedAlterTable.isOpenTable(), partitionName)
+            .executeAlterTableOpenClose(List.of(tableInfo.ident()), analyzedAlterTable.isOpenTable(), partitionName)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/plan/DropSubscriptionPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/DropSubscriptionPlan.java
@@ -21,16 +21,30 @@
 
 package io.crate.replication.logical.plan;
 
+import io.crate.action.FutureActionListener;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
+import io.crate.execution.engine.collect.sources.InformationSchemaIterables;
+import io.crate.execution.support.ChainableAction;
+import io.crate.execution.support.ChainableActions;
 import io.crate.execution.support.OneRowActionListener;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.replication.logical.action.DropSubscriptionRequest;
 import io.crate.replication.logical.analyze.AnalyzedDropSubscription;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
 
 public class DropSubscriptionPlan implements Plan {
 
@@ -51,8 +65,63 @@ public class DropSubscriptionPlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
-        var request = new DropSubscriptionRequest(analyzedDropSubscription.name(), analyzedDropSubscription.ifExists());
-        dependencies.dropSubscriptionAction()
-            .execute(request, new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : 1L)));
+
+        List<RelationName> tables = InformationSchemaIterables.tablesStream(dependencies.schemas())
+            .filter(t -> t instanceof DocTableInfo)
+            .filter(t -> analyzedDropSubscription.name().equals(REPLICATION_SUBSCRIPTION_NAME.get(t.parameters())))
+            .map(t -> t.ident())
+            .collect(Collectors.toList());
+
+        final List<ChainableAction<Long>> actions = new ArrayList<>();
+
+        // Step 1 - Close subscribed tables and consequently stop tracking and remove retention lease.
+        actions.add(new ChainableAction<>(
+            () -> dependencies.alterTableOperation()
+                .executeAlterTableOpenClose(tables, false, null)
+                .exceptionally(error -> {
+                    throw new IllegalStateException(
+                        "Couldn't close subscribed tables, please retry DROP SUBSCRIPTION command."
+                            + error.getMessage(), error
+                    );
+                }),
+            () -> CompletableFuture.completedFuture(-1L)
+        ));
+
+        // Step 2
+        // Drop setting and subscription
+        actions.add(new ChainableAction<>(
+            () -> {
+                FutureActionListener<AcknowledgedResponse, Long> listener = new FutureActionListener<>(r -> 1L);
+                var request = new DropSubscriptionRequest(analyzedDropSubscription.name(), analyzedDropSubscription.ifExists());
+                dependencies.dropSubscriptionAction().execute(request, listener);
+                return listener.exceptionally(error -> {
+                    throw new IllegalStateException(
+                        "Couldn't update metadata, please retry DROP SUBSCRIPTION command."
+                            + error.getMessage(), error
+                    );
+                });
+            },
+            () -> CompletableFuture.completedFuture(-1L)
+        ));
+
+        // Step 3
+        // Reopen table to update table engine to normal (Operation will be reset back to ALL)
+        actions.add(new ChainableAction<>(
+            () -> dependencies.alterTableOperation()
+                .executeAlterTableOpenClose(tables, true, null)
+                .exceptionally(error -> {
+                    String tablesHint = "all subscribed tables. ";
+                    if (tables.size() < 5) {
+                        tablesHint = "tables (" + tables.stream().map(relationName -> relationName.name()).collect(Collectors.joining(",")) + "). ";
+                    }
+                    throw new IllegalStateException(
+                        "Couldn't reopen tables, please run command ALTER TABLE OPEN for " + tablesHint
+                            + error.getMessage(), error
+                    );
+                }),
+            () -> CompletableFuture.completedFuture(-1L)
+        ));
+
+        ChainableActions.run(actions).whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
@@ -42,7 +42,7 @@ public class AlterTableOpenCloseAnalyzerTest extends CrateDummyClusterServiceUni
     public void testCloseSystemTableIsNotAllowed() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow " +
-                                        "ALTER OPEN/CLOSE operations, as it is read-only.");
+                                        "ALTER CLOSE operations, as it is read-only.");
         e.analyze("alter table sys.shards close");
     }
 

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -267,7 +267,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAlterBlobTableOpenClose() {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow ALTER OPEN/CLOSE operations.");
+        expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow ALTER CLOSE operations.");
         e.analyze("alter blob table blobs close");
     }
 

--- a/server/src/test/java/io/crate/metadata/table/OperationTest.java
+++ b/server/src/test/java/io/crate/metadata/table/OperationTest.java
@@ -29,7 +29,8 @@ import org.junit.Test;
 import static io.crate.metadata.table.Operation.ALL;
 import static io.crate.metadata.table.Operation.ALTER;
 import static io.crate.metadata.table.Operation.ALTER_BLOCKS;
-import static io.crate.metadata.table.Operation.ALTER_OPEN_CLOSE;
+import static io.crate.metadata.table.Operation.ALTER_CLOSE;
+import static io.crate.metadata.table.Operation.ALTER_OPEN;
 import static io.crate.metadata.table.Operation.ALTER_REROUTE;
 import static io.crate.metadata.table.Operation.COPY_TO;
 import static io.crate.metadata.table.Operation.CREATE_SNAPSHOT;
@@ -62,18 +63,18 @@ public class OperationTest extends ESTestCase {
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_READ, true).build(), IndexMetadata.State.OPEN),
             containsInAnyOrder(UPDATE, INSERT, DELETE, DROP, ALTER,
-                               ALTER_OPEN_CLOSE, ALTER_BLOCKS, REFRESH, OPTIMIZE, ALTER_REROUTE));
+                ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS, REFRESH, OPTIMIZE, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), IndexMetadata.State.OPEN),
-            containsInAnyOrder(READ, ALTER, ALTER_OPEN_CLOSE, ALTER_BLOCKS,
+            containsInAnyOrder(READ, ALTER, ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS,
                                SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO,
                                CREATE_SNAPSHOT, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN),
             containsInAnyOrder(READ, UPDATE, INSERT, DELETE, ALTER_BLOCKS,
-                               ALTER_OPEN_CLOSE, REFRESH, SHOW_CREATE, OPTIMIZE, ALTER_REROUTE));
+                ALTER_OPEN, ALTER_CLOSE, REFRESH, SHOW_CREATE, OPTIMIZE, ALTER_REROUTE));
     }
 
     @Test
@@ -81,19 +82,19 @@ public class OperationTest extends ESTestCase {
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_READ, true)
                 .put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), IndexMetadata.State.OPEN),
-            containsInAnyOrder(ALTER, ALTER_OPEN_CLOSE, ALTER_BLOCKS, REFRESH,
+            containsInAnyOrder(ALTER, ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS, REFRESH,
                 OPTIMIZE, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_WRITE, true)
                 .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN),
-            containsInAnyOrder(READ, ALTER_OPEN_CLOSE, ALTER_BLOCKS, REFRESH,
+            containsInAnyOrder(READ, ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS, REFRESH,
                                SHOW_CREATE, OPTIMIZE, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_READ, true)
                 .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN),
-            containsInAnyOrder(INSERT, UPDATE, DELETE, ALTER_OPEN_CLOSE,
+            containsInAnyOrder(INSERT, UPDATE, DELETE, ALTER_OPEN, ALTER_CLOSE,
                 ALTER_BLOCKS, REFRESH, OPTIMIZE, ALTER_REROUTE));
     }
 
@@ -104,7 +105,7 @@ public class OperationTest extends ESTestCase {
             .build();
         assertThat(
             Operation.buildFromIndexSettingsAndState(replicatedIndexSettings, IndexMetadata.State.OPEN),
-            containsInAnyOrder(READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE)
+            containsInAnyOrder(READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE, ALTER_OPEN)
         );
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/11897#issuecomment-968953154

Replacement of https://github.com/crate/crate/pull/11937

- [x] stop tracking of remote shards (by CLOSE TABLE)
- [x] remove retention leases on the remote cluster for each table/index (by CLOSE TABLE)
- [x] remove the REPLICATION_SUBSCRIPTION_NAME index setting to turn the tables into normal tables
- [x] update doc info for all subscription tables to make them normal after DROP SUBSCRIPTION (by OPEN TABLE)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
