### PR TITLE
CI/GHA: Run Windows tests on windows-2019 instead of windows-2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Gradle Java


### PR DESCRIPTION
Hi,

the `windows-latest` image label on GHA effectively switched to `windows-2022` [^1] ~~only recently~~ on February 2, 2022 [^2]. The original announcement happened on January 11, 2022: https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/

On the `crash` repository, performance regressions have been observed with that. With https://github.com/crate/crash/pull/351/commits/11d77dcca8 in place, switching back to `windows-2019`, the runtime of an individual test job on Windows decreased from 12 minutes to 6 minutes. It would be sweet to see corresponding improvements here as well.

With kind regards,
Andreas.

[^1]: https://github.com/actions/virtual-environments/issues/4856, see also [Windows Server 2022 (20220330 update)](https://github.com/actions/virtual-environments/releases/tag/win22%2F20220330.1).
[^2]: Officially announced to have happened due March 6, 2022, it might well have been delayed and concluded only 12 days ago, as mentioned at https://github.com/actions/virtual-environments/issues/4856#issuecomment-1083192716.
