### PR TITLE
Ignore setting change if engine is already closed

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1817,6 +1817,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 var msg = "IOException while trying to switch to a new engine";
                 failShard(msg, e);
                 throw new UncheckedIOException(msg, e);
+            } catch (AlreadyClosedException e) {
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

A AlreadyClosedException in the engine switch logic can happen if a
subscription is dropped and immediately after the table is deleted.
Parts of the subscription change are async and it can race with closing
of the table.

    [2022-04-27T06:05:20,424][WARN ][o.e.i.IndexService       ] [[cratedb[subscriber1][clusterApplierService#updateTask][T#1]]] [.partitioned.t1.04132] [2] failed to notify shard about setting change
    org.apache.lucene.store.AlreadyClosedException: engine is closed
    	at org.elasticsearch.index.shard.IndexShard.getEngine(IndexShard.java:2441) ~[crate-server.jar:?]
    	at org.elasticsearch.index.shard.IndexShard.sync(IndexShard.java:3011) ~[crate-server.jar:?]
    	at org.elasticsearch.index.shard.IndexShard.resetEngineToGlobalCheckpoint(IndexShard.java:3334) ~[crate-server.jar:?]
    	at org.elasticsearch.index.shard.IndexShardOperationPermits.blockOperations(IndexShardOperationPermits.java:110) ~[crate-server.jar:?]
    	at org.elasticsearch.index.shard.IndexShard.onSettingsChanged(IndexShard.java:1811) ~[crate-server.jar:?]
    	at org.elasticsearch.index.IndexService.updateMetadata(IndexService.java:571) [crate-server.jar:?]


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
