### PR TITLE
Prevent object creation with invalid key values

### DIFF
--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -295,7 +295,7 @@ public class CastFunctionTest extends ScalarTestCase {
     }
 
     @Test
-    public void test_can_cast_to_object_with_invalid_key_names() throws Exception {
+    public void test_prevent_cast_to_object_with_invalid_key_names() throws Exception {
         assertThrowsMatches(() -> assertEvaluate("('{\"(\": 10}'::json)::object", null),
                             ConversionException.class,
                             "Cannot cast object element `(` with value `10` to type `object`");


### PR DESCRIPTION
Having `(`, `)`, `:`, `,`, `"` as object keys breaks the type signature parser. 
This prevents object creation with these values a keys until the
type signature parsing won't break anymore.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
