### PR TITLE
Don't swap cast when it changes comparison semantics

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -82,4 +82,10 @@ Fixes
   is not used in an upper query. For example:
   ``select x from (select x, ROW_NUMBER() OVER (PARTITION BY y) from t) t1``
 
+- Fixed an issue that caused numbers being compared as strings in queries where
+  selected column is string casted to number and compared with a number or vice
+  versa. Example:
+  ``SELECT * FROM test WHERE strCol::bigint > 3`` or
+  ``SELECT * FROM test WHERE intCol::string > '3'``
+
 - Updated the bundled JDK to 17.0.2+8

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -224,8 +224,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query.toString(), is("_id:[ff 69 31]"));
 
         query = convert("_id = 1");
-        assertThat(query, instanceOf(TermQuery.class));
-        assertThat(query.toString(), is("_id:[fe 1f]"));
+        assertThat(query, instanceOf(GenericFunctionQuery.class));
+        assertThat(query.toString(), is("(_cast(_id, 'integer') = 1)"));
     }
 
     @Test


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/12135

As bug occurs because of cast optimisation which should not be done in some cases, fixed version will compute correctly but would be expensive.

```
CREATE TABLE test ( "intcol" INTEGER, "strcol" TEXT)  
INSERT INTO test VALUES (1, '1'), (10, '10'); 
```
**Before** 
```
SELECT * FROM test WHERE strCol::bigint > 3;
+--------+--------+
| intcol | strcol |
+--------+--------+
+--------+--------+
SELECT 0 rows in set (0.061 sec) // should be 10 row with 1 as 10 > 3
```
```
SELECT * FROM test WHERE intCol::string > '3';
+--------+--------+
| intcol | strcol |
+--------+--------+
|     10 | 10     |
+--------+--------+
SELECT 1 row in set (0.016 sec) // expected no rows as both '1' and '10' alphabetically less than '3'
```

**After**

```
SELECT * FROM test WHERE strCol::bigint > 3;
+--------+--------+
| intcol | strcol |
+--------+--------+
|     10 | 10     |
+--------+--------+
```

As expected, only 10 > 3.

```
SELECT * FROM test WHERE intCol::string > '3';
+--------+--------+
| intcol | strcol |
+--------+--------+
+--------+--------+
SELECT 0 rows in set (0.003 sec) // no rows as both '1' and '10' alphabetically less than '3'
```


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
