### PR TITLE
fix nondeterministic default exprs that were not evaluated per row

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -64,6 +64,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue from ``COPY FROM`` that caused the tables' default expressions
+  to be evaluated only once, causing a single value to be used throughout the
+  table instead of per row. This only affected non-deterministic functions such
+  as ``gen_random_text_uuid()``, ``random()``, etc.
+
 - Fixed an issue that could lead to errors when reading translog files from
   CrateDB versions < 4.0.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
fixes #12173 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
