### PR TITLE
Fix privileges and owner check for DROP/ALTER publication/subscription

### DIFF
--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -651,7 +651,7 @@ public class Analyzer {
         @Override
         public AnalyzedStatement visitDropPublication(DropPublication dropPublication,
                                                       Analysis context) {
-            return logicalReplicationAnalyzer.analyze(dropPublication);
+            return logicalReplicationAnalyzer.analyze(dropPublication, context.sessionContext());
         }
 
         @Override
@@ -673,13 +673,13 @@ public class Analyzer {
         @Override
         public AnalyzedStatement visitDropSubscription(DropSubscription dropSubscription,
                                                        Analysis context) {
-            return logicalReplicationAnalyzer.analyze(dropSubscription);
+            return logicalReplicationAnalyzer.analyze(dropSubscription, context.sessionContext());
         }
 
         @Override
         public AnalyzedStatement visitAlterSubscription(AlterSubscription alterSubscription,
                                                         Analysis context) {
-            return logicalReplicationAnalyzer.analyze(alterSubscription);
+            return logicalReplicationAnalyzer.analyze(alterSubscription, context.sessionContext());
         }
     }
 }

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -77,10 +77,6 @@ import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.analyze.relations.UnionSelect;
-import io.crate.replication.logical.analyze.AnalyzedCreatePublication;
-import io.crate.replication.logical.analyze.AnalyzedCreateSubscription;
-import io.crate.user.Privilege;
-import io.crate.user.Privileges;
 import io.crate.exceptions.ClusterScopeException;
 import io.crate.exceptions.CrateException;
 import io.crate.exceptions.CrateExceptionVisitor;
@@ -92,7 +88,15 @@ import io.crate.exceptions.UnscopedException;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
+import io.crate.replication.logical.analyze.AnalyzedAlterPublication;
+import io.crate.replication.logical.analyze.AnalyzedAlterSubscription;
+import io.crate.replication.logical.analyze.AnalyzedCreatePublication;
+import io.crate.replication.logical.analyze.AnalyzedCreateSubscription;
+import io.crate.replication.logical.analyze.AnalyzedDropPublication;
+import io.crate.replication.logical.analyze.AnalyzedDropSubscription;
 import io.crate.sql.tree.SetStatement;
+import io.crate.user.Privilege;
+import io.crate.user.Privileges;
 import io.crate.user.User;
 import io.crate.user.UserLookup;
 
@@ -772,7 +776,66 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         @Override
+        public Void visitDropPublication(AnalyzedDropPublication dropPublication, User user) {
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.AL,
+                Privilege.Clazz.CLUSTER,
+                null,
+                user,
+                defaultSchema
+            );
+            return null;
+        }
+
+        @Override
+        public Void visitAlterPublication(AnalyzedAlterPublication alterPublication, User user) {
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.AL,
+                Privilege.Clazz.CLUSTER,
+                null,
+                user,
+                defaultSchema
+            );
+            for (RelationName relationName: alterPublication.tables()) {
+                for (Privilege.Type type: READ_WRITE_DEFINE) {
+                    Privileges.ensureUserHasPrivilege(
+                        type,
+                        Privilege.Clazz.TABLE,
+                        relationName.fqn(),
+                        user,
+                        defaultSchema
+                    );
+                }
+            }
+            return null;
+        }
+
+        @Override
         public Void visitCreateSubscription(AnalyzedCreateSubscription createSubscription, User user) {
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.AL,
+                Privilege.Clazz.CLUSTER,
+                null,
+                user,
+                defaultSchema
+            );
+            return null;
+        }
+
+        @Override
+        public Void visitDropSubscription(AnalyzedDropSubscription dropSubscription, User user) {
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.AL,
+                Privilege.Clazz.CLUSTER,
+                null,
+                user,
+                defaultSchema
+            );
+            return null;
+        }
+
+        @Override
+        public Void visitAlterSubscription(AnalyzedAlterSubscription alterSubscription, User user) {
             Privileges.ensureUserHasPrivilege(
                 Privilege.Type.AL,
                 Privilege.Clazz.CLUSTER,

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -620,7 +620,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void test_create_publication_for_specific_tables_asks_clusterAL_and_all_for_each_table() {
+    public void test_create_publication_asks_cluster_AL_and_all_for_each_table() {
         analyze("create publication pub1 FOR TABLE t1, t2", user);
         assertAskedForCluster(Privilege.Type.AL);
         for (Privilege.Type type: READ_WRITE_DEFINE) {
@@ -630,8 +630,55 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void test_drop_publication_asks_cluster_AL() {
+        e = SQLExecutor.builder(clusterService)
+            .setUser(user)
+            .addPublication("pub1", true)
+            .setUserManager(userManager)
+            .build();
+        analyze("DROP PUBLICATION pub1", user);
+        assertAskedForCluster(Privilege.Type.AL);
+    }
+
+    @Test
+    public void test_alter_publication_asks_cluster_AL() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .setUser(user)
+            .addPublication("pub1", false, new RelationName("doc", "t1"))
+            .setUserManager(userManager)
+            .build();
+        analyze("ALTER PUBLICATION pub1 ADD TABLE t2", user);
+        assertAskedForCluster(Privilege.Type.AL);
+        for (Privilege.Type type: READ_WRITE_DEFINE) {
+            assertAskedForTable(type, "doc.t2");
+        }
+    }
+
+    @Test
     public void test_create_subscription_asks_cluster_AL() {
         analyze("create subscription sub1 CONNECTION 'postgresql://user@localhost/crate:5432' PUBLICATION pub1", user);
+        assertAskedForCluster(Privilege.Type.AL);
+    }
+
+    @Test
+    public void test_drop_subscription_asks_cluster_AL() {
+        e = SQLExecutor.builder(clusterService)
+            .setUser(user)
+            .addSubscription("sub1", "pub1")
+            .setUserManager(userManager)
+            .build();
+        analyze("DROP SUBSCRIPTION sub1", user);
+        assertAskedForCluster(Privilege.Type.AL);
+    }
+
+    @Test
+    public void test_alter_subscription_asks_cluster_AL() {
+        e = SQLExecutor.builder(clusterService)
+            .setUser(user)
+            .addSubscription("sub1", "pub1")
+            .setUserManager(userManager)
+            .build();
+        analyze("ALTER SUBSCRIPTION sub1 DISABLE", user);
         assertAskedForCluster(Privilege.Type.AL);
     }
 }


### PR DESCRIPTION
Add missing checks for AL privileges for DROP and ALTER publication and subscription.
Additional add missing owner or superuser check while dropping or altering a publication according to the documentation at https://github.com/crate/crate/blob/master/docs/admin/logical-replication.rst
