### PR TITLE
Fix broken AD application guide link

### DIFF
--- a/docs/admin/discovery.rst
+++ b/docs/admin/discovery.rst
@@ -143,4 +143,4 @@ The configuration settings for authentication are as follows:
 For a complete list of settings please refer to :ref:`conf_azure_discovery`.
 
 .. _`Microsoft Azure`: https://azure.microsoft.com
-.. _`AD Application Guide`: https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/
+.. _`AD Application Guide`: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1462,7 +1462,7 @@ Chunk size to transfer files during the initial recovery of a replicating table.
 Controls the number of file chunk requests that can be sent in parallel between
 clusters during the recovery.
 
-.. _`Active Directory application`: https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/
+.. _`Active Directory application`: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
 .. _`Azure Portal`: https://portal.azure.com
 .. _bootstrap checks: https://crate.io/docs/crate/howtos/en/latest/admin/bootstrap-checks.html
 .. _multi-zone setup how-to guide: https://crate.io/docs/crate/howtos/en/latest/clustering/multi-zone-setup.html


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

I think this should be a suitable replacement - I am not entirely sure
what the old link contained.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
