### PR TITLE
Fix SJK download url used by jmx blackbox tests

### DIFF
--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -56,7 +56,7 @@ enterprise_crate = CrateNode(
 
 class JmxClient:
 
-    SJK_JAR_URL = "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.gridkit.jvmtool&a=sjk&v=LATEST"
+    SJK_JAR_URL = "https://repo1.maven.org/maven2/org/gridkit/jvmtool/sjk/0.20/sjk-0.20.jar"
 
     CACHE_DIR = os.environ.get(
         'XDG_CACHE_HOME',


### PR DESCRIPTION
Sonatype was shutdown some time ago, package must be fetched via maven central instead.
