### PR TITLE
Fix re-open a closed empty partitioned table

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -21,16 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Consumer;
-
+import com.carrotsearch.hppc.cursors.IntObjectCursor;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.cluster.DDLClusterStateHelpers;
+import io.crate.metadata.cluster.DDLClusterStateService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
@@ -79,12 +74,15 @@ import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import com.carrotsearch.hppc.cursors.IntObjectCursor;
-
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.cluster.DDLClusterStateHelpers;
-import io.crate.metadata.cluster.DDLClusterStateService;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 public final class TransportCloseTable extends TransportMasterNodeAction<CloseTableRequest, AcknowledgedResponse> {
 
@@ -253,7 +251,7 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
     @Override
     protected ClusterBlockException checkBlock(CloseTableRequest request, ClusterState state) {
         String partition = request.partition();
-        if (partition == null && isEmptyPartitionedTable(request.table(), state)) {
+        if (partition == null && isEmptyPartitionedTable(request.table(), state, indexNameExpressionResolver)) {
             return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
         }
         String indexName = partition == null ? request.table().indexNameOrAlias() : partition;
@@ -263,7 +261,9 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
         );
     }
 
-    private boolean isEmptyPartitionedTable(RelationName relationName, ClusterState clusterState) {
+    public static boolean isEmptyPartitionedTable(RelationName relationName,
+                                                  ClusterState clusterState,
+                                                  IndexNameExpressionResolver indexNameExpressionResolver) {
         var concreteIndices = indexNameExpressionResolver.concreteIndexNames(
             clusterState,
             IndicesOptions.lenientExpandOpen(),
@@ -386,7 +386,8 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
 
         @Override
         public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-            if (blockedIndices.isEmpty() && isEmptyPartitionedTable(request.table(), newState)) {
+            if (blockedIndices.isEmpty()
+                && isEmptyPartitionedTable(request.table(), newState, indexNameExpressionResolver)) {
                 clusterService.submitStateUpdateTask(
                     "close-indices",
                     new CloseRoutingTableTask(

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -41,6 +41,8 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import static io.crate.execution.ddl.tables.TransportCloseTable.isEmptyPartitionedTable;
+
 @Singleton
 public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTransportAction<OpenCloseTableOrPartitionRequest, AcknowledgedResponse> {
 
@@ -85,6 +87,9 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
 
     @Override
     protected ClusterBlockException checkBlock(OpenCloseTableOrPartitionRequest request, ClusterState state) {
+        if (isEmptyPartitionedTable(request.tableIdent(), state, indexNameExpressionResolver)) {
+            return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        }
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
             indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.tableIdent().indexNameOrAlias()));
     }

--- a/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
@@ -21,6 +21,12 @@
 
 package io.crate.integrationtests;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrowsMatches;
@@ -29,12 +35,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.BAD_REQUEST;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-
-import java.util.List;
-
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.junit.Before;
-import org.junit.Test;
 
 public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
 
@@ -327,10 +327,12 @@ public class OpenCloseTableIntegrationTest extends SQLIntegrationTestCase {
     }
 
     @Test
-    public void test_close_empty_partitioned_table() {
+    public void test_close_open_empty_partitioned_table() {
         execute("create table partitioned_table (i int) partitioned by (i)");
         execute("alter table partitioned_table close");
         assertThat(isClosed("partitioned_table"), is(true));
+        execute("alter table partitioned_table open");
+        assertThat(isClosed("partitioned_table"), is(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Opening a closed table unfortunately uses a different
transport/logic which also must be adjusted.

Follow up of https://github.com/crate/crate/commit/89309883cd8


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
