### PR TITLE
Handle initial logical replication restore via MetadataTracker

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SubscriptionRestoreException.java
+++ b/server/src/main/java/io/crate/exceptions/SubscriptionRestoreException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.exceptions;
+
+public class SubscriptionRestoreException extends RuntimeException {
+
+    private final String subscriptionName;
+
+    public SubscriptionRestoreException(String subscriptionName, String message) {
+        super(message);
+        this.subscriptionName = subscriptionName;
+    }
+
+}

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -384,14 +384,14 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
                         relationNames,
                         Subscription.State.RESTORING,
                         null
-                    ).whenComplete((ignored, ignoredErr) -> CompletableFuture.completedFuture(response));
+                    );
                 } else {
                     updateSubscriptionState(
                         subscriptionName,
                         relationNames,
                         Subscription.State.FAILED,
                         "Failed restoring subscription, error=" + err.getMessage()
-                    ).whenComplete((ignored, ignoredErr) -> CompletableFuture.failedFuture(err));
+                    );
                 }
             }
         );

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -157,10 +157,10 @@ public final class MetadataTracker implements Closeable {
         synchronized (this) {
             var copy = new HashSet<>(subscriptionsToTrack);
             var updated = copy.add(subscriptionName);
+            subscriptionsToTrack = copy;
             if (updated && !isActive) {
                 start();
             }
-            subscriptionsToTrack = copy;
             return updated;
         }
     }

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -441,8 +441,8 @@ public final class MetadataTracker implements Closeable {
             var relationName = RelationName.fromIndexName(indexName);
             if (subscriberState.metadata().hasIndex(indexName) == false) {
                 toRestoreIndices.add(indexName);
-            }
-            if (subscribedRelations.get(relationName) == null) {
+                relationNamesForStateUpdate.add(relationName);
+            } else if (subscribedRelations.get(relationName) == null) {
                 relationNamesForStateUpdate.add(relationName);
             }
         }

--- a/server/src/main/java/io/crate/replication/logical/metadata/Subscription.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Subscription.java
@@ -40,7 +40,6 @@ public class Subscription implements Writeable {
     public enum State {
         INITIALIZING("i"),
         RESTORING("d"),
-        SYNCHRONIZED("s"),
         MONITORING("r"),
         FAILED("e");
 

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -455,7 +455,6 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
                         subscriptionStates,
                         contains(Subscription.State.INITIALIZING,
                                 Subscription.State.RESTORING,
-                                Subscription.State.SYNCHRONIZED,
                                 Subscription.State.MONITORING)
                     );
                 }

--- a/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/replication/logical/SubscriptionDisruptionIT.java
@@ -84,7 +84,7 @@ public class SubscriptionDisruptionIT extends LogicalReplicationITestCase {
                         " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
                         " ORDER BY s.subname");
                     assertThat(printedTable(res.rows()),
-                               is("sub1| [pub1]| doc.t1| e| Failed to request the publications state\n"));
+                               is("sub1| [pub1]| doc.t1| e| Tracking of metadata failed for subscription 'sub1' with unrecoverable error, stop tracking.\nReason: fail on logical replication repository restore\n"));
                 }
             );
         } finally {
@@ -138,8 +138,18 @@ public class SubscriptionDisruptionIT extends LogicalReplicationITestCase {
         executeOnSubscriber("CREATE SUBSCRIPTION " + subscriptionName +
                             " CONNECTION '" + publisherConnectionUrl() + "' publication pub1");
 
-        // Ensure tracker started
-        assertBusy(() -> assertThat(isMetadataTrackerActive(), is(true)));
+        // Ensure tracker started and initial recovery is done
+        assertBusy(() -> {
+            assertThat(isMetadataTrackerActive(), is(true));
+            var res = executeOnSubscriber(
+                "SELECT s.subname, s.subpublications, sr.srrelid::text, sr.srsubstate, sr.srsubstate_reason" +
+                " FROM pg_subscription s" +
+                " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
+                " ORDER BY s.subname");
+            assertThat(printedTable(res.rows()), is(
+                "sub1| [pub1]| doc.t1| r| NULL\n"
+            ));
+        });
 
         var expectedLogMessage = "Tracking of metadata failed for subscription 'sub1' with unrecoverable error, stop tracking";
         var mockAppender = appendLogger(expectedLogMessage, MetadataTracker.class, Level.ERROR);

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -478,7 +478,7 @@ public class MetadataTrackerTest extends ESTestCase {
             publisherStateResponse
         );
 
-        assertThat(restoreDiff.relationsForStateUpdate(), empty());
+        assertThat(restoreDiff.relationsForStateUpdate(), contains(relationName));
         assertThat(restoreDiff.indexNamesToRestore(), contains(newPartitionName.asIndexName()));
         assertThat(restoreDiff.templatesToRestore(), empty());
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
