### PR TITLE
12259 concat ws

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -61,6 +61,13 @@ Changes
 
 - Users with AL privileges can now run ``ANALYZE``
 
+.. vale off
+
+- Added ``concat_ws`` scalar function which allows concatenation with a custom
+  separator.
+
+.. vale on
+
 Fixes
 =====
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -53,6 +53,28 @@ You can also use the ``||`` :ref:`operator <gloss-operator>`::
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-concat-ws:
+
+``concat_ws('separator', second_arg, [ parameter , ... ])``
+------------------------------------------------------------------------------
+
+Concatenates a variable number of arguments into a single string using a
+separator defined by the first argument. If first argument is ``NULL`` the
+return value is ``NULL``. Remaining ``NULL`` arguments are ignored.
+
+Returns: ``text``
+
+::
+
+    cr> select concat_ws(',','foo', null, 'bar') AS col;
+    +---------+
+    | col     |
+    +---------+
+    | foo,bar |
+    +---------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-format:
 
 ``format('format_string', parameter, [ parameter , ... ])``

--- a/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public class ConcatWsFunction extends Scalar<String, String> {
+
+    public static final String NAME = "concat_ws";
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ).withVariableArity(),
+            ConcatWsFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final Signature boundSignature;
+
+    ConcatWsFunction(Signature signature, Signature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
+
+        String separator = (String) args[0].value();
+        if (separator == null) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        boolean firstNonNullProcessed = false;
+        for (int i = 1; i < args.length; i++) {
+            String value = (String) args[i].value();
+            if (value != null) {
+                if (!firstNonNullProcessed) {
+                    firstNonNullProcessed = true;
+                    sb.append(value);
+                } else {
+                    sb.append(separator).append(value);
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public Signature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
+        if (anyNonLiterals(function.arguments())) {
+            return function;
+        }
+        Input[] inputs = new Input[function.arguments().size()];
+        for (int i = 0; i < function.arguments().size(); i++) {
+            inputs[i] = ((Input) function.arguments().get(i));
+        }
+        //noinspection unchecked
+        return Literal.ofUnchecked(boundSignature.getReturnType().createType(), evaluate(txnCtx, nodeCtx, inputs));
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -164,6 +164,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
 
         TranslateFunction.register(this);
         ConcatFunction.register(this);
+        ConcatWsFunction.register(this);
 
         LengthFunction.register(this);
         HashFunctions.register(this);

--- a/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import org.junit.Test;
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class ConcatWsFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void testManyStrings() {
+        assertNormalize("concat_ws(',', '535 Mission St.', '14th floor', 'San Francisco', 'CA', '94105')",
+            isLiteral("535 Mission St.,14th floor,San Francisco,CA,94105"));
+    }
+
+    @Test
+    public void testWithNull() {
+        assertNormalize("concat_ws(',', NULL,'abcde', 2, NULL, 22)",
+            isLiteral("abcde,2,22"));
+    }
+
+    @Test
+    public void testStringAndNumber() {
+        assertNormalize("concat_ws('|','foo', 3)",
+            isLiteral("foo|3"));
+    }
+
+    @Test
+    public void testNumberAndString() {
+        assertNormalize("concat_ws(';',3, 2, 'foo')",
+            isLiteral("3;2;foo"));
+    }
+
+    @Test
+    public void all_non_separator_args_are_nulls_returns_empty_string() {
+        assertNormalize("concat_ws(',',null)",
+            isLiteral(""));
+    }
+
+    @Test
+    public void testNullSeparatorReturnsNull(){
+        assertEvaluate("concat_ws(NULL, 'abcde','2')",
+            null);
+    }
+
+    @Test
+    public void testInvalidArrayArgument(){
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+            "Unknown function: concat_ws(',', 'foo', []), " +
+                "no overload found for matching argument types: (text, text, undefined_array). " +
+                "Possible candidates: concat_ws(text):text"
+        );
+        assertNormalize("concat_ws(',' , 'foo', [])"
+            ,null);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Added concat_ws function to the scalar functions library. User is able to concatenate with a delimiter expanding crateDB's features. https://github.com/crate/crate/issues/12259

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
