### PR TITLE
include 'globbed' into Vale vocab

### DIFF
--- a/.github/styles/Vocab/CrateDB/accept.txt
+++ b/.github/styles/Vocab/CrateDB/accept.txt
@@ -32,6 +32,7 @@ fulltext
 Fulltext
 geo
 Geo
+globbed
 globbing
 grantable
 gzip


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
handles Vale failure introduced by #12156. did not realize it would continue to fail for future CI runs.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
