### PR TITLE
Fix closing of an empty partitioned table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -90,4 +90,5 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue that caused an ``Relation unknown`` error while trying to
+  close an empty partitioned table using ``ALTER TABLE ... CLOSE``.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Without any partitions (concrete indices) the index name resolver
caused a `RelationUnknownException` and thus making it impossible
to close an empty partitioned table using `ALTER TABLE .. CLOSE`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
