### PR TITLE
Catch casting exception thrown from WhereClause normalization

### DIFF
--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -188,7 +188,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
             );
             return parser.map();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ClassCastException(e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
fixes #12352 

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
