### PR TITLE
bp: Ignore shutdown when retrying recoveries

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -216,7 +216,7 @@ should be crossed out as well.
 - [ ] 9f6f66f1567 Fail searchable snapshot shards on invalid license (#60722)
 - [ ] b3ae5d26bd1 Move mapper validation to the mappers themselves (#60072) (#60649)
 - [ ] 212ce22d155 Optimize CS Persistence Stream Use (#60643) (#60647)
-- [ ] 3409e019d23 Ignore shutdown when retrying recoveries (#60586)
+- [x] 3409e019d23 Ignore shutdown when retrying recoveries (#60586)
 - [ ] 2cde43b799d Allows nanosecond resolution in search_after (backport of #60328) (#60426)
 - [ ] d2ddf8cd6a1 Improve deserialization failure logging (#60577)
 - [ ] 3270cb3088c More Efficient Writes for Snapshot Shard Generations (#60458) (#60575)

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -188,7 +188,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
     private void retryRecovery(final long recoveryId, final TimeValue retryAfter, final TimeValue activityTimeout) {
         RecoveryTarget newTarget = onGoingRecoveries.resetRecovery(recoveryId, activityTimeout);
         if (newTarget != null) {
-            threadPool.schedule(new RecoveryRunner(newTarget.recoveryId()), retryAfter, ThreadPool.Names.GENERIC);
+            threadPool.scheduleUnlessShuttingDown(retryAfter, ThreadPool.Names.GENERIC, new RecoveryRunner(newTarget.recoveryId()));
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Applying this out of order because the change is fairly isolated and we
often see harmless but confusing exceptions in the log after test
shutdown when running tests

https://github.com/elastic/elasticsearch/commit/3409e019d234d423e7ca4642086bbf0c65764de9


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
