### PR TITLE
Bump JNA library to 5.10.0 to satisfy warnings on macOS M1

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -103,3 +103,6 @@ Fixes
 
 - Fixed an issue that caused an ``Relation unknown`` error while trying to
   close an empty partitioned table using ``ALTER TABLE ... CLOSE``.
+
+- Bumped JNA library to version 5.10.0. This will make CrateDB start without
+  JNA library warnings on M1 chip based MacOS systems.

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -29,7 +29,7 @@ spatial4j=0.8
 jts=1.18.0
 log4j2=2.17.1
 slf4j=1.6.2
-jna=5.6.0
+jna=5.10.0
 
 # ES test
 randomizedrunner=2.7.7


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will fix the `unable to load JNA native support library, native methods will be disabled.` warning when using crate with macOS with m1 chip. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
