### PR TITLE
Minor proofreading fixes for documentation

### DIFF
--- a/docs/general/ddl/analyzers.rst
+++ b/docs/general/ddl/analyzers.rst
@@ -1356,8 +1356,8 @@ Built-in char filter
 .. rubric:: Parameters
 
 mappings
-    A list of mappings as strings of the form ``[<source>=><replacement>] e.g.
-    "ph=>f"``
+    A list of mappings as strings of the form ``[<source>=><replacement>]``, e.g.
+    ``"ph=>f"``.
 
 mappings_path
     A path to a file with one mapping per line, like above.
@@ -1427,9 +1427,9 @@ hash_set_size
 
 with_rotation
     Whether or not to fill empty buckets with the value of the first non-empty
-    bucket to its circular right. Only takes effect if hash_set_size is equal
-    to one. Defaults to ``true`` if bucket_count is greater than ``1``, else
-    ``false``.
+    bucket to its circular right. Only takes effect if ``hash_set_size`` is
+    equal to one. Defaults to ``true`` if ``bucket_count`` is greater than
+    ``1``, else ``false``.
 
 .. _fingerprint-tokenfilter:
 
@@ -1438,9 +1438,9 @@ with_rotation
 
 ``type='fingerprint'``
 
- Emits a single token which is useful for fingerprinting a body of text, and/or
- providing a token that can be clustered on. It does this by sorting the
- tokens, de-duplicating and then concatenating them back into a single token.
+Emits a single token which is useful for fingerprinting a body of text, and/or
+providing a token that can be clustered on. It does this by sorting the
+tokens, de-duplicating and then concatenating them back into a single token.
 
 .. rubric:: Parameters
 
@@ -1448,7 +1448,7 @@ separator
     Separator which is used for concatenating the tokens. Defaults to a space.
 
 max_output_size
-    If the concatenated fingerprint grows larger than max_output_size, the
+    If the concatenated fingerprint grows larger than ``max_output_size``, the
     token filter will exit and will not emit a token. Defaults to ``255``.
 
 .. _Java Pattern Api: https://download.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html#field_summary

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -9,8 +9,8 @@ Data types
 Data can be stored in different formats. CrateDB has different types that can
 be specified if a table is created using the :ref:`sql-create-table` statement.
 
-Data types play a central role as they limit what kind of data can be inserted,
-how it is stored and they also influence the behaviour when the records are
+Data types play a central role as they limit what kind of data can be inserted
+and how it is stored. They also influence the behaviour when the records are
 queried.
 
 Data type names are reserved words and need to be escaped when used as column
@@ -265,11 +265,12 @@ A ``NULL`` represents a missing value.
 
 
 You can use ``NULL`` values when inserting records to indicate the absence of a
-data point (i.e., the value for a specific column is not known).
+data point when the value for a specific column is not known.
 
 Similarly, CrateDB will produce ``NULL`` values when, for example, data is
-missing from a :ref:`outer left-join <join-types-outer>` operation (i.e., when
-a row from one relation has no corresponding row in the joined relation).
+missing from an :ref:`outer left-join <join-types-outer>` operation. This
+happens when a row from one relation has no corresponding row in the joined
+relation.
 
 If you insert a record without specifying the value for a particular column,
 CrateDB will insert a ``NULL`` value for that column.
@@ -510,7 +511,7 @@ see also :ref:`type aliases <data-types-postgres-aliases>`.
 A text-based basic type containing one or more characters. All Unicode
 characters are allowed.
 
-Create table
+Create table::
 
     cr> CREATE TABLE users (
     ...     name TEXT
@@ -565,9 +566,9 @@ A type representing a JSON string.
 This type only exists for compatibility and interoperability with PostgreSQL. It cannot to be
 used in data definition statements and it is not possible to use it to store data.
 To store JSON data use the existing :ref:`OBJECT <data-types-objects>` type. It is a more powerful
-alternative that offers more flexibility and delivering the same benefits.
+alternative that offers more flexibility but delivers the same benefits.
 
-The JSON types primary use is in :ref:`type casting <data-types-casting>` for
+The primary use of the JSON type is in :ref:`type casting <data-types-casting>` for
 interoperability with PostgreSQL clients which may use the ``JSON`` type.
 The following type casts are example of supported usage of the ``JSON`` data type:
 
@@ -1088,7 +1089,7 @@ CrateDB supports the following types for dates and times:
    :local:
    :depth: 2
 
-With a few exceptions (noted below) the ``+`` and ``-`` :ref:`operators
+With a few exceptions (noted below), the ``+`` and ``-`` :ref:`operators
 <gloss-operator>` can be used to create :ref:`arithmetic expressions
 <arithmetic>` with temporal operands:
 
@@ -1285,7 +1286,7 @@ timestamp into UTC prior to insertion. Contrast this with the behavior of
     This behaviour does not comply with standard SQL and is incompatible with
     PostgreSQL. CrateDB 4.0 :ref:`deprecated this alias <v4.0.0-deprecations>`
     and behavior may change in a future version of CrateDB (see `tracking issue
-    #11491`_). To avoid issued, we recommend that you always specify ``WITH
+    #11491`_). To avoid issues, we recommend that you always specify ``WITH
     TIME ZONE`` or ``WITHOUT TIME ZONE``.
 
 
@@ -1356,7 +1357,7 @@ literal. Contrast this with the behavior of :ref:`WITH TIME ZONE
     This behaviour does not comply with standard SQL and is incompatible with
     PostgreSQL. CrateDB 4.0 :ref:`deprecated this alias <v4.0.0-deprecations>`
     and behavior may change in a future version of CrateDB (see `tracking issue
-    #11491`_). To avoid issued, we recommend that you always specify ``WITH
+    #11491`_). To avoid issues, we recommend that you always specify ``WITH
     TIME ZONE`` or ``WITHOUT TIME ZONE``.
 
 
@@ -1388,7 +1389,7 @@ Convert a timestamp time zone
 `````````````````````````````
 
 If you use ``AT TIME ZONE tz`` with a ``TIMESTAMP WITH TIME ZONE``, CrateDB
-will convert timestamp to time zone ``tz`` and cast the return value as a
+will convert the timestamp to time zone ``tz`` and cast the return value as a
 :ref:`TIMESTAMP WITHOUT TIME ZONE <type-timestamp-without-tz>` (which discards
 the time zone information). This process effectively allows you to correct
 the offset used to calculate UTC.

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -323,7 +323,7 @@ is implemented::
 
 For compatibility with clients that use the PostgresSQL wire protocol (e.g.,
 the Golang lib/pq and pgx drivers), CrateDB will accept the :ref:`BEGIN
-<ref-begin>`, :ref:`COMMIT <ref-commit>`, and :ref:`START TRASNACTION
+<ref-begin>`, :ref:`COMMIT <ref-commit>`, and :ref:`START TRANSACTION
 <sql-start-transaction>` statements. For example::
 
     cr> BEGIN TRANSACTION ISOLATION LEVEL READ UNCOMMITTED,
@@ -381,9 +381,8 @@ Limitations
   Literals <data-types-object-literals>` in case an object key's starting
   character clashes with a JDBC escape keyword (see also `JDBC escape syntax
   <https://docs.oracle.com/javadb/10.10.1.2/ref/rrefjdbc1020262.html>`_).
-  Currently, disabling ``escape processing`` will remedy this, but prevent the
-  `Extended Query`_ API from working due to a `bug
-  <https://github.com/pgjdbc/pgjdbc/issues/653>`_ at `pgjdbc`_.
+  Disabling ``escape processing`` will remedy this appropriately for `pgjdbc`_
+  version >= ``9.4.1212``.
 
 
 .. _postgres-client-jdbc-conn:
@@ -415,12 +414,12 @@ CrateDB's SQL query engine enables real-time search & aggregations for online
 analytic processing (OLAP) and business intelligence (BI) with the benefit of
 the ability to scale horizontally. The use-cases of CrateDB are different than
 those of PostgreSQL, as CrateDB's specialized storage schema and query
-execution engine address different requirements (see :ref:`Clustering
+execution engine addresses different needs (see :ref:`Clustering
 <concept-clustering>`).
 
-The listed features below cover the main differences in implementation and
+The features listed below cover the main differences in implementation and
 dialect between CrateDB and PostgreSQL. A detailed comparison between CrateDB's
-SQL dialect and standard SQL is defined in :ref:`appendix-compatibility`.
+SQL dialect and standard SQL is outlined in :ref:`appendix-compatibility`.
 
 
 .. _postgres-copy:
@@ -439,8 +438,8 @@ Expressions
 -----------
 
 Unlike PostgreSQL, :ref:`expressions <gloss-expression>` are not
-:ref:`evaluated <gloss-evaluation>` if the query results in 0 rows either
-because of the table is empty or by not matching the ``WHERE`` clause.
+:ref:`evaluated <gloss-evaluation>` if the query results in 0 rows, either
+because the table is empty or by not matching the ``WHERE`` clause.
 
 
 .. _postgres-types:


### PR DESCRIPTION
Hi,

those are only some minor adjustments to the documentation, mostly fixing some typos and formatting issues. I will address the other semantic changes by corresponding comments.

With kind regards,
Andreas.