### PR TITLE
Skip indices with non-active primary shards on logical replication 

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -416,6 +416,10 @@ public final class MetadataTracker implements Closeable {
                 if (skipIndexOrTemplate.test(indexName)) {
                     continue;
                 }
+                if (publisherClusterState.routingTable().index(indexName).allPrimaryShardsActive() == false) {
+                    // skip indices where not all shards are active yet, restore will fail if primaries are not (yet) assigned
+                    continue;
+                }
                 var indexParts = new IndexParts(indexName);
                 var relationName = indexParts.toRelationName();
                 if (subscribedRelations.get(relationName) == null) {

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.MetadataTracker;
 import io.crate.testing.UseRandomizedSchema;
-import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -32,22 +31,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
 @UseRandomizedSchema(random = false)
 public class MetadataTrackerITest extends LogicalReplicationITestCase {
-
-    @Override
-    Settings logicalReplicationSettings() {
-        Settings.Builder builder = Settings.builder();
-        builder.put(super.logicalReplicationSettings());
-        // Increase poll duration to 1s to make sure there is an out-of-sync situation
-        // when the mapping changes on the subscriber cluster
-        builder.put(REPLICATION_READ_POLL_DURATION.getKey(), "1s");
-        return builder.build();
-    }
 
     @Test
     public void test_schema_changes_of_subscribed_table_is_replicated() throws Exception {

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -37,6 +37,9 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -58,6 +61,7 @@ import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATIO
 import static io.crate.replication.logical.MetadataTracker.retrieveSubscription;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -90,6 +94,11 @@ public class MetadataTrackerTest extends ESTestCase {
             clusterState = ClusterState.builder(clusterState)
                 .metadata(Metadata.builder(clusterState.metadata())
                               .put(indexMetadata, true))
+                .routingTable(RoutingTable.builder()
+                    .add(IndexRoutingTable.builder(indexMetadata.getIndex())
+                        .addShard(newShardRouting(name, 0, "dummy_node", true, ShardRoutingState.STARTED))
+                        .build())
+                    .build())
                 .incrementVersion()
                 .build();
             return this;


### PR DESCRIPTION
Restoring indices with non-active (unassigned) primary shards will fail, so they must be excluded from the logical-replication repository and metadata tracking.

Also decrease used poll time at the `MetadataTrackerITest` to speed up tests and maybe solve rarely happening timeout issues.