### PR TITLE
Handle case when cluster can subscribe to existing tables 

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
@@ -138,7 +138,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
                 // Publication owner cannot be null as we ensure that users who owns publication cannot be dropped.
                 // Also, before creating publication or subscription we check that owner was not dropped right before creation.
                 User publicationOwner = userLookup.findUser(publication.owner());
-                allRelationsInPublications.putAll(publication.resolveCurrentRelations(state, publicationOwner, subscriber));
+                allRelationsInPublications.putAll(publication.resolveCurrentRelations(state, publicationOwner, subscriber, publicationName));
             }
             listener.onResponse(new Response(allRelationsInPublications));
         }

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
@@ -277,7 +277,9 @@ public abstract class LogicalReplicationITestCase extends ESTestCase {
             executeOnPublisher("CREATE PUBLICATION " + pub + " FOR TABLE " + tablesAsString);
         }
         executeOnPublisher("CREATE USER " + SUBSCRIBING_USER);
-        executeOnPublisher("GRANT DQL ON TABLE " + tablesAsString + " TO " + SUBSCRIBING_USER);
+        if (!tablesAsString.isEmpty()) {
+            executeOnPublisher("GRANT DQL ON TABLE " + tablesAsString + " TO " + SUBSCRIBING_USER);
+        }
     }
 
     protected void createSubscription(String subName, String pubName) throws Exception {

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -547,7 +547,7 @@ public class MetadataTrackerTest extends ESTestCase {
         PublicationsMetadata publicationsMetadata = publisherState.metadata().custom(PublicationsMetadata.TYPE);
         Publication publication = publicationsMetadata.publications().get("pub1");
         var publisherStateResponse = new Response(
-                publication.resolveCurrentRelations(publisherState, User.CRATE_USER, User.CRATE_USER));
+                publication.resolveCurrentRelations(publisherState, User.CRATE_USER, User.CRATE_USER, "dummy"));
 
         var future = MetadataTracker.subscribeToNewRelations(
             retrieveSubscription("sub1", subscriberClusterState),
@@ -584,7 +584,7 @@ public class MetadataTrackerTest extends ESTestCase {
         PublicationsMetadata publicationsMetadata = publisherClusterState.metadata().custom(PublicationsMetadata.TYPE);
         Publication publication = publicationsMetadata.publications().get("pub1");
         var publisherStateResponse = new Response(
-                publication.resolveCurrentRelations(publisherClusterState, User.CRATE_USER, User.CRATE_USER));
+                publication.resolveCurrentRelations(publisherClusterState, User.CRATE_USER, User.CRATE_USER, "dummy"));
 
         var future = MetadataTracker.subscribeToNewRelations(
             retrieveSubscription("sub1", subscriberClusterState),

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -89,7 +89,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             expectedLogMessage
         ));
 
-        Map<RelationName, RelationMetadata> resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), user, user);
+        Map<RelationName, RelationMetadata> resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), user, user, "dummy");
         assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
         appender.assertAllExpectationsMatched();
     }
@@ -122,7 +122,8 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
             publicationOwner,
-            subscriber
+            subscriber,
+            "dummy"
         );
 
         assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
@@ -154,7 +155,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             .build();
         var publication = new Publication("publisher", true, List.of());
 
-        var resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), publicationOwner, subscriber);
+        var resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), publicationOwner, subscriber, "dummy");
         assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
     }
 
@@ -192,7 +193,8 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
             publicationOwner,
-            subscriber
+            subscriber,
+            "dummy"
         );
         assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
     }


### PR DESCRIPTION
Add relation existence check on getting publication state, to avoid subscribing to the own tables.

It can happen if all following conditions are met:

- subscriber/publisher chain forms a loop **and** 
- tables are not yet created on the moment of a subscription creation **and** 
- a publication is created with `ALL TABLES = true`.

Loop forming layouts:
1. a cluster subscribes to a local publication with `ALL TABLES = true`
2. cluster subscribes to the own table via chain of subscriptions:
    C->A->B->C
   
    B subscribes to a C
    A subscribes to B
    C subscribes to ALL TABLES of A (not the same cluster but still has this problem)
    a new table t1 created on the cluster C 
    
another cases causing this: https://github.com/crate/crate/pull/12342#discussion_r857432225

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
