### PR TITLE
use type specific maps in DocValuesGroupByOptimizedIterator

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -185,7 +185,7 @@ final class DocValuesGroupByOptimizedIterator {
     static class GroupByIterator {
 
         @VisibleForTesting
-        static BatchIterator<Row> forSingleKey(List<DocValueAggregator> aggregators,
+        static <K> BatchIterator<Row> forSingleKey(List<DocValueAggregator> aggregators,
                                                IndexSearcher indexSearcher,
                                                Reference keyReference,
                                                List<? extends LuceneCollectorExpression<?>> keyExpressions,
@@ -210,7 +210,7 @@ final class DocValuesGroupByOptimizedIterator {
                 (key, cells) -> cells[0] = key,
                 query,
                 new CollectorContext(collectorContext.readerId()),
-                GroupByMaps.mapForType(keyReference.valueType())
+                (Supplier) GroupByMaps.mapForType(keyReference.valueType())
             );
         }
 


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11413

Use type specific maps in `DocValuesGroupByOptimizedIterator`

`./compare_run.py --v1 branch:master --v2 branch:baur/type-specific-map --spec specs/group_by_distribution_long.toml --env CRATE_HEAP_SIZE=6g -s path.data=/Users/baur/benchmark-data`

<details>
<summary>1 run </summary>
    
```
# Results (server side duration in ms)
V1: 4.8.0-0226630c5fdff2242b6a697beee9aaa198b9a90a
V2: 4.8.0-115c7a0f206f476899b25cf0c6a62a4d4febd3e1

Q: select count(*) from (select distinct x from uniform) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2055.039 ±  569.627 |    664.911 |   1850.642 |   2406.096 |   3859.930 |
|   V2    |     1649.348 ±  496.814 |    760.358 |   1546.514 |   1733.416 |   3848.868 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  21.90%                           -  17.90%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 21.90%
The test has statistical significance

Q: select count(*) from (select distinct x from normal) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2030.731 ±  434.313 |    847.022 |   1928.698 |   2361.427 |   3241.416 |
|   V2    |     1533.797 ±  256.154 |    758.836 |   1485.873 |   1654.030 |   2341.741 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  27.88%                           -  25.94%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 27.88%
The test has statistical significance

Q: select count(*) from (select distinct x from poisson) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       56.078 ±   35.869 |     13.956 |     48.409 |     67.694 |    203.214 |
|   V2    |       76.457 ±  151.196 |     11.674 |     30.798 |     65.421 |    748.282 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  30.75%                           -  44.47%   
There is a 93.56% probability that the observed difference is not random, and the best estimate of that difference is 30.75%
The test has no statistical significance

Q: select count(*) from (select distinct x from exponential) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1941.203 ±  360.593 |    601.849 |   1834.911 |   2246.292 |   2985.000 |
|   V2    |     1504.897 ±  270.696 |    749.806 |   1489.395 |   1662.636 |   2222.652 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  25.32%                           -  20.79%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 25.32%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  298    98.93    29.02 |   29  2808.10  5582.37 |     6442     1387 |     0.00          0
 V2 |  396    95.72   114.01 |   47  1857.29  3639.62 |     6442     5577 |     0.00          0
    
V1 top allocation frames
  HashMap.resize():1154
  LongObjectHashMap.indexOf(long):825
  HashMap.getNode(Object):736
  LongObjectHashMap.rehash(int):533
  Long.valueOf(long):489
V2 top allocation frames
  LongObjectHashMap.indexOf(long):1419
  LongObjectHashMap.rehash(int):1372
  Long.valueOf(long):1122
  AggregateCollector.iterate(...):1064
  LongObjectHashMap$PrimitiveIterator.scanNext():811
```
</details>

<details>
<summary>2 run </summary>
    
```
# Results (server side duration in ms)
V1: 4.8.0-0226630c5fdff2242b6a697beee9aaa198b9a90a
V2: 4.8.0-115c7a0f206f476899b25cf0c6a62a4d4febd3e1

Q: select count(*) from (select distinct x from uniform) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2148.469 ±  715.825 |    660.667 |   1932.030 |   2432.137 |   4893.912 |
|   V2    |     1693.073 ±  624.635 |    500.586 |   1540.272 |   1799.237 |   4208.899 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  23.71%                           -  22.56%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 23.71%
The test has statistical significance

Q: select count(*) from (select distinct x from normal) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2029.295 ±  448.194 |   1180.313 |   1885.072 |   2380.132 |   3508.874 |
|   V2    |     1574.529 ±  261.936 |    879.037 |   1551.008 |   1720.055 |   2223.321 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  25.24%                           -  19.44%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 25.24%
The test has statistical significance

Q: select count(*) from (select distinct x from poisson) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       49.697 ±   28.541 |     12.962 |     38.909 |     68.120 |    127.443 |
|   V2    |       59.041 ±   35.523 |     18.014 |     46.946 |     82.568 |    180.179 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  17.19%                           +  18.72%   
There is a 99.61% probability that the observed difference is not random, and the best estimate of that difference is 17.19%
The test has statistical significance

Q: select count(*) from (select distinct x from exponential) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2029.648 ±  400.393 |    654.845 |   1930.677 |   2342.677 |   3189.665 |
|   V2    |     1495.113 ±  243.989 |    619.822 |   1492.891 |   1621.093 |   2147.071 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  30.33%                           -  25.57%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 30.33%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  342    99.98    38.92 |   35  2806.53  5554.79 |     6442     1373 |     0.00          0
 V2 |  459    83.76    22.42 |   46  1900.56  1659.65 |     6442     1333 |     0.00          0
    
V1 top allocation frames
  HashMap.resize():1446
  LongObjectHashMap.indexOf(long):971
  HashMap.getNode(Object):943
  Long.valueOf(long):585
  ReferencePipeline$3$1.accept(Object):456
V2 top allocation frames
  Long.valueOf(long):1877
  LongObjectHashMap.rehash(int):1421
  LongObjectHashMap.indexOf(long):1290
  LongObjectHashMap$PrimitiveIterator.scanNext():481
  LongObjectHashMap.put(...):415
```
</details>

<details>
<summary>3 run </summary>
    
```
# Results (server side duration in ms)
V1: 4.8.0-0226630c5fdff2242b6a697beee9aaa198b9a90a
V2: 4.8.0-115c7a0f206f476899b25cf0c6a62a4d4febd3e1

Q: select count(*) from (select distinct x from uniform) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2135.631 ±  544.303 |    889.154 |   1940.302 |   2450.121 |   3722.668 |
|   V2    |     1691.216 ±  505.206 |    918.444 |   1561.790 |   1794.358 |   3742.787 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  23.23%                           -  21.62%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 23.23%
The test has statistical significance

Q: select count(*) from (select distinct x from normal) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2003.193 ±  438.424 |    527.055 |   1867.541 |   2333.014 |   3560.711 |
|   V2    |     1538.951 ±  267.016 |    647.080 |   1484.117 |   1707.627 |   2233.237 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  26.21%                           -  22.88%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 26.21%
The test has statistical significance

Q: select count(*) from (select distinct x from poisson) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       46.488 ±   26.995 |     10.785 |     36.597 |     57.238 |    123.277 |
|   V2    |       59.791 ±   90.697 |      9.263 |     32.813 |     62.809 |    486.210 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  25.03%                           -  10.90%   
There is a 95.25% probability that the observed difference is not random, and the best estimate of that difference is 25.03%
The test has no statistical significance

Q: select count(*) from (select distinct x from exponential) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1918.851 ±  399.399 |    905.888 |   1816.002 |   2225.657 |   3142.553 |
|   V2    |     1554.354 ±  338.260 |    576.333 |   1535.188 |   1793.267 |   2472.074 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  20.99%                           -  16.76%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 20.99%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  348    98.54   102.30 |   33  2840.64  5390.35 |     6442     6217 |     0.00          0
 V2 |  544    73.54   137.07 |   52  1715.42  2433.13 |     6442     4134 |     0.00          0
    
V1 top allocation frames
  HashMap.resize():1338
  HashMap.getNode(Object):959
  LongObjectHashMap.indexOf(long):891
  LongObjectHashMap$PrimitiveIterator.hasNext():664
  ReferencePipeline$3$1.accept(Object):517
V2 top allocation frames
  Long.valueOf(long):1596
  LongObjectHashMap.rehash(int):1357
  LongObjectHashMap.indexOf(long):1334
  LongObjectHashMap.put(...):499
  LongObjectHashMap$PrimitiveIterator.scanNext():430

```
</details>

results of 
`./compare_run.py --v1 branch:master --v2 branch:baur/type-specific-map --spec specs/group_by_cardinality_long.toml --forks 2 --env CRATE_HEAP_SIZE=6g -s path.data=/Users/baur/benchmark-data`

<details>
<summary>1 run </summary>
    
```
# Results (server side duration in ms)
V1: 4.8.0-0226630c5fdff2242b6a697beee9aaa198b9a90a
V2: 4.8.0-123c9328cc044f170f96633b2463e9430f062388

Q: select count(*) from (select distinct x from t090) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2148.421 ±  680.499 |    933.527 |   1947.581 |   2382.163 |   4632.250 |
|   V2    |     2413.633 ±  391.343 |   1497.384 |   2344.880 |   2437.415 |   3903.663 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  11.63%                           +  18.51%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 11.63%
The test has statistical significance

Q: select count(*) from (select distinct x from t075) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2294.503 ±  214.553 |   1362.627 |   2299.514 |   2388.371 |   3148.727 |
|   V2    |     3072.750 ±  177.919 |   2381.165 |   3080.738 |   3180.047 |   3600.124 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  29.00%                           +  29.04%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 29.00%
The test has statistical significance

Q: select count(*) from (select distinct x from t050) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1087.882 ±  250.862 |    551.230 |   1020.148 |   1241.809 |   2104.996 |
|   V2    |      904.785 ±  244.440 |    472.127 |    869.308 |   1050.650 |   1559.263 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  18.38%                           -  15.97%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 18.38%
The test has statistical significance

Q: select count(*) from (select distinct x from t025) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      726.540 ±  191.230 |    265.177 |    688.772 |    806.250 |   1526.616 |
|   V2    |      606.985 ±  147.126 |    354.158 |    587.140 |    693.761 |   1043.107 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  17.93%                           -  15.93%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 17.93%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  388    99.99   159.04 |   42  2610.94  3522.77 |     6442     4850 |     0.00          0
 V2 |  289   100.81   213.38 |   59  1263.16  1588.50 |     6442     4069 |     0.00          0
    
V1 top allocation frames
  LongObjectHashMap.indexOf(long):5553
  LongObjectHashMap.growSize():2876
  LongObjectHashMap.put(...):2716
  DocValuesGroupByOptimizedIterator$GroupByIterator.applyAggregatesGroupedByKey(...):1014
  ReferencePipeline$3$1.accept(Object):588
V2 top allocation frames
  LongObjectHashMap.put(...):12722
  LongObjectHashMap.rehash(int):7074
  LongObjectHashMap.indexOf(long):6167
  Long.valueOf(long):967
  LongObjectHashMap$PrimitiveIterator.scanNext():576
```
</details>

<details>
<summary>2 run </summary>
    
```
# Results (server side duration in ms)
V1: 4.8.0-0226630c5fdff2242b6a697beee9aaa198b9a90a
V2: 4.8.0-123c9328cc044f170f96633b2463e9430f062388

Q: select count(*) from (select distinct x from t090) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2232.175 ±  502.189 |   1302.865 |   2068.407 |   2482.502 |   4273.632 |
|   V2    |     2381.987 ±  445.767 |   1795.784 |   2298.612 |   2380.102 |   4265.858 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   6.49%                           +  10.54%   
There is a 99.83% probability that the observed difference is not random, and the best estimate of that difference is 6.49%
The test has statistical significance

Q: select count(*) from (select distinct x from t075) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2414.659 ±  235.004 |   1315.142 |   2418.222 |   2504.517 |   3133.481 |
|   V2    |     3145.900 ±  160.427 |   2648.428 |   3149.831 |   3225.532 |   3659.299 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  26.30%                           +  26.28%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 26.30%
The test has statistical significance

Q: select count(*) from (select distinct x from t050) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1067.011 ±  253.938 |    672.558 |    975.475 |   1234.354 |   2097.532 |
|   V2    |      927.372 ±  263.462 |    325.392 |    908.216 |   1096.234 |   1552.269 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  14.00%                           -   7.14%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 14.00%
The test has statistical significance

Q: select count(*) from (select distinct x from t025) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      679.728 ±  177.048 |    216.658 |    636.741 |    749.736 |   1314.909 |
|   V2    |      615.637 ±  138.068 |    258.506 |    604.770 |    703.859 |    984.877 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   9.90%                           -   5.15%   
There is a 99.99% probability that the observed difference is not random, and the best estimate of that difference is 9.90%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  392    98.02    99.32 |   44  2485.92  4921.27 |     6442     5866 |     0.00          0
 V2 |  303    97.03    64.80 |   61  1254.12  2127.15 |     6442     2915 |     0.00          0
    
V1 top allocation frames
  LongObjectHashMap.put(...):7866
  LongObjectHashMap.get(long):3115
  LongObjectHashMap.indexOf(long):3030
  Long.valueOf(long):634
  HashMap.getNode(Object):596
V2 top allocation frames
  LongObjectHashMap.indexOf(long):13001
  LongObjectHashMap.rehash(int):7357
  LongObjectHashMap.put(...):5819
  Long.valueOf(long):993
  GroupingCollector.reduce(Map, Row):536
```
</details>
## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
