### PR TITLE
remove outdated test and adjust docs for DROP/ALTER PUBLICATION

### DIFF
--- a/docs/sql/statements/alter-publication.rst
+++ b/docs/sql/statements/alter-publication.rst
@@ -43,6 +43,11 @@ of the table stops for all subscribers. Already replicated data remains on
 the subscribed clusters, therefore subscribers can not re-subscribe again to
 the tables removed from the publication.
 
+.. NOTE::
+
+  Replicated tables on a subscriber cluster will turn into regular writable
+  tables after excluding them from a publication on a publishing cluster.
+
 Parameters
 ==========
 

--- a/docs/sql/statements/drop-publication.rst
+++ b/docs/sql/statements/drop-publication.rst
@@ -33,9 +33,8 @@ existing subscriptions.
 
 .. NOTE::
 
-  Replicated tables on a subscriber cluster will stay read-only after dropping
-  a publication on a publishing cluster. To make them writable, use
-  :ref:`DROP SUBSCRIPTION <sql-drop-subscription>`.
+  Replicated tables on a subscriber cluster will turn into regular writable
+  tables after dropping a publication on a publishing cluster.
 
 
 .. _sql-drop-publication-params:


### PR DESCRIPTION
Soft revert of https://github.com/crate/crate/pull/12365/ - not reverting completely, rather adjusting docs and keeping [inclusion](https://github.com/crate/crate/pull/12365/files#diff-4c41ba91caf78ce2a62b4f565161c862e62869a6cf237dfab2e8759aea6e9ff3R242) of failure message into `pg_subscription_rel` 

DROP PUB test is irrelevant after introducing https://github.com/crate/crate/pull/12369

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
