### PR TITLE
Disable renaming of tables included in a publication

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -21,6 +21,21 @@
 
 package io.crate.integrationtests;
 
+import static io.crate.testing.Asserts.assertThrowsMatches;
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.RelationName;
@@ -31,20 +46,7 @@ import io.crate.testing.MoreMatchers;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.user.User;
 import io.crate.user.UserLookup;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.hamcrest.Matchers;
-import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-
-import static io.crate.testing.Asserts.assertThrowsMatches;
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
 
 @UseRandomizedSchema(random = false)
 public class LogicalReplicationITest extends LogicalReplicationITestCase {
@@ -385,7 +387,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         assertThrowsMatches(
             () -> executeOnSubscriber("INSERT INTO doc.t1 (id) VALUES(3)"),
             OperationOnInaccessibleRelationException.class,
-            "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication."
+            "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication subscription."
         );
     }
 
@@ -409,7 +411,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         assertThrowsMatches(
             () -> executeOnSubscriber("INSERT INTO doc.t1 (id) VALUES(3)"),
             OperationOnInaccessibleRelationException.class,
-            "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication."
+            "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication subscription."
         );
     }
 
@@ -541,7 +543,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         assertThrowsMatches(
             () ->  executeOnSubscriber("DROP TABLE t1"),
             OperationOnInaccessibleRelationException.class,
-            "The relation \"doc.t1\" doesn't allow DROP operations, because it is included in a logical replication."
+            "The relation \"doc.t1\" doesn't allow DROP operations, because it is included in a logical replication subscription."
         );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -329,7 +329,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
         assertThrowsMatches(
             () -> executeOnSubscriber("INSERT INTO t1 (id) VALUES(3)"),
             OperationOnInaccessibleRelationException.class,
-            "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication."
+            "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication subscription."
         );
 
         executeOnSubscriber("DROP SUBSCRIPTION sub1");

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -56,8 +56,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import io.crate.types.StringType;
+
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -120,7 +120,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private DocIndexMetadata newMeta(IndexMetadata metadata, String name) throws IOException {
-        return new DocIndexMetadata(nodeCtx, metadata, new RelationName(Schemas.DOC_SCHEMA_NAME, name)).build();
+        return new DocIndexMetadata(nodeCtx, metadata, new RelationName(Schemas.DOC_SCHEMA_NAME, name), null).build();
     }
 
     @Before

--- a/server/src/test/java/io/crate/metadata/table/OperationTest.java
+++ b/server/src/test/java/io/crate/metadata/table/OperationTest.java
@@ -21,11 +21,6 @@
 
 package io.crate.metadata.table;
 
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESTestCase;
-import org.junit.Test;
-
 import static io.crate.metadata.table.Operation.ALL;
 import static io.crate.metadata.table.Operation.ALTER;
 import static io.crate.metadata.table.Operation.ALTER_BLOCKS;
@@ -47,32 +42,37 @@ import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATIO
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
 public class OperationTest extends ESTestCase {
 
     @Test
     public void testBuildFromEmptyIndexBlocks() throws Exception {
-        assertThat(Operation.buildFromIndexSettingsAndState(Settings.EMPTY, IndexMetadata.State.OPEN), is(ALL));
+        assertThat(Operation.buildFromIndexSettingsAndState(Settings.EMPTY, IndexMetadata.State.OPEN, false), is(ALL));
     }
 
     @Test
     public void testBuildFromSingleIndexBlocks() throws Exception {
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder().put(
-                IndexMetadata.SETTING_READ_ONLY, true).build(), IndexMetadata.State.OPEN),
+                IndexMetadata.SETTING_READ_ONLY, true).build(), IndexMetadata.State.OPEN, false),
             is(READ_ONLY));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
-                .put(IndexMetadata.SETTING_BLOCKS_READ, true).build(), IndexMetadata.State.OPEN),
+                .put(IndexMetadata.SETTING_BLOCKS_READ, true).build(), IndexMetadata.State.OPEN, false),
             containsInAnyOrder(UPDATE, INSERT, DELETE, DROP, ALTER,
                 ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS, REFRESH, OPTIMIZE, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
-                .put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), IndexMetadata.State.OPEN),
+                .put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), IndexMetadata.State.OPEN, false),
             containsInAnyOrder(READ, ALTER, ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS,
                                SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO,
                                CREATE_SNAPSHOT, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
-                .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN),
+                .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN, false),
             containsInAnyOrder(READ, UPDATE, INSERT, DELETE, ALTER_BLOCKS,
                 ALTER_OPEN, ALTER_CLOSE, REFRESH, SHOW_CREATE, OPTIMIZE, ALTER_REROUTE));
     }
@@ -81,31 +81,46 @@ public class OperationTest extends ESTestCase {
     public void testBuildFromCompoundIndexBlocks() throws Exception {
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_READ, true)
-                .put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), IndexMetadata.State.OPEN),
+                .put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), IndexMetadata.State.OPEN, false),
             containsInAnyOrder(ALTER, ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS, REFRESH,
                 OPTIMIZE, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_WRITE, true)
-                .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN),
+                .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN, false),
             containsInAnyOrder(READ, ALTER_OPEN, ALTER_CLOSE, ALTER_BLOCKS, REFRESH,
                                SHOW_CREATE, OPTIMIZE, ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetadata.SETTING_BLOCKS_READ, true)
-                .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN),
+                .put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build(), IndexMetadata.State.OPEN, false),
             containsInAnyOrder(INSERT, UPDATE, DELETE, ALTER_OPEN, ALTER_CLOSE,
                 ALTER_BLOCKS, REFRESH, OPTIMIZE, ALTER_REROUTE));
     }
 
     @Test
     public void test_allowed_operations_for_replicated_table() {
-        var replicatedIndexSettings = Settings.builder()
-            .put(REPLICATION_SUBSCRIPTION_NAME.getKey(), "sub1")
-            .build();
+        var replicatedIndexSettings = Settings.builder().put(REPLICATION_SUBSCRIPTION_NAME.getKey(), "sub1").build();
         assertThat(
-            Operation.buildFromIndexSettingsAndState(replicatedIndexSettings, IndexMetadata.State.OPEN),
+            Operation.buildFromIndexSettingsAndState(replicatedIndexSettings, IndexMetadata.State.OPEN, false),
             containsInAnyOrder(READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE, ALTER_OPEN)
+        );
+    }
+
+    @Test
+    public void test_allowed_operations_for_published_table() {
+        assertThat(
+            Operation.buildFromIndexSettingsAndState(Settings.EMPTY, IndexMetadata.State.OPEN, true),
+            is(Operation.PUBLISHED_IN_LOGICAL_REPLICATION)
+        );
+    }
+
+    @Test
+    public void test_allowed_operations_for_published_and_subcribed_table() {
+        var replicatedIndexSettings = Settings.builder().put(REPLICATION_SUBSCRIPTION_NAME.getKey(), "sub1").build();
+        assertThat(
+            Operation.buildFromIndexSettingsAndState(replicatedIndexSettings, IndexMetadata.State.OPEN, true),
+            is(Operation.SUBSCRIBED_IN_LOGICAL_REPLICATION)
         );
     }
 }

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -47,6 +47,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -193,7 +194,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
     public void test_returning_for_update_throw_error_with_4_1_nodes() throws Exception {
         // Make sure the former initialized cluster service is shutdown
         cleanup();
-        this.clusterService = createClusterService(additionalClusterSettings(), Version.V_4_1_0);
+        this.clusterService = createClusterService(additionalClusterSettings(), Metadata.EMPTY_METADATA, Version.V_4_1_0);
         e = buildExecutor(clusterService);
         expectedException.expect(UnsupportedFeatureException.class);
         expectedException.expectMessage(UpdatePlanner.RETURNING_VERSION_ERROR_MSG);

--- a/server/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
@@ -30,6 +30,7 @@ import io.crate.planner.node.dql.Collect;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +60,7 @@ public class InsertFromSubQueryPlannerTest extends CrateDummyClusterServiceUnitT
     public void test_returning_for_insert_from_values_throw_error_with_4_1_nodes() throws Exception {
         // Make sure the former initialized cluster service is shutdown
         cleanup();
-        this.clusterService = createClusterService(additionalClusterSettings(), Version.V_4_1_0);
+        this.clusterService = createClusterService(additionalClusterSettings(), Metadata.EMPTY_METADATA, Version.V_4_1_0);
         e = buildExecutor(clusterService);
         expectedException.expect(UnsupportedFeatureException.class);
         expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
@@ -71,7 +72,7 @@ public class InsertFromSubQueryPlannerTest extends CrateDummyClusterServiceUnitT
     public void test_returning_for_insert_from_subquery_throw_error_with_4_1_nodes() throws Exception {
         // Make sure the former initialized cluster service is shutdown
         cleanup();
-        this.clusterService = createClusterService(additionalClusterSettings(), Version.V_4_1_0);
+        this.clusterService = createClusterService(additionalClusterSettings(), Metadata.EMPTY_METADATA, Version.V_4_1_0);
         e = buildExecutor(clusterService);
         expectedException.expect(UnsupportedFeatureException.class);
         expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);

--- a/server/src/testFixtures/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
+++ b/server/src/testFixtures/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -74,7 +75,9 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
 
     @Before
     public void setupDummyClusterService() {
-        clusterService = createClusterService(additionalClusterSettings().stream().filter(Setting::hasNodeScope).toList(), Version.CURRENT);
+        clusterService = createClusterService(additionalClusterSettings().stream().filter(Setting::hasNodeScope).toList(),
+                                              Metadata.EMPTY_METADATA,
+                                              Version.CURRENT);
     }
 
     @After
@@ -97,7 +100,10 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
         return EMPTY_CLUSTER_SETTINGS;
     }
 
-    protected ClusterService createClusterService(Collection<Setting<?>> additionalClusterSettings, Version version) {
+    protected ClusterService createClusterService(
+        Collection<Setting<?>> additionalClusterSettings,
+        Metadata metaData,
+        Version version) {
         Set<Setting<?>> clusterSettingsSet = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         clusterSettingsSet.addAll(additionalClusterSettings);
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsSet);
@@ -124,7 +130,7 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
             .masterNodeId(NODE_ID)
             .build();
         ClusterState clusterState = ClusterState.builder(new ClusterName(this.getClass().getSimpleName()))
-            .nodes(nodes).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).build();
+            .nodes(nodes).metadata(metaData).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).build();
 
         ClusterApplierService clusterApplierService = clusterService.getClusterApplierService();
         clusterApplierService.setInitialState(clusterState);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This disables `ALTER RENAME TABLE` for tables included in a publication
and introduces a designated set of operations for them.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
