### PR TITLE
Fix conversion of intervals to function expression

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,10 @@ None
 Changes
 =======
 
+- Fixed an issue with the handling of intervals in generated columns. The table
+  creation failed when an interval is included in a function call as part of a
+  generated column.
+
 - Write blocks added due to low disk space are now automatically removed if a
   node again drops below the high watermark.
 

--- a/server/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
+++ b/server/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
@@ -50,8 +50,11 @@ public class LiteralValueFormatter {
             formatIterable((Iterable<?>) value, builder);
         } else if (value.getClass().isArray()) {
             formatArray(value, builder);
-        } else if (value instanceof String || value instanceof Point || value instanceof Period) {
+        } else if (value instanceof String || value instanceof Point) {
             builder.append(Literals.quoteStringLiteral(value.toString()));
+        } else if (value instanceof Period) {
+            builder.append(Literals.quoteStringLiteral(value.toString()));
+            builder.append("::interval");
         } else if (value instanceof Long
                    && ((Long) value <= Integer.MAX_VALUE
                    || (Long) value >= Integer.MIN_VALUE)) {

--- a/server/src/test/java/io/crate/expression/symbol/LiteralValueFormatterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/LiteralValueFormatterTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.symbol;
 
+import org.joda.time.Period;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -33,5 +34,12 @@ public class LiteralValueFormatterTest {
         StringBuilder sb = new StringBuilder();
         LiteralValueFormatter.format(new Object[] { null, null}, sb);
         assertThat(sb.toString(), is("[NULL, NULL]"));
+    }
+
+    @Test
+    public void test_format_intervals() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        LiteralValueFormatter.format(Period.seconds(1), sb);
+        assertThat(sb.toString(), is("'PT1S'::interval"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This adds an explicit cast to the string value of the interval to
make a correct function signature lookup possible.

Fixes https://github.com/crate/crate/issues/12196


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
