### PR TITLE
Revert "Enable lookingForStuckThread for test timeouts"

### DIFF
--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
@@ -165,10 +165,7 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
     public static final String RUN_SLOW_TESTS_PROP = "tests.crate.slow";
 
     @Rule
-    public Timeout globalTimeout = Timeout.builder()
-        .withLookingForStuckThread(true)
-        .withTimeout(5, TimeUnit.MINUTES)
-        .build();
+    public Timeout globalTimeout = new Timeout(5, TimeUnit.MINUTES);
 
     @Rule
     public TestName testName = new TestName();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This reverts commit 0e9dca1abfae57da7a94cd356f09b3e8589323fc.

It appears as if this has caused new test failures:

```
java.lang.IllegalThreadStateException
	at __randomizedtesting.SeedInfo.seed([51B923EB19F2BCE0:6B8805B13B4B3757]:0)
	at java.base/java.lang.ThreadGroup.addUnstarted(ThreadGroup.java:892)
	at java.base/java.lang.Thread.<init>(Thread.java:434)
	at java.base/java.lang.Thread.<init>(Thread.java:708)
	at org.elasticsearch.common.util.concurrent.EsExecutors$EsThreadFactory.newThread(EsExecutors.java:230)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.<init>(ThreadPoolExecutor.java:630)
	at java.base/java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:920)
	at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1364)
	at org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor.execute(EsThreadPoolExecutor.java:71)
	at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:123)
	at org.elasticsearch.test.InternalTestCluster.lambda$startAndPublishNodesAndClients$23(InternalTestCluster.java:1486)
```


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
