### PR TITLE
Handle IllegalIndexShardStateException in getFutureOrderedCollector

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/OrderedDocCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/OrderedDocCollector.java
@@ -33,9 +33,24 @@ import java.util.function.Supplier;
 public abstract class OrderedDocCollector implements Supplier<KeyIterable<ShardId, Row>>, AutoCloseable, Killable {
 
     private final ShardId shardId;
-    private final KeyIterable<ShardId, Row> empty;
+    protected final KeyIterable<ShardId, Row> empty;
 
     boolean exhausted = false;
+
+    public static OrderedDocCollector empty(ShardId shardId) {
+        return new OrderedDocCollector(shardId) {
+
+            @Override
+            protected KeyIterable<ShardId, Row> collect() {
+                return empty;
+            }
+
+            @Override
+            public boolean exhausted() {
+                return true;
+            }
+        };
+    }
 
     OrderedDocCollector(ShardId shardId) {
         this.shardId = shardId;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Additions of partitions shouldn't result in errors on reads.

Fixes flaky
`test_deleted_and_recreated_partition_is_also_deleted_and_restored_on_subscriber`

    [.partitioned.t1.04132/6MlkGiOKR36fmch5NdNQXg][[.partitioned.t1.04132][1]] org.elasticsearch.index.shard.IllegalIndexShardStateException: CurrentState[RECOVERING] operations only allowed when shard state is one of [POST_RECOVERY, STARTED]
    	at app//org.elasticsearch.index.shard.IndexShard.readAllowed(IndexShard.java:1609)
    	at app//org.elasticsearch.index.shard.IndexShard.acquireSearcher(IndexShard.java:1192)
    	at app//org.elasticsearch.index.shard.IndexShard.acquireSearcher(IndexShard.java:1184)
    	at app//io.crate.execution.jobs.SharedShardContext.lambda$new$0(SharedShardContext.java:54)
    	at app//io.crate.common.collections.RefCountedItem.markAcquired(RefCountedItem.java:48)
    	at app//io.crate.execution.jobs.SharedShardContext.acquireSearcher(SharedShardContext.java:60)
    	at app//io.crate.execution.engine.collect.LuceneShardCollectorProvider.getOrderedCollector(LuceneShardCollectorProvider.java:219)
    	at app//io.crate.execution.engine.collect.ShardCollectorProvider.lambda$getFutureOrderedCollector$3(ShardCollectorProvider.java:177)
    	at app//org.elasticsearch.index.shard.IndexShard.awaitShardSearchActive(IndexShard.java:3223)
    	at app//io.crate.execution.engine.collect.ShardCollectorProvider.getFutureOrderedCollector(ShardCollectorProvider.java:175)
    	at app//io.crate.execution.engine.collect.sources.ShardCollectSource.createMultiShardScoreDocCollector(ShardCollectSource.java:335)
    	at app//io.crate.execution.engine.collect.sources.ShardCollectSource.getIterator(ShardCollectSource.java:263)
    	at app//io.crate.execution.engine.collect.MapSideDataCollectOperation.createIterator(MapSideDataCollectOperation.java:58)
    	at app//io.crate.execution.engine.collect.CollectTask.start(CollectTask.java:

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
