### PR TITLE
Retrieve index/template metadata with PublicationsStateAction

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -519,8 +519,8 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
     }
 
     public CompletableFuture<Boolean> updateSubscriptionState(String subscriptionName,
-                                                               Subscription subscription,
-                                                               Map<RelationName, Subscription.RelationState> relations) {
+                                                              Subscription subscription,
+                                                              Map<RelationName, Subscription.RelationState> relations) {
         var newSubscription = new Subscription(
             subscription.owner(),
             subscription.connectionInfo(),

--- a/server/src/main/java/io/crate/replication/logical/metadata/RelationMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/RelationMetadata.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.metadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+
+public record RelationMetadata(RelationName name,
+                               List<IndexMetadata> indices,
+                               @Nullable IndexTemplateMetadata template) implements Writeable {
+
+    public RelationMetadata(StreamInput in) throws IOException {
+        this(
+            new RelationName(in),
+            in.readList(IndexMetadata::readFrom),
+            in.readOptionalWriteable(IndexTemplateMetadata::readFrom)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        name.writeTo(out);
+        out.writeList(indices);
+        out.writeOptionalWriteable(template);
+    }
+
+    public static RelationMetadata fromMetadata(RelationName table, ClusterState state) {
+        Metadata metadata = state.metadata();
+        String indexNameOrAlias = table.indexNameOrAlias();
+        var indexMetadata = metadata.index(indexNameOrAlias);
+        if (indexMetadata == null) {
+            String templateName = PartitionName.templateName(table.schema(), table.name());
+            var templateMetadata = metadata.templates().get(templateName);
+            String[] concreteIndices = IndexNameExpressionResolver.concreteIndexNames(
+                state,
+                IndicesOptions.lenientExpandOpen(),
+                indexNameOrAlias
+            );
+            ArrayList<IndexMetadata> indicesMetadata = new ArrayList<>(concreteIndices.length);
+            for (String concreteIndex : concreteIndices) {
+                indicesMetadata.add(metadata.index(concreteIndex));
+            }
+            return new RelationMetadata(table, indicesMetadata, templateMetadata);
+        }
+        return new RelationMetadata(table, List.of(indexMetadata), null);
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
@@ -146,7 +146,7 @@ public class SubscriptionDisruptionIT extends LogicalReplicationITestCase {
 
         startDisrupting((subscriberTransport, publisherAddress) -> {
             subscriberTransport.addSendBehavior(publisherAddress, (connection, requestId, action, request, options) -> {
-                if (action.equals(ClusterStateAction.NAME)) {
+                if (action.equals(PublicationsStateAction.NAME)) {
                     throw new ElasticsearchException("rejected");
                 }
                 connection.sendRequest(requestId, action, request, options);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a follow up to 557278afc1025891b573b6fe107a91dcc91975aa

Instead of:

1) Get the publisher cluster state
2) Update subscriber cluster state
3) Retrieve publication state

This changes the flow to:

1) Retrieve publication state (including index & template metadata for
  the tables included in the publications)
2) Update subscriber cluster state

This helps avoiding any publisher state divergence between 1) and 3) and
safes one round trip.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
