### PR TITLE
Require only metadata for concreteIndices retrieval

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
@@ -77,9 +77,10 @@ public class SwapRelationsOperation {
         Metadata.Builder updatedMetadata = Metadata.builder(stateAfterRename.metadata());
         RoutingTable.Builder routingBuilder = RoutingTable.builder(stateAfterRename.routingTable());
 
+        Metadata metadata = state.metadata();
         for (RelationName dropRelation : dropRelations) {
             for (Index index : IndexNameExpressionResolver.concreteIndices(
-                state, IndicesOptions.LENIENT_EXPAND_OPEN, dropRelation.indexNameOrAlias())) {
+                    metadata, IndicesOptions.LENIENT_EXPAND_OPEN, dropRelation.indexNameOrAlias())) {
 
                 String indexName = index.getName();
                 updatedMetadata.remove(indexName);
@@ -127,9 +128,9 @@ public class SwapRelationsOperation {
             RelationName source = relationNameSwap.source();
             RelationName target = relationNameSwap.target();
             addSourceIndicesRenamedToTargetName(
-                state, metadata, updatedMetadata, blocksBuilder, routingBuilder, source, target, newIndexNames::add);
+                metadata, updatedMetadata, blocksBuilder, routingBuilder, source, target, newIndexNames::add);
             addSourceIndicesRenamedToTargetName(
-                state, metadata, updatedMetadata, blocksBuilder, routingBuilder, target, source, newIndexNames::add);
+                metadata, updatedMetadata, blocksBuilder, routingBuilder, target, source, newIndexNames::add);
         }
         ClusterState stateAfterSwap = ClusterState.builder(state)
             .metadata(updatedMetadata)
@@ -158,8 +159,9 @@ public class SwapRelationsOperation {
                                    RelationName name) {
         String aliasOrIndexName = name.indexNameOrAlias();
         String templateName = PartitionName.templateName(name.schema(), name.name());
+        Metadata metadata = state.metadata();
         for (Index index : IndexNameExpressionResolver.concreteIndices(
-            state, IndicesOptions.LENIENT_EXPAND_OPEN, aliasOrIndexName)) {
+                metadata, IndicesOptions.LENIENT_EXPAND_OPEN, aliasOrIndexName)) {
 
             String indexName = index.getName();
             routingBuilder.remove(indexName);
@@ -169,8 +171,7 @@ public class SwapRelationsOperation {
         updatedMetadata.removeTemplate(templateName);
     }
 
-    private void addSourceIndicesRenamedToTargetName(ClusterState state,
-                                                     Metadata metadata,
+    private void addSourceIndicesRenamedToTargetName(Metadata metadata,
                                                      Metadata.Builder updatedMetadata,
                                                      ClusterBlocks.Builder blocksBuilder,
                                                      RoutingTable.Builder routingBuilder,
@@ -181,7 +182,7 @@ public class SwapRelationsOperation {
         IndexTemplateMetadata sourceTemplate = metadata.templates().get(sourceTemplateName);
 
         for (Index sourceIndex : IndexNameExpressionResolver.concreteIndices(
-            state, IndicesOptions.LENIENT_EXPAND_OPEN, source.indexNameOrAlias())) {
+                metadata, IndicesOptions.LENIENT_EXPAND_OPEN, source.indexNameOrAlias())) {
 
             String sourceIndexName = sourceIndex.getName();
             IndexMetadata sourceMd = metadata.getIndexSafe(sourceIndex);

--- a/server/src/main/java/io/crate/execution/ddl/TransportSwapRelationsAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/TransportSwapRelationsAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
@@ -122,15 +123,16 @@ public final class TransportSwapRelationsAction extends TransportMasterNodeActio
     @Override
     protected ClusterBlockException checkBlock(SwapRelationsRequest request, ClusterState state) {
         Set<String> affectedIndices = new HashSet<>();
+        Metadata metadata = state.metadata();
         for (RelationNameSwap swapAction : request.swapActions()) {
             affectedIndices.addAll(Arrays.asList(IndexNameExpressionResolver.concreteIndexNames(
-                state, IndicesOptions.LENIENT_EXPAND_OPEN, swapAction.source().indexNameOrAlias())));
+                metadata, IndicesOptions.LENIENT_EXPAND_OPEN, swapAction.source().indexNameOrAlias())));
             affectedIndices.addAll(Arrays.asList(IndexNameExpressionResolver.concreteIndexNames(
-                state, IndicesOptions.LENIENT_EXPAND_OPEN, swapAction.target().indexNameOrAlias())));
+                metadata, IndicesOptions.LENIENT_EXPAND_OPEN, swapAction.target().indexNameOrAlias())));
         }
         for (RelationName dropRelation : request.dropRelations()) {
             affectedIndices.addAll(Arrays.asList(IndexNameExpressionResolver.concreteIndexNames(
-                state, IndicesOptions.LENIENT_EXPAND_OPEN, dropRelation.indexNameOrAlias())));
+                metadata, IndicesOptions.LENIENT_EXPAND_OPEN, dropRelation.indexNameOrAlias())));
         }
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, affectedIndices.toArray(new String[0]));
     }

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableTarget.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableTarget.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.Index;
 
 import io.crate.metadata.PartitionName;
@@ -44,13 +45,14 @@ public final class AlterTableTarget {
     public static AlterTableTarget resolve(ClusterState state,
                                            RelationName table,
                                            @Nullable String partition) {
+        Metadata metadata = state.metadata();
         if (partition == null) {
-            Index[] indices = IndexNameExpressionResolver.concreteIndices(state, IndicesOptions.lenientExpandOpen(), table.indexNameOrAlias());
+            Index[] indices = IndexNameExpressionResolver.concreteIndices(metadata, IndicesOptions.lenientExpandOpen(), table.indexNameOrAlias());
             String templateName = PartitionName.templateName(table.schema(), table.name());
-            IndexTemplateMetadata indexTemplateMetadata = state.metadata().getTemplates().get(templateName);
+            IndexTemplateMetadata indexTemplateMetadata = metadata.getTemplates().get(templateName);
             return new AlterTableTarget(table, partition, indices, indexTemplateMetadata);
         } else {
-            Index[] indices = IndexNameExpressionResolver.concreteIndices(state, IndicesOptions.lenientExpandOpen(), partition);
+            Index[] indices = IndexNameExpressionResolver.concreteIndices(metadata, IndicesOptions.lenientExpandOpen(), partition);
             return new AlterTableTarget(table, partition, indices);
         }
     }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -284,7 +284,7 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
         return state.blocks().indicesBlockedException(
             ClusterBlockLevel.METADATA_WRITE,
             IndexNameExpressionResolver.concreteIndexNames(
-                state,
+                state.metadata(),
                 ignoreUnavailableIndices ? IndicesOptions.lenientExpandOpen() : IndicesOptions.strictExpandOpen(),
                 getIndices(relationsToCheck, partition)
             )
@@ -294,9 +294,10 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
     public static List<RelationName> collectEmptyPartitionedTables(List<RelationName> relationNames,
                                                                    ClusterState clusterState) {
         ArrayList<RelationName> emptyPartitionedTables = new ArrayList<>();
+        Metadata metadata = clusterState.metadata();
         for (var relationName : relationNames) {
             var concreteIndices = IndexNameExpressionResolver.concreteIndexNames(
-                clusterState,
+                metadata,
                 IndicesOptions.lenientExpandOpen(),
                 getIndices(List.of(relationName), null)
             );
@@ -405,7 +406,7 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
 
         @Override
         public ClusterState execute(ClusterState currentState) throws Exception {
-            Index[] indices = IndexNameExpressionResolver.concreteIndices(currentState, IndicesOptions.lenientExpandOpen(), getIndices(request.tables(), request.partition()));
+            Index[] indices = IndexNameExpressionResolver.concreteIndices(currentState.metadata(), IndicesOptions.lenientExpandOpen(), getIndices(request.tables(), request.partition()));
             if (indices.length == 0) {
                 return currentState;
             }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropTableAction.java
@@ -70,6 +70,6 @@ public class TransportDropTableAction extends AbstractDDLTransportAction<DropTab
             indicesOptions = IndicesOptions.lenientExpandOpen();
         }
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            IndexNameExpressionResolver.concreteIndexNames(state, indicesOptions, request.tableIdent().indexNameOrAlias()));
+            IndexNameExpressionResolver.concreteIndexNames(state.metadata(), indicesOptions, request.tableIdent().indexNameOrAlias()));
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
@@ -114,7 +114,7 @@ public class TransportRenameTableAction extends TransportMasterNodeAction<Rename
                         false
                     );
                     newIndexNames.set(IndexNameExpressionResolver.concreteIndexNames(
-                            updatedState, openIndices, request.targetTableIdent().indexNameOrAlias()));
+                        updatedState.metadata(), openIndices, request.targetTableIdent().indexNameOrAlias()));
                     return updatedState;
                 }
 
@@ -128,8 +128,14 @@ public class TransportRenameTableAction extends TransportMasterNodeAction<Rename
     @Override
     protected ClusterBlockException checkBlock(RenameTableRequest request, ClusterState state) {
         try {
-            return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-                IndexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.sourceTableIdent().indexNameOrAlias()));
+            return state.blocks().indicesBlockedException(
+                ClusterBlockLevel.METADATA_WRITE,
+                IndexNameExpressionResolver.concreteIndexNames(
+                    state.metadata(),
+                    STRICT_INDICES_OPTIONS,
+                    request.sourceTableIdent().indexNameOrAlias()
+                )
+            );
         } catch (IndexNotFoundException e) {
             if (request.isPartitioned() == false) {
                 throw e;

--- a/server/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -60,20 +61,20 @@ public class InternalBlobTableInfoFactory implements BlobTableInfoFactory {
         this.globalBlobPath = BlobIndicesService.getGlobalBlobPath(settings);;
     }
 
-    private IndexMetadata resolveIndexMetadata(String tableName, ClusterState state) {
+    private IndexMetadata resolveIndexMetadata(String tableName, Metadata metadata) {
         String indexName = BlobIndex.fullIndexName(tableName);
         Index index;
         try {
-            index = IndexNameExpressionResolver.concreteIndices(state, IndicesOptions.strictExpandOpen(), indexName)[0];
+            index = IndexNameExpressionResolver.concreteIndices(metadata, IndicesOptions.strictExpandOpen(), indexName)[0];
         } catch (IndexNotFoundException ex) {
             throw new RelationUnknown(indexName, ex);
         }
-        return state.metadata().index(index);
+        return metadata.index(index);
     }
 
     @Override
     public BlobTableInfo create(RelationName ident, ClusterState clusterState) {
-        IndexMetadata indexMetadata = resolveIndexMetadata(ident.name(), clusterState);
+        IndexMetadata indexMetadata = resolveIndexMetadata(ident.name(), clusterState.metadata());
         Settings settings = indexMetadata.getSettings();
         return new BlobTableInfo(
             ident,

--- a/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
@@ -87,8 +87,7 @@ public abstract class AbstractOpenCloseTableClusterStateTaskExecutor extends DDL
         String[] indexToResolve = partitionIndexName != null ? new String[] {partitionIndexName} :
             request.tables().stream().map(t -> t.indexNameOrAlias()).toArray(String[]::new);
         PartitionName partitionName = partitionIndexName != null ? PartitionName.fromIndexOrTemplate(partitionIndexName) : null;
-        String[] concreteIndices = IndexNameExpressionResolver.concreteIndexNames(
-            currentState, IndicesOptions.lenientExpandOpen(), indexToResolve);
+        String[] concreteIndices = IndexNameExpressionResolver.concreteIndexNames(currentState.metadata(), IndicesOptions.lenientExpandOpen(), indexToResolve);
         Set<IndexMetadata> indicesMetadata = DDLClusterStateHelpers.indexMetadataSetFromIndexNames(metadata, concreteIndices, indexState());
         List<IndexTemplateMetadata> indexTemplatesMetadata = new ArrayList<>();
         if (partitionIndexName == null) {

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -529,9 +529,10 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
 
     private Index[] resolveIndices(ClusterState currentState, String indexExpressions) {
         return IndexNameExpressionResolver.concreteIndices(
-            currentState,
+            currentState.metadata(),
             FIND_OPEN_AND_CLOSED_INDICES_IGNORE_UNAVAILABLE_AND_NON_EXISTING,
-            indexExpressions);
+            indexExpressions
+        );
     }
 
     /**

--- a/server/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
@@ -50,7 +50,7 @@ public class DropTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
     protected ClusterState execute(ClusterState currentState, DropTableRequest request) throws Exception {
         RelationName relationName = request.tableIdent();
         final Set<Index> concreteIndices = new HashSet<>(Arrays.asList(IndexNameExpressionResolver.concreteIndices(
-            currentState, IndicesOptions.lenientExpandOpen(), relationName.indexNameOrAlias())));
+            currentState.metadata(), IndicesOptions.lenientExpandOpen(), relationName.indexNameOrAlias())));
         currentState = deleteIndexService.deleteIndices(currentState, concreteIndices);
 
         if (request.isPartitioned()) {

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -81,7 +81,7 @@ public class RenameTableClusterStateExecutor {
 
         try {
             Index[] sourceIndices = IndexNameExpressionResolver.concreteIndices(
-                currentState, STRICT_INDICES_OPTIONS, source.indexNameOrAlias());
+                currentState.metadata(), STRICT_INDICES_OPTIONS, source.indexNameOrAlias());
 
             for (Index sourceIndex : sourceIndices) {
                 IndexMetadata sourceIndexMetadata = currentMetadata.getIndexSafe(sourceIndex);

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
@@ -51,7 +51,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF
 public class DocTableInfoBuilder {
 
     private final RelationName ident;
-    private final ClusterState state;
     private final NodeContext nodeCtx;
     private final Metadata metadata;
     private String[] concreteIndices;
@@ -63,7 +62,6 @@ public class DocTableInfoBuilder {
                                ClusterState state) {
         this.nodeCtx = nodeCtx;
         this.ident = ident;
-        this.state = state;
         this.metadata = state.metadata();
     }
 
@@ -74,15 +72,20 @@ public class DocTableInfoBuilder {
             docIndexMetadata = buildDocIndexMetadataFromTemplate(ident.indexNameOrAlias(), templateName);
             // We need all concrete indices, regardless of their state, for operations such as reopening.
             concreteIndices = IndexNameExpressionResolver.concreteIndexNames(
-                state, IndicesOptions.lenientExpandOpen(), ident.indexNameOrAlias());
+                metadata,
+                IndicesOptions.lenientExpandOpen(),
+                ident.indexNameOrAlias()
+            );
             // We need all concrete open indices, as closed indices must not appear in the routing.
             concreteOpenIndices = IndexNameExpressionResolver.concreteIndexNames(
-                state, IndicesOptions.fromOptions(true, true, true,
-                    false, IndicesOptions.strictExpandOpenAndForbidClosed()), ident.indexNameOrAlias());
+                metadata,
+                IndicesOptions.fromOptions(true, true, true, false, IndicesOptions.strictExpandOpenAndForbidClosed()),
+                ident.indexNameOrAlias()
+            );
         } else {
             try {
                 concreteIndices = IndexNameExpressionResolver.concreteIndexNames(
-                    state, IndicesOptions.strictExpandOpen(), ident.indexNameOrAlias());
+                    metadata, IndicesOptions.strictExpandOpen(), ident.indexNameOrAlias());
                 concreteOpenIndices = concreteIndices;
                 if (concreteIndices.length == 0) {
                     // no matching index found

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -453,7 +453,7 @@ public final class MetadataTracker implements Closeable {
                 changedRelations.add(relationName);
             }
             var concreteIndices = IndexNameExpressionResolver.concreteIndices(
-                subscriberClusterState,
+                subscriberClusterState.metadata(),
                 IndicesOptions.lenientExpand(),
                 relationName.indexNameOrAlias()
             );

--- a/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportDropSubscriptionAction.java
@@ -106,9 +106,10 @@ public class TransportDropSubscriptionAction extends AbstractDDLTransportAction<
     private void removeSubscriptionSetting(Subscription subscription,
                                            ClusterState currentState,
                                            Metadata.Builder mdBuilder) {
+        Metadata metadata = currentState.metadata();
         for (var relationName : subscription.relations().keySet()) {
             var concreteIndices = IndexNameExpressionResolver.concreteIndexNames(
-                currentState,
+                metadata,
                 IndicesOptions.lenientExpandOpen(),
                 relationName.indexNameOrAlias()
             );

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -124,7 +124,7 @@ public class Publication implements Writeable {
                 if (indexParts.isPartitioned()
                         && userCanPublish(relationName, publicationOwner)
                         && subscriberCanRead(relationName, subscriber)) {
-                    relations.put(relationName, RelationMetadata.fromMetadata(relationName, state));
+                    relations.put(relationName, RelationMetadata.fromMetadata(relationName, metadata));
                 }
             }
             for (var cursor : metadata.indices().values()) {
@@ -145,7 +145,7 @@ public class Publication implements Writeable {
                     continue;
                 }
                 if (userCanPublish(relationName, publicationOwner) && subscriberCanRead(relationName, subscriber)) {
-                    relations.put(relationName, RelationMetadata.fromMetadata(relationName, state));
+                    relations.put(relationName, RelationMetadata.fromMetadata(relationName, metadata));
                 }
             }
             return relations;
@@ -153,7 +153,7 @@ public class Publication implements Writeable {
             return tables.stream()
                 .filter(relationName -> userCanPublish(relationName, publicationOwner))
                 .filter(relationName -> subscriberCanRead(relationName, subscriber))
-                .map(relationName -> RelationMetadata.fromMetadata(relationName, state))
+                .map(relationName -> RelationMetadata.fromMetadata(relationName, state.metadata()))
                 .collect(Collectors.toMap(x -> x.name(), x -> x));
         }
     }

--- a/server/src/main/java/io/crate/replication/logical/metadata/RelationMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/RelationMetadata.java
@@ -28,7 +28,6 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
@@ -59,15 +58,14 @@ public record RelationMetadata(RelationName name,
         out.writeOptionalWriteable(template);
     }
 
-    public static RelationMetadata fromMetadata(RelationName table, ClusterState state) {
-        Metadata metadata = state.metadata();
+    public static RelationMetadata fromMetadata(RelationName table, Metadata metadata) {
         String indexNameOrAlias = table.indexNameOrAlias();
         var indexMetadata = metadata.index(indexNameOrAlias);
         if (indexMetadata == null) {
             String templateName = PartitionName.templateName(table.schema(), table.name());
             var templateMetadata = metadata.templates().get(templateName);
             String[] concreteIndices = IndexNameExpressionResolver.concreteIndexNames(
-                state,
+                metadata,
                 IndicesOptions.lenientExpandOpen(),
                 indexNameOrAlias
             );

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -273,7 +273,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         }
         if (request.indices() != null && request.indices().length > 0) {
             try {
-                IndexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), request.indices());
+                IndexNameExpressionResolver.concreteIndexNames(clusterState.metadata(), IndicesOptions.strictExpand(), request.indices());
                 waitForCounter++;
             } catch (IndexNotFoundException e) {
                 response.setStatus(ClusterHealthStatus.RED); // no indices, make sure its RED

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -165,7 +165,7 @@ public class SyncedFlushService implements IndexEventListener {
         if (state.nodes().getMinNodeVersion().onOrAfter(Version.V_4_4_0)) {
             DEPRECATION_LOGGER.deprecatedAndMaybeLog("synced_flush", SYNCED_FLUSH_DEPRECATION_MESSAGE);
         }
-        final Index[] concreteIndices = IndexNameExpressionResolver.concreteIndices(state, indicesOptions, aliasesOrIndices);
+        final Index[] concreteIndices = IndexNameExpressionResolver.concreteIndices(state.metadata(), indicesOptions, aliasesOrIndices);
         final Map<String, List<ShardsSyncedFlushResult>> results = ConcurrentCollections.newConcurrentMap();
         int numberOfShards = 0;
         for (Index index : concreteIndices) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -291,8 +291,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     throw new ConcurrentSnapshotExecutionException(repositoryName, snapshotName, " a snapshot is already running");
                 }
                 // Store newSnapshot here to be processed in clusterStateProcessed
-                indices = Arrays.asList(IndexNameExpressionResolver.concreteIndexNames(currentState,
-                    request.indicesOptions(), request.indices()));
+                indices = Arrays.asList(IndexNameExpressionResolver.concreteIndexNames(currentState.metadata(), request.indicesOptions(), request.indices()));
                 LOGGER.trace("[{}][{}] creating snapshot for indices [{}]", repositoryName, snapshotName, indices);
                 newSnapshot = new SnapshotsInProgress.Entry(
                     new Snapshot(repositoryName, snapshotId),

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -260,7 +260,7 @@ public class MetadataTrackerTest extends ESTestCase {
         testTable = new RelationName("doc", "test");
         publicationsStateResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, PUBLISHER_CLUSTER_STATE)));
+            RelationMetadata.fromMetadata(testTable, PUBLISHER_CLUSTER_STATE.metadata())));
 
         SUBSCRIBER_CLUSTER_STATE = new Builder("subscriber")
             .addReplicatingTable("sub1", "test", Map.of("1", "one"), Settings.EMPTY)
@@ -287,7 +287,7 @@ public class MetadataTrackerTest extends ESTestCase {
 
         var updatedResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState)));
+            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())));
 
         syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
@@ -312,7 +312,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .build();
         var updatedResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState)));
+            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())));
         var syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
             retrieveSubscription("sub1", SUBSCRIBER_CLUSTER_STATE),
@@ -335,7 +335,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .build();
         var updatedResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState)));
+            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())));
 
         var syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
@@ -356,7 +356,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .build();
         var updatedResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState)));
+            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())));
 
         var syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
@@ -404,7 +404,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .build();
         var updatedResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, publisherState)));
+            RelationMetadata.fromMetadata(testTable, publisherState.metadata())));
 
         var future = MetadataTracker.subscribeToNewRelations(
             retrieveSubscription("sub1", subscriberClusterState),
@@ -438,7 +438,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPartitionedTable(p1, List.of())
             .addPublication("pub1", List.of(p1.indexNameOrAlias()))
             .build();
-        var publisherStateResponse = new Response(Map.of(p1, RelationMetadata.fromMetadata(p1, publisherState)));
+        var publisherStateResponse = new Response(Map.of(p1, RelationMetadata.fromMetadata(p1, publisherState.metadata())));
 
         var future = MetadataTracker.subscribeToNewRelations(
             retrieveSubscription("sub1", subscriberClusterState),
@@ -472,7 +472,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPublication("pub1", List.of(newRelation.indexNameOrAlias()))
             .addPartitionedTable(newRelation, List.of(newPartitionName))
             .build();
-        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(newRelation, publisherState);
+        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(newRelation, publisherState.metadata());
         var publisherStateResponse = new Response(Map.of(newRelation, relationMetadata));
 
         var future = MetadataTracker.subscribeToNewRelations(
@@ -507,7 +507,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPublication("pub1", List.of(relationName.indexNameOrAlias()))
             .addPartitionedTable(relationName, List.of(newPartitionName))
             .build();
-        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(relationName, publisherState);
+        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(relationName, publisherState.metadata());
         var publisherStateResponse = new Response(Map.of(relationName, relationMetadata));
 
         var future = MetadataTracker.subscribeToNewRelations(


### PR DESCRIPTION
`IndexNameExpressionResolver.concreteIndexNames` and `IndexNameExpressionResolver.concreteIndices` required the full ClusterState but only made use of the Metadata. 