### PR TITLE
implement `union [distinct]`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,10 @@ None
 Changes
 =======
 
+- Added support for :ref:`UNION DISTINCT or UNION <sql-union>` statement to be
+  able to retrieve unique rows from multiple relations without using
+  sub-queries with extra ``GROUP BY`` clauses.
+
 - Implemented cancelling requests section of PostgreSQL wire protocol.
 
 - Added the :ref:`Logical Replication <administration-logical-replication>`

--- a/docs/general/dql/union.rst
+++ b/docs/general/dql/union.rst
@@ -1,13 +1,29 @@
 .. highlight:: psql
 
-.. _sql_union:
+.. _sql-union:
 
-=========
-Union All
-=========
+=====
+Union
+=====
 
-:ref:`UNION ALL <sql-select-union-all>` can be used to combine results from
+:ref:`UNION <sql-select-union>` can be used to combine results from
 multiple :ref:`SELECT <sql-select>` statements.
+
+.. SEEALSO::
+
+    `Union (SQL)`_
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+.. _union-all:
+
+Union All
+---------
+
+If duplicates are allowed, use ``UNION ALL``.
 
 ::
 
@@ -31,3 +47,34 @@ multiple :ref:`SELECT <sql-select>` statements.
     | Turkey       |
     +--------------+
     SELECT 9 rows in set (... sec)
+
+.. _union-distinct:
+
+Union Distinct
+--------------
+
+To remove duplicates, use ``UNION DISTINCT`` or simply ``UNION``.
+
+::
+
+    cr> select name from photos
+    ... union distinct
+    ... select name from countries
+    ... union
+    ... select name from photos
+    ... order by name;
+    +--------------+
+    | name         |
+    +--------------+
+    | Austria      |
+    | Berlin Wall  |
+    | Eiffel Tower |
+    | France       |
+    | Germany      |
+    | South Africa |
+    | Turkey       |
+    +--------------+
+    SELECT 7 rows in set (... sec)
+
+
+.. _Union (SQL): https://en.wikipedia.org/wiki/Set_operations_(SQL)#UNION_operator

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -26,7 +26,7 @@ Synopsis
       [ FROM relation ]
       [ WHERE condition ]
       [ GROUP BY expression [, ...] [HAVING condition] ]
-      [ UNION ALL query_specification ]
+      [ UNION [ ALL | DISTINCT ] query_specification ]
       [ WINDOW window_name AS ( window_definition ) [, ...] ]
       [ ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
       [ LIMIT num_results ]
@@ -331,21 +331,22 @@ within a resulting row of a ``GROUP BY`` clause.
     :ref:`Fulltext indices : Disable indexing <sql_ddl_index_off>`
 
 
-.. _sql-select-union-all:
+.. _sql-select-union:
 
-UNION ALL
-.........
+UNION
+.....
 
 The ``UNION ALL`` :ref:`operator <gloss-operator>` combines the result sets of
 two or more ``SELECT`` statements. The two ``SELECT`` statements that represent
 the direct :ref:`operands <gloss-operand>` of the ``UNION ALL`` must produce
 the same number of columns, and corresponding columns must be of the same data
-types. The result of ``UNION ALL`` may contain duplicate rows. You can find
-:ref:`here <sql_union>` sample usage of ``UNION ALL``.
+types. The result of ``UNION ALL`` may contain duplicate rows. Use
+``UNION DISTINCT`` or ``UNION`` to remove duplicates. You can find
+:ref:`here <sql-union>` sample usages of the variations of ``UNION``.
 
 ::
 
-    UNION ALL query_specification
+    UNION [ ALL | DISTINCT ] query_specification
 
 :query_specification:
   Can be any ``SELECT`` statement.

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -208,16 +208,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
     @Override
     protected AnalyzedRelation visitUnion(Union node, StatementAnalysisContext context) {
-        if (node.isDistinct()) {
-            throw new UnsupportedFeatureException("UNION [DISTINCT] is not supported");
-        }
         AnalyzedRelation left = node.getLeft().accept(this, context);
         AnalyzedRelation right = node.getRight().accept(this, context);
 
         ensureUnionOutputsHaveTheSameSize(left, right);
         ensureUnionOutputsHaveCompatibleTypes(left, right);
 
-        return new UnionSelect(left, right);
+        return new UnionSelect(left, right, node.isDistinct());
     }
 
     private static void ensureUnionOutputsHaveTheSameSize(AnalyzedRelation left, AnalyzedRelation right) {

--- a/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -43,8 +43,9 @@ public class UnionSelect implements AnalyzedRelation {
     private final AnalyzedRelation right;
     private final List<ScopedSymbol> outputs;
     private final RelationName name;
+    private final boolean isDistinct;
 
-    public UnionSelect(AnalyzedRelation left, AnalyzedRelation right) {
+    public UnionSelect(AnalyzedRelation left, AnalyzedRelation right, boolean isDistinct) {
         assert left.outputs().size() == right.outputs().size()
             : "Both the left side and the right side of UNION must have the same number of outputs";
         this.left = left;
@@ -57,6 +58,7 @@ public class UnionSelect implements AnalyzedRelation {
             outputs.add(new ScopedSymbol(name, Symbols.pathFromSymbol(field), field.valueType()));
         }
         this.outputs = List.copyOf(outputs);
+        this.isDistinct = isDistinct;
     }
 
     public AnalyzedRelation left() {
@@ -95,6 +97,10 @@ public class UnionSelect implements AnalyzedRelation {
 
     @Override
     public String toString() {
-        return left + " UNION ALL " + right;
+        return left + " UNION " + (isDistinct ? "DISTINCT " : "ALL ") + right;
+    }
+
+    public boolean isDistinct() {
+        return isDistinct;
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -321,10 +321,14 @@ public class LogicalPlanner {
         public LogicalPlan visitUnionSelect(UnionSelect union, List<Symbol> outputs) {
             var lhsRel = union.left();
             var rhsRel = union.right();
-            return new Union(
-                lhsRel.accept(this, lhsRel.outputs()),
-                rhsRel.accept(this, rhsRel.outputs()),
-                union.outputs()
+            return Distinct.create(
+                new Union(
+                    lhsRel.accept(this, lhsRel.outputs()),
+                    rhsRel.accept(this, rhsRel.outputs()),
+                    union.outputs()),
+                union.isDistinct(),
+                union.outputs(),
+                tableStats
             );
         }
 

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -951,17 +951,6 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testUnionDistinct() throws Exception {
-        var executor = SQLExecutor.builder(clusterService)
-            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addTable(TableDefinitions.USER_TABLE_MULTI_PK_DEFINITION)
-            .build();
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage("UNION [DISTINCT] is not supported");
-        executor.analyze("select * from users union select * from users_multi_pk");
-    }
-
-    @Test
     public void testIntersect() throws Exception {
         var executor = SQLExecutor.builder(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)

--- a/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
@@ -315,4 +315,16 @@ public class UnionIntegrationTest extends SQLIntegrationTestCase {
             is("{b=3, c=4}\n{a=1, c=2}\n")
         ));
     }
+
+    @Test
+    public void testSimpleUnionDistinct() {
+        execute("create table x (a int)");
+        execute("create table y (a int)");
+        execute("insert into x values (1), (1), (2), (3)");
+        execute("insert into y values (1), (3), (3), (5)");
+        execute("refresh table x, y");
+
+        execute("select a from x union distinct select a from y order by a");
+        assertThat(printedTable(response.rows()), is("1\n2\n3\n5\n"));
+    }
 }

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -25,6 +25,7 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.projection.TopNProjection;
 import io.crate.planner.node.dql.Collect;
+import io.crate.planner.operators.Distinct;
 import io.crate.planner.operators.LogicalPlannerTest;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -144,6 +145,20 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
             "      │  └ Collect[doc.users | [1 AS x] | true]\n" +
             "      └ OrderBy[2 ASC]\n" +
             "        └ Collect[doc.users | [2] | true]";
+        assertThat(logicalPlan, is(LogicalPlannerTest.isPlan(expectedPlan)));
+    }
+
+    @Test
+    public void testUnionDistinct() {
+        var logicalPlan = e.logicalPlan(
+            "select id from users " +
+            "union distinct " +
+            "select id from locations ");
+        String expectedPlan =
+            "GroupHashAggregate[id]\n" +
+            "  └ Union[id]\n" +
+            "    ├ Collect[doc.users | [id] | true]\n" +
+            "    └ Collect[doc.locations | [id] | true]";
         assertThat(logicalPlan, is(LogicalPlannerTest.isPlan(expectedPlan)));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
resolves https://github.com/crate/crate/issues/12100

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
