### PR TITLE
Revert "Update bundled JDK to 18+36"

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,13 +25,13 @@ jobs:
 
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
-      
+
     - name: Setup Gradle Java
       uses: actions/setup-java@v2
       with:
-        java-version: 18
+        java-version: 17
         distribution: 'temurin'
-    
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ allprojects {
     }
 
     jacoco {
-        toolVersion = "0.8.8"
+        toolVersion = "0.8.7"
     }
 
     group = 'io.crate'

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,8 +56,6 @@ None
 Changes
 =======
 
-- Updated the bundled JDK to 18+36
-
 - Implemented cancelling requests section of PostgreSQL wire protocol.
 
 - Added the :ref:`Logical Replication <administration-logical-replication>`

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -48,5 +48,5 @@ graalvm=22.0.0
 
 jmh=1.33
 
-bundled_jdk_version=18+36
+bundled_jdk_version=17.0.2+8
 bundled_jdk_vendor=adoptium


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This reverts commit d7dda448d479e43662e3410a62339d0e4ef33edf.

Saw JVM crashes on the development cluster:

    Apr 06 12:37:47 cratedb-dev-02 crate[396678]: # JRE version: OpenJDK Runtime Environment Temurin-18+36 (18.0+36) (build 18+36)
    Apr 06 12:37:47 cratedb-dev-02 crate[396678]: # Java VM: OpenJDK 64-Bit Server VM Temurin-18+36 (18+36, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
    Apr 06 12:37:47 cratedb-dev-02 crate[396678]: # Problematic frame:
    Apr 06 12:37:47 cratedb-dev-02 crate[396678]: # v  ~StubRoutines::jshort_disjoint_arraycopy

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
