### PR TITLE
group by - all maps comparison

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -41,6 +41,13 @@ dependencies {
     // Dependencies of JMH
     runtimeOnly 'net.sf.jopt-simple:jopt-simple:4.6'
     runtimeOnly 'org.apache.commons:commons-math3:3.2'
+
+
+    implementation  'com.koloboke:koloboke-api-jdk8:1.0.0'
+    runtimeOnly 'com.koloboke:koloboke-impl-jdk8:1.0.0'
+
+    implementation 'it.unimi.dsi:fastutil:8.5.8'
+    implementation 'org.lz4:lz4-java:1.8.0'
 }
 
 application {

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -212,7 +212,7 @@ public class GroupingLongCollectorBenchmark {
     }
 
     @Benchmark
-    public void measureGroupBySumLongFastutilCustom(Blackhole blackhole) throws Exception {
+    public void measureGroupBySumLongFastutilCustomHash(Blackhole blackhole) throws Exception {
         var rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
         blackhole.consume(BatchIterators.collect(rowsIterator, fastutilCustomHashCollector).get());
     }

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -111,7 +111,8 @@ public class GroupingStringCollectorBenchmark {
             Version.CURRENT,
             keyInputs.get(0),
             DataTypes.STRING,
-            Version.CURRENT
+            Version.CURRENT,
+            null
         );
     }
 

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.aggregation;
 
+import com.koloboke.collect.map.hash.HashObjObjMaps;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.BatchIterators;
@@ -38,6 +39,11 @@ import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.jpountz.xxhash.XXHash32;
+import net.jpountz.xxhash.XXHashFactory;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -49,12 +55,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static io.crate.data.SentinelRow.SENTINEL;
 
@@ -63,17 +67,48 @@ import static io.crate.data.SentinelRow.SENTINEL;
 @State(Scope.Benchmark)
 public class GroupingStringCollectorBenchmark {
 
-    private GroupingCollector groupByMinCollector;
+    private GroupingCollector currentNettyMapCollector;
+    private GroupingCollector kolobokeCollector;
+    private GroupingCollector fastutilCollector;
+    private GroupingCollector fastutilCustomHashCollector;
+    private GroupingCollector jdkCollector;
     private BatchIterator<Row> rowsIterator;
     private List<Row> rows;
     private OnHeapMemoryManager memoryManager;
+
+    private static final XXHash32 xxHash32 = XXHashFactory.fastestInstance().hash32();
+
+
+    private static final class StringHashStrategy implements Hash.Strategy<String> {
+
+        private static final StringHashStrategy INSTANCE = new StringHashStrategy();
+
+        @Override
+        public int hashCode(String o) {
+            byte[] bytes = o.getBytes(StandardCharsets.UTF_8);
+            return xxHash32.hash(bytes, 0, bytes.length, 0);
+        }
+
+        @Override
+        public boolean equals(String a, String b) {
+            return a.equals(b);
+        }
+    }
 
     @Setup
     public void createGroupingCollector() {
         Functions functions = new ModulesBuilder().add(new AggregationImplModule())
             .createInjector().getInstance(Functions.class);
 
-        groupByMinCollector = createGroupByMinBytesRefCollector(functions);
+        currentNettyMapCollector = createGroupByMinBytesRefCollector(functions, () -> new HashMap()); // We use JDK map for Strings currently.
+        jdkCollector = createGroupByMinBytesRefCollector(functions, () -> new HashMap());
+        kolobokeCollector = createGroupByMinBytesRefCollector(functions, () -> new PrimitiveMapWithNulls(HashObjObjMaps.newMutableMap()));
+        fastutilCollector = createGroupByMinBytesRefCollector(functions, () -> new PrimitiveMapWithNulls(new Object2ObjectOpenHashMap()));
+        fastutilCustomHashCollector = createGroupByMinBytesRefCollector(functions,
+            () -> new PrimitiveMapWithNulls(
+                new Object2ObjectOpenCustomHashMap(StringHashStrategy.INSTANCE)
+            )
+        );
         memoryManager = new OnHeapMemoryManager(bytes -> {});
 
         List<String> keys = new ArrayList<>(Locale.getISOCountries().length);
@@ -85,7 +120,7 @@ public class GroupingStringCollectorBenchmark {
         }
     }
 
-    private GroupingCollector createGroupByMinBytesRefCollector(Functions functions) {
+    private GroupingCollector createGroupByMinBytesRefCollector(Functions functions, Supplier<Map<Object, Object[]>> supplier) {
         InputCollectExpression keyInput = new InputCollectExpression(0);
         List<Input<?>> keyInputs = Collections.singletonList(keyInput);
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
@@ -112,13 +147,37 @@ public class GroupingStringCollectorBenchmark {
             keyInputs.get(0),
             DataTypes.STRING,
             Version.CURRENT,
-            null
+            supplier
         );
     }
 
     @Benchmark
     public void measureGroupByMinString(Blackhole blackhole) throws Exception {
         rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
-        blackhole.consume(BatchIterators.collect(rowsIterator, groupByMinCollector).get());
+        blackhole.consume(BatchIterators.collect(rowsIterator, currentNettyMapCollector).get());
+    }
+
+    @Benchmark
+    public void measureGroupByMinStringJDK(Blackhole blackhole) throws Exception {
+        rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
+        blackhole.consume(BatchIterators.collect(rowsIterator, jdkCollector).get());
+    }
+
+    @Benchmark
+    public void measureGroupByMinStringFastutil(Blackhole blackhole) throws Exception {
+        rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
+        blackhole.consume(BatchIterators.collect(rowsIterator, fastutilCollector).get());
+    }
+
+    @Benchmark
+    public void measureGroupByMinStringFastutilCustomHash(Blackhole blackhole) throws Exception {
+        rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
+        blackhole.consume(BatchIterators.collect(rowsIterator, fastutilCustomHashCollector).get());
+    }
+
+    @Benchmark
+    public void measureGroupByMinStringKoloboke(Blackhole blackhole) throws Exception {
+        rowsIterator = InMemoryBatchIterator.of(rows, SENTINEL, true);
+        blackhole.consume(BatchIterators.collect(rowsIterator, kolobokeCollector).get());
     }
 }

--- a/libs/shared/src/main/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/libs/shared/src/main/java/org/elasticsearch/bootstrap/JarHell.java
@@ -278,6 +278,9 @@ public class JarHell {
                 if (clazz.startsWith("org.apache.lucene.index.AssertingLeafReader")) {
                     return; // overwritten to disable thread-change assertion
                 }
+                if (clazz.endsWith(".package-info")) {
+                    return;
+                }
                 throw new IllegalStateException("jar hell!" + System.lineSeparator() +
                         "class: " + clazz + System.lineSeparator() +
                         "jar1: " + previous + System.lineSeparator() +

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -81,6 +81,39 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                                                Version minNodeVersion,
                                                Input<?> keyInput,
                                                DataType keyType,
+                                               Version indexVersionCreated) {
+        return new GroupingCollector<>(
+            expressions,
+            aggregations,
+            mode,
+            inputs,
+            filters,
+            ramAccounting,
+            memoryManager,
+            minNodeVersion,
+            (key, cells) -> cells[0] = key,
+            1,
+            GroupByMaps.accountForNewEntry(
+                ramAccounting,
+                SizeEstimatorFactory.create(keyType),
+                keyType
+            ),
+            row -> keyInput.value(),
+            indexVersionCreated,
+            GroupByMaps.mapForType(keyType)
+        );
+    }
+
+    static GroupingCollector<Object> singleKey(CollectExpression<Row, ?>[] expressions,
+                                               AggregateMode mode,
+                                               AggregationFunction[] aggregations,
+                                               Input[][] inputs,
+                                               Input<Boolean>[] filters,
+                                               RamAccounting ramAccounting,
+                                               MemoryManager memoryManager,
+                                               Version minNodeVersion,
+                                               Input<?> keyInput,
+                                               DataType keyType,
                                                Version indexVersionCreated,
                                                Supplier<Map<Object, Object[]>> supplier) {
         return new GroupingCollector<>(
@@ -101,7 +134,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
             ),
             row -> keyInput.value(),
             indexVersionCreated,
-            supplier == null ? GroupByMaps.mapForType(keyType) : supplier
+            supplier
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -116,26 +116,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                                                DataType keyType,
                                                Version indexVersionCreated,
                                                Supplier<Map<Object, Object[]>> supplier) {
-        return new GroupingCollector<>(
-            expressions,
-            aggregations,
-            mode,
-            inputs,
-            filters,
-            ramAccounting,
-            memoryManager,
-            minNodeVersion,
-            (key, cells) -> cells[0] = key,
-            1,
-            GroupByMaps.accountForNewEntry(
-                ramAccounting,
-                SizeEstimatorFactory.create(keyType),
-                keyType
-            ),
-            row -> keyInput.value(),
-            indexVersionCreated,
-            supplier
-        );
+        return singleKey(expressions, mode, aggregations, inputs, filters, ramAccounting, memoryManager, minNodeVersion, keyInput, keyType, indexVersionCreated,supplier);
     }
 
     static GroupingCollector<List<Object>> manyKeys(CollectExpression<Row, ?>[] expressions,

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -81,7 +81,8 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                                                Version minNodeVersion,
                                                Input<?> keyInput,
                                                DataType keyType,
-                                               Version indexVersionCreated) {
+                                               Version indexVersionCreated,
+                                               Supplier<Map<Object, Object[]>> supplier) {
         return new GroupingCollector<>(
             expressions,
             aggregations,
@@ -100,7 +101,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
             ),
             row -> keyInput.value(),
             indexVersionCreated,
-            GroupByMaps.mapForType(keyType)
+            supplier == null ? GroupByMaps.mapForType(keyType) : supplier
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -80,7 +80,8 @@ public class GroupingProjector implements Projector {
                 minNodeVersion,
                 keyInputs.get(0),
                 key.valueType(),
-                indexVersionCreated
+                indexVersionCreated,
+                null
             );
         } else {
             //noinspection unchecked

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -80,8 +80,7 @@ public class GroupingProjector implements Projector {
                 minNodeVersion,
                 keyInputs.get(0),
                 key.valueType(),
-                indexVersionCreated,
-                null
+                indexVersionCreated
             );
         } else {
             //noinspection unchecked


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11413

1. `GroupingStringCollectorBenchmark` will be updated as well as we [use JDK map](https://github.com/crate/crate/blob/8f05a367f85610c951a632e2235da6833721c570/server/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java#L86) for String (and other non numeric types) and would be interesting to compare it with fastutil's `Object2ObjectOpenHashMap` and koloboke's `HashObjObjMaps::newMutableMap` - currently not in PR as I wanted to get feedback first.

2. Will not include [baseline](https://github.com/crate/crate/blob/35d6614a396f68dbfd77500548e01151ffe9599c/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java#L208-L219) benchmarks for all maps as it would be repeat of http://java-performance.info/hashmap-overview-jdk-fastutil-goldman-sachs-hppc-koloboke-trove-january-2015/ and probably can find more comparisons - would rather focus on maps behaviour in our concrete case (collector).


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
