### PR TITLE
Fix handling of missing indexMetadata in createMultiShardScoreDocCollector

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -314,8 +314,15 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
         Metadata metadata = clusterService.state().metadata();
         for (Map.Entry<String, IntIndexedContainer> entry : indexShards.entrySet()) {
             String indexName = entry.getKey();
-            Index index = metadata.index(indexName).getIndex();
-
+            IndexMetadata indexMetadata = metadata.index(indexName);
+            if (indexMetadata == null) {
+                if (IndexParts.isPartitioned(indexName)) {
+                    continue;
+                } else {
+                    throw new IndexNotFoundException(indexName);
+                }
+            }
+            Index index = indexMetadata.getIndex();
             for (IntCursor shard : entry.getValue()) {
                 ShardId shardId = new ShardId(index, shard.value);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes the flaky test `MetadataTrackerITest.test_deleted_partition_is_replicated`

Failed with:

    java.lang.NullPointerException: Cannot invoke "org.elasticsearch.cluster.metadata.IndexMetadata.getIndex()" because the return value of "org.elasticsearch.cluster.metadata.Metadata.index(String)" is null
    	at __randomizedtesting.SeedInfo.seed([DAF7CE9C990E194C:3B74E831F40DDD04]:0)
    	at io.crate.execution.engine.collect.sources.ShardCollectSource.createMultiShardScoreDocCollector(ShardCollectSource.java:317)
    	at io.crate.execution.engine.collect.sources.ShardCollectSource.getIterator(ShardCollectSource.java:260)
    	at io.crate.execution.engine.collect.MapSideDataCollectOperation.createIterator(MapSideDataCollectOperation.java:58)
    	at io.crate.execution.engine.collect.CollectTask.start(CollectTask.java:162)
    	at io.crate.execution.jobs.RootTask.start(RootTask.java:191)
    	at io.crate.execution.jobs.transport.TransportJobAction.nodeOperation(TransportJobAction.java:103)
    	at io.crate.execution.jobs.transport.TransportJobAction.nodeOperation(TransportJobAction.java:50)
    	at io.crate.execution.support.NodeActionRequestHandler.messageReceived(NodeActionRequestHandler.java:48)
    	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:59)
    	at org.elasticsearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:257)
    	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    	at java.lang.Thread.run(Thread.java:833)



I suspect this is related to how we handle deleted partitions in the
subscription/replication logic as this is the first time we're seeing this
error. Otherwise I'd have added a changes entry and mark this for a backport.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
