### PR TITLE
 use default trust store if not configured

### DIFF
--- a/server/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
+++ b/server/src/test/java/io/crate/protocols/ssl/SslContextProviderTest.java
@@ -25,9 +25,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -42,6 +40,7 @@ import java.security.cert.X509Certificate;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 
 import io.crate.auth.Protocol;
 import org.elasticsearch.common.settings.Settings;
@@ -98,6 +97,12 @@ public class SslContextProviderTest extends ESTestCase {
         assertThat(sslContext, instanceOf(SslContext.class));
         assertThat(sslContext.isServer(), is(true));
         assertThat(sslContext.cipherSuites(), not(empty()));
+    }
+
+    @Test
+    public void test_no_truststore_gets_defaults_certs() {
+        TrustManager[] trustManagers = SslContextProvider.createTrustManagers(null);
+        assertThat(SslContextProvider.getDefaultCertificates(trustManagers).length, greaterThan(0));
     }
 
     @Test


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/12333

https://stackoverflow.com/a/40157719/2104560

when keystore is null, java internally uses 
```
if (ks == null) {
            try {
                trustManager = getInstance(TrustStoreManager.getTrustedCerts());
```

`getTrustedCerts()` is not public so using null init.


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
