### PR TITLE
catch possible StackOverFlow from Symbol streaming

### DIFF
--- a/server/src/main/java/io/crate/expression/symbol/SymbolType.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolType.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.symbol;
 
+import io.crate.exceptions.JobKilledException;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.IndexReference;
@@ -69,7 +70,11 @@ public enum SymbolType {
     }
 
     public Symbol newInstance(StreamInput in) throws IOException {
-        return reader.read(in);
+        try {
+            return reader.read(in);
+        } catch (StackOverflowError e) {
+            throw JobKilledException.of("Maximum call stack size exceeded");
+        }
     }
 
     public boolean isValueSymbol() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
an attempt to fix #12227 

A query like:
```
select 
    concat('1',concat('2',concat('3',concat('4',concat('5',concat('6',concat('7',concat('8',concat('9',concat('10',concat('11',concat('12',concat('13',concat(
    '14',concat('15',concat('16',concat('17',concat('18',concat('19',concat('20',concat('21',concat('22',concat('23',concat('24',concat('25',concat('26',conca
    t('27',concat('28',concat('29',concat('30',concat('31',concat('32',concat('33',concat('34',concat('35',concat('36',concat('37',concat('38',concat('39',con
    cat('40',concat('41',concat('42',concat('43',concat('44',concat('45',concat('46',concat('47',concat('48',concat('49',concat('50',concat('51',concat('52',c
    oncat('53',concat('54',concat('55',concat('56',concat('57',concat('58',concat('59',concat('60',concat('61',concat('62',concat('63',concat('64',concat('65'
    ,concat('66',concat('67',concat('68',concat('69',concat('70',concat('71',concat('72',concat('73',concat('74',concat('75',concat('76',concat('77',concat('7
    8',concat('79',concat('80',concat('81',concat('82',concat('83',concat('84',concat('85',concat('86',concat('87',concat('88',concat('89',concat('90',concat(
    '91',concat('92',concat('93',concat('94',concat('95',concat('96',concat('97',concat('98',concat('99',concat('100',concat('101',concat('102',concat('103',c
    oncat('104',concat('105',concat('106',concat('107',concat('108',concat('109',concat('110',concat('111',concat('112',concat('113',concat('114',concat('115'
    ,concat('116',concat('117',concat('118',concat('119',concat('120',concat('121',concat('122',concat('123',concat('124',concat('125',concat('126',concat('12
    7',concat('128',concat('129',concat('130',concat('131',concat('132',concat('133',concat('134',concat('135',concat('136',concat('137',concat('138',concat('
    139',concat('140',concat('141',concat('142',concat('143',concat('144',concat('145',concat('146',concat('147',concat('148',concat('149',concat('150',a)))))
    ))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) from t;
```
takes up too much call stack when streaming to a node with not enough free space.
Need to surround with a try-catch at least to be able to prevent the node from crashing.

****

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
