### PR TITLE
Try to fix thread leak in PgClientTest

### DIFF
--- a/server/src/main/java/io/crate/netty/NettyBootstrap.java
+++ b/server/src/main/java/io/crate/netty/NettyBootstrap.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.transport.netty4.Netty4Transport;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.BorrowedItem;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
@@ -56,6 +57,11 @@ public class NettyBootstrap {
 
     private int refs = 0;
     private EventLoopGroup worker;
+
+    @VisibleForTesting
+    public boolean workerIsShutdown() {
+        return worker == null || worker.isShutdown();
+    }
 
     public synchronized BorrowedItem<EventLoopGroup> getSharedEventLoopGroup(Settings settings) {
         if (worker == null) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Failed on CI, but couldn't reproduce it locally.
This moves closing of the resources into a `@After` method and in case
that doesn't help it adds new assertions - this may help to get more
insights in case it fails again.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
