### PR TITLE
revert readList to narrow down what produces diff

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -1055,7 +1055,16 @@ public abstract class StreamInput extends InputStream {
      * Reads a set of objects
      */
     public <T> Set<T> readSet(Writeable.Reader<T> reader) throws IOException {
-        return readCollection(reader, HashSet::new);
+        int size = readVInt();
+        if (size > ArrayUtil.MAX_ARRAY_LENGTH) {
+            throw new IllegalStateException("array length must be <= to " + ArrayUtil.MAX_ARRAY_LENGTH + " but was: " + size);
+        }
+        ensureCanReadBytes(size);
+        HashSet<T> set = new HashSet<>((int) (size / 0.75 + 1.0));
+        for (int i = 0; i < size; i++) {
+            set.add(reader.read(this));
+        }
+        return set;
     }
 
     /**


### PR DESCRIPTION
checked out to the state before https://github.com/crate/crate/pull/12241 and also reverted readList change to check only readSet impact.

local hash_joins.toml looks like (setup/teardown excluded, only problematic query with concurrency 20 is kept):

```
[[queries]]
statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000'
iterations = 20
min_version = '3.0.0'
concurrency = 20
```

result of running
`./compare_run.py --v1 branch:master --v2 branch:baur/before-read-set2 --spec specs/select/hash_joins.toml --env CRATE_HEAP_SIZE=6g -s path.data=/Users/baur/benchmark-data`

<details>
<summary>1 run </summary>

```
V1: 4.8.0-38904ed5d094772fc4e8c21ba32e6272708fa54e
V2: 4.8.0-0e1e987f2fd61b189bee5aeaed66db8639a3fe1a
Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000
C: 20
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |   155520.623 ± 8929.925 | 151863.830 | 153606.780 | 154390.170 | 193226.220 |
|   V2    |   165849.498 ± 9947.490 | 162266.600 | 163208.770 | 164378.840 | 207931.120 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   6.43%                           +   6.06%
There is a 99.86% probability that the observed difference is not random, and the best estimate of that difference is 6.43%
The test has statistical significance
System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  245    68.78    52.56 |   19  4652.81  3378.41 |     6442      493 |     0.00          0
 V2 |  237    66.55    35.54 |   20  4547.78  1746.56 |     6442     1734 |     0.00          0
V1 top allocation frames
  Unsafe.copyMemory(...):5108
  IntObjectHashMap.indexOf(int):3103
  Lucene80DocValuesProducer$TermsDict.seekExact(long):2432
  ByteBuffer.getArray(...):2293
  UnicodeUtil.UTF8toUTF16(...):1326
V2 top allocation frames
  ByteBuffer.getArray(...):10278
  IntObjectHashMap.indexOf(int):3014
  UnicodeUtil.UTF8toUTF16(...):1837
  StringLatin1.hashCode(byte[]):632
  Lucene80DocValuesProducer$TermsDict.seekExact(long):618
```
</details>

<details>
<summary>2 run </summary>

```
V1: 4.8.0-38904ed5d094772fc4e8c21ba32e6272708fa54e
V2: 4.8.0-0e1e987f2fd61b189bee5aeaed66db8639a3fe1a
Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000
C: 20
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |   164900.201 ± 10089.602 | 161174.140 | 162710.780 | 163321.020 | 207616.970 |
|   V2    |   175254.372 ± 9202.660 | 171459.500 | 173380.330 | 173903.530 | 214159.920 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   6.09%                           +   6.35%
There is a 99.84% probability that the observed difference is not random, and the best estimate of that difference is 6.09%
The test has statistical significance
System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  204    62.30    35.34 |   16  4668.27  4490.30 |     6442     1512 |     0.00          0
 V2 |  240    63.05    19.29 |   20  4216.12  1685.58 |     6442      728 |     0.00          0
V1 top allocation frames
  Unsafe.copyMemory(...):5751
  IntObjectHashMap.indexOf(int):2707
  Lucene80DocValuesProducer$TermsDict.seekExact(long):2184
  UnicodeUtil.UTF8toUTF16(...):1503
  ByteBuffer.getArray(...):1373
V2 top allocation frames
  ByteBuffer.getArray(...):7848
  IntObjectHashMap.indexOf(int):3213
  UnicodeUtil.UTF8toUTF16(...):1736
  Lucene80DocValuesProducer$TermsDict.seekExact(long):1709
  HashJoinOperation.lambda$getHashBuilderFromSymbols$1(...):861
```
</details>

<details>

<summary>3 run </summary>

```
V1: 4.8.0-38904ed5d094772fc4e8c21ba32e6272708fa54e
V2: 4.8.0-0e1e987f2fd61b189bee5aeaed66db8639a3fe1a
Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000
C: 20
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |   170832.546 ± 9563.999 | 167510.100 | 168760.970 | 169448.110 | 211326.660 |
|   V2    |   160845.590 ± 9695.024 | 156899.940 | 158786.620 | 159377.400 | 201802.380 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   6.02%                           -   6.09%
There is a 99.78% probability that the observed difference is not random, and the best estimate of that difference is 6.02%
The test has statistical significance
System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  248    59.59    37.55 |   19  4592.78  3255.72 |     6442      488 |     0.00          0
 V2 |  252    62.33    35.98 |   20  4352.43  2400.57 |     6442      708 |     0.00          0
V1 top allocation frames
  Unsafe.copyMemory(...):6935
  IntObjectHashMap.indexOf(int):3169
  Lucene80DocValuesProducer$TermsDict.seekExact(long):2427
  UnicodeUtil.UTF8toUTF16(...):1625
  ByteBuffer.getArray(...):1585
V2 top allocation frames
  Unsafe.copyMemory(...):7359
  IntObjectHashMap.indexOf(int):3253
  Lucene80DocValuesProducer$TermsDict.seekExact(long):2624
  UnicodeUtil.UTF8toUTF16(...):1816
  ByteBuffer.getArray(...):1634
```
</details>


<details>
<summary>4 run </summary>

```
V1: 4.8.0-38904ed5d094772fc4e8c21ba32e6272708fa54e
V2: 4.8.0-0e1e987f2fd61b189bee5aeaed66db8639a3fe1a
Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000
C: 20
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |   168915.715 ± 9629.414 | 165332.610 | 166719.190 | 167387.190 | 209643.250 |
|   V2    |   163604.137 ± 9390.760 | 159890.600 | 161692.880 | 162469.440 | 203252.600 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   3.19%                           -   3.06%
There is a 91.46% probability that the observed difference is not random, and the best estimate of that difference is 3.19%
The test has no statistical significance
System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  213    72.76    35.63 |   20  4416.84  3321.53 |     6442     1356 |     0.00          0
 V2 |  250    62.79    37.77 |   20  4336.20  2433.48 |     6442      580 |     0.00          0
V1 top allocation frames
  Unsafe.copyMemory(...):6965
  IntObjectHashMap.indexOf(int):3104
  Lucene80DocValuesProducer$TermsDict.seekExact(long):2399
  UnicodeUtil.UTF8toUTF16(...):1785
  ByteBuffer.getArray(...):1603
V2 top allocation frames
  ByteBuffer.getArray(...):7714
  IntObjectHashMap.indexOf(int):3139
  UnicodeUtil.UTF8toUTF16(...):1822
  Lucene80DocValuesProducer$TermsDict.seekExact(long):1542
  Unsafe.copyMemory(...):1098
```

</details>

<details>
<summary>5 run </summary>

```
V1: 4.8.0-38904ed5d094772fc4e8c21ba32e6272708fa54e
V2: 4.8.0-0e1e987f2fd61b189bee5aeaed66db8639a3fe1a
Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000
C: 20
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |   166495.574 ± 9511.176 | 162874.900 | 164337.200 | 164968.470 | 206766.250 |
|   V2    |   159735.209 ± 9823.962 | 155803.720 | 157615.340 | 158569.700 | 201207.360 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   4.14%                           -   4.18%
There is a 96.69% probability that the observed difference is not random, and the best estimate of that difference is 4.14%
The test has no statistical significance
System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  249    60.57    35.80 |   20  4889.38  5091.99 |     6442     1393 |     0.00          0
 V2 |  236    63.49    35.40 |   20  4269.10  1156.78 |     6442     1439 |     0.00          0
V1 top allocation frames
  Unsafe.copyMemory(...):6710
  IntObjectHashMap.indexOf(int):2992
  Lucene80DocValuesProducer$TermsDict.seekExact(long):2559
  UnicodeUtil.UTF8toUTF16(...):1744
  ByteBuffer.getArray(...):1565
V2 top allocation frames
  Unsafe.copyMemory(...):6753
  IntObjectHashMap.indexOf(int):2980
  Lucene80DocValuesProducer$TermsDict.seekExact(long):2396
  UnicodeUtil.UTF8toUTF16(...):1696
  ByteBuffer.getArray(...):1530
```
</details>

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
