### PR TITLE
Use correct regex case-insensitive match operator

### DIFF
--- a/docs/general/builtins/comparison-operators.rst
+++ b/docs/general/builtins/comparison-operators.rst
@@ -96,7 +96,7 @@ Operator                    Description
 ==========================  ===================================================
 ``~``                       Matches regular expression (case sensitive)
 --------------------------  ---------------------------------------------------
-``!~``                      Matches regular expression (case insensitive)
+``~*``                      Matches regular expression (case insensitive)
 --------------------------  ---------------------------------------------------
 ``!~``                      Does not match regular expression (case sensitive)
 --------------------------  ---------------------------------------------------


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes operator for "Matches regular expression (case insensitive)" as documented on [Comparison Operators doc page](https://crate.io/docs/crate/reference/en/4.7/general/builtins/comparison-operators.html#where-clause-operators) and now matches correctly documented operator on [Selecting data doc page](https://crate.io/docs/crate/reference/en/4.7/general/dql/selects.html#regular-expressions)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
