### PR TITLE
Optimize parsing of pg arrays when array is a string literal

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,9 @@ None
 Changes
 =======
 
+- Optimized the casting from string to arrays by avoiding an unnecessary string
+  to byte conversion.
+
 - Fixed an issue with the handling of intervals in generated columns. The table
   creation failed when an interval is included in a function call as part of a
   generated column.

--- a/libs/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
+++ b/libs/pgwire/src/test/java/io/crate/protocols/postgres/parser/PgArrayParserTest.java
@@ -51,7 +51,7 @@ public class PgArrayParserTest {
     };
 
     private static <T> T parse(String array, Function<byte[], Object> convert) {
-        return (T) PgArrayParser.parse(array.getBytes(UTF_8), convert);
+        return (T) PgArrayParser.parse(array, convert);
     }
 
     @Test

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -205,13 +205,13 @@ public class ArrayType<T> extends DataType<List<T>> {
         if (value instanceof Collection<?> values) {
             return Lists2.map(values, convertInner);
         } else if (value instanceof String string) {
-            byte[] utf8Bytes = string.getBytes(StandardCharsets.UTF_8);
             try {
                 return (List<T>) PgArrayParser.parse(
-                    utf8Bytes,
+                    string,
                     bytes -> convertInner.apply(new String(bytes, StandardCharsets.UTF_8))
                 );
             } catch (PgArrayParsingException e) {
+                byte[] utf8Bytes = string.getBytes(StandardCharsets.UTF_8);
                 if (innerType instanceof JsonType) {
                     try {
                         return (List<T>) parseJsonList(utf8Bytes);


### PR DESCRIPTION
This avoids the unnecessary string to byte to stream conversion
in the pg array parser when the input is a string literal.

```
Q: SELECT '{ab, CD, CD, null, null, w, foo}'::ARRAY(TEXT) AS arr
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        0.188 ±    0.190 |      0.081 |      0.137 |      0.189 |      3.588 |
|   V2    |        0.166 ±    0.140 |      0.076 |      0.126 |      0.161 |      1.787 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  12.44%                           -   8.78%
There is a 99.67% probability that the observed difference is not random, and the best estimate of that difference is 12.44%
The test has statistical significance
```

Follow up from https://github.com/crate/crate/commit/0226630c5fdff2242b6a697beee9aaa198b9a90a

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
