### PR TITLE
Ignore partitions still recovering in FetchTask

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -46,6 +46,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.ShardId;
 
 import io.crate.common.collections.BorrowedItem;
@@ -264,7 +265,7 @@ public class FetchTask implements Task {
                                 if (tablesWithFetchRefs.contains(ident)) {
                                     searchers.put(readerId, shardContext.acquireSearcher(source));
                                 }
-                            } catch (IndexNotFoundException e) {
+                            } catch (IllegalIndexShardStateException | IndexNotFoundException e) {
                                 if (!IndexParts.isPartitioned(indexName)) {
                                     throw e;
                                 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If a new partition gets created via a subscription it will initially be
in a recovery state. SELECT statements should ignore these partitiosn
until they're ready.

Should fix flaky
`test_deleted_and_recreated_partition_is_also_deleted_and_restored_on_subscriber`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
