### PR TITLE
Don't apply swap cast optimization when explicit cast of the column is used

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -82,4 +82,8 @@ Fixes
   is not used in an upper query. For example:
   ``select x from (select x, ROW_NUMBER() OVER (PARTITION BY y) from t) t1``
 
+- Fixed an incorrect optimization of comparison function arguments for explicit
+  cast arguments resulting in a wrong result set. Example:
+  ```WHERE strCol::bigint > 3```
+
 - Updated the bundled JDK to 17.0.2+8

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -22,13 +22,14 @@
 package io.crate.planner.optimizer.symbol.rule;
 
 import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
-import static io.crate.expression.scalar.cast.CastFunctionResolver.CAST_FUNCTION_NAMES;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
 import java.util.Optional;
 
 import io.crate.expression.scalar.cast.CastFunctionResolver;
+import io.crate.expression.scalar.cast.ImplicitCastFunction;
+import io.crate.expression.scalar.cast.TryCastFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
@@ -52,7 +53,8 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> CAST_FUNCTION_NAMES.contains(f.name()))
+                // We have to respect explicit casts, see https://github.com/crate/crate/issues/12135
+                .with(f -> f.name().equals(ImplicitCastFunction.NAME) || f.name().equals(TryCastFunction.NAME))
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
             );
     }

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/OptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/OptimizerTest.java
@@ -22,6 +22,7 @@
 package io.crate.planner.optimizer.symbol;
 
 
+import io.crate.expression.operator.GtOperator;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Symbol;
@@ -41,6 +42,21 @@ public class OptimizerTest extends CrateDummyClusterServiceUnitTest {
             "op_like",
             SymbolMatchers.isFunction("_cast"),
             SymbolMatchers.isLiteral("10")
+        ));
+    }
+
+    @Test
+    public void test_cast_is_not_swapped_when_column_explicitly_casted() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (strCol string, intCol int)")
+            .build();
+
+        Symbol symbol = Optimizer.optimizeCasts(e.asSymbol("strCol::bigint > 3"), e.getPlannerContext(clusterService.state()));
+
+        assertThat(symbol, SymbolMatchers.isFunction(
+            GtOperator.NAME,
+            SymbolMatchers.isFunction("cast"),
+            SymbolMatchers.isLiteral(3L)
         ));
     }
 }


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/12135

Replaces https://github.com/crate/crate/pull/12153

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
