### PR TITLE
Don't wrap exceptions into RuntimeException/handle ConnectException

### DIFF
--- a/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/libs/shared/src/main/java/io/crate/exceptions/Exceptions.java
@@ -22,6 +22,7 @@
 package io.crate.exceptions;
 
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 public final class Exceptions {
 
@@ -42,6 +43,16 @@ public final class Exceptions {
     }
 
     public static Exception toException(Throwable t) {
+        if (t instanceof CompletionException || t instanceof ExecutionException) {
+            var cause = t.getCause();
+            if (cause instanceof Exception ex) {
+                return ex;
+            }
+            // Prefer to keep CompletionException/ExecutionException as is over wrapping.
+            // The CompletionException/ExecutionException have a chance of being unwrapped
+            // later to get the real cause. RuntimeExceptions are never unwrapped.
+            return (Exception) t;
+        }
         if (t instanceof Exception) {
             return (Exception) t;
         } else {

--- a/server/src/main/java/io/crate/execution/support/NodeActionRequestHandler.java
+++ b/server/src/main/java/io/crate/execution/support/NodeActionRequestHandler.java
@@ -21,8 +21,8 @@
 
 package io.crate.execution.support;
 
-import io.crate.exceptions.Exceptions;
-import io.crate.exceptions.SQLExceptions;
+import java.io.IOException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.transport.TransportChannel;
@@ -30,7 +30,7 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponse;
 
-import java.io.IOException;
+import io.crate.exceptions.Exceptions;
 
 public final class NodeActionRequestHandler<TRequest extends TransportRequest, TResponse extends TransportResponse>
     implements TransportRequestHandler<TRequest> {
@@ -54,7 +54,7 @@ public final class NodeActionRequestHandler<TRequest extends TransportRequest, T
                     }
                 } else {
                     try {
-                        channel.sendResponse(Exceptions.toRuntimeException(SQLExceptions.unwrap(throwable)));
+                        channel.sendResponse(Exceptions.toException(throwable));
                     } catch (IOException e) {
                         LOGGER.error("Error sending failure: " + e.getMessage(), e);
                     }
@@ -62,7 +62,7 @@ public final class NodeActionRequestHandler<TRequest extends TransportRequest, T
             });
         } catch (Throwable t) {
             try {
-                channel.sendResponse(Exceptions.toRuntimeException(SQLExceptions.unwrap(t)));
+                channel.sendResponse(Exceptions.toException(t));
             } catch (IOException e) {
                 LOGGER.error("Error sending failure: " + e.getMessage(), e);
             }

--- a/server/src/main/java/io/crate/execution/support/Transports.java
+++ b/server/src/main/java/io/crate/execution/support/Transports.java
@@ -67,7 +67,7 @@ public class Transports {
         try {
             transportService.sendRequest(discoveryNode, action, request, options, handler);
         } catch (Throwable t) {
-            listener.onFailure(Exceptions.toRuntimeException(t));
+            listener.onFailure(Exceptions.toException(t));
         }
     }
 

--- a/server/src/main/java/io/crate/protocols/postgres/PgClient.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PgClient.java
@@ -648,7 +648,7 @@ public class PgClient extends AbstractClient {
                                                                                                     ActionListener<Response> listener) {
         ensureConnected().whenComplete((connection, e) -> {
             if (e != null) {
-                listener.onFailure(Exceptions.toRuntimeException(e));
+                listener.onFailure(Exceptions.toException(e));
             } else {
                 if (request instanceof RemoteClusterAwareRequest remoteClusterAware) {
                     DiscoveryNode targetNode = remoteClusterAware.getPreferredTargetNode();

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
@@ -21,13 +21,11 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.exceptions.Exceptions;
-import io.crate.metadata.RelationName;
-import io.crate.replication.logical.LogicalReplicationService;
-import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsException;
-import io.crate.replication.logical.metadata.Subscription;
-import io.crate.replication.logical.metadata.SubscriptionsMetadata;
-import io.crate.user.UserLookup;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -43,10 +41,13 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
+import io.crate.exceptions.Exceptions;
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsException;
+import io.crate.replication.logical.metadata.Subscription;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import io.crate.user.UserLookup;
 
 public class TransportCreateSubscriptionAction extends TransportMasterNodeAction<CreateSubscriptionRequest, AcknowledgedResponse> {
 
@@ -116,7 +117,7 @@ public class TransportCreateSubscriptionAction extends TransportMasterNodeAction
                     if (err == null) {
                         listener.onResponse(new AcknowledgedResponse(true));
                     } else {
-                        listener.onFailure(Exceptions.toRuntimeException(err));
+                        listener.onFailure(Exceptions.toException(err));
                     }
                 }
             );

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -264,7 +264,7 @@ public class SQLTransportExecutor {
             }
             session.sync();
         } catch (Throwable t) {
-            listener.onFailure(Exceptions.toRuntimeException(t));
+            listener.onFailure(Exceptions.toException(t));
         }
     }
 
@@ -295,13 +295,13 @@ public class SQLTransportExecutor {
                 if (t == null) {
                     listener.onResponse(rowCounts);
                 } else {
-                    listener.onFailure(Exceptions.toRuntimeException(t));
+                    listener.onFailure(Exceptions.toException(t));
                 }
                 session.close();
             });
         } catch (Throwable t) {
             session.close();
-            listener.onFailure(Exceptions.toRuntimeException(t));
+            listener.onFailure(Exceptions.toException(t));
         }
     }
 
@@ -622,7 +622,7 @@ public class SQLTransportExecutor {
 
         @Override
         public void fail(@Nonnull Throwable t) {
-            listener.onFailure(Exceptions.toRuntimeException(t));
+            listener.onFailure(Exceptions.toException(t));
             super.fail(t);
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `MetadataTracker` should retry on a `ConnectException`, and we must
not use `Exceptions.toRuntimeException` but `Exceptions.toException`. If
exceptions are wrapped in a `RuntimeException` instanceof checks for
concrete exception types don't work correctly.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
