### PR TITLE
Remove wacklig upload from GHA workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,6 @@ jobs:
         with:
           arguments: :server:test -Dtests.crate.run-windows-incompatible=${{ matrix.os == 'ubuntu-latest' }}
 
-      - name: Upload results to wacklig
-        if: always()
-        shell: bash
-        env:
-          WACKLIG_TOKEN: ${{ secrets.WACKLIG_TOKEN }}
-        run: |
-          curl -s https://raw.githubusercontent.com/pipifein/wacklig-uploader/master/wacklig.py | python - --token $WACKLIG_TOKEN || echo "Upload to wacklig failed"
-
 
   forbiddenApis:
     name: forbiddenApisMain


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We added the "on-pr" upload with the intention of figuring out if there
are tests that are only flaky on windows, but that didn't really work
out. We cannot easily tell if PRs failed because they were still work in
progress or because the tests are really flaky. This makes the wacklig
dashboard overall less useful - so this commit reverts the upload.

To accomplish the original goal we'd instead need to add another
periodic test run on windows that runs against the master branch.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
