### PR TITLE
Fix BWC handling in translog index operation serialization

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -69,6 +69,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could lead to errors when reading translog files from
+  CrateDB versions < 4.0.
+
 - Fixed an issue that could lead to an ``Couldn't create execution plan`` error
   when using a join condition referencing multiple other relations.
 

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1080,7 +1080,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         private final BytesReference source;
         private final String routing;
 
-        private Index(final StreamInput in) throws IOException {
+        Index(final StreamInput in) throws IOException {
             final int format = in.readVInt(); // SERIALIZATION_FORMAT
             assert format >= FORMAT_6_0 : "format was: " + format;
             id = in.readString();
@@ -1090,10 +1090,10 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             }
             source = in.readBytesReference();
             routing = in.readOptionalString();
+            version = in.readLong();
             if (format < FORMAT_NO_PARENT) {
                 in.readOptionalString(); // _parent
             }
-            this.version = in.readLong();
             if (format < FORMAT_NO_VERSION_TYPE) {
                 in.readByte(); // _version_type
             }
@@ -1173,7 +1173,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             return new Source(source, routing);
         }
 
-        private void write(final StreamOutput out) throws IOException {
+        void write(final StreamOutput out) throws IOException {
             final int format;
             if (out.getVersion().onOrAfter(Version.V_4_3_0)) {
                 format = SERIALIZATION_FORMAT;
@@ -1190,6 +1190,9 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             out.writeBytesReference(source);
             out.writeOptionalString(routing);
             out.writeLong(version);
+            if (format < FORMAT_NO_PARENT) {
+                out.writeOptionalString(null); // _parent
+            }
             if (format < FORMAT_NO_VERSION_TYPE) {
                 out.writeByte(VersionType.EXTERNAL.getValue());
             }

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -3317,6 +3317,22 @@ public class TranslogTests extends ESTestCase {
         }
     }
 
+    @Test
+    public void test_translog_index_operation_bwc_serialization() throws Throwable {
+        Translog.Index index = new Translog.Index("id1", 2L, 1L, new byte[] { 1, 2, 3, 4 });
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_3_2_0);
+        index.write(out);
+        StreamInput in = out.bytes().streamInput();
+
+        Translog.Index index2 = new Translog.Index(in);
+        assertThat(index.id(), is(index2.id()));
+        assertThat(index.version(), is(index2.version()));
+        assertThat(index.seqNo(), is(index2.seqNo()));
+        assertThat(index.primaryTerm(), is(index2.primaryTerm()));
+        assertThat(index.source(), is(index2.source()));
+    }
+
     static boolean hasCircularReference(Exception cause) {
         final Queue<Throwable> queue = new LinkedList<>();
         queue.add(cause);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The version field was read after the `_parent` field instead of before.

(The change in `write` was only necessary for the test, we never write
to <4.0 versions in production)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
