### PR TITLE
Proofreading of logical replication docs

### DIFF
--- a/docs/admin/logical-replication.rst
+++ b/docs/admin/logical-replication.rst
@@ -13,7 +13,7 @@ Logical replication is a method of data replication across multiple clusters.
 CrateDB uses a publish and subscribe model where subscribers pull data from the
 publications of the publisher they subscribed to.
 
-Replicated tables on a subscriber can be in turn, published further to other
+Replicated tables on a subscriber can again be published further to other
 clusters and thus chaining subscriptions is possible.
 
 .. NOTE::
@@ -27,7 +27,7 @@ Logical replication is useful for the following use cases:
 - Consolidating data from multiple clusters into a single one for aggregated
   reports.
 
-- Ensure High Availability if one cluster becomes unavailable.
+- Ensure high availability if one cluster becomes unavailable.
 
 - Replicating between different compatible versions of CrateDB.
 
@@ -48,26 +48,28 @@ A publication is the upstream side of logical replication and it's created on
 the cluster which acts as a data source.
 
 Each table can be added to multiple publications if needed. Publications can
-only contain tables. All operation types (INSERT, UPDATE, DELETE and schema
-changes) are replicated.
+only contain tables. All operation types (``INSERT``, ``UPDATE``, ``DELETE`` and
+schema changes) are replicated.
 
 Every publication can have multiple subscribers.
 
 A publication is created using the
 :ref:`CREATE PUBLICATION <sql-create-publication>` command. The individual
 tables can be added or removed dynamically using
-:ref:`ALTER PUBLICATION <sql-alter-publication>`. Publication can be removed
-using :ref:`DROP PUBLICATION <sql-drop-publication>` command.
+:ref:`ALTER PUBLICATION <sql-alter-publication>`. Publications can be removed
+using the :ref:`DROP PUBLICATION <sql-drop-publication>` command.
 
 .. CAUTION::
 
-    Publishing cluster must have
-    :ref:`sql-create-table-soft-deletes-enabled` setting
-    set to ``true`` so that subscribing cluster can catch up all changes made
-    during replication pause caused by network issues or explicitly done by a user.
+    The publishing cluster must have
+    :ref:`sql-create-table-soft-deletes-enabled`
+    set to ``true`` so that a subscribing cluster can catch up with all changes
+    made during replication pauses caused by network issues or explicitly done by
+    a user.
+
     Also, :ref:`sql-create-table-soft-deletes-retention-lease-period`
     should be greater than or equal to
-    :ref:`replication.logical.reads_poll_duration <replication.logical.reads_poll_duration>`
+    :ref:`replication.logical.reads_poll_duration <replication.logical.reads_poll_duration>`.
 
 
 .. _logical-replication-subscription:
@@ -77,23 +79,23 @@ Subscription
 
 A subscription is the downstream side of logical replication. A subscription
 defines the connection to another database and set of publications to which it
-wants to subscribe. By default, subscription creation triggers the replication
+wants to subscribe. By default, the subscription creation triggers the replication
 process on the subscriber cluster. The subscriber cluster behaves in the same
 way as any other CrateDB cluster and can be used as a publisher for other
 clusters by defining its own publications.
 
 A cluster can have multiple subscriptions. It is also possible for a cluster to
-have both subscriptions and publications. A cluster cannot subscribe to already
-existing locally table, therefore it is not possible to setup a bi-directional
-replication (both sides subscribing to ALL TABLES leads to a cluster trying to
-replicate its own tables from another cluster). However, 2 clusters still can
-cross subscribe to each other if one cluster subscribes to non-existing locally
+have both subscriptions and publications. A cluster cannot subscribe to locally
+already existing tables, therefore it is not possible to setup a bi-directional
+replication (both sides subscribing to ``ALL TABLES`` leads to a cluster trying to
+replicate its own tables from another cluster). However, two clusters still can
+cross-subscribe to each other if one cluster subscribes to locally non-existing
 tables of another cluster and vice versa.
 
-A subscription is added using
+A subscription is added using the
 :ref:`CREATE SUBSCRIPTION <sql-create-subscription>` command and can be
 stopped/resumed at any time using the
-:ref:`ALTER SUBSCRIPTION <sql-alter-subscription>` command and removed using
+:ref:`ALTER SUBSCRIPTION <sql-alter-subscription>` command and removed using the
 :ref:`DROP SUBSCRIPTION <sql-drop-subscription>` command.
 
 Published tables must not exist on the subscriber. A cluster cannot subscribe
@@ -101,8 +103,8 @@ to a table on another cluster if it exists already on its side, therefore it's
 not possible to drop and re-create a subscription without starting from scratch
 i.e removing all replicated tables.
 
-Only regular tables (including partitions) may be the target of replication.
-For example, you can't replicate a view.
+Only regular tables (including partitions) may be the target of a replication.
+For example, you can not replicate system tables or views.
 
 The tables are matched between the publisher and the subscriber using the fully
 qualified table name. Replication to differently-named tables on the subscriber
@@ -113,15 +115,15 @@ Security
 
 To create, alter or drop a publication, a user must have the ``AL`` privilege
 on the cluster. Only the owner (the user who created the publication) or a
-superuser is allowed to ALTER or DROP a publication.
+superuser is allowed to ``ALTER`` or ``DROP`` a publication.
 To add tables to a publication, the user must have
-``DQL``, ``DML``, ``DDL`` privileges on the table. When a user creates a
-publication that publishes all tables automatically, only those tables where
-user has ``DQL``, ``DML``, ``DDL`` privileges will be published.
+``DQL``, ``DML``, and ``DDL`` privileges on the table. When a user creates a
+publication that publishes all tables automatically, only those tables where the
+user has ``DQL``, ``DML``, and ``DDL`` privileges will be published.
 
 To create, alter or drop a subscription, a user must have the ``AL`` privilege
 on the cluster. Only the owner (the user who created the subscription) or a
-superuser is allowed to ALTER or DROP a subscription.
+superuser is allowed to ``ALTER`` or ``DROP`` a subscription.
 
 .. CAUTION::
 
@@ -138,6 +140,6 @@ More details for a publication are available in the
 specific publication.
 
 All subscriptions are listed in the :ref:`pg_subscription` table.
-More details for a subscription are available in the:ref:`pg_subscription_rel`
+More details for a subscription are available in the :ref:`pg_subscription_rel`
 table. The table contains detailed information about the replication state per
 table, including error messages if there was an error.

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -2338,30 +2338,30 @@ pg_publication
 The ``pg_publication`` table in the ``pg_catalog`` system schema contains all
 publications created in the cluster.
 
-+----------------- +------------------------------------------+-------------+
++------------------+------------------------------------------+-------------+
 | Column Name      | Description                              | Return Type |
 +==================+==========================================+=============+
-| ``oid``          | Row identifier                           | ``INTEGER`` |
+| ``oid``          | Row identifier.                          | ``INTEGER`` |
 +------------------+------------------------------------------+-------------+
 | ``pubname``      | Name of the publication.                 | ``TEXT``    |
 +------------------+------------------------------------------+-------------+
-| ``pubowner``     | oid of the owner of the publication.     | ``INTEGER`` |
+| ``pubowner``     | ``oid`` of the owner of the publication. | ``INTEGER`` |
 +------------------+------------------------------------------+-------------+
 | ``puballtables`` | Whether this publication includes all    | ``BOOLEAN`` |
 |                  | tables in the cluster, including         |             |
 |                  | tables created in the future.            |             |
 +------------------+------------------------------------------+-------------+
-| ``pubinsert``    | Whether INSERT operations are replicated | ``BOOLEAN`` |
-|                  | for tables in the publication. Always    |             |
-|                  | ``true``                                 |             |
+| ``pubinsert``    | Whether ``INSERT`` operations are        | ``BOOLEAN`` |
+|                  | replicated for tables in the publication.|             |
+|                  | Always ``true``.                         |             |
 +------------------+------------------------------------------+-------------+
-| ``pubupdate``    | Whether UPDATE operations are replicated | ``BOOLEAN`` |
-|                  | for tables in the publication. Always    |             |
-|                  | ``true``                                 |             |
+| ``pubupdate``    | Whether ``UPDATE`` operations are        | ``BOOLEAN`` |
+|                  | replicated for tables in the publication.|             |
+|                  | Always ``true``.                         |             |
 +------------------+------------------------------------------+-------------+
-| ``pubdelete``    | Whether DELETE operations are replicated | ``BOOLEAN`` |
-|                  | for tables in the publication. Always    |             |
-|                  | ``true``                                 |             |
+| ``pubdelete``    | Whether ``DELETE`` operations are        | ``BOOLEAN`` |
+|                  | replicated for tables in the publication.|             |
+|                  | Always ``true``.                         |             |
 +------------------+------------------------------------------+-------------+
 
 .. _pg_publication_tables:
@@ -2370,15 +2370,15 @@ pg_publication_tables
 =====================
 
 The ``pg_publication_tables`` table in the ``pg_catalog`` system schema
-contains tables replicated by the publication.
+contains tables replicated by a publication.
 
 +----------------+--------------------------------------+-------------+
 | Column Name    | Description                          | Return Type |
-+================+===+==================================+=============+
++================+======================================+=============+
 | ``pubname``    | Name of the publication.             | ``TEXT``    |
 +----------------+--------------------------------------+-------------+
 | ``schemaname`` | Name of the schema containing table. | ``TEXT``    |
-+----------------+---+---------------------+------------+-------------+
++----------------+--------------------------------------+-------------+
 | ``tablename``  | Name of the table.                   | ``TEXT``    |
 +----------------+--------------------------------------+-------------+
 
@@ -2399,10 +2399,10 @@ subscriptions created in the cluster.
 +---------------------+------------------------------------------+-------------+
 | ``subname``         | Name of the subscription.                | ``TEXT``    |
 +---------------------+------------------------------------------+-------------+
-| ``subowner``        | oid of the owner of the subscription.    | ``INTEGER`` |
+| ``subowner``        | ``oid`` of the owner of the subscription.| ``INTEGER`` |
 +---------------------+------------------------------------------+-------------+
-| ``subenabled``      | Whether subscription is enabled, always  | ``BOOLEAN`` |
-|                     | ``true``.                                |             |
+| ``subenabled``      | Whether the subscription is enabled,     | ``BOOLEAN`` |
+|                     | always ``true``.                         |             |
 +---------------------+------------------------------------------+-------------+
 | ``subbinary``       | Noop value, always ``true``.             | ``BOOLEAN`` |
 |                     |                                          |             |
@@ -2440,13 +2440,13 @@ contains the state for each replicated relation in each subscription.
 +-----------------------+--------------------------------------+--------------+
 | ``srsubstate``        | Replication state of the relation.   | ``TEXT``     |
 |                       | State code:                          |              |
-|                       | i - initializing;                    |              |
-|                       | d - restoring;                       |              |
-|                       | s - synchronized, i.e replication is |              |
-|                       | done;                                |              |
-|                       | r - monitoring, i.e. waiting for the |              |
+|                       | ``i`` - initializing;                |              |
+|                       | ``d`` - restoring;                   |              |
+|                       | ``s`` - synchronized, i.e replication|              |
+|                       | is done;                             |              |
+|                       | ``r`` - monitoring, i.e. waiting for |              |
 |                       | new changes;                         |              |
-|                       | e - error.                           |              |
+|                       | ``e`` - error.                       |              |
 +-----------------------+--------------------------------------+--------------+
 | ``srsubstate_reason`` | Error message if there was a         | ``TEXT``     |
 |                       | replication error for the relation   |              |

--- a/docs/sql/statements/alter-publication.rst
+++ b/docs/sql/statements/alter-publication.rst
@@ -37,7 +37,7 @@ Synopsis
 Description
 ===========
 
-Update the list of published table according to the command. If a table gets
+Update the list of published tables according to the command. If a table gets
 deleted from the publication and it has existing subscriptions, the replication
 of the table stops for all subscribers. Already replicated data remains on
 the subscribed clusters, therefore subscribers can not re-subscribe again to
@@ -50,7 +50,7 @@ Parameters
   The name of the publication to be updated.
 
 **ADD TABLE**
-  Add one or more tables into the list of existing publications.
+  Add one or more tables to the list of existing publications.
 
 **DROP TABLE**
    Remove one or more tables from the list of existing publications.

--- a/docs/sql/statements/alter-subscription.rst
+++ b/docs/sql/statements/alter-subscription.rst
@@ -7,7 +7,7 @@
 ======================
 
 You can use the ``ALTER SUBSCRIPTION`` :ref:`statement <gloss-statement>` to
-update subscription status on the current cluster.
+update the subscription status on the current cluster.
 
 .. SEEALSO::
 
@@ -35,14 +35,14 @@ Synopsis
 Description
 ===========
 
-Disable or enable the subscription. Disabling subscription does not remove it
-but stops getting updates from the publisher. After re-enabling it replication
-resumes back. The replication will try to catch up with all changes made
-in-between which could cause some initial delay based on the amount of changes.
-Availability of the recent changes depends on publishing cluster's
-:ref:`retention setting <sql-create-table-soft-deletes-retention-lease-period>`
+Disable or enable the subscription. Disabling a subscription does not remove it
+but stops getting updates from the publisher. After re-enabling it, replication
+resumes. The replication will try to catch up with all changes made
+in-between which could cause some initial delay based on the number of changes.
+Availability of recent changes depends on the publishing cluster's
+:ref:`retention setting <sql-create-table-soft-deletes-retention-lease-period>`.
 For update and delete operations, changes may not be available anymore on the
-source shard, resulting in an error. In such cases a subscription must be
+source shard, resulting in an error. In such cases, a subscription must be
 re-created to trigger a full restore of the data.
 
 Parameters

--- a/docs/sql/statements/create-publication.rst
+++ b/docs/sql/statements/create-publication.rst
@@ -7,7 +7,7 @@
 ======================
 
 You can use the ``CREATE PUBLICATION`` :ref:`statement <gloss-statement>` to
-add a new publication into the current cluster.
+add a new publication to the current cluster.
 
 .. SEEALSO::
 
@@ -36,13 +36,13 @@ Synopsis
 Description
 ===========
 
-Add a new :ref:`publication <logical-replication-publication>` into the current
+Add a new :ref:`publication <logical-replication-publication>` to the current
 cluster. The publication name must be distinct from the name of any existing
 publication in the current cluster. A publication represents a group of tables
 whose data changes can be replicated by other clusters (subscribers) by
 creating a :ref:`subscription <logical-replication-subscription>`.
 
-If neither FOR TABLE nor FOR ALL TABLES is specified, then the publication
+If neither ``FOR TABLE`` nor ``FOR ALL TABLES`` is specified, then the publication
 starts out with an empty set of tables. That is useful if tables are to be
 added later. The creation of a publication does not start any replication.
 
@@ -61,4 +61,3 @@ Parameters
 **FOR ALL TABLES**
   Marks the publication as one that replicates changes for all tables in the
   cluster, including tables created in the future.
-

--- a/docs/sql/statements/create-subscription.rst
+++ b/docs/sql/statements/create-subscription.rst
@@ -7,7 +7,7 @@
 =======================
 
 You can use the ``CREATE SUBSCRIPTION`` :ref:`statement <gloss-statement>` to
-add a new subscription into the current cluster.
+add a new subscription to the current cluster.
 
 .. SEEALSO::
 
@@ -43,7 +43,7 @@ more :ref:`publications <logical-replication-publication>` on a publisher. The
 subscription name must be distinct from the name of any existing subscription
 in the cluster. The subscription represents a replication connection to the
 publisher. A logical replication will be started on a publisher once
-subscription is enabled, which is by default on creation.
+the subscription is enabled, which is by default on creation.
 
 .. _sql-create-subscription-params:
 
@@ -56,8 +56,7 @@ Parameters
 .. _sql-create-subscription-conn-info:
 
 **CONNECTION 'conninfo'**
-
-  The connection string to the publisher, which is URL in the following format:
+  The connection string to the publisher, which is a URL in the following format:
   ::
 
       crate://host:[port]?params
@@ -79,8 +78,8 @@ Parameters
   connections to each node of the publisher cluster. The ``port`` defaults to
   4300.
 
-  In ``sniff`` mode there can be multiple ``host:port`` pairs, separated by a
-  comma. Parameters will be same for all hosts. Example:
+  In the ``sniff`` mode, there can be multiple ``host:port`` pairs, separated by a
+  comma. Parameters will be the same for all hosts. Example:
 
   ::
 
@@ -95,20 +94,20 @@ Parameters
   only established to the first host listed in the connection string.
 
 
-Parameters supported with both modes:
+  Parameters supported with both modes:
 
   ``user``: name of the user who connects to a publishing cluster. Required.
 
   ``password``: user password.
 
 
-Parameters supported in the ``sniff`` mode:
+  Parameters supported in the ``sniff`` mode:
 
-  ``seeds``:  A comma separated list of initial seed nodes to discover eligible
+  ``seeds``:  A comma-separated list of initial seed nodes to discover eligible
   nodes from the remote cluster.
 
 
-Parameters supported in the ``pg_tunnel`` mode:
+  Parameters supported in the ``pg_tunnel`` mode:
 
   ``sslmode``: Configures whether the connection should use SSL. You must have
   a working SSL setup for the PostgreSQL wire protocol on both the subscriber
@@ -142,6 +141,4 @@ parameters are supported:
 
 **enabled**
   Specifies whether the subscription should be actively replicating, or whether
-  it should be just setup but not started yet. The default is true.
-
-
+  it should be just setup but not started yet. The default is ``true``.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
* Fix a few formatting issues on the [CREATE SUBSCRIPTION](https://crate.io/docs/crate/reference/en/master/sql/statements/create-subscription.html#sql-create-subscription) page
* Added missing backticks and interpunctation
* A few grammar fixes as reported by Grammarly

## Checklist

 - [X] Added an entry in `CHANGES.txt` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
