### PR TITLE
Fix failed connectionFuture handling in PgClient.ensureConnected

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/PgClient.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PgClient.java
@@ -159,15 +159,10 @@ public class PgClient extends AbstractClient {
                 future = connectionFuture;
                 // fall-through to connect
             } else {
-                if (connectionFuture.isDone()) {
-                    Connection connection = connectionFuture.join();
-                    if (connection.isClosed() || connectionFuture.isCompletedExceptionally()) {
-                        connectionFuture = new CompletableFuture<>();
-                        future = connectionFuture;
-                        // fall-through to connect
-                    } else {
-                        return connectionFuture;
-                    }
+                if (connectionFuture.isCompletedExceptionally() || (connectionFuture.isDone() && connectionFuture.join().isClosed())) {
+                    connectionFuture = new CompletableFuture<>();
+                    future = connectionFuture;
+                    // fall-through to connect
                 } else {
                     return connectionFuture;
                 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`connectionFuture.join()` raises an exception if the future completed
exceptionally. The `isCompletedExceptionally` check _after_ it never
worked.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
