### PR TITLE
Updated to Admin UI 1.20.2, fixing duplicate entries in query history

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -113,3 +113,5 @@ Fixes
 
 - Bumped JNA library to version 5.10.0. This will make CrateDB start without
   JNA library warnings on M1 chip based MacOS systems.
+
+- Updated to Admin UI 1.20.2, which fixes duplicate entries in query history.

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -15,7 +15,7 @@ jackson_jaxrs=1.9.13
 jackson_xc=1.9.13
 jacksonasl=1.9.13
 
-crate_admin_ui = 1.20.0
+crate_admin_ui = 1.20.2
 jdbc=42.3.1
 
 lucene=8.11.0


### PR DESCRIPTION
Hi.

This patch updates to Admin UI 1.20.2, which fixes duplicate entries in query history per https://github.com/crate/crate-admin/pull/753. Thanks, @proddata!

Let me know if the changelog item has been done in the right way. Also please advise if the patch should also be backported.

With kind regards,
Andreas.
