### PR TITLE
tests: Try to include jobs-log information in stuck tasks assertion error

### DIFF
--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
@@ -100,6 +100,8 @@ import io.crate.data.Row;
 import io.crate.execution.dml.TransportShardAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
 import io.crate.execution.dml.upsert.TransportShardUpsertAction;
+import io.crate.execution.engine.collect.stats.JobsLogService;
+import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.execution.jobs.NodeLimits;
 import io.crate.execution.jobs.RootTask;
 import io.crate.execution.jobs.TasksService;
@@ -320,6 +322,14 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
             }, 10L, TimeUnit.SECONDS);
         } catch (AssertionError e) {
             StringBuilder errorMessageBuilder = new StringBuilder();
+            errorMessageBuilder.append("Open jobs:\n");
+            for (var jobsLogService : internalCluster().getInstances(JobsLogService.class)) {
+                JobsLogs jobsLogs = jobsLogService.get();
+                for (var jobContent : jobsLogs.activeJobs()) {
+                    errorMessageBuilder.append(jobContent.toString()).append("\n");
+                }
+            }
+            errorMessageBuilder.append("Active tasks:\n");
             String[] nodeNames = internalCluster().getNodeNames();
             for (String nodeName : nodeNames) {
                 TasksService tasksService = internalCluster().getInstance(TasksService.class, nodeName);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There are occasional test failures like
`testRestoreEmptyPartitionedTableUsingALL`:

    java.lang.AssertionError: ## node: node_sc4
    {e66bb76b-156d-d2f8-cf52-28be5a8e93a0=Task{id=e66bb76b-156d-d2f8-cf52-28be5a8e93a0, tasks=[DistResultRXTask{id=1, numBuckets=1, isDone=false}], closed=false}}

    	at __randomizedtesting.SeedInfo.seed([E86E12E22654DE54:47D455E736DF12]:0)
    	at io.crate.integrationtests.SQLIntegrationTestCase.assertNoTasksAreLeftOpen(SQLIntegrationTestCase.java:342)
    	at jdk.internal.reflect.GeneratedMethodAccessor87.invoke(Unknown Source)
    	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004)
    	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
    	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
    	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    	at java.base/java.lang.Thread.run(Thread.java:833)
    Caused by: java.lang.AssertionError:
    Expected: is <0>
         but: was <1>
    	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
    	at org.junit.Assert.assertThat(Assert.java:964)
    	at org.junit.Assert.assertThat(Assert.java:930)
    	at io.crate.integrationtests.SQLIntegrationTestCase.lambda$assertNoTasksAreLeftOpen$0(SQLIntegrationTestCase.java:299)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:755)
    	at io.crate.integrationtests.SQLIntegrationTestCase.assertNoTasksAreLeftOpen(SQLIntegrationTestCase.java:294)
    	... 9 more
    	Suppressed: java.lang.AssertionError:

This is an attempt to get more information from a failure.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
