### PR TITLE
added test case: drop_publication_stops_the_replication_on_subscriber

### DIFF
--- a/docs/sql/statements/drop-publication.rst
+++ b/docs/sql/statements/drop-publication.rst
@@ -31,6 +31,13 @@ Description
 Removes an existing publication from the cluster. Stops the replication for all
 existing subscriptions.
 
+.. NOTE::
+
+  Replicated tables on a subscriber cluster will stay read-only after dropping
+  a publication on a publishing cluster. To make them writable, use
+  :ref:`DROP SUBSCRIPTION <sql-drop-subscription>`.
+
+
 .. _sql-drop-publication-params:
 
 Parameters

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -239,7 +239,7 @@ public final class MetadataTracker implements Closeable {
                 }
                 var msg = "Tracking of metadata failed for subscription '" + subscriptionName + "'" + " with unrecoverable error, stop tracking";
                 LOGGER.error(msg, e);
-                return replicationService.updateSubscriptionState(subscriptionName, Subscription.State.FAILED, msg)
+                return replicationService.updateSubscriptionState(subscriptionName, Subscription.State.FAILED, msg + ".\nReason: " + e.getMessage())
                     .handle((ignoredAck, ignoredErr) -> {
                         stopTracking(subscriptionName);
                         return null;

--- a/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
@@ -169,7 +169,7 @@ public class SubscriptionDisruptionIT extends LogicalReplicationITestCase {
             " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
             " ORDER BY s.subname");
         assertThat(printedTable(res.rows()),
-                   is("sub1| [pub1]| doc.t1| e| Tracking of metadata failed for subscription 'sub1' with unrecoverable error, stop tracking\n"));
+                   is("sub1| [pub1]| doc.t1| e| Tracking of metadata failed for subscription 'sub1' with unrecoverable error, stop tracking.\nReason: rejected\n"));
     }
 
     private boolean isMetadataTrackerActive() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
