### PR TITLE
Add support for replicating dropped tables and partitions 

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -21,46 +21,6 @@
 
 package io.crate.replication.logical;
 
-import static io.crate.replication.logical.repository.LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX;
-import static io.crate.replication.logical.repository.LogicalReplicationRepository.TYPE;
-import static org.elasticsearch.action.support.master.MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
-import javax.annotation.Nullable;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreClusterStateListener;
-import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
-import org.elasticsearch.action.bulk.BackoffPolicy;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.settings.IndexScopedSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.repositories.RepositoriesService;
-import org.elasticsearch.snapshots.RestoreInfo;
-import org.elasticsearch.snapshots.RestoreService;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.RemoteClusters;
-
 import io.crate.action.FutureActionListener;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.SQLExceptions;
@@ -75,6 +35,45 @@ import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.replication.logical.repository.LogicalReplicationRepository;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreClusterStateListener;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.snapshots.RestoreInfo;
+import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.RemoteClusters;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static io.crate.replication.logical.repository.LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX;
+import static io.crate.replication.logical.repository.LogicalReplicationRepository.TYPE;
+import static org.elasticsearch.action.support.master.MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
 public class LogicalReplicationService implements ClusterStateListener, Closeable {
 
@@ -91,23 +90,28 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
     private volatile PublicationsMetadata currentPublicationsMetadata = new PublicationsMetadata();
     private final MetadataTracker metadataTracker;
 
-    public LogicalReplicationService(IndexScopedSettings indexScopedSettings,
+    public LogicalReplicationService(Settings settings,
+                                     IndexScopedSettings indexScopedSettings,
                                      ClusterService clusterService,
                                      RemoteClusters remoteClusters,
                                      ThreadPool threadPool,
                                      Client client,
+                                     AllocationService allocationService,
                                      LogicalReplicationSettings replicationSettings) {
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.remoteClusters = remoteClusters;
         this.client = client;
         this.metadataTracker = new MetadataTracker(
+            settings,
             indexScopedSettings,
             threadPool,
             this,
             replicationSettings,
             remoteClusters::getClient,
-            clusterService
+            client,
+            clusterService,
+            allocationService
         );
         clusterService.addListener(this);
     }
@@ -504,7 +508,7 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
         return updateSubscriptionState(subscriptionName, oldSubscription, relations);
     }
 
-    private CompletableFuture<Boolean> updateSubscriptionState(String subscriptionName,
+    public CompletableFuture<Boolean> updateSubscriptionState(String subscriptionName,
                                                                Subscription subscription,
                                                                Map<RelationName, Subscription.RelationState> relations) {
         var newSubscription = new Subscription(

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
@@ -21,8 +21,7 @@
 
 package io.crate.replication.logical;
 
-import java.util.Set;
-
+import io.crate.common.unit.TimeValue;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -38,7 +37,7 @@ import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.MergeSchedulerConfig;
 import org.elasticsearch.index.engine.EngineConfig;
 
-import io.crate.common.unit.TimeValue;
+import java.util.Set;
 
 public class LogicalReplicationSettings {
 
@@ -80,6 +79,16 @@ public class LogicalReplicationSettings {
      */
     public static final Setting<String> REPLICATION_SUBSCRIPTION_NAME = Setting.simpleString(
         "index.replication.logical.subscription_name",
+        Setting.Property.InternalIndex,
+        Setting.Property.IndexScope
+    );
+
+    /**
+     * Internal index setting to store the original index UUID of the publisher cluster.
+     * The index UUID on the subscriber cluster will be re-generated thus it differs from the original one.
+     */
+    public static final Setting<String> PUBLISHER_INDEX_UUID = Setting.simpleString(
+        "index.replication.logical.publisher_index_uuid",
         Setting.Property.InternalIndex,
         Setting.Property.IndexScope
     );

--- a/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
@@ -91,7 +91,9 @@ public class ReleasePublisherResourcesAction extends ActionType<AcknowledgedResp
         @Override
         protected AcknowledgedResponse shardOperation(Request request,
                                                       ShardId shardId) throws IOException {
-            LOGGER.info("Releasing resources for {} with restore-id as {}", shardId, request.restoreUUID());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Releasing resources for {} with restore-id as {}", shardId, request.restoreUUID());
+            }
             publisherRestoreService.removeRestoreContext(request.restoreUUID());
             return new AcknowledgedResponse(true);
         }

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -173,6 +173,8 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                 // Add replication specific settings, this setting will trigger a custom engine, see {@link SQLPlugin#getEngineFactory}
                 var builder = Settings.builder().put(indexMetadata.getSettings());
                 builder.put(LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME.getKey(), subscriptionName);
+                // Store publishers original index UUID to be able to resolve the original index later on
+                builder.put(LogicalReplicationSettings.PUBLISHER_INDEX_UUID.getKey(), indexMetadata.getIndexUUID());
 
                 var indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder);
                 indexMetadata.getAliases().valuesIt().forEachRemaining(a -> indexMdBuilder.putAlias(a.get()));
@@ -191,6 +193,8 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
             // Add replication specific settings, this setting will trigger a custom engine, see {@link SQLPlugin#getEngineFactory}
             var builder = Settings.builder().put(indexMetadata.getSettings());
             builder.put(LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME.getKey(), subscriptionName);
+            // Store publishers original index UUID to be able to resolve the original index later on
+            builder.put(LogicalReplicationSettings.PUBLISHER_INDEX_UUID.getKey(), indexMetadata.getIndexUUID());
 
             var indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder);
             indexMetadata.getAliases().valuesIt().forEachRemaining(a -> indexMdBuilder.putAlias(a.get()));

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -21,12 +21,13 @@
 
 package io.crate.replication.logical.repository;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
+import io.crate.common.unit.TimeValue;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.LogicalReplicationSettings;
+import io.crate.replication.logical.action.GetStoreMetadataAction;
+import io.crate.replication.logical.action.PublicationsStateAction;
+import io.crate.replication.logical.action.ReleasePublisherResourcesAction;
+import io.crate.replication.logical.metadata.ConnectionInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexCommit;
@@ -65,13 +66,11 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.RemoteClusters;
 
-import io.crate.common.unit.TimeValue;
-import io.crate.replication.logical.LogicalReplicationService;
-import io.crate.replication.logical.LogicalReplicationSettings;
-import io.crate.replication.logical.action.GetStoreMetadataAction;
-import io.crate.replication.logical.action.PublicationsStateAction;
-import io.crate.replication.logical.action.ReleasePublisherResourcesAction;
-import io.crate.replication.logical.metadata.ConnectionInfo;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Derived from org.opensearch.replication.repository.RemoteClusterRepository
@@ -469,10 +468,12 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                 @Override
                 public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                     if (acknowledgedResponse.isAcknowledged()) {
-                        LOGGER.info("Successfully released resources at the publisher cluster for {} at {}",
-                                    shardId,
-                                    publisherShardNode
-                        );
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("Successfully released resources at the publisher cluster for {} at {}",
+                                shardId,
+                                publisherShardNode
+                            );
+                        }
                     }
                 }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
@@ -82,7 +82,7 @@ public class MetadataDeleteIndexService {
 
                 @Override
                 public ClusterState execute(final ClusterState currentState) {
-                    return deleteIndices(currentState, Set.of(request.indices()));
+                    return deleteIndices(currentState, settings, allocationService, Set.of(request.indices()));
                 }
             }
         );
@@ -92,6 +92,13 @@ public class MetadataDeleteIndexService {
      * Delete some indices from the cluster state.
      */
     public ClusterState deleteIndices(ClusterState currentState, Set<Index> indices) {
+        return deleteIndices(currentState, settings, allocationService, indices);
+    }
+
+    public static ClusterState deleteIndices(ClusterState currentState,
+                                             Settings settings,
+                                             AllocationService allocationService,
+                                             Set<Index> indices) {
         final Metadata meta = currentState.metadata();
         final Set<Index> indicesToDelete = indices.stream().map(i -> meta.getIndexSafe(i).getIndex()).collect(toSet());
 

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.common.settings;
 
-import java.util.Collections;
-import java.util.Set;
-import java.util.function.Predicate;
-
+import io.crate.blob.v2.BlobIndicesService;
+import io.crate.replication.logical.LogicalReplicationSettings;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -39,8 +37,9 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.store.FsDirectoryFactory;
 import org.elasticsearch.index.store.Store;
 
-import io.crate.blob.v2.BlobIndicesService;
-import io.crate.replication.logical.LogicalReplicationSettings;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Encapsulates all valid index level settings.
@@ -120,7 +119,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         Setting.groupSetting("index.analysis.", Property.IndexScope),
         BlobIndicesService.SETTING_INDEX_BLOBS_ENABLED,
         BlobIndicesService.SETTING_INDEX_BLOBS_PATH,
-        LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME
+        LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME,
+        LogicalReplicationSettings.PUBLISHER_INDEX_UUID
     );
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -604,11 +604,13 @@ public class Node implements Closeable {
                 clusterService
             );
             final LogicalReplicationService logicalReplicationService = new LogicalReplicationService(
+                settings,
                 settingsModule.getIndexScopedSettings(),
                 clusterService,
                 remoteClusters,
                 threadPool,
                 client,
+                clusterModule.getAllocationService(),
                 logicalReplicationSettings
             );
             resourcesToClose.add(logicalReplicationService);

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -25,6 +25,7 @@ import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.MetadataTracker;
 import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -214,7 +215,40 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
     }
 
     @Test
-    public void test_dropped_partited_table_is_replicated() throws Exception {
+    public void test_deleted_and_recreated_partition_is_also_deleted_and_restored_on_subscriber() throws Exception {
+        executeOnPublisher("CREATE TABLE t1 (id INT, p INT) PARTITIONED BY (p)");
+        executeOnPublisher("INSERT INTO t1 (id, p) VALUES (1, 1), (2, 2)");
+        createPublication("pub1", true, List.of("t1"));
+        createSubscription("sub1", "pub1");
+
+        // Ensure tracker has started
+        assertBusy(() -> assertThat(isTrackerActive(), is(true)));
+
+        // Wait until table is replicated
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE t1");
+            var r = executeOnSubscriber("SELECT id, p FROM t1 ORDER BY id");
+            assertThat(printedTable(r.rows()), is(
+                "1| 1\n" +
+                "2| 2\n"));
+        });
+
+        // Drop partition
+        executeOnPublisher("DELETE FROM t1 WHERE p = 1");
+        // Re-create same partition with different value
+        executeOnPublisher("INSERT INTO t1 (id, p) VALUES (11, 1)");
+
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE t1");
+            var r = executeOnSubscriber("SELECT id, p FROM t1 ORDER BY id");
+            assertThat(printedTable(r.rows()), is(
+                "2| 2\n" +
+                    "11| 1\n"));        // <- this must contain the id of the re-created partition
+        });
+    }
+
+    @Test
+    public void test_dropped_partitioned_table_is_replicated() throws Exception {
         executeOnPublisher("CREATE TABLE t1 (id INT, p INT) PARTITIONED BY (p)");
         executeOnPublisher("INSERT INTO t1 (id, p) VALUES (1, 1), (2, 2)");
         createPublication("pub1", true, List.of("t1"));

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -21,88 +21,6 @@
 
 package io.crate.testing;
 
-import static io.crate.analyze.TableDefinitions.DEEPLY_NESTED_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.NESTED_PK_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_CLUSTER_BY_STRING_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_DOC_TRANSACTIONS_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_MULTI_PK_DEFINITION;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_REFRESH_INTERVAL_BY_ONLY_DEFINITION;
-import static io.crate.blob.v2.BlobIndex.fullIndexName;
-import static io.crate.testing.DiscoveryNodes.newFakeAddress;
-import static io.crate.testing.TestingHelpers.createNodeContext;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
-import static org.elasticsearch.env.Environment.PATH_HOME_SETTING;
-import static org.mockito.Mockito.mock;
-
-import java.io.File;
-import java.io.IOException;
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Stream;
-
-import javax.annotation.Nullable;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
-import org.elasticsearch.action.admin.cluster.repositories.delete.TransportDeleteRepositoryAction;
-import org.elasticsearch.action.admin.cluster.repositories.put.TransportPutRepositoryAction;
-import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.EmptyClusterInfoService;
-import org.elasticsearch.cluster.metadata.AliasMetadata;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.RoutingTable;
-import org.elasticsearch.cluster.routing.allocation.AllocationService;
-import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
-import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
-import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Randomness;
-import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.common.settings.IndexScopedSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.analysis.AnalysisRegistry;
-import org.elasticsearch.indices.analysis.AnalysisModule;
-import org.elasticsearch.plugins.AnalysisPlugin;
-import org.elasticsearch.repositories.RepositoriesService;
-import org.elasticsearch.test.ClusterServiceUtils;
-import org.elasticsearch.test.gateway.TestGatewayAllocator;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.RemoteClusters;
-
 import io.crate.Constants;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.AnalyzedCreateBlobTable;
@@ -181,6 +99,86 @@ import io.crate.statistics.TableStats;
 import io.crate.user.StubUserManager;
 import io.crate.user.User;
 import io.crate.user.UserManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.repositories.delete.TransportDeleteRepositoryAction;
+import org.elasticsearch.action.admin.cluster.repositories.put.TransportPutRepositoryAction;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.EmptyClusterInfoService;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.analysis.AnalysisRegistry;
+import org.elasticsearch.indices.analysis.AnalysisModule;
+import org.elasticsearch.plugins.AnalysisPlugin;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.gateway.TestGatewayAllocator;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.RemoteClusters;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.crate.analyze.TableDefinitions.DEEPLY_NESTED_TABLE_DEFINITION;
+import static io.crate.analyze.TableDefinitions.NESTED_PK_TABLE_DEFINITION;
+import static io.crate.analyze.TableDefinitions.TEST_CLUSTER_BY_STRING_TABLE_DEFINITION;
+import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINITION;
+import static io.crate.analyze.TableDefinitions.TEST_DOC_TRANSACTIONS_TABLE_DEFINITION;
+import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION;
+import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS;
+import static io.crate.analyze.TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION;
+import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
+import static io.crate.analyze.TableDefinitions.USER_TABLE_MULTI_PK_DEFINITION;
+import static io.crate.analyze.TableDefinitions.USER_TABLE_REFRESH_INTERVAL_BY_ONLY_DEFINITION;
+import static io.crate.blob.v2.BlobIndex.fullIndexName;
+import static io.crate.testing.DiscoveryNodes.newFakeAddress;
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
+import static org.elasticsearch.env.Environment.PATH_HOME_SETTING;
+import static org.mockito.Mockito.mock;
 
 /**
  * Lightweight alternative to {@link SQLTransportExecutor}.
@@ -313,11 +311,13 @@ public class SQLExecutor {
             var threadPool = mock(ThreadPool.class);
             var logicalReplicationSettings = new LogicalReplicationSettings(Settings.EMPTY, clusterService);
             logicalReplicationService = new LogicalReplicationService(
+                Settings.EMPTY,
                 IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
                 clusterService,
                 mock(RemoteClusters.class),
                 threadPool,
                 new NodeClient(Settings.EMPTY, threadPool),
+                allocationService,
                 logicalReplicationSettings
             );
             logicalReplicationService.repositoriesService(mock(RepositoriesService.class));


### PR DESCRIPTION
Dropped tables and partitions will be removed on the subscriber.
If a user want to prevent this, the subscription could be dropped which turns replicating tables into normal ones.