### PR TITLE
Require medium sized runners for itests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
           }
         }
         stage('itest') {
-          agent { label 'small' }
+          agent { label 'medium' }
           steps {
             sh 'git clean -xdff'
             checkout scm


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://github.com/crate/crate/pull/12370#issuecomment-1103889406

We've had itest fail occasionally since the infrastructure changes.
Looks like the cause is memory pressure.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
