### PR TITLE
Opt out of join order optimization if join condition references foreign relation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could lead to an ``Couldn't create execution plan`` error
+  when using a join condition referencing multiple other relations.
+
 - Fixed an issue that led to an ``Invalid query used in CREATE VIEW`` error if
   using a scalar subquery within the query part of a ``CREATE VIEW`` statement.
 

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -27,6 +27,7 @@ import io.crate.analyze.relations.QuerySplitter;
 import io.crate.common.collections.Lists2;
 import io.crate.execution.engine.join.JoinOperations;
 import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.planner.node.dql.join.JoinType;
@@ -65,17 +66,26 @@ public class JoinPlanBuilder {
             return Filter.create(plan.apply(from.get(0)), whereClause);
         }
         Map<Set<RelationName>, Symbol> queryParts = QuerySplitter.split(whereClause);
-        LinkedHashMap<Set<RelationName>, JoinPair> joinPairsByRelations =
-            JoinOperations.buildRelationsToJoinPairsMap(
-                JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, queryParts));
-
-        Collection<RelationName> orderedRelationNames = JoinOrdering.getOrderedRelationNames(
-            Lists2.map(from, AnalyzedRelation::relationName),
-            joinPairsByRelations.keySet(),
-            queryParts.keySet()
-        );
-
-        Iterator<RelationName> it = orderedRelationNames.iterator();
+        List<JoinPair> allJoinPairs = JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, queryParts);
+        boolean optimizeOrder = true;
+        for (var joinPair : allJoinPairs) {
+            if (hasAdditionalDependencies(joinPair)) {
+                optimizeOrder = false;
+                break;
+            }
+        }
+        LinkedHashMap<Set<RelationName>, JoinPair> joinPairsByRelations = JoinOperations.buildRelationsToJoinPairsMap(allJoinPairs);
+        Iterator<RelationName> it;
+        if (optimizeOrder) {
+            Collection<RelationName> orderedRelationNames = JoinOrdering.getOrderedRelationNames(
+                Lists2.map(from, AnalyzedRelation::relationName),
+                joinPairsByRelations.keySet(),
+                queryParts.keySet()
+            );
+            it = orderedRelationNames.iterator();
+        } else {
+            it = Lists2.map(from, AnalyzedRelation::relationName).iterator();
+        }
 
         final RelationName lhsName = it.next();
         final RelationName rhsName = it.next();
@@ -134,6 +144,21 @@ public class JoinPlanBuilder {
         assert joinPairsByRelations.isEmpty() : "Must've applied all joinPairs";
 
         return joinPlan;
+    }
+
+    private static boolean hasAdditionalDependencies(JoinPair joinPair) {
+        Symbol condition = joinPair.condition();
+        if (condition == null) {
+            return false;
+        }
+        boolean[] hasAdditionalDependencies = {false};
+        FieldsVisitor.visitFields(condition, scopedSymbol -> {
+            RelationName relation = scopedSymbol.relation();
+            if (!relation.equals(joinPair.left()) && !relation.equals(joinPair.right())) {
+                hasAdditionalDependencies[0] = true;
+            }
+        });
+        return hasAdditionalDependencies[0];
     }
 
     private static LogicalPlan createJoinPlan(LogicalPlan lhsPlan,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We don't take the dependencies of a join condition into consideration
when optimizing the join order. This could lead to invalid plans if a
join condition references a relation that the immediate `left` or
`right`.

This is a quick fix for backport that disables the optimization if a
join condition depends on an additional relation.

The proper solution would be to move the join ordering optimization into
a optimization rule, and consider the dependencies as well as costs (by
calculating the expected rows using selectivity functions).

Closes https://github.com/crate/crate/issues/12119


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
