### PR TITLE
fix for COPY-FROM throwing NPE when the URI is globbed and unknown directory

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -75,6 +75,10 @@ Fixes
 - Fixed an issue that could lead to an ``Couldn't create execution plan`` error
   when using a join condition referencing multiple other relations.
 
+- Fixed an issue that caused an NPE when executing ``COPY FROM`` with a globbed
+  URI having a parent directory that does not exist in the filesystem. This
+  affected copying from filesystems local to CrateDB nodes only.
+
 - Fixed an issue that led to an ``Invalid query used in CREATE VIEW`` error if
   using a scalar subquery within the query part of a ``CREATE VIEW`` statement.
 

--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -97,7 +97,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
         this.shared = shared;
         this.numReaders = numReaders;
         this.readerNumber = readerNumber;
-        this.fileInputs = fileUris.stream().map(uri -> toFileInput(uri, withClauseOptions)).toList();
+        this.fileInputs = fileUris.stream().map(uri -> toFileInput(uri, withClauseOptions)).filter(Objects::nonNull).toList();
         this.collectorExpressions = collectorExpressions;
         this.parserProperties = parserProperties;
         this.inputFormat = inputFormat;

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -84,6 +84,12 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     public CopyIntegrationTest() throws URISyntaxException {
     }
 
+    @Test
+    public void testCopyFromUnknownDirectory() {
+        execute("create table t (a int)");
+        ensureYellow();
+        execute("copy t from 'file:///tmp/unknown_dir/*'");
+    }
 
     @Test
     public void testCopyFromFileWithJsonExtension() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

```sql
copy t from '/tmp/unknown_dir/*' return summary;
NullPointerException[Cannot invoke "io.crate.execution.engine.collect.files.FileInput.expandUri()" because "this.currentInput" is null]

```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
