### PR TITLE
set default port to 5432 if creating a subscription with pg_tunnel mode

### DIFF
--- a/docs/sql/statements/create-subscription.rst
+++ b/docs/sql/statements/create-subscription.rst
@@ -91,7 +91,8 @@ Parameters
   via the transport protocol, but within the connection established via the
   PostgreSQL protocol. All requests from the subscriber cluster to the
   publisher cluster will get routed through a single node. The connection is
-  only established to the first host listed in the connection string.
+  only established to the first host listed in the connection string. The ``port``
+  defaults to 5432.
 
 
   Parameters supported with both modes:

--- a/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
@@ -74,6 +74,12 @@ public class ConnectionInfoTest extends ESTestCase {
     }
 
     @Test
+    public void test_port_defaults_to_5432_in_pg_tunnel_mode() {
+        var connInfo = ConnectionInfo.fromURL("crate://123.123.123.123?mode=pg_tunnel");
+        assertThat(connInfo.hosts(), contains("123.123.123.123:5432"));
+    }
+
+    @Test
     public void test_multiple_hosts() {
         var connInfo = ConnectionInfo.fromURL("crate://example.com:4310,123.123.123.123");
         assertThat(connInfo.hosts(), contains("example.com:4310","123.123.123.123:4300"));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Changes the default port to 5432 if creating a subscription with pg_tunnel mode

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
