### PR TITLE
Remove shouldRebuildConnection from connectionStrategy

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -67,8 +67,10 @@ public final class RemoteClusterConnection implements Closeable {
                                    TransportService transportService) {
         this.transportService = transportService;
         ConnectionProfile profile = RemoteConnectionStrategy.buildConnectionProfile(nodeSettings, connectionSettings);
-        this.remoteConnectionManager = new RemoteConnectionManager(clusterAlias,
-                                                                   createConnectionManager(profile, transportService));
+        this.remoteConnectionManager = new RemoteConnectionManager(
+            clusterAlias,
+            new ClusterConnectionManager(profile, transportService.transport)
+        );
         this.connectionStrategy = RemoteConnectionStrategy.buildStrategy(
             clusterAlias,
             transportService,
@@ -176,16 +178,7 @@ public final class RemoteClusterConnection implements Closeable {
         return connectionStrategy.assertNoRunningConnections();
     }
 
-    private static ConnectionManager createConnectionManager(ConnectionProfile connectionProfile,
-                                                             TransportService transportService) {
-        return new ClusterConnectionManager(connectionProfile, transportService.transport);
-    }
-
     ConnectionManager getConnectionManager() {
         return remoteConnectionManager;
-    }
-
-    public boolean shouldRebuildConnection(Settings newSettings) {
-        return connectionStrategy.shouldRebuildConnection(newSettings);
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
@@ -29,7 +29,6 @@ import java.net.UnknownHostException;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -254,29 +253,6 @@ public abstract class RemoteConnectionStrategy implements TransportConnectionLis
         }
     }
 
-    boolean shouldRebuildConnection(Settings newSettings) {
-        ConnectionStrategy newMode = REMOTE_CONNECTION_MODE.get(newSettings);
-        if (newMode.equals(strategyType()) == false) {
-            return true;
-        } else {
-            Boolean compressionEnabled = REMOTE_CONNECTION_COMPRESS
-                .get(newSettings);
-            TimeValue pingSchedule = REMOTE_CONNECTION_PING_SCHEDULE
-                .get(newSettings);
-
-            ConnectionProfile oldProfile = connectionManager.getConnectionProfile();
-            ConnectionProfile.Builder builder = new ConnectionProfile.Builder(oldProfile);
-            builder.setCompressionEnabled(compressionEnabled);
-            builder.setPingInterval(pingSchedule);
-            ConnectionProfile newProfile = builder.build();
-            return connectionProfileChanged(oldProfile, newProfile) || strategyMustBeRebuilt(newSettings);
-        }
-    }
-
-    protected abstract boolean strategyMustBeRebuilt(Settings newSettings);
-
-    protected abstract ConnectionStrategy strategyType();
-
     @Override
     public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
         if (shouldOpenMoreConnections()) {
@@ -332,11 +308,6 @@ public abstract class RemoteConnectionStrategy implements TransportConnectionLis
             }
         }
         return result;
-    }
-
-    private boolean connectionProfileChanged(ConnectionProfile oldProfile, ConnectionProfile newProfile) {
-        return Objects.equals(oldProfile.getCompressionEnabled(), newProfile.getCompressionEnabled()) == false
-               || Objects.equals(oldProfile.getPingInterval(), newProfile.getPingInterval()) == false;
     }
 
     static class StrategyValidator<T> implements Setting.Validator<T> {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Connections are managed as part of subscriptions and don't implicitly
change due to some setting changes.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
