### PR TITLE
Enable lookingForStuckThread for test timeouts

### DIFF
--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
@@ -165,7 +165,10 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
     public static final String RUN_SLOW_TESTS_PROP = "tests.crate.slow";
 
     @Rule
-    public Timeout globalTimeout = new Timeout(5, TimeUnit.MINUTES);
+    public Timeout globalTimeout = Timeout.builder()
+        .withLookingForStuckThread(true)
+        .withTimeout(5, TimeUnit.MINUTES)
+        .build();
 
     @Rule
     public TestName testName = new TestName();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Might help getting more insights into why some tests occasionally timeout on CI.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
