### PR TITLE
Close connection on error on initial discovery in sniff client

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/SniffRemoteClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffRemoteClient.java
@@ -229,6 +229,7 @@ public final class SniffRemoteClient extends AbstractClient {
 
                 @Override
                 public void handleException(TransportException exp) {
+                    connection.close();
                     result.completeExceptionally(exp.unwrapCause());
                 }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The connection is otherwise not getting closed

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
