### PR TITLE
Raise user friendly error on invalid subscription connection mode

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteCluster.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteCluster.java
@@ -50,7 +50,12 @@ public class RemoteCluster implements Closeable {
     public static final Setting<ConnectionStrategy> REMOTE_CONNECTION_MODE = new Setting<>(
         "mode",
         ConnectionStrategy.SNIFF.name(),
-        value -> ConnectionStrategy.valueOf(value.toUpperCase(Locale.ROOT)),
+        value -> switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "sniff" -> ConnectionStrategy.SNIFF;
+            case "pg_tunnel" -> ConnectionStrategy.PG_TUNNEL;
+            default -> throw new IllegalArgumentException(
+                "Invalid connection mode `" + value + "`, supported modes are: `sniff`, `pg_tunnel`");
+        },
         DataTypes.STRING,
         Setting.Property.Dynamic
     );
@@ -79,7 +84,7 @@ public class RemoteCluster implements Closeable {
         this.connectionInfo = connectionInfo;
         this.pgClientFactory = pgClientFactory;
         this.transportService = transportService;
-        this.connectionStrategy = REMOTE_CONNECTION_MODE.get(connectionInfo.settings());
+        this.connectionStrategy = connectionInfo.mode();
     }
 
     public Client client() {

--- a/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
@@ -133,4 +133,19 @@ public class ConnectionInfoTest extends ESTestCase {
             "Connection string argument 'foo' is not supported"
         );
     }
+
+    @Test
+    public void test_setting_invalid_mode_raises_error_including_valid_options() {
+        assertThrowsMatches(
+            () -> ConnectionInfo.fromURL("crate://example.com?mode=foo"),
+            IllegalArgumentException.class,
+            "Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`"
+        );
+
+        assertThrowsMatches(
+            () -> ConnectionInfo.fromURL("crate://example.com:5432?mode=foo"),
+            IllegalArgumentException.class,
+            "Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`"
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Includes the available modes in the error.

Also makes the validation eager in both implicit/explicit port cases.
Before the validation only happened in `ConnectionInfo.fromURL` if the
port is missing and the default port got evaluated. The mode validation
then happened on first access within `RemoteCluster`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
