### PR TITLE
Fix flaky testFatalIOExceptionsWhileWritingConcurrently

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -107,7 +107,7 @@ should be crossed out as well.
 - [ ] 88b45dfa611 Convert TextFieldMapper to parametrized form (#63269) (#63392)
 - [ ] 244f1a60f92 Selectively Add ClusterState Listeners Depending on Node Roles (#63223) (#63396)
 - [ ] eac99dd594a SnapshotShardSizeInfo should prefer default value when provided (#63390) (#63394)
-- [ ] dd4b0d85fe0 Write translog operation bytes to byte stream (#63298)
+- [x] dd4b0d85fe0 Write translog operation bytes to byte stream (#63298)
 - [x] 64bbbaeef1a Do not block Translog add on file write (#63374)
 - [ ] f17ca18dfa8 Make array value parsing flag more robust. (#63371)
 - [ ] 87076c32e21 Determine shard size before allocating shards recovering from snapshots (#61906) (#63337)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -100,7 +100,7 @@ should be crossed out as well.
 - [ ] 845ccc22646 [DOCS] Fix dup word in ShardRouting hashcode method. (#63452) (#63583)
 - [ ] 8499924e51e InternalSnapshotsInfoService should also removed failed snapshot shard size infos (#63492) (#63592)
 - [ ] 9e52513c7bf Add support for missing value fetchers. (#63585)
-- [ ] 56092b1a9fd Flush translog writer before adding new operation (#63505)
+- [x] 56092b1a9fd Flush translog writer before adding new operation (#63505)
 - [ ] ae2fc4118d2 Add factory methods for common value fetchers. (#63438)
 - [ ] c6b915c8e67 Make TextFieldMapper.FAST_PHRASE_SUFFIX private.
 - [ ] c4726a2cece Don't emit separate warnings for type filters (#63391)

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -26,7 +26,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -72,6 +71,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
 /**
  * A Translog is a per index shard component that records all non-committed index operations in a durable manner.
  * In Elasticsearch there is one Translog instance per {@link org.elasticsearch.index.engine.InternalEngine}.
@@ -114,7 +114,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     // the list of translog readers is guaranteed to be in order of translog generation
     private final List<TranslogReader> readers = new ArrayList<>();
-    private BigArrays bigArrays;
+    private final BigArrays bigArrays;
     protected final ReleasableLock readLock;
     protected final ReleasableLock writeLock;
     private final Path location;
@@ -477,7 +477,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 config.getBufferSize(),
                 initialMinTranslogGen, initialGlobalCheckpoint,
                 globalCheckpointSupplier, this::getMinFileGeneration, primaryTermSupplier.getAsLong(), tragedy,
-                persistedSequenceNumberConsumer);
+                persistedSequenceNumberConsumer,
+                bigArrays);
         } catch (final IOException e) {
             throw new TranslogException(shardId, "failed to create new translog file", e);
         }
@@ -493,7 +494,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      */
     public Location add(final Operation operation) throws IOException {
         final ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(bigArrays);
-        boolean successfullySerialized = false;
         try {
             final long start = out.position();
             out.skip(Integer.BYTES);
@@ -503,9 +503,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             out.seek(start);
             out.writeInt(operationSize);
             out.seek(end);
-            successfullySerialized = true;
-            try (ReleasableBytesReference bytes = new ReleasableBytesReference(out.bytes(), out);
-                 ReleasableLock ignored = readLock.acquire()) {
+            final BytesReference bytes = out.bytes();
+            try (ReleasableLock ignored = readLock.acquire()) {
                 ensureOpen();
                 if (operation.primaryTerm() > current.getPrimaryTerm()) {
                     assert false :
@@ -523,9 +522,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             closeOnTragicEvent(ex);
             throw new TranslogException(shardId, "Failed to write operation [" + operation + "]", ex);
         } finally {
-            if (successfullySerialized == false) {
-                Releasables.close(out);
-            }
+            Releasables.close(out);
         }
     }
 
@@ -1886,7 +1883,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             new TragicExceptionHolder(),
             seqNo -> {
                 throw new UnsupportedOperationException();
-            }
+            },
+            BigArrays.NON_RECYCLING_INSTANCE
         );
         writer.close();
         return translogUUID;

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogConfig.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 public final class TranslogConfig {
 
     public static final ByteSizeValue DEFAULT_BUFFER_SIZE = new ByteSizeValue(1, ByteSizeUnit.MB);
+    public static final ByteSizeValue EMPTY_TRANSLOG_BUFFER_SIZE = new ByteSizeValue(10, ByteSizeUnit.BYTES);
     private final BigArrays bigArrays;
     private final IndexSettings indexSettings;
     private final ShardId shardId;

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -89,6 +89,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
 
     private LongArrayList nonFsyncedSequenceNumbers = new LongArrayList(64);
     private final int forceWriteThreshold;
+    private volatile long bufferedBytes;
     private ReleasableBytesStreamOutput buffer;
 
     private final Map<Long, Tuple<BytesReference, Exception>> seenSequenceNumbers;
@@ -187,13 +188,18 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
      * @throws IOException if writing to the translog resulted in an I/O exception
      */
     public Translog.Location add(final BytesReference data, final long seqNo) throws IOException {
+        long bufferedBytesBeforeAdd = this.bufferedBytes;
+        if (bufferedBytesBeforeAdd >= forceWriteThreshold) {
+            writeBufferedOps(Long.MAX_VALUE, bufferedBytesBeforeAdd >= forceWriteThreshold * 4);
+        }
+
         final Translog.Location location;
-        final long bytesBufferedAfterAdd;
         synchronized (this) {
             ensureOpen();
             if (buffer == null) {
                 buffer = new ReleasableBytesStreamOutput(bigArrays);
             }
+            assert bufferedBytes == buffer.size();
             final long offset = totalOffset;
             totalOffset += data.length();
             data.writeTo(buffer);
@@ -211,11 +217,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
             assert assertNoSeqNumberConflict(seqNo, data);
 
             location = new Translog.Location(generation, offset, data.length());
-            bytesBufferedAfterAdd = buffer.size();
-        }
-
-        if (bytesBufferedAfterAdd >= forceWriteThreshold) {
-            writeBufferedOps(Long.MAX_VALUE, bytesBufferedAfterAdd >= forceWriteThreshold * 4);
+            bufferedBytes = buffer.size();
         }
 
         return location;
@@ -457,6 +459,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
         if (this.buffer != null) {
             ReleasableBytesStreamOutput toWrite = this.buffer;
             this.buffer = null;
+            this.bufferedBytes = 0;
             return new ReleasableBytesReference(toWrite.bytes(), toWrite);
         } else {
             return ReleasableBytesReference.wrap(BytesArray.EMPTY);
@@ -550,6 +553,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
             synchronized (this) {
                 Releasables.closeWhileHandlingException(buffer);
                 buffer = null;
+                bufferedBytes = 0;
             }
             IOUtils.close(checkpointChannel, channel);
         }

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -25,8 +25,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -47,9 +45,10 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.Channels;
 import org.elasticsearch.common.io.DiskIoBufferPool;
-import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
@@ -63,6 +62,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
     private final ShardId shardId;
     private final FileChannel checkpointChannel;
     private final Path checkpointPath;
+    private final BigArrays bigArrays;
     // the last checkpoint that was written when the translog was last synced
     private volatile Checkpoint lastSyncedCheckpoint;
     /* the number of translog operations written to this file */
@@ -89,8 +89,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
 
     private LongArrayList nonFsyncedSequenceNumbers = new LongArrayList(64);
     private final int forceWriteThreshold;
-    private final ArrayList<ReleasableBytesReference> bufferedOps = new ArrayList<>();
-    private long bufferedBytes = 0L;
+    private ReleasableBytesStreamOutput buffer;
 
     private final Map<Long, Tuple<BytesReference, Exception>> seenSequenceNumbers;
 
@@ -103,8 +102,9 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
         final Path checkpointPath,
         final ByteSizeValue bufferSize,
         final LongSupplier globalCheckpointSupplier, LongSupplier minTranslogGenerationSupplier, TranslogHeader header,
-        TragicExceptionHolder tragedy,
-        final LongConsumer persistedSequenceNumberConsumer)
+        final TragicExceptionHolder tragedy,
+        final LongConsumer persistedSequenceNumberConsumer,
+        final BigArrays bigArrays)
             throws
             IOException {
         super(initialCheckpoint.generation, channel, path, header);
@@ -125,6 +125,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
         assert initialCheckpoint.trimmedAboveSeqNo == SequenceNumbers.UNASSIGNED_SEQ_NO : initialCheckpoint.trimmedAboveSeqNo;
         this.globalCheckpointSupplier = globalCheckpointSupplier;
         this.persistedSequenceNumberConsumer = persistedSequenceNumberConsumer;
+        this.bigArrays = bigArrays;
         this.seenSequenceNumbers = Assertions.ENABLED ? new HashMap<>() : null;
         this.tragedy = tragedy;
     }
@@ -132,7 +133,8 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
     public static TranslogWriter create(ShardId shardId, String translogUUID, long fileGeneration, Path file, ChannelFactory channelFactory,
                                         ByteSizeValue bufferSize, final long initialMinTranslogGen, long initialGlobalCheckpoint,
                                         final LongSupplier globalCheckpointSupplier, final LongSupplier minTranslogGenerationSupplier,
-                                        final long primaryTerm, TragicExceptionHolder tragedy, LongConsumer persistedSequenceNumberConsumer)
+                                        final long primaryTerm, TragicExceptionHolder tragedy,
+                                        final LongConsumer persistedSequenceNumberConsumer, final BigArrays bigArrays)
         throws IOException {
         final Path checkpointFile = file.getParent().resolve(Translog.CHECKPOINT_FILE_NAME);
 
@@ -157,7 +159,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                 writerGlobalCheckpointSupplier = globalCheckpointSupplier;
             }
             return new TranslogWriter(shardId, checkpoint, channel, checkpointChannel, file, checkpointFile, bufferSize,
-                writerGlobalCheckpointSupplier, minTranslogGenerationSupplier, header, tragedy, persistedSequenceNumberConsumer);
+                writerGlobalCheckpointSupplier, minTranslogGenerationSupplier, header, tragedy, persistedSequenceNumberConsumer, bigArrays);
         } catch (Exception exception) {
             // if we fail to bake the file-generation into the checkpoint we stick with the file and once we recover and that
             // file exists we remove it. We only apply this logic to the checkpoint.generation+1 any other file with a higher generation
@@ -184,15 +186,17 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
      * @return the location the bytes were written to
      * @throws IOException if writing to the translog resulted in an I/O exception
      */
-    public Translog.Location add(final ReleasableBytesReference data, final long seqNo) throws IOException {
+    public Translog.Location add(final BytesReference data, final long seqNo) throws IOException {
         final Translog.Location location;
         final long bytesBufferedAfterAdd;
         synchronized (this) {
             ensureOpen();
+            if (buffer == null) {
+                buffer = new ReleasableBytesStreamOutput(bigArrays);
+            }
             final long offset = totalOffset;
             totalOffset += data.length();
-            bufferedBytes += data.length();
-            bufferedOps.add(data.retain());
+            data.writeTo(buffer);
 
             assert minSeqNo != SequenceNumbers.NO_OPS_PERFORMED || operationCounter == 0;
             assert maxSeqNo != SequenceNumbers.NO_OPS_PERFORMED || operationCounter == 0;
@@ -207,7 +211,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
             assert assertNoSeqNumberConflict(seqNo, data);
 
             location = new Translog.Location(generation, offset, data.length());
-            bytesBufferedAfterAdd = bufferedBytes;
+            bytesBufferedAfterAdd = buffer.size();
         }
 
         if (bytesBufferedAfterAdd >= forceWriteThreshold) {
@@ -334,7 +338,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                         throw ex;
                     }
                     // If we reached this point, all of the buffered ops should have been flushed successfully.
-                    assert bufferedOps.size() == 0;
+                    assert buffer == null;
                     assert checkChannelPositionWhileHandlingException(totalOffset);
                     assert totalOffset == lastSyncedCheckpoint.offset;
                     if (closed.compareAndSet(false, true)) {
@@ -371,7 +375,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                         throw new TranslogException(shardId, "exception while syncing before creating a snapshot", e);
                     }
                     // If we reached this point, all of the buffered ops should have been flushed successfully.
-                    assert bufferedOps.size() == 0;
+                    assert buffer == null;
                     assert checkChannelPositionWhileHandlingException(totalOffset);
                     assert totalOffset == lastSyncedCheckpoint.offset;
                     return super.newSnapshot();
@@ -397,7 +401,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                     // the lock we should check again since if this code is busy we might have fsynced enough already
                     final Checkpoint checkpointToSync;
                     final LongArrayList flushedSequenceNumbers;
-                    final ArrayDeque<ReleasableBytesReference> toWrite;
+                    final ReleasableBytesReference toWrite;
                     try (ReleasableLock toClose = writeLock.acquire()) {
                         synchronized (this) {
                             ensureOpen();
@@ -448,44 +452,39 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
         }
     }
 
-    private synchronized ArrayDeque<ReleasableBytesReference> pollOpsToWrite() {
+    private synchronized ReleasableBytesReference pollOpsToWrite() {
         ensureOpen();
-        final ArrayDeque<ReleasableBytesReference> operationsToWrite = new ArrayDeque<>(bufferedOps.size());
-        operationsToWrite.addAll(bufferedOps);
-        bufferedOps.clear();
-        bufferedBytes = 0;
-        return operationsToWrite;
+        if (this.buffer != null) {
+            ReleasableBytesStreamOutput toWrite = this.buffer;
+            this.buffer = null;
+            return new ReleasableBytesReference(toWrite.bytes(), toWrite);
+        } else {
+            return ReleasableBytesReference.wrap(BytesArray.EMPTY);
+        }
     }
 
-    private void writeAndReleaseOps(final ArrayDeque<ReleasableBytesReference> operationsToWrite) throws IOException {
-        try {
+    private void writeAndReleaseOps(ReleasableBytesReference toWrite) throws IOException {
+        try (ReleasableBytesReference toClose = toWrite) {
             assert writeLock.isHeldByCurrentThread();
             ByteBuffer ioBuffer = DiskIoBufferPool.getIoBuffer();
 
-            ReleasableBytesReference operation;
-            while ((operation = operationsToWrite.pollFirst()) != null) {
-                try (Releasable toClose = operation) {
-                    BytesRefIterator iterator = operation.iterator();
-                    BytesRef current;
-                    while ((current = iterator.next()) != null) {
-                        int currentBytesConsumed = 0;
-                        while (currentBytesConsumed != current.length) {
-                            int nBytesToWrite = Math.min(current.length - currentBytesConsumed, ioBuffer.remaining());
-                            ioBuffer.put(current.bytes, current.offset + currentBytesConsumed, nBytesToWrite);
-                            currentBytesConsumed += nBytesToWrite;
-                            if (ioBuffer.hasRemaining() == false) {
-                                ioBuffer.flip();
-                                writeToFile(ioBuffer);
-                                ioBuffer.clear();
-                            }
-                        }
+            BytesRefIterator iterator = toWrite.iterator();
+            BytesRef current;
+            while ((current = iterator.next()) != null) {
+                int currentBytesConsumed = 0;
+                while (currentBytesConsumed != current.length) {
+                    int nBytesToWrite = Math.min(current.length - currentBytesConsumed, ioBuffer.remaining());
+                    ioBuffer.put(current.bytes, current.offset + currentBytesConsumed, nBytesToWrite);
+                    currentBytesConsumed += nBytesToWrite;
+                    if (ioBuffer.hasRemaining() == false) {
+                        ioBuffer.flip();
+                        writeToFile(ioBuffer);
+                        ioBuffer.clear();
                     }
                 }
             }
             ioBuffer.flip();
             writeToFile(ioBuffer);
-        } finally {
-            Releasables.close(operationsToWrite);
         }
     }
 
@@ -549,8 +548,8 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
     public final void close() throws IOException {
         if (closed.compareAndSet(false, true)) {
             synchronized (this) {
-                Releasables.closeWhileHandlingException(bufferedOps);
-                bufferedOps.clear();
+                Releasables.closeWhileHandlingException(buffer);
+                buffer = null;
             }
             IOUtils.close(checkpointChannel, channel);
         }

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogDeletionPolicyTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
@@ -197,7 +198,7 @@ public class TranslogDeletionPolicyTests extends ESTestCase {
             }
             writer = TranslogWriter.create(new ShardId("index", "uuid", 0), translogUUID, gen,
                 tempDir.resolve(Translog.getFilename(gen)), FileChannel::open, TranslogConfig.DEFAULT_BUFFER_SIZE, 1L, 1L, () -> 1L,
-                () -> 1L, randomNonNegativeLong(), new TragicExceptionHolder(), seqNo -> {});
+                () -> 1L, randomNonNegativeLong(), new TragicExceptionHolder(), seqNo -> {}, BigArrays.NON_RECYCLING_INSTANCE);
             writer = Mockito.spy(writer);
             Mockito.doReturn(now - (numberOfReaders - gen + 1) * 1000).when(writer).getLastModifiedTime();
 

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1198,7 +1198,7 @@ public class TranslogTests extends ESTestCase {
         final TranslogWriter writer = translog.createWriter(translog.currentFileGeneration() + 1);
         final Set<Long> persistedSeqNos = new HashSet<>();
         persistedSeqNoConsumer.set(persistedSeqNos::add);
-        final int numOps = randomIntBetween(8, 128);
+        final int numOps = scaledRandomIntBetween(8, 250000);
         final Set<Long> seenSeqNos = new HashSet<>();
         boolean opsHaveValidSequenceNumbers = randomBoolean();
         for (int i = 0; i < numOps; i++) {

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1315,12 +1315,13 @@ public class TranslogTests extends ESTestCase {
             writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 1);
             writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 2);
             writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 3);
+            writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 4);
             assertThat(persistedSeqNos, empty());
             assertEquals(initialWriteCalls, writeCalls.get());
 
             if (randomBoolean()) {
-                // This will fill the buffer and force a flush
-                writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 4);
+                // Since the buffer is full, this will flush before performing the add.
+                writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 5);
                 assertThat(persistedSeqNos, empty());
                 assertThat(writeCalls.get(), greaterThan(initialWriteCalls));
             } else {
@@ -1330,13 +1331,13 @@ public class TranslogTests extends ESTestCase {
                 assertThat(writeCalls.get(), greaterThan(initialWriteCalls));
 
                 // Add after we the read flushed the buffer
-                writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 4);
+                writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), 5);
             }
 
             writer.sync();
 
             // Sequence numbers are marked as persisted after sync
-            assertThat(persistedSeqNos, contains(1L, 2L, 3L, 4L));
+            assertThat(persistedSeqNos, contains(1L, 2L, 3L, 4L, 5L));
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Second commit should fix the flaky `testFatalIOExceptionsWhileWritingConcurrently`

```
java.lang.AssertionError: expected:<19> but was:<20>
	at __randomizedtesting.SeedInfo.seed([8C1F6E4E33DFE3CE:DBD7E9813109418D]:0)
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.elasticsearch.index.translog.TranslogTests.testFatalIOExceptionsWhileWritingConcurrently(TranslogTests.java:2322
```

Picked the first commit as well to have the `Translog` patches in the right order.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
