### PR TITLE
Set CrateDB heap size in itests

### DIFF
--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -97,6 +97,7 @@ crate = ConnectingCrateLayer(
     env={
         'JAVA_HOME': os.environ.get('JAVA_HOME', ''),
         'CRATE_JAVA_OPTS': '-Dio.netty.leakDetection.level=paranoid',
+        'CRATE_HEAP_SIZE': '640M'
     },
     settings=CRATE_SETTINGS,
     version=(4, 0, 0)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

itests fail sometimes with:

    * What went wrong:
    Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)

This could indicate that the process was killed by the OOM reaper.
The small Jenkins runners have 2GB memory. Setting the heap to 512
should be enough for the doc tests and leave more memory for other
processes.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
