### PR TITLE
Add flush_stats to sys.shards table

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1082,6 +1082,15 @@ Table schema
     * - ``retention_leases``
       - Versioned collection of retention leases.
       - ``OBJECT``
+    * - ``flush_stats``
+      - Flush information. Shard relocation resets this information.
+      - ``OBJECT``
+    * - ``flush_stats['count']``
+      - The total amount of flush operations that happened on the shard.
+      - ``BIGINT``
+    * - ``flush_stats['total_time_ns']``
+      - The total time spent on flush operations on the shard.
+      - ``BIGINT``
 
 
 .. NOTE::

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1088,6 +1088,11 @@ Table schema
     * - ``flush_stats['count']``
       - The total amount of flush operations that happened on the shard.
       - ``BIGINT``
+    * - ``flush_stats['periodic_count']``
+      - The number of periodic flushes. Each periodic flush also counts as a
+        regular flush. A periodic flush can happen after writes depending on
+        settings like the translog flush threshold.
+      - ``BIGINT``
     * - ``flush_stats['total_time_ns']``
       - The total time spent on flush operations on the shard.
       - ``BIGINT``

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,8 @@ None
 Changes
 =======
 
+- Added a ``flush_stats`` column to the :ref:`sys.shards <sys-shards>` table.
+
 - Allowed users to be able to specify different S3 compatible storage endpoints
   to ``COPY FROM/TO`` statements by embedding the host and port to the ``URI``
   parameter and also a ``WITH`` clause parameter ``protocol`` to choose between

--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -382,4 +382,12 @@ public class ShardRowContext {
             return List.of();
         }
     }
+
+    public long flushCount() {
+        return indexShard.getFlushMetric().count();
+    }
+
+    public long flushTotalTimeNs() {
+        return indexShard.getFlushMetric().sum();
+    }
 }

--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -390,4 +390,8 @@ public class ShardRowContext {
     public long flushTotalTimeNs() {
         return indexShard.getFlushMetric().sum();
     }
+
+    public long flushPeriodicCount() {
+        return indexShard.periodicFlushCount();
+    }
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -191,6 +191,7 @@ public class SysShardsTableInfo {
             .endObject()
             .startObject(Columns.FLUSH_STATS.name())
                 .add("count", LONG, ShardRowContext::flushCount)
+                .add("periodic_count", LONG, ShardRowContext::flushPeriodicCount)
                 .add("total_time_ns", LONG, ShardRowContext::flushTotalTimeNs)
             .endObject()
             .setPrimaryKeys(

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -96,6 +96,7 @@ public class SysShardsTableInfo {
         static final ColumnIdent SEQ_NO_STATS = new ColumnIdent("seq_no_stats");
         static final ColumnIdent TRANSLOG_STATS = new ColumnIdent("translog_stats");
         static final ColumnIdent RETENTION_LEASES = new ColumnIdent("retention_leases");
+        static final ColumnIdent FLUSH_STATS = new ColumnIdent("flush_stats");
     }
 
     public static Map<ColumnIdent, RowCollectExpressionFactory<UnassignedShard>> unassignedShardsExpressions() {
@@ -119,7 +120,8 @@ public class SysShardsTableInfo {
             entry(Columns.NODE, NestedNullObjectExpression::new),
             entry(Columns.SEQ_NO_STATS, NestedNullObjectExpression::new),
             entry(Columns.TRANSLOG_STATS, NestedNullObjectExpression::new),
-            entry(Columns.RETENTION_LEASES, NestedNullObjectExpression::new)
+            entry(Columns.RETENTION_LEASES, NestedNullObjectExpression::new),
+            entry(Columns.FLUSH_STATS, NestedNullObjectExpression::new)
         );
     }
 
@@ -186,6 +188,10 @@ public class SysShardsTableInfo {
                     .add("timestamp", DataTypes.TIMESTAMPZ, RetentionLease::timestamp)
                     .add("source", STRING, RetentionLease::source)
                 .endObjectArray()
+            .endObject()
+            .startObject(Columns.FLUSH_STATS.name())
+                .add("count", LONG, ShardRowContext::flushCount)
+                .add("total_time_ns", LONG, ShardRowContext::flushTotalTimeNs)
             .endObject()
             .setPrimaryKeys(
                 Columns.SCHEMA_NAME,

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3367,4 +3367,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public MeanMetric getFlushMetric() {
         return flushMetric;
     }
+
+    public long periodicFlushCount() {
+        return periodicFlushMetric.count();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3363,4 +3363,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public void verifyShardBeforeIndexClosing() throws IllegalStateException {
         getEngine().verifyEngineBeforeIndexClosing();
     }
+
+    public MeanMetric getFlushMetric() {
+        return flushMetric;
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -532,7 +532,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(883, response.rowCount());
+        assertEquals(886, response.rowCount());
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -532,7 +532,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(886, response.rowCount());
+        assertEquals(887, response.rowCount());
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -296,9 +296,9 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
         assertThat(printedTable(response.rows()),
             is("strict| blob_path\n" +
                "strict| closed\n" +
-               "strict| id\n" +
-               "strict| min_lucene_version\n" +
-               "strict| node\n"));
+               "strict| flush_stats\n" +
+               "strict| flush_stats['count']\n" +
+               "strict| flush_stats['total_time_ns']\n"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -298,7 +298,7 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
                "strict| closed\n" +
                "strict| flush_stats\n" +
                "strict| flush_stats['count']\n" +
-               "strict| flush_stats['total_time_ns']\n"));
+               "strict| flush_stats['periodic_count']\n"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -172,10 +172,11 @@ public class SysShardsTest extends SQLIntegrationTestCase {
     public void testSelectStarAllTables() throws Exception {
         SQLResponse response = execute("select * from sys.shards");
         assertEquals(26L, response.rowCount());
-        assertEquals(20, response.cols().length);
+        assertEquals(21, response.cols().length);
         assertThat(response.cols(), arrayContaining(
             "blob_path",
             "closed",
+            "flush_stats",
             "id",
             "min_lucene_version",
             "node",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To get insights into whether flushes are happening and how much time is
spent on them.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
