### PR TITLE
Fix issue with translog recovery when engine is switched by setting change

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1521,7 +1521,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
         // time elapses after the engine is created above (pulling the config settings) until we set the engine reference, during
         // which settings changes could possibly have happened, so here we forcefully push any config changes to the new engine.
-        onSettingsChanged(indexSettings.getSettings());
+        applyEngineSettings();
         assert assertSequenceNumbersInCommit();
         assert recoveryState.getStage() == RecoveryState.Stage.TRANSLOG : "TRANSLOG stage expected but was: " + recoveryState.getStage();
     }
@@ -1820,6 +1820,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             }
         }
 
+        applyEngineSettings();
+    }
+
+    private void applyEngineSettings() {
         Engine engineOrNull = getEngineOrNull();
         if (engineOrNull != null) {
             final boolean disableTranslogRetention = indexSettings.isSoftDeleteEnabled() && useRetentionLeasesInPeerRecovery;
@@ -1845,7 +1849,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
             @Override
             protected void doRun() {
-                onSettingsChanged(indexSettings.getSettings());
+                applyEngineSettings();
                 trimTranslog();
             }
         });
@@ -3399,7 +3403,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
         // time elapses after the engine is created above (pulling the config settings) until we set the engine reference, during
         // which settings changes could possibly have happened, so here we forcefully push any config changes to the new engine.
-        onSettingsChanged(indexSettings.getSettings());
+        applyEngineSettings();
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The internal IndexShard calls to apply engine settings after a engine is
created to catch a race condition of concurrently creating a engine and
applying new settings must not include the engine switch logic.
Concurrently running engine switches a new engine creation like
openEngineAndSkipTranslogRecovery will conflict as both skip translog
recovery while expecting an ongoing translog recovery.

Such we split internal safety logic to re-apply possible in-between setting
changes to new engines and on-setting-changes calls triggered by metadata
changes.

Fixes "translogRecovery is not pending but should be" assertions errors.

Follow up of c00ee7f92d66e3e8592b74b711a70e5fb79fd77b.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
