### PR TITLE
Remove Netty4Utils.setup

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -125,10 +125,6 @@ import io.netty.util.concurrent.Future;
 
 public class Netty4HttpServerTransport extends AbstractLifecycleComponent implements HttpServerTransport {
 
-    static {
-        Netty4Utils.setup();
-    }
-
     /*
      * Size in bytes of an individual message received by io.netty.handler.codec.MessageAggregator which accumulates the content for an
      * HTTP request. This number is used for estimating the maximum number of allowed buffers before the MessageAggregator's internal

--- a/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -19,8 +19,13 @@
 
 package org.elasticsearch.transport;
 
-import io.crate.netty.NettyBootstrap;
-import io.crate.netty.channel.PipelineRegistry;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -41,20 +46,11 @@ import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty4.Netty4Transport;
-import org.elasticsearch.transport.netty4.Netty4Utils;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
+import io.crate.netty.NettyBootstrap;
+import io.crate.netty.channel.PipelineRegistry;
 
 public class Netty4Plugin extends Plugin implements NetworkPlugin {
-
-    static {
-        Netty4Utils.setup();
-    }
 
     public static final String NETTY_TRANSPORT_NAME = "netty4";
     public static final String NETTY_HTTP_TRANSPORT_NAME = "netty4";

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -82,10 +82,6 @@ import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.new
  */
 public class Netty4Transport extends TcpTransport {
 
-    static {
-        Netty4Utils.setup();
-    }
-
     public static final Setting<Integer> WORKER_COUNT =
         new Setting<>("transport.netty.worker_count",
             (s) -> Integer.toString(EsExecutors.numberOfProcessors(s)),

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -19,19 +19,6 @@
 
 package org.elasticsearch.transport.netty4;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.util.NettyRuntime;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.Log4J2LoggerFactory;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
-import io.crate.common.Booleans;
-import org.elasticsearch.common.bytes.BytesReference;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,15 +26,19 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.elasticsearch.common.bytes.BytesReference;
+
+import io.crate.common.Booleans;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.util.NettyRuntime;
+
 public class Netty4Utils {
-
-    static {
-        InternalLoggerFactory.setDefaultFactory(Log4J2LoggerFactory.INSTANCE);
-    }
-
-    public static void setup() {
-
-    }
 
     private static final AtomicBoolean IS_AVAILABLE_PROCESSORS_SET = new AtomicBoolean();
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This was used to initiate the logging factory for netty, but it is not
needed because the default of netty already uses log4j if available:

https://github.com/netty/netty/blob/982b890095a11242fff0e90558f0f3b883f52bc9/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java#L41-L58


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
