### PR TITLE
Include stacktrace in PostgreSQL error response

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/SQLErrorMatcher.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLErrorMatcher.java
@@ -30,6 +30,7 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
 
 import io.crate.protocols.postgres.PGError;
 import io.crate.protocols.postgres.PGErrorStatus;
@@ -99,7 +100,8 @@ public class SQLErrorMatcher {
     }
 
     private static PGError fromPSQLException(PSQLException e) {
-        var sqlState = e.getServerErrorMessage().getSQLState();
+        ServerErrorMessage serverErrorMessage = e.getServerErrorMessage();
+        var sqlState = serverErrorMessage.getSQLState();
         PGErrorStatus errorStatus = null;
         for (var status : PGErrorStatus.values()) {
             if (status.code().equals(sqlState)) {
@@ -108,6 +110,6 @@ public class SQLErrorMatcher {
             }
         }
         assert errorStatus != null : "Unknown psql error code: " + sqlState;
-        return new PGError(errorStatus, e.getMessage(), e);
+        return new PGError(errorStatus, serverErrorMessage.getMessage(), e);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Makes it easier to see where something went wrong in our test suite if a
test case executes queries via JDBC.

In addition to showing the stacktrace from the testlayer like this:

    at __randomizedtesting.SeedInfo.seed([8374F31602C3F2DE:F43AFAE18FBCF6AE]:0)
    at app//org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2674)
    at app//org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2364)
    at app//org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:354)
    at app//org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:484)
    at app//org.postgresql.jdbc.PgStatement.execute(PgStatement.java:404)
    at app//org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:162)
    at app//org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:151)
    at app//io.crate.testing.SQLTransportExecutor.executeAndConvertResult(SQLTransportExecutor.java:379)
    at app//io.crate.testing.SQLTransportExecutor.executeWithPg(SQLTransportExecutor.java:330)
    at app//io.crate.testing.SQLTransportExecutor.executeTransportOrJdbc(SQLTransportExecutor.java:179)
    at app//io.crate.testing.SQLTransportExecutor.exec(SQLTransportExecutor.java:136)

It now starts the error with the CrateDB stack trace:

    at：org.elasticsearch.cluster.block.ClusterBlocks.indexBlockedException(ClusterBlocks.java:207)
    org.elasticsearch.action.support.replication.TransportReplicationAction.blockExceptions(TransportReplicationAction.java:245)
    org.elasticsearch.action.support.replication.TransportReplicationAction$ReroutePhase.doRun(TransportReplicationAction.java:632)
    org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
    org.elasticsearch.action.support.replication.TransportReplicationAction.doExecute(TransportReplicationAction.java:173)
    org.elasticsearch.action.support.replication.TransportReplicationAction.doExecute(TransportReplicationAction.java:90)
    org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:51)
    io.crate.planner.operators.InsertFromValues.execute(InsertFromValues.java:714)
    io.crate.planner.operators.InsertFromValues.lambda$execute$0(InsertFromValues.java:285)
    java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
    java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
    io.crate.planner.operators.InsertFromValues.execute(InsertFromValues.java:281)
    io.crate.action.sql.Session.singleExec(Session.java:679)
    io.crate.action.sql.Session.exec(Session.java:542)
    io.crate.action.sql.Session.triggerDeferredExecutions(Session.java:516)
    io.crate.action.sql.Session.sync(Session.java:500)



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
