### PR TITLE
Resolve subscripted relations by subscription metadata

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
@@ -21,10 +21,8 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.execution.ddl.AbstractDDLTransportAction;
-import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
-import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
-import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -34,17 +32,17 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import javax.annotation.Nonnull;
-import java.util.Iterator;
-
-import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
+import io.crate.replication.logical.metadata.Subscription;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 
 @Singleton
 public class TransportDropSubscriptionAction extends AbstractDDLTransportAction<DropSubscriptionRequest, AcknowledgedResponse> {
@@ -81,11 +79,11 @@ public class TransportDropSubscriptionAction extends AbstractDDLTransportAction<
                     // This is second step out of 3. Tracking of shards is already stopped on the first step (CLOSE TABLE).
                     // Removing setting so that last step (OPEN TABLE) will update engine.
                     SubscriptionsMetadata newMetadata = SubscriptionsMetadata.newInstance(oldMetadata);
-                    newMetadata.subscription().remove(request.name());
+                    var subscription = newMetadata.subscription().remove(request.name());
                     assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
                     mdBuilder.putCustom(SubscriptionsMetadata.TYPE, newMetadata);
 
-                    mdBuilder = removeSubscriptionSetting(currentMetadata.indices(), mdBuilder, request.name());
+                    removeSubscriptionSetting(subscription, currentMetadata, mdBuilder);
 
                     return ClusterState.builder(currentState).metadata(mdBuilder).build();
                 } else if (request.ifExists() == false) {
@@ -103,28 +101,23 @@ public class TransportDropSubscriptionAction extends AbstractDDLTransportAction<
     }
 
     /**
-     * Removes the REPLICATION_SUBSCRIPTION_NAME index setting from all relevant to subscription indices.
+     * Removes the REPLICATION_SUBSCRIPTION_NAME index setting from all indices included by the subscription.
      */
-    private Metadata.Builder removeSubscriptionSetting(ImmutableOpenMap<String, IndexMetadata> indices,
-                                                       Metadata.Builder mdBuilder,
-                                                       @Nonnull String subscriptionToDrop) {
-        Iterator<IndexMetadata> indicesIterator = indices.valuesIt();
-        while (indicesIterator.hasNext()) {
-            IndexMetadata indexMetadata = indicesIterator.next();
-            var settings = indexMetadata.getSettings();
-            var subscriptionName = REPLICATION_SUBSCRIPTION_NAME.get(settings); // Can be null.
-            if (subscriptionToDrop.equals(subscriptionName)) {
-                var settingsBuilder = Settings.builder().put(settings);
-                settingsBuilder.remove(REPLICATION_SUBSCRIPTION_NAME.getKey());
-                mdBuilder.put(
-                    IndexMetadata
-                        .builder(indexMetadata)
-                        .settingsVersion(1 + indexMetadata.getSettingsVersion())
-                        .settings(settingsBuilder)
-                );
-            }
+    private void removeSubscriptionSetting(Subscription subscription,
+                                           Metadata metadata,
+                                           Metadata.Builder mdBuilder) {
+        for (var relationName : subscription.relations().keySet()) {
+            IndexMetadata indexMetadata = metadata.index(relationName.indexNameOrAlias());
+            assert indexMetadata != null : "Cannot resolve indexMetadata for relation=" + relationName;
+            var settingsBuilder = Settings.builder().put(indexMetadata.getSettings());
+            settingsBuilder.remove(REPLICATION_SUBSCRIPTION_NAME.getKey());
+            mdBuilder.put(
+                IndexMetadata
+                    .builder(indexMetadata)
+                    .settingsVersion(1 + indexMetadata.getSettingsVersion())
+                    .settings(settingsBuilder)
+            );
         }
-        return mdBuilder;
     }
 
 }

--- a/server/src/main/java/io/crate/replication/logical/analyze/AnalyzedDropSubscription.java
+++ b/server/src/main/java/io/crate/replication/logical/analyze/AnalyzedDropSubscription.java
@@ -21,24 +21,31 @@
 
 package io.crate.replication.logical.analyze;
 
+import java.util.function.Consumer;
+
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.DDLStatement;
 import io.crate.expression.symbol.Symbol;
-
-import java.util.function.Consumer;
+import io.crate.replication.logical.metadata.Subscription;
 
 public class AnalyzedDropSubscription implements DDLStatement {
 
     private final String name;
+    private final Subscription subscription;
     private final boolean ifExists;
 
-    public AnalyzedDropSubscription(String name, boolean ifExists) {
+    public AnalyzedDropSubscription(String name, Subscription subscription, boolean ifExists) {
         this.name = name;
+        this.subscription = subscription;
         this.ifExists = ifExists;
     }
 
     public String name() {
         return name;
+    }
+
+    public Subscription subscription() {
+        return subscription;
     }
 
     public boolean ifExists() {

--- a/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
+++ b/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
@@ -21,22 +21,26 @@
 
 package io.crate.replication.logical.analyze;
 
+import java.util.Locale;
+
+import org.elasticsearch.index.IndexSettings;
+
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.common.collections.Lists2;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.replication.logical.exceptions.PublicationAlreadyExistsException;
-import io.crate.replication.logical.exceptions.PublicationUnknownException;
 import io.crate.exceptions.RelationUnknown;
-import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.exceptions.PublicationAlreadyExistsException;
+import io.crate.replication.logical.exceptions.PublicationUnknownException;
 import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsException;
 import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
 import io.crate.sql.tree.AlterPublication;
@@ -47,9 +51,6 @@ import io.crate.sql.tree.DropPublication;
 import io.crate.sql.tree.DropSubscription;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
-import org.elasticsearch.index.IndexSettings;
-
-import java.util.Locale;
 
 public class LogicalReplicationAnalyzer {
 
@@ -150,11 +151,11 @@ public class LogicalReplicationAnalyzer {
     }
 
     public AnalyzedDropSubscription analyze(DropSubscription dropSubscription) {
-        if (dropSubscription.ifExists() == false
-            && logicalReplicationService.subscriptions().containsKey(dropSubscription.name()) == false) {
+        var subscription = logicalReplicationService.subscriptions().get(dropSubscription.name());
+        if (dropSubscription.ifExists() == false && subscription == null) {
             throw new SubscriptionUnknownException(dropSubscription.name());
         }
-        return new AnalyzedDropSubscription(dropSubscription.name(), dropSubscription.ifExists());
+        return new AnalyzedDropSubscription(dropSubscription.name(), subscription, dropSubscription.ifExists());
     }
 
     public AnalyzedAlterSubscription analyze(AlterSubscription alterSubscription) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The subscription metadata contains all relations belonging to it.
Use this information instead of filtering all tables by the subscription
index setting.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
