### PR TITLE
Remove markSeqNoAsSeen call from planDeletionAsNonPrimary

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1362,7 +1362,6 @@ public class InternalEngine extends Engine {
                 plan = DeletionStrategy.processNormally(opVsLucene == OpVsLuceneDocStatus.LUCENE_DOC_NOT_FOUND, delete.version());
             }
         }
-        markSeqNoAsSeen(delete.seqNo());
         return plan;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We applied some ES patches out of order:

- First https://github.com/crate/crate/commit/a0007366d8f595054d333af99029140291e25fd4
- then https://github.com/crate/crate/commit/a5ebf734128a847b7ded68f58c0d479319e4cfbb

This led to an error which we tried to fix in
https://github.com/crate/crate/commit/f2f5201433f94fa29932201294cff87b78d4d6f7
but there was one more leftover call.

I suspect this led to seqNo being incorrectly advanced and causing checkpoint sync hiccups
(not sure about changes entry as this is missing a test case)

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
