### PR TITLE
Don't warn about GraalVM interpreter mode for JS udf

### DIFF
--- a/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
+++ b/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
@@ -47,6 +47,7 @@ public class JavaScriptLanguage implements UDFLanguage {
 
     private static final Engine ENGINE = Engine.newBuilder()
         .option("js.foreign-object-prototype", "true")
+        .option("engine.WarnInterpreterOnly", "false")
         .build();
 
     private static final HostAccess HOST_ACCESS = HostAccess.newBuilder()


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

That we don't use the GraalVM compiler is intentional.
Closes https://github.com/crate/crate/issues/12133


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
