### PR TITLE
Treat IndexNotFoundException as potentially temporary error in logical replication

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -141,6 +141,7 @@ public class SQLExceptions {
             || t instanceof ConnectException
             || t instanceof ClusterBlockException
             || t instanceof NoSeedNodeLeftException
+            || t instanceof IndexNotFoundException
             || t instanceof NoShardAvailableActionException
             || t instanceof AlreadyClosedException
             || t instanceof ElasticsearchTimeoutException;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `MetadataTracker` will remove permanently deleted indices from the
subscription and the `ShardReplicationChangesTracker` would stop due to
the `ShardReplicationService`.

Because of that it should be safe to treat a `IndexNotFoundException`
happening during changes tracking as temporary (e.g. a partition being
deleted or something like that)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
