### PR TITLE
Add support for detecting and replicating new tables and partitions of a subscription

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -146,6 +146,7 @@ public class AlterTableOperation {
 
     public CompletableFuture<Long> executeAlterTableOpenClose(List<RelationName> tables,
                                                               boolean openTable,
+                                                              boolean ignoreUnavailableIndices,
                                                               @Nullable PartitionName partitionName) {
         String partitionIndexName = null;
         if (partitionName != null) {
@@ -153,11 +154,16 @@ public class AlterTableOperation {
         }
         FutureActionListener<AcknowledgedResponse, Long> listener = new FutureActionListener<>(r -> -1L);
         if (openTable || clusterService.state().getNodes().getMinNodeVersion().before(Version.V_4_3_0)) {
-            OpenCloseTableOrPartitionRequest request = new OpenCloseTableOrPartitionRequest(tables, partitionIndexName, openTable);
+            OpenCloseTableOrPartitionRequest request = new OpenCloseTableOrPartitionRequest(
+                tables,
+                partitionIndexName,
+                openTable,
+                ignoreUnavailableIndices
+            );
             transportOpenCloseTableOrPartitionAction.execute(request, listener);
         } else {
             transportCloseTable.execute(
-                new CloseTableRequest(tables, partitionIndexName),
+                new CloseTableRequest(tables, partitionIndexName, ignoreUnavailableIndices),
                 listener
             );
         }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -86,6 +86,7 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
         return TransportCloseTable.checkBlock(
             state,
             indexNameExpressionResolver,
+            request.ignoreUnavailableIndices(),
             request.tables(),
             request.partitionIndexName()
         );

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
@@ -75,7 +75,7 @@ public class AlterTableOpenClosePlan implements Plan {
         }
 
         dependencies.alterTableOperation()
-            .executeAlterTableOpenClose(List.of(tableInfo.ident()), analyzedAlterTable.isOpenTable(), partitionName)
+            .executeAlterTableOpenClose(List.of(tableInfo.ident()), analyzedAlterTable.isOpenTable(), false, partitionName)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -19,7 +19,8 @@
 
 package org.elasticsearch.action.admin.cluster.state;
 
-import io.crate.common.unit.TimeValue;
+import java.io.IOException;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -28,7 +29,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
+import io.crate.common.unit.TimeValue;
 
 public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateRequest> implements IndicesRequest.Replaceable {
 
@@ -42,6 +43,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
     private Long waitForMetadataVersion;
     private TimeValue waitForTimeout = DEFAULT_WAIT_FOR_NODE_TIMEOUT;
     private String[] indices = Strings.EMPTY_ARRAY;
+    private String[] templates = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.lenientExpandOpen();
 
     public ClusterStateRequest() {
@@ -54,6 +56,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         blocks = true;
         customs = true;
         indices = Strings.EMPTY_ARRAY;
+        templates = Strings.EMPTY_ARRAY;
         return this;
     }
 
@@ -64,6 +67,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         blocks = false;
         customs = false;
         indices = Strings.EMPTY_ARRAY;
+        templates = Strings.EMPTY_ARRAY;
         return this;
     }
 
@@ -124,6 +128,15 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         return this;
     }
 
+    public String[] templates() {
+        return templates;
+    }
+
+    public ClusterStateRequest templates(String... templates) {
+        this.templates = templates;
+        return this;
+    }
+
     public ClusterStateRequest customs(boolean customs) {
         this.customs = customs;
         return this;
@@ -159,6 +172,9 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
             waitForTimeout = in.readTimeValue();
             waitForMetadataVersion = in.readOptionalLong();
         }
+        if (in.getVersion().onOrAfter(Version.V_4_8_0)) {
+            templates = in.readStringArray();
+        }
     }
 
     @Override
@@ -174,6 +190,9 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         if (out.getVersion().onOrAfter(Version.V_4_4_0)) {
             out.writeTimeValue(waitForTimeout);
             out.writeOptionalLong(waitForMetadataVersion);
+        }
+        if (out.getVersion().onOrAfter(Version.V_4_8_0)) {
+            out.writeStringArray(templates);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
@@ -19,12 +19,13 @@
 
 package org.elasticsearch.action.admin.cluster.state;
 
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+
+import io.crate.common.unit.TimeValue;
 
 public class ClusterStateRequestBuilder extends MasterNodeReadOperationRequestBuilder<ClusterStateRequest, ClusterStateResponse, ClusterStateRequestBuilder> {
 
@@ -100,6 +101,11 @@ public class ClusterStateRequestBuilder extends MasterNodeReadOperationRequestBu
 
     public ClusterStateRequestBuilder setIndicesOptions(IndicesOptions indicesOptions) {
         request.indicesOptions(indicesOptions);
+        return this;
+    }
+
+    public ClusterStateRequestBuilder setTemplates(String... templates) {
+        request.templates(templates);
         return this;
     }
 

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -430,9 +430,9 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
     @Test
     public void test_write_to_subscribed_table_is_allowed_after_dropping_subscription() throws Exception {
         executeOnPublisher("CREATE TABLE doc.t1 (id INT) WITH(" + defaultTableSettings() + ")");
-        executeOnPublisher("CREATE TABLE doc.t2 (id INT) WITH(" + defaultTableSettings() + ")");
+        executeOnPublisher("CREATE TABLE doc.t2 (id INT, p INT) PARTITIONED BY (p) WITH(" + defaultTableSettings() + ")");
         executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (1), (2)");
-        executeOnPublisher("INSERT INTO doc.t2 (id) VALUES (1), (2)");
+        executeOnPublisher("INSERT INTO doc.t2 (id, p) VALUES (1, 1), (2, 2)");
 
         // It's important to subscribe to more than 1 table to check
         // that re-used close/open table logic works with multiple tables
@@ -444,7 +444,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         var response = executeOnSubscriber("INSERT INTO doc.t1 (id) VALUES(3)");
         assertThat(response.rowCount(), is(1L));
 
-        response = executeOnSubscriber("INSERT INTO doc.t2 (id) VALUES(3)");
+        response = executeOnSubscriber("INSERT INTO doc.t2 (id, p) VALUES(3, 3)");
         assertThat(response.rowCount(), is(1L));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
@@ -21,15 +21,10 @@
 
 package io.crate.integrationtests.disruption.replication.logical;
 
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.hamcrest.Matchers.is;
-
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
-
+import io.crate.integrationtests.LogicalReplicationITestCase;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.MetadataTracker;
+import io.crate.replication.logical.action.PublicationsStateAction;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,10 +36,14 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
-import io.crate.integrationtests.LogicalReplicationITestCase;
-import io.crate.replication.logical.LogicalReplicationService;
-import io.crate.replication.logical.MetadataTracker;
-import io.crate.replication.logical.action.PublicationsStateAction;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.Matchers.is;
 
 @LogicalReplicationITestCase.PublisherClusterScope(numberOfNodes = 1, supportsDedicatedMasters = false)
 @LogicalReplicationITestCase.SubscriberClusterScope(numberOfNodes = 1, supportsDedicatedMasters = false)
@@ -103,7 +102,7 @@ public class SubscriptionDisruptionIT extends LogicalReplicationITestCase {
         // Ensure tracker started
         assertBusy(() -> assertThat(isMetadataTrackerActive(), is(true)));
 
-        var expectedLogMessage = "Tracking of metadata failed for subscription 'sub1', will retry";
+        var expectedLogMessage = "Retrieving remote metadata failed for subscription 'sub1', will retry";
         var mockAppender = appendLogger(expectedLogMessage, MetadataTracker.class, Level.WARN);
 
         startDisrupting(MockTransportService::addFailToSendNoConnectRule);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionTests.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.action.admin.cluster.state;
+
+import static org.elasticsearch.action.admin.cluster.state.TransportClusterStateAction.buildResponse;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+public class TransportClusterStateActionTests extends ESTestCase {
+
+    private final Logger logger = Loggers.getLogger(getClass());
+
+    private static final ClusterState CLUSTER_STATE = ClusterState.builder(new ClusterName("test"))
+        .metadata(Metadata.builder()
+                      .persistentSettings(Settings.builder().put("setting1", "bar").build())
+                      .put(IndexTemplateMetadata.builder("template1").patterns(List.of("*")).build())
+                      .put(IndexMetadata.builder("index1")
+                               .settings(settings(Version.CURRENT))
+                               .numberOfShards(1)
+                               .numberOfReplicas(0)
+                               .build(),
+                           true
+                      )
+                      .build())
+        .build();
+
+    @Test
+    public void test_response_contains_complete_metadata_if_no_indices_or_templates_requested() {
+        var request = new ClusterStateRequest();
+        request.metadata(true);
+
+        var response = buildResponse(request, CLUSTER_STATE, new IndexNameExpressionResolver(), logger);
+        assertThat(response.getState().metadata().templates().get("template1"), notNullValue());
+        assertThat(response.getState().metadata().hasIndex("index1"), is(true));
+        assertThat(response.getState().metadata().persistentSettings().get("setting1"), is("bar"));
+    }
+
+    @Test
+    public void test_response_contains_templates_only() {
+        var request = new ClusterStateRequest();
+        request.metadata(true);
+        request.templates("template1");
+
+        var response = buildResponse(request, CLUSTER_STATE, new IndexNameExpressionResolver(), logger);
+        assertThat(response.getState().metadata().templates().get("template1"), notNullValue());
+        assertThat(response.getState().metadata().hasIndex("index1"), is(false));
+        assertThat(response.getState().metadata().persistentSettings().get("setting1"), nullValue());
+    }
+
+    @Test
+    public void test_response_contains_indices_only() {
+        var request = new ClusterStateRequest();
+        request.metadata(true);
+        request.indices("index1");
+
+        var response = buildResponse(request, CLUSTER_STATE, new IndexNameExpressionResolver(), logger);
+        assertThat(response.getState().metadata().templates().get("template1"), nullValue());
+        assertThat(response.getState().metadata().hasIndex("index1"), is(true));
+        assertThat(response.getState().metadata().persistentSettings().get("setting1"), nullValue());
+    }
+
+    @Test
+    public void test_response_contains_indices_and_templates_only() {
+        var request = new ClusterStateRequest();
+        request.metadata(true);
+        request.templates("template1");
+        request.indices("index1");
+
+        var response = buildResponse(request, CLUSTER_STATE, new IndexNameExpressionResolver(), logger);
+        assertThat(response.getState().metadata().templates().get("template1"), notNullValue());
+        assertThat(response.getState().metadata().hasIndex("index1"), is(true));
+        assertThat(response.getState().metadata().persistentSettings().get("setting1"), nullValue());
+    }
+}


### PR DESCRIPTION
Detect new tables and partitions exposed by subscribed publications and initiate a complete restore of these tables/partitions using `LogicalReplicationRepository`.
