### PR TITLE
Use hosts as seed nodes at `sniff` remote connection mode

### DIFF
--- a/docs/sql/statements/create-subscription.rst
+++ b/docs/sql/statements/create-subscription.rst
@@ -78,8 +78,10 @@ Parameters
   connections to each node of the publisher cluster. The ``port`` defaults to
   4300.
 
-  In the ``sniff`` mode, there can be multiple ``host:port`` pairs, separated by a
-  comma. Parameters will be the same for all hosts. Example:
+  In the ``sniff`` mode, there can be multiple ``host:port`` pairs, separated
+  by a comma. Parameters will be the same for all hosts. These hosts are used
+  as initial seed nodes to discover all eligible nodes from the remote cluster.
+  Example:
 
   ::
 
@@ -100,12 +102,6 @@ Parameters
   ``user``: name of the user who connects to a publishing cluster. Required.
 
   ``password``: user password.
-
-
-  Parameters supported in the ``sniff`` mode:
-
-  ``seeds``:  A comma-separated list of initial seed nodes to discover eligible
-  nodes from the remote cluster.
 
 
   Parameters supported in the ``pg_tunnel`` mode:

--- a/server/src/main/java/org/elasticsearch/transport/RemoteCluster.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteCluster.java
@@ -21,25 +21,23 @@
 
 package org.elasticsearch.transport;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-
-import org.elasticsearch.client.Client;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.threadpool.ThreadPool;
-
 import io.crate.action.FutureActionListener;
 import io.crate.common.io.IOUtils;
 import io.crate.protocols.postgres.PgClient;
 import io.crate.protocols.postgres.PgClientFactory;
 import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.types.DataTypes;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 
 
 public class RemoteCluster implements Closeable {
@@ -55,28 +53,6 @@ public class RemoteCluster implements Closeable {
         value -> ConnectionStrategy.valueOf(value.toUpperCase(Locale.ROOT)),
         DataTypes.STRING,
         Setting.Property.Dynamic
-    );
-
-    /**
-     * A list of initial seed nodes to discover eligible nodes from the remote cluster
-     */
-    public static final Setting<List<String>> REMOTE_CLUSTER_SEEDS = Setting.listSetting(
-        "seeds",
-        null,
-        s -> {
-            // validate seed address
-            RemoteConnectionParser.parsePort(s);
-            return s;
-        },
-        s -> List.of(),
-        value -> {},
-        DataTypes.STRING_ARRAY,
-        Setting.Property.Dynamic
-    );
-
-    public static Set<String> SETTING_NAMES = Set.of(
-        REMOTE_CONNECTION_MODE.getKey(),
-        REMOTE_CLUSTER_SEEDS.getKey()
     );
 
     private final String clusterName;
@@ -144,7 +120,7 @@ public class RemoteCluster implements Closeable {
     private CompletableFuture<Client> connectSniff() {
         var remoteConnection = new RemoteClusterConnection(
             settings,
-            connectionInfo.settings(),
+            connectionInfo,
             clusterName,
             transportService
         );

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.transport;
 
 import io.crate.common.io.IOUtils;
+import io.crate.replication.logical.metadata.ConnectionInfo;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
@@ -62,11 +63,11 @@ public final class RemoteClusterConnection implements Closeable {
      * @param transportService the local nodes transport service
      */
     public RemoteClusterConnection(Settings nodeSettings,
-                                   Settings connectionSettings,
+                                   ConnectionInfo connectionInfo,
                                    String clusterAlias,
                                    TransportService transportService) {
         this.transportService = transportService;
-        ConnectionProfile profile = RemoteConnectionStrategy.buildConnectionProfile(nodeSettings, connectionSettings);
+        ConnectionProfile profile = RemoteConnectionStrategy.buildConnectionProfile(nodeSettings, connectionInfo.settings());
         this.remoteConnectionManager = new RemoteConnectionManager(
             clusterAlias,
             new ClusterConnectionManager(profile, transportService.transport)
@@ -76,7 +77,7 @@ public final class RemoteClusterConnection implements Closeable {
             transportService,
             remoteConnectionManager,
             nodeSettings,
-            connectionSettings
+            connectionInfo
         );
         // we register the transport service here as a listener to make sure we notify handlers on disconnect etc.
         this.remoteConnectionManager.addListener(transportService);

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -19,13 +19,10 @@
 
 package org.elasticsearch.transport;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-
+import io.crate.common.Booleans;
+import io.crate.common.collections.Lists2;
+import io.crate.common.io.IOUtils;
+import io.crate.replication.logical.metadata.ConnectionInfo;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
@@ -41,9 +38,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import io.crate.common.Booleans;
-import io.crate.common.collections.Lists2;
-import io.crate.common.io.IOUtils;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class SniffConnectionStrategy extends RemoteConnectionStrategy {
 
@@ -62,13 +62,13 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                             TransportService transportService,
                             RemoteConnectionManager connectionManager,
                             Settings nodeSettings,
-                            Settings connectionSettings) {
+                            ConnectionInfo connectionInfo) {
         this(
             clusterAlias,
             transportService,
             connectionManager,
             getNodePredicate(nodeSettings),
-            RemoteCluster.REMOTE_CLUSTER_SEEDS.get(connectionSettings)
+            connectionInfo.hosts()
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
@@ -21,17 +21,14 @@
 
 package io.crate.integrationtests;
 
-import io.crate.action.sql.SQLOperations;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.replication.logical.LogicalReplicationSettings;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.user.User;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
@@ -244,12 +241,10 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
             InetSocketAddress address = transportService.boundAddress().publishAddress().address();
             return String.format(
                 Locale.ENGLISH,
-                "crate://%s:%d?user=%s&mode=sniff&seeds=%s:%d",
+                "crate://%s:%d?user=%s&mode=sniff",
                 address.getHostName(),
                 address.getPort(),
-                SUBSCRIBING_USER,
-                address.getHostName(),
-                address.getPort()
+                SUBSCRIBING_USER
             );
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The hosts of a connection URI must be used as seed nodes when using the `sniff` remote connection mode.
This makes the additional `seed` URI parameter (setting) obsolete.
As all hosts are already parsed and validated while analyzing, this also results in good errors when using invalid hosts instead of hard to understand `NoSeedNodeLeftException`.


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
