### PR TITLE
Improve performance of implicit casts by moving parsing of target type into compile

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,9 @@ None
 Changes
 =======
 
+- Improved the evaluation performance of implicit casts by utilize the compile
+  step of the function to determine the return type.
+
 - Added a ``flush_stats`` column to the :ref:`sys.shards <sys-shards>` table.
 
 - Allowed users to be able to specify different S3 compatible storage endpoints

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -33,6 +33,8 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
+
+import org.hamcrest.core.IsSame;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -51,6 +53,7 @@ import static io.crate.types.DataTypes.GEO_SHAPE;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -297,5 +300,10 @@ public class CastFunctionTest extends ScalarTestCase {
     @Test
     public void test_can_cast_text_to_json_array() throws Exception {
         assertEvaluate("'[{\"x\": 10}, {\"x\": 20}]'::json[]", is(List.of("{\"x\":10}", "{\"x\":20}")));
+    }
+
+    @Test
+    public void test_implicit_cast_is_compiled() throws Exception {
+        assertCompile("_cast(a, 'double precision')", (s) -> not(IsSame.sameInstance(s)) );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This moves the parsing of the target type of the Implicit cast function
    into the compile stage. This will make sure the target type is parsed
    only once for a lifecycle of the Implicit cast function.


```
V1: 4.8.0-dee6c9fadbb3042ec3ee4406e91f20a80852447b
V2: 4.8.0-85e2a06f1e084b9e6ccc788df08a45c08c7ac4f2

Q: select a + b from test -> (_cast(a, 'double precision') + b)
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       65.452 ±   22.555 |     53.347 |     63.808 |     65.971 |    760.005 |
|   V2    |       52.901 ±   20.962 |     45.828 |     51.259 |     53.315 |    701.356 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  21.21%                           -  21.81%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 21.21%
The test has statistical significance
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
