### PR TITLE
Add old docs admonition to 3.3 docs

### DIFF
--- a/blackbox/docs/_include/version-note.rst
+++ b/blackbox/docs/_include/version-note.rst
@@ -1,0 +1,9 @@
+.. NOTE::
+
+    You are reading the reference documentation for CrateDB 3.3,
+    released in March 2019.
+
+    If you are using a newer version of CrateDB make sure to use the
+    `current CrateDB reference documentation`.
+
+.. _current CrateDB reference documentation: https://crate.io/docs/crate/reference/en/latest/

--- a/blackbox/docs/_include/version-note.rst
+++ b/blackbox/docs/_include/version-note.rst
@@ -4,6 +4,6 @@
     released in March 2019.
 
     If you are using a newer version of CrateDB make sure to use the
-    `current CrateDB reference documentation`.
+    `current CrateDB reference documentation`_.
 
 .. _current CrateDB reference documentation: https://crate.io/docs/crate/reference/en/latest/

--- a/blackbox/docs/admin/auth/hba.rst
+++ b/blackbox/docs/admin/auth/hba.rst
@@ -4,6 +4,8 @@
 Host Based Authentication (HBA)
 ===============================
 
+.. include:: ../../_include/version-note.rst
+
 This section explains how to configure CrateDB client connection and
 authentication.
 

--- a/blackbox/docs/admin/auth/index.rst
+++ b/blackbox/docs/admin/auth/index.rst
@@ -4,6 +4,8 @@
 Authentication
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. toctree::

--- a/blackbox/docs/admin/auth/methods.rst
+++ b/blackbox/docs/admin/auth/methods.rst
@@ -4,6 +4,8 @@
 Authentication Methods
 ======================
 
+.. include:: ../../_include/version-note.rst
+
 There are multiple ways to authenticate against CrateDB.
 
 .. NOTE::

--- a/blackbox/docs/admin/discovery.rst
+++ b/blackbox/docs/admin/discovery.rst
@@ -4,6 +4,8 @@
 Cloud Discovery
 ===============
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/admin/index.rst
+++ b/blackbox/docs/admin/index.rst
@@ -4,6 +4,8 @@
 Administration
 ==============
 
+.. include:: ../_include/version-note.rst
+
 This section of the documentation covers any feature primarily of interest to a
 database administrator.
 

--- a/blackbox/docs/admin/ingestion/index.rst
+++ b/blackbox/docs/admin/ingestion/index.rst
@@ -4,6 +4,8 @@
 Ingestion Framework
 ===================
 
+.. include:: ../../_include/version-note.rst
+
 .. sidebar:: Overview
 
    .. figure:: ingestion-01.png

--- a/blackbox/docs/admin/ingestion/rules.rst
+++ b/blackbox/docs/admin/ingestion/rules.rst
@@ -15,6 +15,8 @@
 Ingestion Rules
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 Ingestion rules define where and how the incoming data of a specific
 :ref:`ingestion source <administration-ingestion-sources>` should be routed and
 stored.

--- a/blackbox/docs/admin/ingestion/sources/index.rst
+++ b/blackbox/docs/admin/ingestion/sources/index.rst
@@ -4,6 +4,8 @@
 Ingestion Sources
 =================
 
+.. include:: ../../../_include/version-note.rst
+
 Builtin ingestion sources for CrateDB's :ref:`ingestion framework <ingestion>`.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/admin/ingestion/sources/mqtt.rst
+++ b/blackbox/docs/admin/ingestion/sources/mqtt.rst
@@ -5,6 +5,8 @@
 MQTT Ingestion Source
 =====================
 
+.. include:: ../../../_include/version-note.rst
+
 .. sidebar:: Overview
 
    .. figure:: mqtt-01.png

--- a/blackbox/docs/admin/jobs-management.rst
+++ b/blackbox/docs/admin/jobs-management.rst
@@ -5,6 +5,8 @@
 Jobs Management
 ===============
 
+.. include:: ../_include/version-note.rst
+
 Each executed sql statement results in a corresponding job. Jobs that are
 currently executing are logged in the system table ``sys.jobs`` (see
 :ref:`jobs_operations_logs`).

--- a/blackbox/docs/admin/monitoring.rst
+++ b/blackbox/docs/admin/monitoring.rst
@@ -4,6 +4,8 @@
 JMX Monitoring
 ==============
 
+.. include:: ../_include/version-note.rst
+
 The JMX monitoring feature exposes query metrics via the `JMX`_ API.
 
 .. NOTE::

--- a/blackbox/docs/admin/optimization.rst
+++ b/blackbox/docs/admin/optimization.rst
@@ -5,6 +5,8 @@
 Optimization
 ============
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/admin/privileges.rst
+++ b/blackbox/docs/admin/privileges.rst
@@ -5,6 +5,8 @@
 Privileges
 ==========
 
+.. include:: ../_include/version-note.rst
+
 The superuser is allowed to execute any statement without any privilege checks.
 
 The superuser uses ``GRANT``, ``DENY`` and ``REVOKE`` statements to control

--- a/blackbox/docs/admin/runtime-config.rst
+++ b/blackbox/docs/admin/runtime-config.rst
@@ -4,6 +4,8 @@
 Runtime Configuration
 =====================
 
+.. include:: ../_include/version-note.rst
+
 The CrateDB cluster can be configured at runtime using the :ref:`SET <ref-set>`
 and :ref:`RESET <ref-set>` statement. See the :ref:`Cluster Settings
 <conf-cluster-settings>` configuration section for details about the supported
@@ -56,9 +58,9 @@ settings::
 
 ::
 
-    cr> SELECT 
+    cr> SELECT
     ...   settings['stats']['jobs_log_size'] AS jobs_size,
-    ...   settings['stats']['operations_log_size'] AS op_size 
+    ...   settings['stats']['operations_log_size'] AS op_size
     ... FROM sys.cluster;
     +-----------+---------+
     | jobs_size | op_size |
@@ -75,9 +77,9 @@ startup defined configuration file value or to its default value::
 
 ::
 
-    cr> SELECT 
+    cr> SELECT
     ...   settings['stats']['jobs_log_size'] AS jobs_size,
-    ...   settings['stats']['operations_log_size'] AS op_size 
+    ...   settings['stats']['operations_log_size'] AS op_size
     ... FROM sys.cluster;
     +-----------+---------+
     | jobs_size | op_size |
@@ -93,9 +95,9 @@ startup defined configuration file value or to its default value::
 
 ::
 
-    cr> SELECT 
+    cr> SELECT
     ...   settings['stats']['jobs_log_size'] AS jobs_size,
-    ...   settings['stats']['operations_log_size'] AS op_size 
+    ...   settings['stats']['operations_log_size'] AS op_size
     ... FROM sys.cluster;
     +-----------+---------+
     | jobs_size | op_size |

--- a/blackbox/docs/admin/snapshots.rst
+++ b/blackbox/docs/admin/snapshots.rst
@@ -5,6 +5,8 @@
 Snapshots
 =========
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/admin/ssl.rst
+++ b/blackbox/docs/admin/ssl.rst
@@ -4,6 +4,8 @@
 Secured Communications (SSL/TLS)
 ================================
 
+.. include:: ../_include/version-note.rst
+
 Secured communication allows you to encrypt traffic between the CrateDB node
 and a client. This applies to connections using HTTP (i.e. `Admin UI
 <https://crate.io/docs/crate/guide/getting_started/connect/admin_ui.html>`_,

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -5,6 +5,8 @@
 System Information
 ==================
 
+.. include:: ../_include/version-note.rst
+
 CrateDB provides the ``sys`` schema which contains virtual tables. These tables
 are read-only and can be queried to get statistical real-time information about
 the cluster, its nodes and their shards:
@@ -1200,8 +1202,8 @@ statements.
 +------------------------------+----------------------------------------------------+------------------+
 | ``total_count``              | Total number of queries executed                   | ``LONG``         |
 +------------------------------+----------------------------------------------------+------------------+
-| ``failed_count``             | Total number of queries that failed to complete    | ``LONG``         |  
-|                              | successfully.                                      |                  | 
+| ``failed_count``             | Total number of queries that failed to complete    | ``LONG``         |
+|                              | successfully.                                      |                  |
 +------------------------------+----------------------------------------------------+------------------+
 | ``sum_of_durations``         | Sum of durations in ms of all executed queries per | ``LONG``         |
 |                              | statement type.                                    |                  |

--- a/blackbox/docs/admin/udc.rst
+++ b/blackbox/docs/admin/udc.rst
@@ -4,6 +4,8 @@
 Usage Data Collector
 ====================
 
+.. include:: ../_include/version-note.rst
+
 The CrateDB Usage Data Collector (UDC) is a sub-system that gathers usage data,
 reporting it to the UDC server at https://udc.crate.io. It is easy to disable,
 and does not collect any data that is confidential. For more information about
@@ -45,7 +47,7 @@ CrateDB Version   The CrateDB version.
 Java Version      The Java version CrateDB is currently running with.
 Hardware Address  MAC address to uniquely identify instances behind
                   firewalls.
-Processor count   Number of available CPUs as reported by 
+Processor count   Number of available CPUs as reported by
                   ``Runtime.availableProcessors``
 Enterprise        Identifies whether the Enterprise Edition is used.
 License           License information of the CrateDB Enterprise Edition.

--- a/blackbox/docs/admin/user-management.rst
+++ b/blackbox/docs/admin/user-management.rst
@@ -4,6 +4,8 @@
 User Management
 ===============
 
+.. include:: ../_include/version-note.rst
+
 .. NOTE::
 
    User management is an

--- a/blackbox/docs/appendices/compatibility.rst
+++ b/blackbox/docs/appendices/compatibility.rst
@@ -4,6 +4,8 @@
 Compatibility
 =============
 
+.. include:: ../_include/version-note.rst
+
 CrateDB aims to provide an SQL implementation that is familiar to anyone having
 used other databases providing a standards-compliant SQL language. However, it
 is worth being aware of some unique characteristics in CrateDB's SQL dialect.

--- a/blackbox/docs/appendices/compliance.rst
+++ b/blackbox/docs/appendices/compliance.rst
@@ -5,6 +5,8 @@
 SQL Standard Compliance
 =======================
 
+.. include:: ../_include/version-note.rst
+
 This section provides a list of features that CrateDB supports and to what
 extent it conforms to the current SQL standard `ISO/IEC 9075`_ "Database
 Language SQL".

--- a/blackbox/docs/appendices/index.rst
+++ b/blackbox/docs/appendices/index.rst
@@ -4,6 +4,8 @@
 Appendices
 ==========
 
+.. include:: ../_include/version-note.rst
+
 Supplementary information for the CrateDB reference manual.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -4,6 +4,8 @@
 Release Notes
 =============
 
+.. include:: ../../_include/version-note.rst
+
 Information about individual CrateDB releases, typically including upgrade
 information and changelog.
 

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -6,6 +6,8 @@
 Cluster Wide Settings
 =====================
 
+.. include:: ../_include/version-note.rst
+
 All current applied cluster settings can be read by querying the
 :ref:`sys.cluster.settings <sys-cluster-settings>` column. Most
 cluster settings can be :ref:`changed at runtime

--- a/blackbox/docs/config/environment.rst
+++ b/blackbox/docs/config/environment.rst
@@ -4,6 +4,8 @@
 Environment Variables
 =====================
 
+.. include:: ../_include/version-note.rst
+
 CrateDB can be configured with some `environment variables`_.
 
 There are many different ways to set environment variables, depending on how

--- a/blackbox/docs/config/index.rst
+++ b/blackbox/docs/config/index.rst
@@ -4,6 +4,8 @@
 Configuration
 =============
 
+.. include:: ../_include/version-note.rst
+
 CrateDB ships with sensible defaults, so configuration is typically not needed
 for basic, single node use.
 

--- a/blackbox/docs/config/logging.rst
+++ b/blackbox/docs/config/logging.rst
@@ -4,6 +4,8 @@
 Logging
 =======
 
+.. include:: ../_include/version-note.rst
+
 CrateDB supports two kinds of logging:
 
 - Application logging with `Log4j`_

--- a/blackbox/docs/config/node.rst
+++ b/blackbox/docs/config/node.rst
@@ -6,6 +6,8 @@
 Node Specific Settings
 ======================
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/config/session.rst
+++ b/blackbox/docs/config/session.rst
@@ -4,6 +4,8 @@
 Session Settings
 ================
 
+.. include:: ../_include/version-note.rst
+
 This section documents settings that only apply to the currently connected client
 session. Currently, there is only one of these settings.
 

--- a/blackbox/docs/editions/community.rst
+++ b/blackbox/docs/editions/community.rst
@@ -4,6 +4,8 @@
 Community Edition
 =================
 
+.. include:: ../_include/version-note.rst
+
 The community edition (``CE``) of CrateDB is a distribution that excludes
 enterprise modules which are licensed under a more restrictive license. The
 ``CE`` can be used under the terms of the Apache License version 2 without

--- a/blackbox/docs/editions/enterprise.rst
+++ b/blackbox/docs/editions/enterprise.rst
@@ -4,6 +4,8 @@
 Enterprise Features
 ===================
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/editions/index.rst
+++ b/blackbox/docs/editions/index.rst
@@ -2,6 +2,8 @@
 CrateDB Editions
 ================
 
+.. include:: ../_include/version-note.rst
+
 .. toctree::
    enterprise
    community

--- a/blackbox/docs/general/blobs.rst
+++ b/blackbox/docs/general/blobs.rst
@@ -5,6 +5,8 @@
 Blobs
 =====
 
+.. include:: ../_include/version-note.rst
+
 CrateDB includes support to store `binary large objects`_. By utilizing
 CrateDB's cluster features the files can be replicated and sharded just like
 regular data.

--- a/blackbox/docs/general/builtins/aggregation.rst
+++ b/blackbox/docs/general/builtins/aggregation.rst
@@ -5,6 +5,8 @@
 Aggregation
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/builtins/arithmetic.rst
+++ b/blackbox/docs/general/builtins/arithmetic.rst
@@ -6,6 +6,8 @@
 Arithmetic Operators
 ====================
 
+.. include:: ../../_include/version-note.rst
+
 Arithmetic operators perform mathematical operations on two expressions of
 numeric data types or timestamps.
 

--- a/blackbox/docs/general/builtins/array-comparisons.rst
+++ b/blackbox/docs/general/builtins/array-comparisons.rst
@@ -4,6 +4,8 @@
 Array Comparisons
 =================
 
+.. include:: ../../_include/version-note.rst
+
 This section contains several constructs that can be used to make comparisons
 between a list of values. Comparison operations result in a boolean value
 (``true``/``false``) or ``null``.

--- a/blackbox/docs/general/builtins/index.rst
+++ b/blackbox/docs/general/builtins/index.rst
@@ -5,6 +5,8 @@
 Built-in Functions and Operators
 ================================
 
+.. include:: ../../_include/version-note.rst
+
 This chapter provides an overview of built-in functions and operators.
 
 Operators are reserved keywords that are primarily used in a

--- a/blackbox/docs/general/builtins/operators.rst
+++ b/blackbox/docs/general/builtins/operators.rst
@@ -4,6 +4,8 @@
 Comparison Operators
 ====================
 
+.. include:: ../../_include/version-note.rst
+
 These operations test whether two expressions are equal. Comparison Operators
 result in a value of ``true``, ``false`` or ``null``.
 The following tables show the usual comparison operators that can be used for

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -5,6 +5,8 @@
 Scalar Functions
 ================
 
+.. include:: ../../_include/version-note.rst
+
 Scalar functions return a single value (not a table).
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/general/builtins/subquery-expressions.rst
+++ b/blackbox/docs/general/builtins/subquery-expressions.rst
@@ -4,6 +4,8 @@
 Subquery Expressions
 ====================
 
+.. include:: ../../_include/version-note.rst
+
 The following operators can be used with a subquery to form a subquery
 expression that results in a boolean value (``true``/``false``) or ``null``.
 

--- a/blackbox/docs/general/builtins/table-functions.rst
+++ b/blackbox/docs/general/builtins/table-functions.rst
@@ -6,6 +6,8 @@
 Table Functions
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 Table functions are functions that produce a set of rows. They are used like a
 table or subquery in the ``FROM`` clause of a query.
 
@@ -16,7 +18,7 @@ If multiple table functions with different amount of rows are used, ``null``
 values will be returned for the functions that are exhausted. An example::
 
 
-    cr> select unnest([1, 2, 3]), unnest([1, 2]); 
+    cr> select unnest([1, 2, 3]), unnest([1, 2]);
     +-------------------+----------------+
     | unnest([1, 2, 3]) | unnest([1, 2]) |
     +-------------------+----------------+

--- a/blackbox/docs/general/builtins/window-functions.rst
+++ b/blackbox/docs/general/builtins/window-functions.rst
@@ -5,6 +5,8 @@
 Window Functions
 ================
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/ddl/alter-table.rst
+++ b/blackbox/docs/general/ddl/alter-table.rst
@@ -4,6 +4,8 @@
 Altering Tables
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 .. NOTE::
 
    ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported.

--- a/blackbox/docs/general/ddl/analyzers.rst
+++ b/blackbox/docs/general/ddl/analyzers.rst
@@ -4,6 +4,8 @@
 Fulltext Analyzers
 ==================
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/ddl/column-policy.rst
+++ b/blackbox/docs/general/ddl/column-policy.rst
@@ -4,6 +4,8 @@
 Column Policy
 =============
 
+.. include:: ../../_include/version-note.rst
+
 The Column Policy defines if a table enforces its defined schema or if it's
 allowed to store additional columns which are a not defined in the table
 schema.

--- a/blackbox/docs/general/ddl/constraints.rst
+++ b/blackbox/docs/general/ddl/constraints.rst
@@ -2,6 +2,8 @@
 Constraints
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 Columns can be constrained in two ways:
 
 .. contents::

--- a/blackbox/docs/general/ddl/create-table.rst
+++ b/blackbox/docs/general/ddl/create-table.rst
@@ -4,6 +4,8 @@
 Creating Tables
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/ddl/data-types.rst
+++ b/blackbox/docs/general/ddl/data-types.rst
@@ -6,6 +6,8 @@
 Data Types
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 Data can be stored in different formats. CrateDB has different types that can
 be specified if a table is created using the the :ref:`ref-create-table`
 statement. Data types play a central role as they limit what kind of data can

--- a/blackbox/docs/general/ddl/fulltext-indices.rst
+++ b/blackbox/docs/general/ddl/fulltext-indices.rst
@@ -6,6 +6,8 @@
 Fulltext Indices
 ================
 
+.. include:: ../../_include/version-note.rst
+
 Fulltext indices take the contents of one or more fields and split it up into
 tokens that are used for fulltext-search. The transformation from a text to
 separate tokens is done by an analyzer. In order to create fulltext search

--- a/blackbox/docs/general/ddl/generated-columns.rst
+++ b/blackbox/docs/general/ddl/generated-columns.rst
@@ -4,6 +4,8 @@
 Generated Columns
 =================
 
+.. include:: ../../_include/version-note.rst
+
 It is possible to define columns whose value is computed by applying a
 *generation expression* in the context of the current row. The generation
 expression can reference the values of other columns.

--- a/blackbox/docs/general/ddl/index.rst
+++ b/blackbox/docs/general/ddl/index.rst
@@ -5,6 +5,8 @@
 Data Definition
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. toctree::

--- a/blackbox/docs/general/ddl/partitioned-tables.rst
+++ b/blackbox/docs/general/ddl/partitioned-tables.rst
@@ -5,6 +5,8 @@
 Partitioned Tables
 ==================
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/ddl/replication.rst
+++ b/blackbox/docs/general/ddl/replication.rst
@@ -4,6 +4,8 @@
 Replication
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 Replication of a table in CrateDB means that each primary shard of a table is
 stored additionally on so called secondary shards. This can be useful for
 better read performance and high availability.

--- a/blackbox/docs/general/ddl/shard-allocation.rst
+++ b/blackbox/docs/general/ddl/shard-allocation.rst
@@ -4,6 +4,8 @@
  Shard Allocation Filtering
 ============================
 
+.. include:: ../../_include/version-note.rst
+
 Shard allocation filters allows to configure shard and replicas allocation per
 table across generic attributes associated with nodes.
 

--- a/blackbox/docs/general/ddl/sharding.rst
+++ b/blackbox/docs/general/ddl/sharding.rst
@@ -4,6 +4,8 @@
 Sharding
 ========
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/ddl/show-create-table.rst
+++ b/blackbox/docs/general/ddl/show-create-table.rst
@@ -2,6 +2,8 @@
 Show Create Table
 =================
 
+.. include:: ../../_include/version-note.rst
+
 .. hide:
     cr> create table if not exists my_table (
     ...   first_column integer primary key,

--- a/blackbox/docs/general/ddl/storage.rst
+++ b/blackbox/docs/general/ddl/storage.rst
@@ -4,6 +4,8 @@
  Storage
 =========
 
+.. include:: ../../_include/version-note.rst
+
 Data storage options can be tuned for each column similar to how indexing is defined.
 
 .. _ddl-storage-columnstore:

--- a/blackbox/docs/general/ddl/system-columns.rst
+++ b/blackbox/docs/general/ddl/system-columns.rst
@@ -4,6 +4,8 @@
 System Columns
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 On every table CrateDB implements several implicitly defined system columns.
 Their names are reserved and cannot be used as user-defined column names. All
 system columns are prefixed with an underscore, consist of lowercase letters

--- a/blackbox/docs/general/ddl/views.rst
+++ b/blackbox/docs/general/ddl/views.rst
@@ -4,6 +4,8 @@
 Views
 =====
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/dml.rst
+++ b/blackbox/docs/general/dml.rst
@@ -6,6 +6,8 @@
 Data Manipulation
 =================
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/dql/fulltext.rst
+++ b/blackbox/docs/general/dql/fulltext.rst
@@ -5,6 +5,8 @@
 Fulltext Search
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 In order to use fulltext search on one or more columns, a
 :ref:`fulltext index with an analyzer <sql_ddl_index_fulltext>` has to be
 defined while creating the column: either with ``CREATE TABLE`` or ``ALTER

--- a/blackbox/docs/general/dql/geo.rst
+++ b/blackbox/docs/general/dql/geo.rst
@@ -5,6 +5,8 @@
 Geo Search
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/dql/index.rst
+++ b/blackbox/docs/general/dql/index.rst
@@ -5,6 +5,8 @@
 Querying Crate
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 This section provides an overview on how to query documents using SQL.  See
 :ref:`sql_ddl` for information about `Table creation` and other Data Definition
 statements.

--- a/blackbox/docs/general/dql/joins.rst
+++ b/blackbox/docs/general/dql/joins.rst
@@ -4,6 +4,8 @@
 Joins
 =====
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/dql/refresh.rst
+++ b/blackbox/docs/general/dql/refresh.rst
@@ -5,6 +5,8 @@
 Refresh
 =======
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/dql/selects.rst
+++ b/blackbox/docs/general/dql/selects.rst
@@ -5,6 +5,8 @@
 Selecting Data
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 Selecting (i.e. retrieving) data from CrateDB is done by using a SQL ``SELECT``
 statement. The response to a ``SELECT`` query contains the column names of the
 result, the actual result rows as a two-dimensional array of values, the row
@@ -687,7 +689,7 @@ Object Arrays
 =============
 
 Arrays in CrateDB can be queried for containment using the
-:ref:`sql_dql_any_array` operator. 
+:ref:`sql_dql_any_array` operator.
 
 It is possible to access fields of :ref:`sql_dql_objects` using subscript
 expressions. If the parent is an object array, you'll get an array of the

--- a/blackbox/docs/general/dql/union.rst
+++ b/blackbox/docs/general/dql/union.rst
@@ -5,6 +5,8 @@
 Union All
 =========
 
+.. include:: ../../_include/version-note.rst
+
 UNION ALL can be used to combine results from multiple ``SELECT`` statements.
 For further information on the syntax and usages see :ref:`sql_reference_union`.
 ::

--- a/blackbox/docs/general/index.rst
+++ b/blackbox/docs/general/index.rst
@@ -4,6 +4,8 @@
 General Use
 ===========
 
+.. include:: ../_include/version-note.rst
+
 This section of the documentation covers any feature primarily of interest to a
 general user.
 

--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -5,6 +5,8 @@
 Information Schema
 ==================
 
+.. include:: ../_include/version-note.rst
+
 ``information_schema`` is a special schema that contains virtual tables which
 are read-only and can be queried to get information about the state of the
 cluster.

--- a/blackbox/docs/general/occ.rst
+++ b/blackbox/docs/general/occ.rst
@@ -5,6 +5,8 @@
 Optimistic Concurrency Control
 ==============================
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/general/user-defined-functions.rst
+++ b/blackbox/docs/general/user-defined-functions.rst
@@ -4,6 +4,8 @@
 User-Defined Functions
 ======================
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/index.rst
+++ b/blackbox/docs/index.rst
@@ -4,6 +4,8 @@
 CrateDB Reference
 =================
 
+.. include:: ./_include/version-note.rst
+
 CrateDB is a distributed SQL database that makes it simple to store and analyze
 massive amounts of machine data in real-time.
 

--- a/blackbox/docs/interfaces/http.rst
+++ b/blackbox/docs/interfaces/http.rst
@@ -6,6 +6,8 @@
 HTTP Endpoint
 =============
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/interfaces/index.rst
+++ b/blackbox/docs/interfaces/index.rst
@@ -4,6 +4,8 @@
 Client Interfaces
 =================
 
+.. include:: ../_include/version-note.rst
+
 There are two ways for clients to talk to CrateDB. This section of the documentation covers both from a
 client implementation perspective.
 

--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -4,6 +4,8 @@
 PostgreSQL Wire Protocol
 ========================
 
+.. include:: ../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/requirements.txt
+++ b/blackbox/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme
+crate-docs-theme>=0.12.0
 sphinx-csv-filter
-Pygments==2.3.1
+Pygments>=2.7.4,<3

--- a/blackbox/docs/run.rst
+++ b/blackbox/docs/run.rst
@@ -5,6 +5,8 @@
 Running CrateDB
 ===============
 
+.. include:: ./_include/version-note.rst
+
 This document covers the basics of running CrateDB from the command line.
 
 .. SEEALSO::

--- a/blackbox/docs/sql/general/constraints.rst
+++ b/blackbox/docs/sql/general/constraints.rst
@@ -5,6 +5,8 @@
 Constraints
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/sql/general/index.rst
+++ b/blackbox/docs/sql/general/index.rst
@@ -2,6 +2,8 @@
 General SQL
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. toctree::

--- a/blackbox/docs/sql/general/lexical-structure.rst
+++ b/blackbox/docs/sql/general/lexical-structure.rst
@@ -5,6 +5,8 @@
 Lexical Structure
 =================
 
+.. include:: ../../_include/version-note.rst
+
 An SQL input consists of a sequence of commands each of which is a sequence of
 tokens, terminated by a semicolon (``;``).
 

--- a/blackbox/docs/sql/general/value-expressions.rst
+++ b/blackbox/docs/sql/general/value-expressions.rst
@@ -5,6 +5,8 @@
 Value Expressions
 =================
 
+.. include:: ../../_include/version-note.rst
+
 Value expressions are expressions which return a single value.
 
 They can be used in many contexts of many statements.

--- a/blackbox/docs/sql/index.rst
+++ b/blackbox/docs/sql/index.rst
@@ -2,6 +2,8 @@
 SQL Syntax
 ==========
 
+.. include:: ../_include/version-note.rst
+
 CrateDB uses `SQL`_ to query documents.
 
 This section of the documentation provides a full SQL syntax reference.

--- a/blackbox/docs/sql/statements/alter-cluster.rst
+++ b/blackbox/docs/sql/statements/alter-cluster.rst
@@ -5,6 +5,8 @@
 ``ALTER CLUSTER``
 =================
 
+.. include:: ../../_include/version-note.rst
+
 Alter the state of an existing cluster.
 
 .. rubric:: Table of Contents
@@ -17,7 +19,7 @@ Synopsis
 
 ::
 
-    ALTER CLUSTER 
+    ALTER CLUSTER
       { REROUTE RETRY FAILED
       | DECOMMISSION <nodeId | nodeName>
       | SWAP TABLE source TO target [ WITH ( expr = expr [ , ... ] ) ]

--- a/blackbox/docs/sql/statements/alter-table.rst
+++ b/blackbox/docs/sql/statements/alter-table.rst
@@ -5,6 +5,8 @@
 ``ALTER TABLE``
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 Alter an existing table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/alter-user.rst
+++ b/blackbox/docs/sql/statements/alter-user.rst
@@ -5,6 +5,8 @@
 ``ALTER USER``
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 Alter an existing database user.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/begin.rst
+++ b/blackbox/docs/sql/statements/begin.rst
@@ -5,6 +5,8 @@
 ``BEGIN``
 =========
 
+.. include:: ../../_include/version-note.rst
+
 Start a transaction block
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/commit.rst
+++ b/blackbox/docs/sql/statements/commit.rst
@@ -5,6 +5,8 @@
 ``COMMIT``
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 Commit the current transaction
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/copy-from.rst
+++ b/blackbox/docs/sql/statements/copy-from.rst
@@ -5,6 +5,8 @@
 ``COPY FROM``
 =============
 
+.. include:: ../../_include/version-note.rst
+
 Copy data from files into a table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/copy-to.rst
+++ b/blackbox/docs/sql/statements/copy-to.rst
@@ -5,6 +5,8 @@
 ``COPY TO``
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 Export table contents to files on CrateDB node machines.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/create-analyzer.rst
+++ b/blackbox/docs/sql/statements/create-analyzer.rst
@@ -5,6 +5,8 @@
 ``CREATE ANALYZER``
 ===================
 
+.. include:: ../../_include/version-note.rst
+
 Define a new fulltext analyzer.
 
 .. rubric:: Table of Contents
@@ -89,4 +91,3 @@ Parameters
 :custom_name:
   A custom unqiue name needed when defining custom
   tokenizers/token_filter/char_filter.
-

--- a/blackbox/docs/sql/statements/create-blob-table.rst
+++ b/blackbox/docs/sql/statements/create-blob-table.rst
@@ -5,6 +5,8 @@
 ``CREATE BLOB TABLE``
 =====================
 
+.. include:: ../../_include/version-note.rst
+
 Define a new table for storing binary large objects.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/create-function.rst
+++ b/blackbox/docs/sql/statements/create-function.rst
@@ -5,6 +5,8 @@
 ``CREATE FUNCTION``
 ===================
 
+.. include:: ../../_include/version-note.rst
+
 Create a new function.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/create-ingest-rule.rst
+++ b/blackbox/docs/sql/statements/create-ingest-rule.rst
@@ -4,6 +4,8 @@
 ``CREATE INGEST RULE``
 ======================
 
+.. include:: ../../_include/version-note.rst
+
 Defines a new ingestion rule.
 
    .. WARNING::
@@ -39,14 +41,14 @@ Parameters
 
 :rule_name:
   The rule name.
-  
+
 :source_ident:
   The ingestion source identifier.
-  
+
 :condition:
   A boolean expression using references specific to the ingestion
   implementation.
-  
+
 :table_ident:
   The target table identifier.
 

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -5,6 +5,8 @@
 ``CREATE REPOSITORY``
 =====================
 
+.. include:: ../../_include/version-note.rst
+
 Register a new repository used to store, manage and restore snapshots.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/create-snapshot.rst
+++ b/blackbox/docs/sql/statements/create-snapshot.rst
@@ -5,6 +5,8 @@
 ``CREATE SNAPSHOT``
 ===================
 
+.. include:: ../../_include/version-note.rst
+
 Create a new incremental snapshot inside a repository that contains the current
 state of the given tables and/or partitions and the cluster metadata.
 

--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -5,6 +5,8 @@
 ``CREATE TABLE``
 ================
 
+.. include:: ../../_include/version-note.rst
+
 Define a new table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/create-user.rst
+++ b/blackbox/docs/sql/statements/create-user.rst
@@ -4,6 +4,8 @@
 ``CREATE USER``
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 Create a new database user.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/create-view.rst
+++ b/blackbox/docs/sql/statements/create-view.rst
@@ -5,6 +5,8 @@
 ``CREATE VIEW``
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 Define a new view.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/deallocate.rst
+++ b/blackbox/docs/sql/statements/deallocate.rst
@@ -5,6 +5,8 @@
 ``DEALLOCATE``
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 Deallocate a prepared statement
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/delete.rst
+++ b/blackbox/docs/sql/statements/delete.rst
@@ -4,6 +4,8 @@
 ``DELETE``
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 Delete rows of a table
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/deny.rst
+++ b/blackbox/docs/sql/statements/deny.rst
@@ -4,6 +4,8 @@
 ``DENY``
 ========
 
+.. include:: ../../_include/version-note.rst
+
 Denies privilege to an existing user on the whole cluster or on a specific
 object.
 

--- a/blackbox/docs/sql/statements/drop-analyzer.rst
+++ b/blackbox/docs/sql/statements/drop-analyzer.rst
@@ -4,6 +4,8 @@
 ``DROP ANALYZER``
 =================
 
+.. include:: ../../_include/version-note.rst
+
 Remove a custom analzer.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/drop-function.rst
+++ b/blackbox/docs/sql/statements/drop-function.rst
@@ -5,6 +5,8 @@
 ``DROP FUNCTION``
 =================
 
+.. include:: ../../_include/version-note.rst
+
 Drop a function.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/drop-ingest-rule.rst
+++ b/blackbox/docs/sql/statements/drop-ingest-rule.rst
@@ -6,6 +6,8 @@
 ``DROP INGEST RULE``
 ====================
 
+.. include:: ../../_include/version-note.rst
+
 Deletes an existing ingestion rule.
 
    .. WARNING::

--- a/blackbox/docs/sql/statements/drop-repository.rst
+++ b/blackbox/docs/sql/statements/drop-repository.rst
@@ -5,6 +5,8 @@
 ``DROP REPOSITORY``
 ===================
 
+.. include:: ../../_include/version-note.rst
+
 Unregister a repository.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/drop-snapshot.rst
+++ b/blackbox/docs/sql/statements/drop-snapshot.rst
@@ -5,6 +5,8 @@
 ``DROP SNAPSHOT``
 =================
 
+.. include:: ../../_include/version-note.rst
+
 Delete an existing snapshot and all files referenced only by this snapshot.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/drop-table.rst
+++ b/blackbox/docs/sql/statements/drop-table.rst
@@ -4,6 +4,8 @@
 ``DROP TABLE``
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 Remove a table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/drop-user.rst
+++ b/blackbox/docs/sql/statements/drop-user.rst
@@ -4,6 +4,8 @@
 ``DROP USER``
 =============
 
+.. include:: ../../_include/version-note.rst
+
 Drop an existing database user.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/drop-view.rst
+++ b/blackbox/docs/sql/statements/drop-view.rst
@@ -5,6 +5,8 @@
 ``DROP VIEW``
 =============
 
+.. include:: ../../_include/version-note.rst
+
 Drop one or more views.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/explain.rst
+++ b/blackbox/docs/sql/statements/explain.rst
@@ -4,6 +4,8 @@
 ``EXPLAIN``
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 Explain or analyze the plan for a given statement.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/grant.rst
+++ b/blackbox/docs/sql/statements/grant.rst
@@ -4,6 +4,8 @@
 ``GRANT``
 =========
 
+.. include:: ../../_include/version-note.rst
+
 Grants privilege to an existing user on the whole cluster or on a specific object.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/index.rst
+++ b/blackbox/docs/sql/statements/index.rst
@@ -2,6 +2,8 @@
 SQL Statements
 ==============
 
+.. include:: ../../_include/version-note.rst
+
 .. rubric:: Table of Contents
 
 .. toctree::

--- a/blackbox/docs/sql/statements/insert.rst
+++ b/blackbox/docs/sql/statements/insert.rst
@@ -5,6 +5,8 @@
 ``INSERT``
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 Create new rows in a table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/kill.rst
+++ b/blackbox/docs/sql/statements/kill.rst
@@ -5,6 +5,8 @@
 ``KILL``
 ========
 
+.. include:: ../../_include/version-note.rst
+
 Kills active jobs in the CrateDB cluster.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/optimize.rst
+++ b/blackbox/docs/sql/statements/optimize.rst
@@ -5,6 +5,8 @@
 ``OPTIMIZE``
 ============
 
+.. include:: ../../_include/version-note.rst
+
 Optimize one or more tables explicitly.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/refresh.rst
+++ b/blackbox/docs/sql/statements/refresh.rst
@@ -5,6 +5,8 @@
 ``REFRESH``
 ===========
 
+.. include:: ../../_include/version-note.rst
+
 Refresh one or more tables explicitly.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/restore-snapshot.rst
+++ b/blackbox/docs/sql/statements/restore-snapshot.rst
@@ -5,6 +5,8 @@
 ``RESTORE SNAPSHOT``
 ====================
 
+.. include:: ../../_include/version-note.rst
+
 Restore a snapshot into the cluster.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/revoke.rst
+++ b/blackbox/docs/sql/statements/revoke.rst
@@ -4,6 +4,8 @@
 ``REVOKE``
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 Revokes a previously granted privilege on the whole cluster or on a specific
 object.
 

--- a/blackbox/docs/sql/statements/select.rst
+++ b/blackbox/docs/sql/statements/select.rst
@@ -5,6 +5,8 @@
 ``SELECT``
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 Retrieve rows from a table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/set-license.rst
+++ b/blackbox/docs/sql/statements/set-license.rst
@@ -5,6 +5,8 @@
 ``SET LICENSE``
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 Sets the license Key.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/set-transaction.rst
+++ b/blackbox/docs/sql/statements/set-transaction.rst
@@ -5,6 +5,8 @@
 ``SET TRANSACTION``
 ===================
 
+.. include:: ../../_include/version-note.rst
+
 Sets the characteristics of transactions.
 
 .. rubric:: Table of Contents
@@ -27,4 +29,3 @@ subsequent transactions of a session.
 
 As CrateDB does not support transactions, this command has no effect and will be
 ignored. The support was added for compatibility reasons.
-

--- a/blackbox/docs/sql/statements/set.rst
+++ b/blackbox/docs/sql/statements/set.rst
@@ -5,6 +5,8 @@
 ``SET`` and ``RESET``
 =====================
 
+.. include:: ../../_include/version-note.rst
+
 Change and restore settings at runtime. To get an overview of available CrateDB
 settings, see :ref:`config`. Only settings documented with *Runtime:* ``yes``
 can be changed.

--- a/blackbox/docs/sql/statements/show-columns.rst
+++ b/blackbox/docs/sql/statements/show-columns.rst
@@ -4,6 +4,8 @@
 ``SHOW COLUMNS``
 ================
 
+.. include:: ../../_include/version-note.rst
+
 ``SHOW COLUMNS`` displays information about columns in a given table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/show-create-table.rst
+++ b/blackbox/docs/sql/statements/show-create-table.rst
@@ -5,6 +5,8 @@
 ``SHOW CREATE TABLE``
 =====================
 
+.. include:: ../../_include/version-note.rst
+
 Shows the ``CREATE TABLE`` statement that creates the named table.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/show-schemas.rst
+++ b/blackbox/docs/sql/statements/show-schemas.rst
@@ -4,6 +4,8 @@
 ``SHOW SCHEMAS``
 ================
 
+.. include:: ../../_include/version-note.rst
+
 Lists the table schemas of the database.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/show-tables.rst
+++ b/blackbox/docs/sql/statements/show-tables.rst
@@ -4,6 +4,8 @@
 ``SHOW TABLES``
 ===============
 
+.. include:: ../../_include/version-note.rst
+
 Lists the tables in the database.
 
 .. rubric:: Table of Contents

--- a/blackbox/docs/sql/statements/show.rst
+++ b/blackbox/docs/sql/statements/show.rst
@@ -5,6 +5,8 @@
 ``SHOW (session settings)``
 ===========================
 
+.. include:: ../../_include/version-note.rst
+
 The ``SHOW`` statement can display the value of either one or all session
 setting variables. Some of these can also be configured via
 :ref:`SET SESSION <ref-set>`.

--- a/blackbox/docs/sql/statements/update.rst
+++ b/blackbox/docs/sql/statements/update.rst
@@ -5,6 +5,8 @@
 ``UPDATE``
 ==========
 
+.. include:: ../../_include/version-note.rst
+
 Update rows of a table.
 
 .. rubric:: Table of Contents


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add admonition to old docs to make readers aware that they are not looking at latest version of CrateDB reference documentation

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
