### PR TITLE
increase timeout for replication in tests

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -159,7 +159,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                                         " ORDER BY partition_ident");
             assertThat(printedTable(r.rows()), is("{p=1}\n"));
             ensureGreenOnSubscriber();
-        }, 30, TimeUnit.SECONDS);
+        }, 50, TimeUnit.SECONDS);
     }
 
     @Test
@@ -244,7 +244,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
             assertThat(printedTable(r.rows()), is(
                 "2| 2\n" +
                     "11| 1\n"));        // <- this must contain the id of the re-created partition
-        }, 30, TimeUnit.SECONDS);
+        }, 50, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
follow up to https://github.com/crate/crate/pull/12276 - the test still fails often on CI and fails consistently on my Windows laptop (passed only with 100 locally but I guess CI machine should be fine with 50 given that it passes sometimes even with 30)


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
