### PR TITLE
Fix formatting of scalar subqueries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that led to an ``Invalid query used in CREATE VIEW`` error if
+  using a scalar subquery within the query part of a ``CREATE VIEW`` statement.
+
 - Fixed an issue that caused a failure when a window function over a partition
   is not used in an upper query. For example:
   ``select x from (select x, ROW_NUMBER() OVER (PARTITION BY y) from t) t1``

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -121,7 +121,9 @@ public final class ExpressionFormatter {
                                                                           @Nullable List<Expression> parameters,
                                                                           T formatter) {
         String formattedExpression = expression.accept(formatter, parameters);
-        if (formattedExpression.startsWith("(") && formattedExpression.endsWith(")")) {
+        if (formattedExpression.startsWith("(")
+                && formattedExpression.endsWith(")")
+                && !(expression instanceof SubqueryExpression)) {
             return formattedExpression.substring(1, formattedExpression.length() - 1);
         } else {
             return formattedExpression;
@@ -162,20 +164,20 @@ public final class ExpressionFormatter {
         public String visitArrayComparisonExpression(ArrayComparisonExpression node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
 
-            String array = node.getRight().toString();
-            String left = node.getLeft().toString();
+            String array = node.getRight().accept(this, parameters);
+            String left = node.getLeft().accept(this, parameters);
             String type = node.getType().getValue();
 
-            builder.append(left + " " + type + " ANY(" + array + ")");
+            builder.append("(" + left + " " + type + " ANY(" + array + "))");
             return builder.toString();
         }
 
         @Override
         protected String visitArraySubQueryExpression(ArraySubQueryExpression node, @Nullable List<Expression> parameters) {
             StringBuilder builder = new StringBuilder();
-            String subqueryExpression = node.subqueryExpression().toString();
-
-            return builder.append("ARRAY(").append(subqueryExpression).append(")").toString();
+            String subqueryExpression = node.subqueryExpression().accept(this, parameters);
+            assert subqueryExpression.startsWith("(") : "subqueryExpression must be enclosed in parenthesis";
+            return builder.append("ARRAY").append(subqueryExpression).append("").toString();
         }
 
         @Override

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1747,6 +1747,12 @@ public class TestStatementBuilder {
         printStatement("RESTORE SNAPSHOT repo1.snap1 TABLES, PRIVILEGES");
     }
 
+    @Test
+    public void test_scalar_subquery_in_selectlist() {
+        printStatement("SELECT (SELECT 1)");
+        printStatement("SELECT (SELECT 1) = ANY([5])");
+    }
+
     private static void printStatement(String sql) {
         println(sql.trim());
         println("");

--- a/server/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
@@ -125,4 +125,15 @@ public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         expectedException.expect(UnsupportedOperationException.class);
         e.analyze("create view blob.v1 as select 1");
     }
+
+    @Test
+    public void test_create_view_with_any_select() {
+        CreateViewStmt stmt = e.analyze(
+            "CREATE OR REPLACE VIEW subselect_view_any AS SELECT (SELECT 1) = ANY([5])");
+        assertThat(
+            stmt.analyzedQuery().outputs(), contains(
+                isSQL("((SELECT 1 FROM (empty_row)) = ANY([5]))")
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `SqlFormatter` / `ExpressionFormatter` stripped away the parenthesis
in `SELECT (SELECT 1)` leading to `SELECT SELECT 1`

Fixes https://github.com/crate/crate/issues/12125


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
