### PR TITLE
Remove unnecessary subscriptions copy from MetadataTracker

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -98,7 +98,7 @@ public final class MetadataTracker implements Closeable {
     private final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
     // Using a copy-on-write approach. The assumption is that subscription changes are rare and reads happen more frequently
-    private volatile Set<String> subscriptionsToTrack = new HashSet<>();
+    private volatile Set<String> subscriptionsToTrack = Set.of();
     private volatile Scheduler.Cancellable cancellable;
     private volatile boolean isActive = false;
 
@@ -181,7 +181,8 @@ public final class MetadataTracker implements Closeable {
     }
 
     private void run() {
-        var currentSubscriptionsToTrack = new HashSet<>(subscriptionsToTrack);
+        // single volatile read
+        var currentSubscriptionsToTrack = subscriptionsToTrack;
 
         var countDown = new CountdownFutureCallback(currentSubscriptionsToTrack.size());
         countDown.thenRun(this::schedule);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

No need to make a defensive copy in `run` - the subscriptions already
get copied on every update (copy-on-write).


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
