### PR TITLE
Replace use of deprecated APIs in SysSnapshots

### DIFF
--- a/libs/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
+++ b/libs/shared/src/main/java/io/crate/concurrent/CompletableFutures.java
@@ -35,6 +35,32 @@ public final class CompletableFutures {
     private CompletableFutures() {
     }
 
+    /**
+     * Return a new {@link CompletableFuture} that is completed when all of the given futures
+     * complete. The future contains a List containing the results of all futures that completed successfully.
+     *
+     * Failed futures are skipped. Their result is not included in the result list.
+     */
+    public static <T> CompletableFuture<List<T>> allSuccessfulAsList(Collection<? extends CompletableFuture<? extends T>> futures) {
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .handle((ignored, ignoredErr) -> {
+                ArrayList<T> results = new ArrayList<>(futures.size());
+                for (CompletableFuture<? extends T> future : futures) {
+                    if (future.isCompletedExceptionally()) {
+                        continue;
+                    }
+                    results.add(future.join());
+                }
+                return results;
+            });
+    }
+
+    /**
+     * Return a new {@link CompletableFuture} that is completed when all of the given futures
+     * complete. The future contains a List containing the result of all futures.
+     *
+     * If any future failed, the result is a failed future.
+     */
     public static <T> CompletableFuture<List<T>> allAsList(Collection<? extends CompletableFuture<? extends T>> futures) {
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
             .thenApply(aVoid -> {

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -141,7 +141,11 @@ public interface Repository extends LifecycleComponent {
      */
     default CompletableFuture<RepositoryData> getRepositoryData() {
         FutureActionListener<RepositoryData, RepositoryData> future = FutureActionListener.newInstance();
-        getRepositoryData(future);
+        try {
+            getRepositoryData(future);
+        } catch (Exception e) {
+            future.onFailure(e);
+        }
         return future;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

🧹

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
