### PR TITLE
Set concrete relation in hash-join correctly to right-hand relation in optimizer rule

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -39,7 +39,6 @@ import javax.annotation.Nullable;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Tuple;
 import io.crate.data.Row;
@@ -67,8 +66,7 @@ import io.crate.statistics.TableStats;
 public class HashJoin implements LogicalPlan {
 
     private final Symbol joinCondition;
-    @VisibleForTesting
-    final AnalyzedRelation concreteRelation;
+    private final AnalyzedRelation concreteRelation;
     private final List<Symbol> outputs;
     final LogicalPlan rhs;
     final LogicalPlan lhs;
@@ -98,6 +96,10 @@ public class HashJoin implements LogicalPlan {
 
     public LogicalPlan rhs() {
         return rhs;
+    }
+
+    public AnalyzedRelation concreteRelation() {
+        return concreteRelation;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -305,6 +306,13 @@ public class HashJoin implements LogicalPlan {
 
         // First extract the symbols that belong to the concrete relation
         List<Symbol> hashJoinSymbolsForConcreteRelation = hashJoinSymbols.remove(concreteRelation.relationName());
+        if (hashJoinSymbolsForConcreteRelation == null) {
+            throw new IllegalStateException(
+                String.format(Locale.ENGLISH,
+                          "Join Condition `%s` must only reference the concrete relation `%s` of the HashJoin",
+                          joinCondition,
+                          concreteRelation.relationName().name()));
+        }
 
         // All leftover extracted symbols belong to the other relation which might be a
         // "concrete" relation too but can already be a tree of relation.

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.optimizer.rule;
 
-import static io.crate.common.collections.Lists2.getOnlyElement;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.getNewSource;
 
@@ -103,7 +102,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 newLhs,
                 newRhs,
                 AndOperator.join(nonConstantConditions),
-                getOnlyElement(rhs.baseTables())
+                newRhs.baseTables().get(0)
             );
         }
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.common.collections.Lists2.getOnlyElement;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.getNewSource;
 
@@ -102,7 +103,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 newLhs,
                 newRhs,
                 AndOperator.join(nonConstantConditions),
-                nl.topMostLeftRelation()
+                getOnlyElement(rhs.baseTables())
             );
         }
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -77,6 +77,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 nonConstantConditions.add(condition.getValue());
             }
         }
+
         if (constantConditions.isEmpty() || nonConstantConditions.isEmpty()) {
             // Nothing to optimize, just mark nestedLoopJoin to skip the rule the next time
             return new NestedLoopJoin(

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1322,14 +1322,10 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
                 SELECT doc.t3.id, doc.t3.reference
                 FROM doc.t3
                 JOIN doc.t1 ON doc.t1.subscription_id = doc.t3.id
-                JOIN doc.t2 ON doc.t2.cluster_id = doc.t1.id
-                AND doc.t2.kind = 'bar'
-                LEFT OUTER JOIN doc.t2 AS temp ON temp.cluster_id = doc.t1.id
-                AND temp.kind = 'bar'
                 WHERE doc.t3.reference in
-                (select reference from doc.t3 where reference = 'bazinga' union select kind from doc.t2 where kind = 'bar');
+                (select reference from doc.t3 where reference = 'bazinga' union select reference from doc.t3 where reference != 'foo');
             """;
-
+        
         execute(stmt);
         assertThat(printedTable(response.rows()), is("2| bazinga\n"));
     }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1301,4 +1301,37 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
         execute(stmt);
         assertThat(printedTable(response.rows()), is("2| bazinga\n"));
     }
+
+    @Test
+    @UseHashJoins(1)
+    public void test_union_subselect_in_hashjoin() {
+        execute("CREATE TABLE doc.t1 (id TEXT, name TEXT, subscription_id TEXT, PRIMARY KEY (id))");
+        execute("CREATE TABLE doc.t2 (kind TEXT, cluster_id TEXT, PRIMARY KEY (kind, cluster_id))");
+        execute("CREATE TABLE doc.t3 (id TEXT PRIMARY KEY, reference TEXT)");
+
+        execute("insert into doc.t1 values ('1', 'foo', '2')");
+        execute("insert into doc.t2 values ('bar', '1')");
+        execute("insert into doc.t3 values ('2', 'bazinga')");
+        execute("insert into doc.t3 values ('3', 'test')");
+
+        execute("refresh table doc.t1");
+        execute("refresh table doc.t2");
+        execute("refresh table doc.t3");
+
+        var stmt = """
+                SELECT doc.t3.id, doc.t3.reference
+                FROM doc.t3
+                JOIN doc.t1 ON doc.t1.subscription_id = doc.t3.id
+                JOIN doc.t2 ON doc.t2.cluster_id = doc.t1.id
+                AND doc.t2.kind = 'bar'
+                LEFT OUTER JOIN doc.t2 AS temp ON temp.cluster_id = doc.t1.id
+                AND temp.kind = 'bar'
+                WHERE doc.t3.reference in
+                (select reference from doc.t3 where reference = 'bazinga' union select kind from doc.t2 where kind = 'bar');
+            """;
+
+        execute(stmt);
+        assertThat(printedTable(response.rows()), is("2| bazinga\n"));
+    }
+
 }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -246,7 +246,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(HashJoin.class));
-        assertThat(((HashJoin) operator).concreteRelation.toString(), is("DocTableRelation{doc.locations}"));
+        assertThat(((HashJoin) operator).concreteRelation().toString(), is("DocTableRelation{doc.locations}"));
 
         Join join = buildJoin(operator);
         assertThat(((Collect) join.left()).collectPhase().toCollect().get(1), isReference("other_id"));
@@ -266,7 +266,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(HashJoin.class));
-        assertThat(((HashJoin) operator).concreteRelation.toString(), is("DocTableRelation{doc.locations}"));
+        assertThat(((HashJoin) operator).concreteRelation().toString(), is("DocTableRelation{doc.locations}"));
 
         Join join = buildJoin(operator);
         assertThat(((Collect) join.left()).collectPhase().toCollect().get(1), isReference("loc"));

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -86,6 +86,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
 
         assertThat(result.joinCondition(), is(nonConstantPart));
         assertThat(result.lhs(), is(c1));
+        assertThat(result.concreteRelation(), is(t2));
         Filter filter = (Filter) result.rhs();
         assertThat(filter.source(), is(c2));
         assertThat(filter.query(), is(constantPart));


### PR DESCRIPTION
The concrete relation on the hash-join was not correctly set in the `MoveConstantJoinConditionsBeneathNestedLoop` rule.
It has to be set to the right-hand relation.

Fixes https://github.com/crate/crate/issues/12357


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
