### PR TITLE
make INSERT to exclude partitionedBy at projection stage

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -119,14 +119,6 @@ public final class InsertSourceFromCells implements InsertSourceGen {
 
         generatedColumns.setNextRow(row);
         generatedColumns.validateValues(source);
-        for (int i = 0; i < partitionedByColumns.size(); i++) {
-            var pCol = partitionedByColumns.get(i);
-            var column = pCol.column();
-            ArrayList<String> fullPath = new ArrayList<>(1 + column.path().size());
-            fullPath.add(column.name());
-            fullPath.addAll(column.path());
-            Maps.removeByPath(source, fullPath);
-        }
         for (var entry : generatedColumns.generatedToInject()) {
             var reference = entry.getKey();
             var value = entry.getValue().value();

--- a/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -81,10 +81,12 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        Settings settings,
                                        boolean autoCreateIndices,
                                        List<? extends Symbol> outputs,
-                                       List<Symbol> returnValues
+                                       List<Symbol> returnValues,
+                                       @Nullable String[] includes,
+                                       @Nullable String[] excludes
                                        ) {
 
-        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
+        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices, includes, excludes);
         assert partitionedBySymbols.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN, s))
             : "All references and fields in partitionedBySymbols must be resolved to inputColumns, got: " + partitionedBySymbols;
         this.allTargetColumns = allTargetColumns;
@@ -303,7 +305,9 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
             Settings.EMPTY,
             autoCreateIndices(),
             outputs,
-            returnValues
+            returnValues,
+            includes(),
+            excludes()
             );
     }
 }

--- a/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -97,6 +97,8 @@ public class ColumnIndexWriterProjectionTest {
             Settings.EMPTY,
             true,
             List.of(),
+            null,
+            null,
             null
         );
 
@@ -142,7 +144,9 @@ public class ColumnIndexWriterProjectionTest {
             Settings.EMPTY,
             true,
             List.of(),
-            List.of()
+            List.of(),
+            null,
+            null
         );
 
         BytesStreamOutput out = new BytesStreamOutput();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
partitionedBy columns are excluded from insertion.
But the stage where the columns are excluded for INSERT stmts is currently not consistent with COPY stmts.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
