### PR TITLE
Add a `prefer` ssl mode for the pg_tunnel subscription mode

### DIFF
--- a/docs/sql/statements/create-subscription.rst
+++ b/docs/sql/statements/create-subscription.rst
@@ -114,7 +114,8 @@ Parameters supported in the ``pg_tunnel`` mode:
   a working SSL setup for the PostgreSQL wire protocol on both the subscriber
   and publisher cluster.
 
-  Allowed values are ``require`` or ``disable``. Defaults to ``disable``.
+  Allowed values are ``prefer``, ``require`` or ``disable``. Defaults to
+  ``prefer``.
 
 
 **PUBLICATION publication_name**

--- a/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
@@ -53,21 +53,19 @@ public class ConnectionInfo implements Writeable {
 
 
     public enum SSLMode {
+        PREFER,
         DISABLE,
         REQUIRE
     }
 
     public static final Setting<SSLMode> SSLMODE = new Setting<>(
         "sslmode",
-        SSLMode.DISABLE.name(),
-        input -> {
-            if (input.equalsIgnoreCase("disable")) {
-                return SSLMode.DISABLE;
-            } else if (input.equalsIgnoreCase("require")) {
-                return SSLMode.REQUIRE;
-            } else {
-                throw new InvalidArgumentException("Invalid value for sslmode: " + input);
-            }
+        SSLMode.PREFER.name(),
+        input -> switch (input.toLowerCase(Locale.ENGLISH)) {
+            case "prefer" -> SSLMode.PREFER;
+            case "disable" -> SSLMode.DISABLE;
+            case "require" -> SSLMode.REQUIRE;
+            default -> throw new InvalidArgumentException("Invalid value for sslmode: " + input + " expected one of: prefer, disable, require");
         },
         DataTypes.STRING
     );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Using `prefer` will work if the server supports SSL or if it doesn't.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
