### PR TITLE
Mention soft delete requirement in logical replication docs

### DIFF
--- a/docs/admin/logical-replication.rst
+++ b/docs/admin/logical-replication.rst
@@ -50,6 +50,16 @@ A publication is created using the
 altered or dropped using corresponding commands. The individual tables can be
 added and removed dynamically using ALTER PUBLICATION.
 
+.. CAUTION::
+
+    Publishing cluster must have
+    :ref:`setting <sql-create-table-soft-deletes-enabled>`
+    set to ``true`` so that subscribing cluster can catch up all changes made
+    during replication pause caused by network issues or explicitly done by a user.
+    Also, :ref:`setting <sql-create-table-soft-deletes-retention-lease-period>`
+    should be greater than or equal to
+    ``replication.logical.reads_poll_duration``.
+
 .. _logical-replication-subscription:
 
 Subscription

--- a/docs/sql/statements/alter-subscription.rst
+++ b/docs/sql/statements/alter-subscription.rst
@@ -39,7 +39,7 @@ Disable or enable the subscription. Disabling subscription does not remove it
 but stops getting updates from the publisher. After re-enabling it replication
 resumes back. The replication will try to catch up with all changes made
 in-between which could cause some initial delay based on the amount of changes.
-Availability of the recent changes depends on
+Availability of the recent changes depends on publishing cluster's
 :ref:`retention setting <sql-create-table-soft-deletes-retention-lease-period>`
 For update and delete operations, changes may not be available anymore on the
 source shard, resulting in an error. In such cases a subscription must be


### PR DESCRIPTION
see commit

we already have soft-delete mention in the [alter-subscription docs](https://github.com/crate/crate/blob/49f456c9073d00f6d390704a2cb31a2d186e1ff9/docs/sql/statements/alter-subscription.rst) - I added a bit of clarification there and also mentioned the requirement in the general section

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
