### PR TITLE
bp: Auto-release flood-stage write block

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,9 @@ None
 Changes
 =======
 
+- Write blocks added due to low disk space are now automatically removed if a
+  node again drops below the high watermark.
+
 - Added type validation logic to ``COPY FROM``. Now raw data will be parsed and
   validated against the target table schema and casted if possible utilizing
   :ref:`type casting <data-types-casting>`.

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -272,6 +272,11 @@ public class InternalClusterInfoService implements ClusterInfoService, LocalNode
         }
     }
 
+    // allow tests to adjust the node stats on receipt
+    List<NodeStats> adjustNodesStats(List<NodeStats> nodeStats) {
+        return nodeStats;
+    }
+
     /**
      * Refreshes the ClusterInfo in a blocking fashion
      */
@@ -284,11 +289,11 @@ public class InternalClusterInfoService implements ClusterInfoService, LocalNode
             public void onResponse(NodesStatsResponse nodesStatsResponse) {
                 ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsagesBuilder = ImmutableOpenMap.builder();
                 ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableUsagesBuilder = ImmutableOpenMap.builder();
-                fillDiskUsagePerNode(
-                    LOGGER,
-                    nodesStatsResponse.getNodes(),
+                fillDiskUsagePerNode(LOGGER,
+                    adjustNodesStats(nodesStatsResponse.getNodes()),
                     leastAvailableUsagesBuilder,
-                    mostAvailableUsagesBuilder);
+                    mostAvailableUsagesBuilder
+                );
                 leastAvailableSpaceUsages = leastAvailableUsagesBuilder.build();
                 mostAvailableSpaceUsages = mostAvailableUsagesBuilder.build();
             }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -19,11 +19,21 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import com.carrotsearch.hppc.ObjectLookupContainer;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.client.Client;
@@ -34,20 +44,15 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import io.crate.common.collections.Sets;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
+import io.crate.common.collections.Sets;
 
 /**
  * Listens for a node to go over the high watermark and kicks off an empty
@@ -141,21 +146,33 @@ public class DiskThresholdMonitor {
         }
         final ClusterState state = clusterStateSupplier.get();
         final Set<String> indicesToMarkReadOnly = new HashSet<>();
+        RoutingNodes routingNodes = state.getRoutingNodes();
+        Set<String> indicesNotToAutoRelease = new HashSet<>();
+        markNodesMissingUsageIneligibleForRelease(routingNodes, usages, indicesNotToAutoRelease);
 
         for (final ObjectObjectCursor<String, DiskUsage> entry : usages) {
             final String node = entry.key;
             final DiskUsage usage = entry.value;
             warnAboutDiskIfNeeded(usage);
+            RoutingNode routingNode = routingNodes.node(node);
+            // Only unblock index if all nodes that contain shards of it are below the high disk watermark
             if (usage.getFreeBytes() < diskThresholdSettings.getFreeBytesThresholdFloodStage().getBytes() ||
                 usage.getFreeDiskAsPercentage() < diskThresholdSettings.getFreeDiskThresholdFloodStage()) {
-                final RoutingNode routingNode = state.getRoutingNodes().node(node);
                 if (routingNode != null) { // this might happen if we haven't got the full cluster-state yet?!
                     for (ShardRouting routing : routingNode) {
-                        indicesToMarkReadOnly.add(routing.index().getName());
+                        String indexName = routing.index().getName();
+                        indicesToMarkReadOnly.add(indexName);
+                        indicesNotToAutoRelease.add(indexName);
                     }
                 }
             } else if (usage.getFreeBytes() < diskThresholdSettings.getFreeBytesThresholdHigh().getBytes() ||
                 usage.getFreeDiskAsPercentage() < diskThresholdSettings.getFreeDiskThresholdHigh()) {
+                if (routingNode != null) {
+                    for (ShardRouting routing : routingNode) {
+                        String indexName = routing.index().getName();
+                        indicesNotToAutoRelease.add(indexName);
+                    }
+                }
                 if (lastRunTimeMillis.get() < currentTimeMillis - diskThresholdSettings.getRerouteInterval().millis()) {
                     reroute = true;
                     explanation = "high disk watermark exceeded on one or more nodes";
@@ -187,7 +204,7 @@ public class DiskThresholdMonitor {
             }
         }
 
-        final ActionListener<Void> listener = new GroupedActionListener<>(ActionListener.wrap(this::checkFinished), 2);
+        final ActionListener<Void> listener = new GroupedActionListener<>(ActionListener.wrap(this::checkFinished), 3);
 
         if (reroute) {
             LOGGER.info("rerouting shards: [{}]", explanation);
@@ -204,34 +221,62 @@ public class DiskThresholdMonitor {
         } else {
             listener.onResponse(null);
         }
+        Set<String> indicesToAutoRelease = StreamSupport.stream(state.routingTable().indicesRouting()
+            .spliterator(), false)
+            .map(c -> c.key)
+            .filter(index -> indicesNotToAutoRelease.contains(index) == false)
+            .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK))
+            .collect(Collectors.toSet());
 
-        indicesToMarkReadOnly.removeIf(index -> state.getBlocks().indexBlocked(ClusterBlockLevel.WRITE, index));
-        if (indicesToMarkReadOnly.isEmpty() == false) {
-            markIndicesReadOnly(indicesToMarkReadOnly, ActionListener.wrap(
-                r -> {
-                    setLastRunTimeMillis();
-                    listener.onResponse(r);
-                },
-                e -> {
-                    LOGGER.debug("marking indices readonly failed", e);
-                    setLastRunTimeMillis();
-                    listener.onFailure(e);
-                }
-            ));
+        if (indicesToAutoRelease.isEmpty() == false) {
+            LOGGER.info("releasing read-only-allow-delete block on indices: [{}]", indicesToAutoRelease);
+            updateIndicesReadOnly(indicesToAutoRelease, listener, false);
         } else {
             listener.onResponse(null);
         }
+
+        indicesToMarkReadOnly.removeIf(index -> state.getBlocks().indexBlocked(ClusterBlockLevel.WRITE, index));
+        if (indicesToMarkReadOnly.isEmpty() == false) {
+            updateIndicesReadOnly(indicesToMarkReadOnly, listener, true);
+        } else {
+            listener.onResponse(null);
+        }
+    }
+
+    private void markNodesMissingUsageIneligibleForRelease(RoutingNodes routingNodes, ImmutableOpenMap<String, DiskUsage> usages,
+                                                           Set<String> indicesToMarkIneligibleForAutoRelease) {
+        for (RoutingNode routingNode : routingNodes) {
+            if (usages.containsKey(routingNode.nodeId()) == false) {
+                if (routingNode != null) {
+                    for (ShardRouting routing : routingNode) {
+                        String indexName = routing.index().getName();
+                        indicesToMarkIneligibleForAutoRelease.add(indexName);
+                    }
+                }
+            }
+        }
+
     }
 
     private void setLastRunTimeMillis() {
         lastRunTimeMillis.getAndUpdate(l -> Math.max(l, currentTimeMillisSupplier.getAsLong()));
     }
 
-    protected void markIndicesReadOnly(Set<String> indicesToMarkReadOnly, ActionListener<Void> listener) {
+    protected void updateIndicesReadOnly(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readOnly) {
         // set read-only block but don't block on the response
-        client.admin().indices()
-            .prepareUpdateSettings(indicesToMarkReadOnly.toArray(Strings.EMPTY_ARRAY))
-            .setSettings(Settings.builder().put(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, true).build())
-            .execute(ActionListener.map(listener, r -> null));
+        ActionListener<Void> wrappedListener = ActionListener.wrap(r -> {
+            setLastRunTimeMillis();
+            listener.onResponse(r);
+        }, e -> {
+            LOGGER.debug(new ParameterizedMessage("setting indices [{}] read-only failed", readOnly), e);
+            setLastRunTimeMillis();
+            listener.onFailure(e);
+        });
+        Settings readOnlySettings = readOnly ? Settings.builder()
+            .put(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, Boolean.TRUE.toString()).build() :
+            Settings.builder().putNull(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE).build();
+        client.admin().indices().prepareUpdateSettings(indicesToUpdate.toArray(Strings.EMPTY_ARRAY))
+            .setSettings(readOnlySettings)
+            .execute(ActionListener.map(wrappedListener, r -> null));
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -95,6 +95,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                                               Metadata metadata,
                                               RoutingTable routingTable) {
         long totalSize = 0L;
+
         for (ShardRouting routing : node.shardsWithState(ShardRoutingState.INITIALIZING)) {
             if (routing.relocatingNodeId() == null) {
                 // in practice the only initializing-but-not-relocating shards with a nonzero expected shard size will be ones created

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -21,6 +21,13 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.Collections;
+import java.util.HashSet;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterName;
@@ -50,13 +57,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.HashSet;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
-import static org.hamcrest.Matchers.containsString;
 
 public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
 

--- a/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -105,7 +105,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
         });
     }
 
-    private List<NodeStats> adjustNodesStats(List<NodeStats> nodesStats) {
+    @Override
+    List<NodeStats> adjustNodesStats(List<NodeStats> nodesStats) {
         BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction = this.diskUsageFunction;
         if (diskUsageFunction == null) {
             return nodesStats;

--- a/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -65,6 +65,17 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
         super(settings, clusterService, threadPool, client);
     }
 
+
+    public void setDiskUsageFunctionAndRefresh(BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction) {
+        this.diskUsageFunction = diskUsageFunction;
+        refresh();
+    }
+
+    public void setShardSizeFunctionAndRefresh(Function<ShardRouting, Long> shardSizeFunction) {
+        this.shardSizeFunction = shardSizeFunction;
+        refresh();
+    }
+
     @Override
     public ClusterInfo getClusterInfo() {
         final ClusterInfo clusterInfo = super.getClusterInfo();

--- a/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -53,10 +53,10 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
     public static class TestPlugin extends Plugin {}
 
     @Nullable // if no fakery should take place
-    public volatile Function<ShardRouting, Long> shardSizeFunction;
+    private volatile Function<ShardRouting, Long> shardSizeFunction;
 
     @Nullable // if no fakery should take place
-    public volatile BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction;
+    private volatile BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction;
 
     public MockInternalClusterInfoService(Settings settings,
                                           ClusterService clusterService,
@@ -64,7 +64,6 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                                           NodeClient client) {
         super(settings, clusterService, threadPool, client);
     }
-
 
     public void setDiskUsageFunctionAndRefresh(BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction) {
         this.diskUsageFunction = diskUsageFunction;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Based on

- https://github.com/elastic/elasticsearch/commit/cd304c4def3e0622666746f9fe54355217131860

But doesn't add the setting to disable it & no deprecation logging
The test already contains fixes from:

- https://github.com/elastic/elasticsearch/commit/b19de550959df6630b560a1132b2cd44ba6f9675
- https://github.com/elastic/elasticsearch/commit/d340530a4753b66da75766b752dada943029ec78 (got applied with https://github.com/crate/crate/commit/a39b7f29d59279c9db5fb013838428087ca7b516)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
