### PR TITLE
Increase timeout for replication in test_new_table_and_new_partition_is_replicated

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -158,7 +159,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                                         " ORDER BY partition_ident");
             assertThat(printedTable(r.rows()), is("{p=1}\n"));
             ensureGreenOnSubscriber();
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -243,7 +244,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
             assertThat(printedTable(r.rows()), is(
                 "2| 2\n" +
                     "11| 1\n"));        // <- this must contain the id of the re-created partition
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

On CI the test `test_new_table_and_new_partition_is_replicated` fails
occassionally with:

    java.lang.AssertionError:
    Expected: is "id\n"
         but: was ""
    	at __randomizedtesting.SeedInfo.seed([3A1F762496632DC2:FB2648E819D2EB93]:0)
    	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
    	at org.junit.Assert.assertThat(Assert.java:964)
    	at org.junit.Assert.assertThat(Assert.java:930)
    	at io.crate.integrationtests.MetadataTrackerITest.lambda$test_new_table_and_new_partition_is_replicated$7(MetadataTrackerITest.java:155)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:770)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:744)
    	at io.crate.integrationtests.MetadataTrackerITest.test_new_table_and_new_partition_is_replicated(MetadataTrackerITest.java:151)

Given that I cannot reproduce the issue locally an assumption is that it
is a timing issue with CI being slower.

This increases the time we wait for the data to be replicated before
failing the test case. If it is indeed a timing issue this should
resolve it. If it will still fail we must assume that there is a bug.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
