### PR TITLE
Adding target columns and csv header option for copyfrom statement

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -149,6 +149,7 @@ public class CsvReaderBenchmark {
             false,
             1,
             0,
+            List.of("id", "name"),
             CopyFromParserProperties.DEFAULT,
             CSV,
             Settings.EMPTY);

--- a/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -149,6 +149,7 @@ public class JsonReaderBenchmark {
             false,
             1,
             0,
+            List.of("id", "name"),
             CopyFromParserProperties.DEFAULT,
             JSON,
             Settings.EMPTY);

--- a/docs/appendices/release-notes/3.0.7.rst
+++ b/docs/appendices/release-notes/3.0.7.rst
@@ -74,4 +74,3 @@ Fixes
 
 - Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
   repository parameters.
-

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -63,6 +63,11 @@ Changes
   parameter and also a ``WITH`` clause parameter ``protocol`` to choose between
   ``HTTP`` or ``HTTPS``.
 
+- Added the option to import CSV files without field headers using the ``COPY
+  FROM`` statement.
+
+- Added the option to import only a subset of columns using ``COPY FROM`` when
+  import CSV files with headers.
 
 Fixes
 =====

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -31,8 +31,10 @@ Synopsis
 
 ::
 
-    COPY table_ident [ PARTITION (partition_column = value [ , ... ]) ]
-    FROM uri [ WITH ( option = value [, ...] ) ] [ RETURN SUMMARY ]
+    COPY table_identifier
+      [ ( column_ident [, ...] ) ]
+      [ PARTITION (partition_column = value [ , ... ]) ]
+      FROM uri [ WITH ( option = value [, ...] ) ] [ RETURN SUMMARY ]
 
 
 .. _sql-copy-from-desc:
@@ -84,6 +86,11 @@ Example CSV data::
     1,"Don't panic"
     2,"Ford, you're turning into a penguin. Stop it."
 
+Example CSV data with no header::
+
+    1,"Don't panic"
+    2,"Ford, you're turning into a penguin. Stop it."
+
 See also: :ref:`dml-importing-data`.
 
 
@@ -118,6 +125,13 @@ Parameters
 ``table_ident``
   The name (optionally schema-qualified) of an existing table where the data
   should be put.
+
+.. _sql-copy-from-column_ident:
+
+``column_ident``
+  Used in an optional columns declaration, each ``column_ident`` is the name of a column in the ``table_ident`` table.
+
+  This currently only has an effect if using the CSV file format. See the ``header`` section for how it behaves.
 
 .. _sql-copy-from-uri:
 
@@ -513,6 +527,36 @@ be ignored.
 This option specifies the format of the input file. Available formats are
 ``csv`` or ``json``. If a format is not specified and the format cannot be
 guessed from the file extension, the file will be processed as JSON.
+
+
+.. _sql-copy-from-header:
+
+``header``
+''''''''''
+
+Used to indicate if the first line of a CSV file contains a header with the
+column names. Defaults to ``true``.
+
+If set to ``false``, the CSV must not contain column names in the first line
+and instead the columns declared in the statement are used. If no columns are
+declared in the statement, it will default to all columns present in the table
+in their ``CREATE TABLE`` declaration order.
+
+If set to ``true`` the first line in the CSV file must contain the column
+names. You can use the optional column declaration in addition to import only a
+subset of the data.
+
+If the statement contains no column declarations, all fields in the CSV are
+read and if it contains fields where there is no matching column in the table,
+the behavior depends on the ``column_policy`` table setting. If ``dynamic`` it
+implicitly adds new columns, if ``strict`` the operation will fail.
+
+An example of using input file with no header
+
+::
+
+    cr> COPY quotes FROM 'file:///tmp/import_data/quotes.csv' with (format='csv', header=false);
+    COPY OK, 3 rows affected (... sec)
 
 
 .. _sql-copy-from-return-summary:

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -87,7 +87,8 @@ statement
     | RESTORE SNAPSHOT qname
         (ALL | METADATA | TABLE tableWithPartitions | metatypes=idents)
         withProperties?                                                              #restore
-    | COPY tableWithPartition FROM path=expr withProperties? (RETURN SUMMARY)?       #copyFrom
+    | COPY tableWithPartition ('(' ident (',' ident)* ')')?
+         FROM path=expr withProperties? (RETURN SUMMARY)?                            #copyFrom
     | COPY tableWithPartition columns? where?
         TO DIRECTORY? path=expr withProperties?                                      #copyTo
     | DROP BLOB TABLE (IF EXISTS)? table                                             #dropBlobTable

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -182,6 +182,17 @@ public final class SqlFormatter {
 
             append(indent, "COPY ");
             copyFrom.table().accept(this, indent);
+            var columns = node.columns().iterator();
+            if (columns.hasNext()) {
+                builder.append('(');
+                while (columns.hasNext()) {
+                    builder.append(columns.next());
+                    if (columns.hasNext()) {
+                        builder.append(", ");
+                    }
+                }
+                builder.append(')');
+            }
             append(indent, " FROM ");
             copyFrom.path().accept(this, indent);
             if (!copyFrom.properties().isEmpty()) {

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -599,6 +599,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         boolean returnSummary = context.SUMMARY() != null;
         return new CopyFrom(
             (Table) visit(context.tableWithPartition()),
+            context.ident() == null ? emptyList() : identsToStrings(context.ident()),
             visit(context.path),
             extractGenericProperties(context.withProperties()),
             returnSummary);

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CopyFrom.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CopyFrom.java
@@ -21,20 +21,24 @@
 
 package io.crate.sql.tree;
 
+import java.util.List;
 import java.util.Objects;
 
 public class CopyFrom<T> extends Statement {
 
     private final Table<T> table;
+    private final List<String> columns;
     private final T path;
     private final GenericProperties<T> properties;
     private final boolean returnSummary;
 
     public CopyFrom(Table<T> table,
+                    List<String> columns,
                     T path,
                     GenericProperties<T> properties,
                     boolean returnSummary) {
         this.table = table;
+        this.columns = columns;
         this.path = path;
         this.properties = properties;
         this.returnSummary = returnSummary;
@@ -42,6 +46,10 @@ public class CopyFrom<T> extends Statement {
 
     public Table<T> table() {
         return table;
+    }
+
+    public List<String> columns() {
+        return columns;
     }
 
     public T path() {
@@ -67,19 +75,21 @@ public class CopyFrom<T> extends Statement {
         CopyFrom<?> copyFrom = (CopyFrom<?>) o;
         return returnSummary == copyFrom.returnSummary &&
                Objects.equals(table, copyFrom.table) &&
+               Objects.equals(columns, copyFrom.columns) &&
                Objects.equals(path, copyFrom.path) &&
                Objects.equals(properties, copyFrom.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(table, path, properties, returnSummary);
+        return Objects.hash(table, columns, path, properties, returnSummary);
     }
 
     @Override
     public String toString() {
         return "CopyFrom{" +
                "table=" + table +
+               ", columns=" + columns +
                ", path=" + path +
                ", properties=" + properties +
                ", returnSummary=" + returnSummary +

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1109,6 +1109,7 @@ public class TestStatementBuilder {
         printStatement("copy foo partition (a={key='value'}) from ?");
         printStatement("copy foo from '/folder/file.extension'");
         printStatement("copy foo from ?");
+        printStatement("copy foo (a,b) from ?");
         printStatement("copy foo from ? with (some_property=1)");
         printStatement("copy foo from ? with (some_property=false)");
         printStatement("copy schemah.foo from '/folder/file.extension'");

--- a/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
+++ b/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
@@ -246,6 +246,7 @@ public class S3FileReadingCollectorTest extends ESTestCase {
             false,
             1,
             0,
+            List.of("id", "name", "details"),
             CopyFromParserProperties.DEFAULT,
             FileUriCollectPhase.InputFormat.JSON,
             Settings.EMPTY);

--- a/server/src/main/java/io/crate/analyze/AnalyzedCopyFrom.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCopyFrom.java
@@ -27,20 +27,24 @@ import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.Table;
 import io.crate.types.DataType;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 public class AnalyzedCopyFrom implements AnalyzedStatement {
 
     private final DocTableInfo tableInfo;
+    private final List<String> targetColumns;
     private final Table<Symbol> table;
     private final GenericProperties<Symbol> properties;
     private final Symbol uri;
 
     AnalyzedCopyFrom(DocTableInfo tableInfo,
+                     List<String> targetColumns,
                      Table<Symbol> table,
                      GenericProperties<Symbol> properties,
                      Symbol uri) {
         this.tableInfo = tableInfo;
+        this.targetColumns = targetColumns;
         this.table = table;
         this.properties = properties;
         this.uri = uri;
@@ -48,6 +52,10 @@ public class AnalyzedCopyFrom implements AnalyzedStatement {
 
     public DocTableInfo tableInfo() {
         return tableInfo;
+    }
+
+    public List<String> targetColumns() {
+        return targetColumns;
     }
 
     public GenericProperties<Symbol> properties() {

--- a/server/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
@@ -44,10 +44,11 @@ public class AnalyzedCopyFromReturnSummary extends AnalyzedCopyFrom implements A
     private final List<ScopedSymbol> fields;
 
     AnalyzedCopyFromReturnSummary(DocTableInfo tableInfo,
+                                  List<String> targetColumns,
                                   Table<Symbol> table,
                                   GenericProperties<Symbol> properties,
                                   Symbol uri) {
-        super(tableInfo, table, properties, uri);
+        super(tableInfo, targetColumns, table, properties, uri);
         this.fields = List.of(
             new ScopedSymbol(tableInfo.ident(), new ColumnIdent("node"), ObjectType.builder()
                 .setInnerType("id", DataTypes.STRING)

--- a/server/src/main/java/io/crate/analyze/BoundCopyFrom.java
+++ b/server/src/main/java/io/crate/analyze/BoundCopyFrom.java
@@ -28,6 +28,8 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
+
+import java.util.List;
 import java.util.function.Predicate;
 
 public class BoundCopyFrom {
@@ -35,6 +37,7 @@ public class BoundCopyFrom {
     private final DocTableInfo tableInfo;
     @Nullable
     private final String partitionIdent;
+    private final List<String> targetColumns;
     private final Settings settings;
     private final Symbol uri;
     private final FileUriCollectPhase.InputFormat inputFormat;
@@ -42,12 +45,14 @@ public class BoundCopyFrom {
 
     public BoundCopyFrom(DocTableInfo tableInfo,
                          @Nullable String partitionIdent,
+                         List<String> targetColumns,
                          Settings settings,
                          Symbol uri,
                          FileUriCollectPhase.InputFormat inputFormat,
                          Predicate<DiscoveryNode> nodeFilters) {
         this.tableInfo = tableInfo;
         this.partitionIdent = partitionIdent;
+        this.targetColumns = targetColumns;
         this.settings = settings;
         this.uri = uri;
         this.inputFormat = inputFormat;
@@ -61,6 +66,10 @@ public class BoundCopyFrom {
     @Nullable
     public String partitionIdent() {
         return partitionIdent;
+    }
+
+    public List<String> targetColumns() {
+        return targetColumns;
     }
 
     public Settings settings() {

--- a/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -83,12 +83,14 @@ class CopyAnalyzer {
         if (node.isReturnSummary()) {
             return new AnalyzedCopyFromReturnSummary(
                 tableInfo,
+                node.columns(),
                 table,
                 properties,
                 normalizer.normalize(uri, txnCtx));
         } else {
             return new AnalyzedCopyFrom(
                 tableInfo,
+                node.columns(),
                 table,
                 properties,
                 normalizer.normalize(uri, txnCtx));

--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -57,6 +57,11 @@ public final class CopyStatementSettings {
         false,
         Setting.Property.Dynamic);
 
+    public static final Setting<Boolean> INPUT_HEADER_SETTINGS = Setting.boolSetting(
+        "header",
+        true,
+        Setting.Property.Dynamic);
+
     public static final Setting<Character> CSV_COLUMN_SEPARATOR = new Setting<>(
         "delimiter",
         String.valueOf(CsvSchema.DEFAULT_COLUMN_SEPARATOR),

--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -225,7 +225,7 @@ class InsertAnalyzer {
         }
     }
 
-    private static Collection<Reference> resolveTargetColumns(Collection<String> targetColumnNames,
+    public static Collection<Reference> resolveTargetColumns(Collection<String> targetColumnNames,
                                                               DocTableInfo targetTable) {
         if (targetColumnNames.isEmpty()) {
             return targetTable.columns();

--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -69,6 +69,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     private final Iterable<LineCollectorExpression<?>> collectorExpressions;
 
     private volatile Throwable killed;
+    private final List<String> targetColumns;
     private final CopyFromParserProperties parserProperties;
     private final FileUriCollectPhase.InputFormat inputFormat;
     private Iterator<FileInput> fileInputsIterator = null;
@@ -88,6 +89,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
                                 Boolean shared,
                                 int numReaders,
                                 int readerNumber,
+                                List<String> targetColumns,
                                 CopyFromParserProperties parserProperties,
                                 FileUriCollectPhase.InputFormat inputFormat,
                                 Settings withClauseOptions) {
@@ -99,6 +101,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
         this.readerNumber = readerNumber;
         this.fileInputs = fileUris.stream().map(uri -> toFileInput(uri, withClauseOptions)).filter(Objects::nonNull).toList();
         this.collectorExpressions = collectorExpressions;
+        this.targetColumns = targetColumns;
         this.parserProperties = parserProperties;
         this.inputFormat = inputFormat;
         initCollectorState();
@@ -122,6 +125,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
                                                  Boolean shared,
                                                  int numReaders,
                                                  int readerNumber,
+                                                 List<String> targetColumns,
                                                  CopyFromParserProperties parserProperties,
                                                  FileUriCollectPhase.InputFormat inputFormat,
                                                  Settings withClauseOptions) {
@@ -134,13 +138,14 @@ public class FileReadingIterator implements BatchIterator<Row> {
             shared,
             numReaders,
             readerNumber,
+            targetColumns,
             parserProperties,
             inputFormat,
             withClauseOptions);
     }
 
     private void initCollectorState() {
-        lineProcessor = new LineProcessor(parserProperties);
+        lineProcessor = new LineProcessor(parserProperties, targetColumns);
         lineProcessor.startCollect(collectorExpressions);
         fileInputsIterator = fileInputs.iterator();
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
@@ -28,14 +28,15 @@ import io.crate.expression.reference.file.LineContext;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
 public final class LineProcessor {
 
     private final LineContext lineContext = new LineContext();
     private final LineParser lineParser;
 
-    public LineProcessor(CopyFromParserProperties parserProperties) {
-        lineParser = new LineParser(parserProperties);
+    public LineProcessor(CopyFromParserProperties parserProperties, List<String> targetColumns) {
+        lineParser = new LineParser(parserProperties, targetColumns);
     }
 
     public void startCollect(Iterable<LineCollectorExpression<?>> collectorExpressions) {
@@ -55,7 +56,7 @@ public final class LineProcessor {
 
     public void process(String line) throws IOException {
         lineContext.incrementCurrentLineNumber();
-        byte[] jsonByteArray = lineParser.getByteArray(line);
+        byte[] jsonByteArray = lineParser.getByteArray(line, lineContext.getCurrentLineNumber());
         lineContext.rawSource(jsonByteArray);
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -87,6 +87,7 @@ public class FileCollectSource implements CollectSource {
             fileUriCollectPhase.sharedStorage(),
             fileUriCollectPhase.nodeIds().size(),
             getReaderNumber(fileUriCollectPhase.nodeIds(), clusterService.state().nodes().getLocalNodeId()),
+            fileUriCollectPhase.targetColumns(),
             fileUriCollectPhase.parserProperties(),
             fileUriCollectPhase.inputFormat(),
             fileUriCollectPhase.withClauseOptions()

--- a/server/src/main/java/io/crate/expression/reference/file/LineContext.java
+++ b/server/src/main/java/io/crate/expression/reference/file/LineContext.java
@@ -111,7 +111,7 @@ public class LineContext {
         currentLineNumber++;
     }
 
-    long getCurrentLineNumber() {
+    public long getCurrentLineNumber() {
         return currentLineNumber;
     }
 }

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -158,10 +158,16 @@ public final class CopyFromPlan implements Plan {
         // instead of the Symbol type, such as the uri can be evaluated and converted
         // to the required type already at this stage, but not later on in FileCollectSource.
         var boundedURI = validateAndConvertToLiteral(eval.apply(copyFrom.uri()));
+        var header = settings.getAsBoolean("header", true);
+        var targetColumns = copyFrom.targetColumns();
+        if (!header && copyFrom.targetColumns().isEmpty()) {
+            targetColumns = Lists2.map(copyFrom.tableInfo().columns(), Reference::toString);
+        }
 
         return new BoundCopyFrom(
             copyFrom.tableInfo(),
             partitionIdent,
+            targetColumns,
             settings,
             boundedURI,
             inputFormat,
@@ -299,6 +305,7 @@ public final class CopyFromPlan implements Plan {
                 boundedCopyFrom.settings().getAsInt("num_readers", allNodes.getSize()),
                 boundedCopyFrom.nodePredicate()),
             boundedCopyFrom.uri(),
+            boundedCopyFrom.targetColumns(),
             toCollect,
             Collections.emptyList(),
             boundedCopyFrom.settings().get("compression", null),

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -138,6 +138,15 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testCopyFromWithColumnList() throws Exception {
+        BoundCopyFrom analysis = analyze("COPY users (id, name) FROM  '/some/distant/file.ext'");
+        List<String> outputs = analysis.targetColumns();
+        assertThat(outputs.size(), is(2));
+        assertThat(outputs.get(0), is("id"));
+        assertThat(outputs.get(1), is("name"));
+    }
+
+    @Test
     public void testCopyFromUnknownSchema() throws Exception {
         expectedException.expect(SchemaUnknownException.class);
         analyze("COPY suess.shards FROM '/nope/nope/still.nope'");
@@ -174,6 +183,19 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             is(Settings.builder()
                    .put("empty_string_as_null", true)
                    .put("format", "csv")
+                   .build())
+        );
+    }
+
+    @Test
+    public void test_copy_from_supports_header_setting_option() {
+        BoundCopyFrom analysis = analyze(
+            "COPY users FROM '/some/distant/file.ext' WITH (format='csv', header=false)");
+        assertThat(
+            analysis.settings(),
+            is(Settings.builder()
+                   .put("format", "csv")
+                   .put("header", false)
                    .build())
         );
     }

--- a/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
@@ -51,11 +51,12 @@ public class FileUriCollectPhaseTest {
             "test",
             Collections.singletonList("noop_id"),
             Literal.of("uri"),
+            List.of(),
             List.of(createReference("name", DataTypes.STRING)),
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, '|'),
+            new CopyFromParserProperties(true, true, '|'),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.EMPTY
         );
@@ -71,6 +72,7 @@ public class FileUriCollectPhaseTest {
         assertThat(expected.nodeIds(), is(actual.nodeIds()));
         assertThat(expected.distributionInfo(), is(actual.distributionInfo()));
         assertThat(expected.targetUri(), is(actual.targetUri()));
+        assertThat(expected.targetColumns(), is(actual.targetColumns()));
         assertThat(expected.toCollect(), is(actual.toCollect()));
 
         // parser properties option serialization implemented in crate >= 4.4.0
@@ -92,11 +94,12 @@ public class FileUriCollectPhaseTest {
             "test",
             Collections.singletonList("noop_id"),
             Literal.of("uri"),
+            List.of(),
             List.of(createReference("name", DataTypes.STRING)),
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, '|'),
+            new CopyFromParserProperties(true, true, '|'),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.EMPTY
         );
@@ -122,11 +125,12 @@ public class FileUriCollectPhaseTest {
             "test",
             Collections.singletonList("noop_id"),
             Literal.of("uri"),
+            List.of(),
             List.of(createReference("name", DataTypes.STRING)),
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, '|'),
+            new CopyFromParserProperties(true, true, '|'),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.EMPTY
         );
@@ -137,11 +141,12 @@ public class FileUriCollectPhaseTest {
             "test",
             Collections.singletonList("noop_id"),
             Literal.of("uri"),
+            List.of("a", "b"),
             List.of(createReference("name", DataTypes.STRING)),
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, '|'),
+            new CopyFromParserProperties(true, true, '|'),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.builder().put("protocol", "http").build()
         );
@@ -165,11 +170,12 @@ public class FileUriCollectPhaseTest {
             "test",
             Collections.singletonList("noop_id"),
             Literal.of("uri"),
+            List.of("a", "b"),
             List.of(createReference("name", DataTypes.STRING)),
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, '|'),
+            new CopyFromParserProperties(true, true, '|'),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.builder().put("protocol", "http").build()
         );

--- a/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -45,6 +45,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -76,6 +77,7 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
             "test",
             Collections.singletonList("noop_id"),
             Literal.of(Paths.get(tmpFile.toURI()).toUri().toString()),
+            List.of("a", "b"),
             Arrays.asList(
                 createReference("name", DataTypes.STRING),
                 createReference(new ColumnIdent("details", "age"), DataTypes.INTEGER)

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -244,6 +244,7 @@ public class FileReadingCollectorTest extends ESTestCase {
             false,
             1,
             0,
+            List.of("a", "b"),
             CopyFromParserProperties.DEFAULT,
             FileUriCollectPhase.InputFormat.JSON,
             Settings.EMPTY);

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -176,6 +176,7 @@ public class FileReadingIteratorTest extends ESTestCase {
             false,
             1,
             0,
+            List.of("name", "id", "age"),
             CopyFromParserProperties.DEFAULT,
             format,
             Settings.EMPTY);

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -31,6 +31,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.CSV;
 import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.JSON;
@@ -46,7 +47,7 @@ public class LineProcessorTest {
 
     @Before
     public void setup() {
-        subjectUnderTest  = new LineProcessor(CopyFromParserProperties.DEFAULT);
+        subjectUnderTest  = new LineProcessor(CopyFromParserProperties.DEFAULT, List.of("a", "b"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
+++ b/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,42 +40,42 @@ public class CSVLineParserTest {
 
     @Before
     public void setup() {
-        csvParser = new CSVLineParser(CopyFromParserProperties.DEFAULT);
+        csvParser = new CSVLineParser(CopyFromParserProperties.DEFAULT, List.of("Code", "Country", "City"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenEmptyHeader_thenThrowsException() throws IOException {
         String header = "\n";
         csvParser.parseHeader(header);
-        csvParser.parse("GER,Germany\n");
+        csvParser.parse("GER,Germany\n", 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenDuplicateKey_thenThrowsException() throws IOException {
         String header = "Code,Country,Country\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,Germany,Another\n");
+        result = csvParser.parse("GER,Germany,Another\n", 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenMissingKey_thenThrowsException() throws IOException {
         String header = "Code,\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,Germany\n");
+        result = csvParser.parse("GER,Germany\n", 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parse_givenExtraValue_thenIgnoresTheKeyWithoutValue() throws IOException {
         String header = "Code,Country\n";
         csvParser.parseHeader(header);
-        csvParser.parse("GER,Germany,Berlin\n");
+        csvParser.parse("GER,Germany,Berlin\n", 0);
     }
 
     @Test
     public void parse_givenExtraKey_thenIgnoresTheKeyWithoutValue() throws IOException {
         String header = "Code,Country,Another\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,Germany\n");
+        result = csvParser.parse("GER,Germany\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
@@ -83,7 +84,7 @@ public class CSVLineParserTest {
     public void parse_givenCSVInput_thenParsesToMap() throws IOException {
         String header = "Code,Country\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,Germany\n");
+        result = csvParser.parse("GER,Germany\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
@@ -92,7 +93,7 @@ public class CSVLineParserTest {
     public void parse_givenEmptyRow_thenParsesToEmptyJson() throws IOException {
         String header = "Code,Country\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("");
+        result = csvParser.parse("", 0);
 
         assertThat(result, is("{}".getBytes(StandardCharsets.UTF_8)));
     }
@@ -101,7 +102,7 @@ public class CSVLineParserTest {
     public void parse_givenEmptyRowWithCommas_thenParsesAsEmptyStrings() throws IOException {
         String header ="Code,Country\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse(",");
+        result = csvParser.parse(",", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"\",\"Country\":\"\"}"));
     }
@@ -109,8 +110,11 @@ public class CSVLineParserTest {
     @Test
     public void parse_givenEscapedComma_thenParsesLineCorrectly() throws IOException {
         String header = "Code,\"Coun, try\"\n";
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            List.of("Code", "Coun, try", "City"));
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,Germany\n");
+        result = csvParser.parse("GER,Germany\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Coun, try\":\"Germany\"}"));
     }
@@ -119,10 +123,10 @@ public class CSVLineParserTest {
     public void test_quoted_and_unquoted_empty_string_converted_to_null_empty_string_as_null_is_set() throws IOException {
         String header = "Code,Country,City\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, CsvSchema.DEFAULT_COLUMN_SEPARATOR)
-        );
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+                                          List.of("Code", "Country", "City"));
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,,\"\"\n");
+        result = csvParser.parse("GER,,\"\"\n", 0);
 
         assertThat(
             new String(result, StandardCharsets.UTF_8),
@@ -133,9 +137,11 @@ public class CSVLineParserTest {
     @Test
     public void test_parse_csv_with_configured_delimiter_parses_lines_correctly() throws IOException {
         String header = "Code|Country|City\n";
-        csvParser = new CSVLineParser(new CopyFromParserProperties(true, '|'));
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, true, '|'),
+                                          List.of("Code", "Country", "City"));
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER|Germany|Berlin\n");
+        result = csvParser.parse("GER|Germany|Berlin\n", 0);
 
         assertThat(
             new String(result, StandardCharsets.UTF_8),
@@ -147,7 +153,7 @@ public class CSVLineParserTest {
     public void parse_givenRowWithMissingValue_thenTheValueIsAssignedToKeyAsAnEmptyString() throws IOException {
         String header = "Code,Country,City\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,,Berlin\n");
+        result = csvParser.parse("GER,,Berlin\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"\",\"City\":\"Berlin\"}"));
     }
@@ -156,7 +162,7 @@ public class CSVLineParserTest {
     public void parse_givenTrailingWhiteSpaceInHeader_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "Code ,Country  \n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,Germany\n");
+        result = csvParser.parse("GER,Germany\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
@@ -165,7 +171,7 @@ public class CSVLineParserTest {
     public void parse_givenTrailingWhiteSpaceInRow_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "Code ,Country\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER        ,Germany\n");
+        result = csvParser.parse("GER        ,Germany\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
@@ -174,7 +180,7 @@ public class CSVLineParserTest {
     public void parse_givenPrecedingWhiteSpaceInHeader_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "         Code,         Country\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,Germany\n");
+        result = csvParser.parse("GER,Germany\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
     }
@@ -183,8 +189,80 @@ public class CSVLineParserTest {
     public void parse_givenPrecedingWhiteSpaceInRow_thenParsesToMapWithoutWhitespace() throws IOException {
         String header = "Code,Country\n";
         csvParser.parseHeader(header);
-        result = csvParser.parse("GER,               Germany\n");
+        result = csvParser.parse("GER,               Germany\n", 0);
 
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+    }
+
+    @Test
+    public void parse_targetColumnsMoreThanCsvHeader_thenKeepOnlyTargetValues() throws IOException {
+        String header = "Code,Country\n";
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, true,CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            List.of("Code", "Country", "City"));
+
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany\n", 0);
+
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+    }
+
+    @Test
+    public void parse_targetColumnsLessThanCsvHeader_thenDropExtraCsvValues() throws IOException {
+        String header = "Code,Country,City\n";
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, true,CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+                                          List.of("Code", "Country"));
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany,Berlin\n", 0);
+
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+    }
+
+    @Test
+    public void parse_targetColumnsSameCsvValuesNoHeader_thenParseAsIs() throws IOException {
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            List.of("Code", "Country", "City"));
+        csvParser.parseWithoutHeader("GER,Germany,Berlin\n", 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parse_targetColumnsMoreThanCsvValuesNoHeader_thenThrowException() throws IOException {
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            List.of("Code", "Country", "City"));
+        csvParser.parseWithoutHeader("GER,Germany\n", 0);
+    }
+
+    @Test
+    public void parse_targetColumnsLessThanCsvValuesNoHeader_thenDropExtraCsvValues() throws IOException {
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            List.of("Code", "Country"));
+        result = csvParser.parseWithoutHeader("GER,Germany,Berlin\n", 0);
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+    }
+
+    @Test
+    public void parse_targetColumnsNotInOrder_thenParseWithOrder() throws IOException {
+        String header = "Code,Country,City\n";
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            List.of("City", "Code"));
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany,Berlin\n", 0);
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"City\":\"Berlin\"}"));
+    }
+
+    @Test
+    public void parse_targetColumnsEmpty_thenParseFromHeader() throws IOException {
+        String header = "Code,Country,City\n";
+        csvParser = new CSVLineParser(
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            List.of());
+        csvParser.parseHeader(header);
+        result = csvParser.parse("GER,Germany,Berlin\n", 0);
+        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\",\"City\":\"Berlin\"}"));
     }
 }

--- a/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
@@ -80,6 +80,14 @@ public class CopyFromPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(((Literal) collectPhase.targetUri()).value(), is("/path/to/file.extension"));
     }
 
+    public void testCopyFromPlanWithTargetColumns() {
+        Collect plan = plan("copy users(id, name) from '/path/to/file.extension'");
+        assertThat(plan.collectPhase(), instanceOf(FileUriCollectPhase.class));
+
+        FileUriCollectPhase collectPhase = (FileUriCollectPhase) plan.collectPhase();
+        assertThat(collectPhase.targetColumns(), is(List.of("id", "name")));
+    }
+
     @Test
     public void testCopyFromNumReadersSetting() {
         Collect plan = plan("copy users from '/path/to/file.extension' with (num_readers=1)");

--- a/server/src/test/resources/essetup/data/copy/test_copy_from_csv_extra_column.ext
+++ b/server/src/test/resources/essetup/data/copy/test_copy_from_csv_extra_column.ext
@@ -1,0 +1,4 @@
+id,quote,comment
+1,"Don't pañic.","good one"
+2,"Would it save you a lot of time if I just gave up and went mad now?","ok"
+3,"Time is an illusion. Lunchtime doubly so.","perfecto"

--- a/server/src/test/resources/essetup/data/copy/test_copy_from_csv_no_header.ext
+++ b/server/src/test/resources/essetup/data/copy/test_copy_from_csv_no_header.ext
@@ -1,0 +1,3 @@
+1,"Don't pañic."
+2,"Would it save you a lot of time if I just gave up and went mad now?"
+3,"Time is an illusion. Lunchtime doubly so."

--- a/server/src/test/resources/essetup/data/copy/test_copy_from_extra_column.json
+++ b/server/src/test/resources/essetup/data/copy/test_copy_from_extra_column.json
@@ -1,0 +1,3 @@
+{"id": 1, "quote": "Don't pañic.", "comment": "Good one"}
+{"id": 2, "quote": "Would it save you a lot of time if I just gave up and went mad now?", "comment": "Ok"}
+{"id": 3, "quote": "Time is an illusion. Lunchtime doubly so.", "comment": "Perfecto"}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Implementation of the of the #11751

The implementation adds functionality to the copy from statement for importing data from files.
The user can now add target columns to the destination table and only these columns will get written.
Also a header option is made available inside where clause. 

There are two issues worth mentioning:
1. Added to documentation that columns idents can be used only with csv file inputs. The current implementation did not deal with the target columns in the case of a json input file.
2. Maybe there is a performance optimization issue when parsing a csv file. Now that a user can choose the target columns, there is no need to parse a whole line if the target columns have been written.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
