### PR TITLE
Revert "Send rst/don't linger on channel close in tests"

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -33,7 +33,6 @@ import org.elasticsearch.transport.TransportException;
 import io.crate.concurrent.CompletableContext;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
 
 public class Netty4TcpChannel implements TcpChannel {
@@ -44,7 +43,6 @@ public class Netty4TcpChannel implements TcpChannel {
     private final CompletableContext<Void> connectContext;
     private final CompletableFuture<Void> closeContext = new CompletableFuture<>();
     private final ChannelStats stats = new ChannelStats();
-    private final boolean rstOnClose = System.getProperty("cr8.transport.rst_on_close", "false").equals("true");
 
     public Netty4TcpChannel(Channel channel, boolean isServer, String profile, @Nullable ChannelFuture connectFuture) {
         this.channel = channel;
@@ -82,12 +80,6 @@ public class Netty4TcpChannel implements TcpChannel {
 
     @Override
     public void close() {
-        if (channel.isOpen() && rstOnClose) {
-            try {
-                channel.config().setOption(ChannelOption.SO_LINGER, 0);
-            } catch (Exception ignored) {
-            }
-        }
         channel.close();
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -242,8 +242,6 @@ public abstract class ESTestCase extends LuceneTestCase {
 
         // Enable Netty leak detection and monitor logger for logged leak errors
         System.setProperty("io.netty.leakDetection.level", "paranoid");
-
-        System.setProperty("cr8.transport.rst_on_close", "true");
     }
 
     protected final Logger logger = LogManager.getLogger(getClass());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This reverts commit ddd027c91facbde6e15103743358ce886d967416.

Setting SO_LINGER to 0 had the side effect that in some disruption tests
new connections - created after the disruption cleared - were
terminated.

    [DEBUG][o.e.t.n.Netty4Transport  ] [[cratedb[publisher0][netty-worker][T#1]]] close connection exception caught on transport layer [Netty4TcpChannel{localAddress=/127.0.0.1:36233, remoteAddress=/127.0.0.1:34660}], disconnecting from relevant node
    io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer
    [DEBUG][o.e.t.n.Netty4Transport  ] [[cratedb[publisher0][netty-worker][T#1]]] close connection exception caught on transport layer [Netty4TcpChannel{localAddress=/127.0.0.1:36233, remoteAddress=/127.0.0.1:34662}], disconnecting from relevant node
    io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer

Given that seeing SO_LINGER showed otherwise little/no improvement it's
probably better to revert this for now.

An example test case is `test_subscription_metadata_tracker_retries_on_publisher_disconnect`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
