### PR TITLE
Ensure closing SniffRemoteClient closes pending connection

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/SniffRemoteClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffRemoteClient.java
@@ -102,16 +102,23 @@ public final class SniffRemoteClient extends AbstractClient {
     @Override
     public void close() {
         synchronized (this) {
-            if (discoveredNodes != null && discoveredNodes.isDone() && !discoveredNodes.isCompletedExceptionally()) {
-                DiscoveredNodes nodes = discoveredNodes.join();
-
-                var it = nodes.connections.entrySet().iterator();
-                while (it.hasNext()) {
-                    DiscoveryNode node = it.next().getKey();
-                    transportService.disconnectFromNode(node);
-                    it.remove();
-                }
+            if (discoveredNodes == null) {
+                return;
             }
+            if (discoveredNodes.isCompletedExceptionally()) {
+                discoveredNodes = null;
+                return;
+            }
+            discoveredNodes.thenAccept(nodes -> {
+                synchronized (nodes) {
+                    var it = nodes.connections.entrySet().iterator();
+                    while (it.hasNext()) {
+                        DiscoveryNode node = it.next().getKey();
+                        transportService.disconnectFromNode(node);
+                        it.remove();
+                    }
+                }
+            });
             discoveredNodes = null;
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closing the SniffRemoteClient didn't take care of the case that the
`discoveredNodes` future may not be completed yet.

There were some CI failures with thread leaks. Couldn't reproduce them
locally - this is just a guess that they're related to connections not
getting closed.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
