### PR TITLE
Stop the ShardReplicationTracker if index switched to normal index

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
+++ b/server/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexEventListener;
@@ -31,6 +30,7 @@ import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -254,6 +254,18 @@ final class CompositeIndexEventListener implements IndexEventListener {
                 listener.onStoreClosed(shardId);
             } catch (Exception e) {
                 logger.warn("failed to invoke on store closed", e);
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public void beforeIndexSettingsChangesApplied(IndexShard indexShard, Settings oldSettings, Settings newSettings) {
+        for (IndexEventListener listener : listeners) {
+            try {
+                listener.beforeIndexSettingsChangesApplied(indexShard, oldSettings, newSettings);
+            } catch (Exception e) {
+                logger.warn("failed to invoke before index settings changes applied", e);
                 throw e;
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -568,7 +568,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         if (updateIndexSettings) {
             for (final IndexShard shard : this.shards.values()) {
                 try {
-                    shard.onSettingsChanged();
+                    shard.onSettingsChanged(currentIndexMetadata.getSettings());
                 } catch (Exception e) {
                     logger.warn(
                         () -> new ParameterizedMessage(

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
@@ -20,12 +20,13 @@
 package org.elasticsearch.index.shard;
 
 import org.elasticsearch.cluster.routing.ShardRouting;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason;
+
+import javax.annotation.Nullable;
 
 /**
  * An index event listener is the primary extension point for plugins and build-in services
@@ -187,5 +188,11 @@ public interface IndexEventListener {
      * @param shardId the shard ID the store belongs to
      */
     default void onStoreClosed(ShardId shardId) {
+    }
+
+    /**
+     * Called when the setting of the index has changed but *before* the new setting is processed by the shard.
+     */
+    default void beforeIndexSettingsChangesApplied(IndexShard indexShard, Settings oldSettings, Settings newSettings) {
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1521,7 +1521,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
         // time elapses after the engine is created above (pulling the config settings) until we set the engine reference, during
         // which settings changes could possibly have happened, so here we forcefully push any config changes to the new engine.
-        onSettingsChanged();
+        onSettingsChanged(indexSettings.getSettings());
         assert assertSequenceNumbersInCommit();
         assert recoveryState.getStage() == RecoveryState.Stage.TRANSLOG : "TRANSLOG stage expected but was: " + recoveryState.getStage();
     }
@@ -1801,7 +1801,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return false;
     }
 
-    public void onSettingsChanged() {
+    public void onSettingsChanged(Settings oldSettings) {
+        this.indexEventListener.beforeIndexSettingsChangesApplied(this, oldSettings, indexSettings.getSettings());
+
         var newEngineFactory = getEngineFactory();
         if (newEngineFactory.getClass() != engineFactory.getClass()) {
             try {
@@ -1843,7 +1845,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
             @Override
             protected void doRun() {
-                onSettingsChanged();
+                onSettingsChanged(indexSettings.getSettings());
                 trimTranslog();
             }
         });
@@ -3397,7 +3399,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
         // time elapses after the engine is created above (pulling the config settings) until we set the engine reference, during
         // which settings changes could possibly have happened, so here we forcefully push any config changes to the new engine.
-        onSettingsChanged();
+        onSettingsChanged(indexSettings.getSettings());
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up of c00ee7f92d66e3e8592b74b711a70e5fb79fd77b.
From this commit on, the shards won't be closed and re-open if an index is turning from a replicated one into a normal one (e.g. when the subscription is dropped), but the engine is just switched.

Thus the existing close-shard event listener, used to stop the tracker, won't be triggered.
The new event listener API `beforeIndexSettingsChangesApplied` will be triggered by setting changed, which we can utilize to stop the tracker.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
