### PR TITLE
Update subscription in one cluster state update on changed metadata

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/ShardReplicationChangesTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/ShardReplicationChangesTracker.java
@@ -58,7 +58,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -362,13 +361,12 @@ public class ShardReplicationChangesTracker implements Closeable {
                     onFailure.accept(new RuntimeException(msg));
                 }
             };
-            BiConsumer<ReplayChangesAction.Request, ActionListener<ReplicationResponse>> operation =
-                (req, l) -> localClient.execute(ReplayChangesAction.INSTANCE, req, l);
-            operation.accept(
+            localClient.execute(
+                ReplayChangesAction.INSTANCE,
                 replayRequest,
                 new ReplayChangesRetryListener<>(
                     threadPool.scheduler(),
-                    l -> operation.accept(replayRequest, l),
+                    l -> localClient.execute(ReplayChangesAction.INSTANCE, replayRequest, l),
                     listener,
                     BackoffPolicy.exponentialBackoff()
                 ));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`removeDroppedTablesOrPartitions` is called from within a cluster state
update task. It can and should modify the subscription metadata directly
instead of firing off another cluster state update task as a side effect

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
