### PR TITLE
WIP: Revert close table changes, related to old DROP SUBSCRIPTION implementation

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -145,23 +145,17 @@ public class AlterTableOperation {
 
     public CompletableFuture<Long> executeAlterTableOpenClose(List<RelationName> tables,
                                                               boolean openTable,
-                                                              boolean ignoreUnavailableIndices,
                                                               @Nullable PartitionName partitionName) {
         String partitionIndexName = null;
         if (partitionName != null) {
             partitionIndexName = partitionName.asIndexName();
         }
         if (openTable || clusterService.state().getNodes().getMinNodeVersion().before(Version.V_4_3_0)) {
-            OpenCloseTableOrPartitionRequest request = new OpenCloseTableOrPartitionRequest(
-                tables,
-                partitionIndexName,
-                openTable,
-                ignoreUnavailableIndices
-            );
+            OpenCloseTableOrPartitionRequest request = new OpenCloseTableOrPartitionRequest(tables, partitionIndexName, openTable);
             return transportOpenCloseTableOrPartitionAction.execute(request, r -> -1L);
         } else {
             return transportCloseTable.execute(
-                new CloseTableRequest(tables, partitionIndexName, ignoreUnavailableIndices), r -> -1L);
+                new CloseTableRequest(tables, partitionIndexName), r -> -1L);
         }
     }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
@@ -22,41 +22,39 @@
 
 package io.crate.execution.ddl.tables;
 
-import io.crate.metadata.RelationName;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import io.crate.metadata.RelationName;
 
 public class CloseTableRequest extends AcknowledgedRequest<CloseTableRequest> {
 
     private final List<RelationName> tables;
     private final String partition;
-    private final boolean ignoreUnavailableIndices;
 
-    public CloseTableRequest(List<RelationName> tables, @Nullable String partition, boolean ignoreUnavailableIndices) {
+    public CloseTableRequest(List<RelationName> tables, @Nullable String partition) {
         this.tables = tables;
         this.partition = partition;
-        this.ignoreUnavailableIndices = ignoreUnavailableIndices;
     }
 
     public CloseTableRequest(StreamInput in) throws IOException {
         super(in);
         if (in.getVersion().before(Version.V_4_8_0)) {
             tables = List.of(new RelationName(in));
-            ignoreUnavailableIndices = false;
         } else {
             int count = in.readVInt();
             tables = new ArrayList<>(count);
             for (int i = 0; i < count; i++) {
                 tables.add(new RelationName(in));
             }
-            ignoreUnavailableIndices = in.readBoolean();
         }
         partition = in.readOptionalString();
     }
@@ -74,7 +72,6 @@ public class CloseTableRequest extends AcknowledgedRequest<CloseTableRequest> {
             for (int i = 0; i < tables.size(); i++) {
                 tables.get(i).writeTo(out);
             }
-            out.writeBoolean(ignoreUnavailableIndices);
         }
         out.writeOptionalString(partition);
     }
@@ -86,9 +83,5 @@ public class CloseTableRequest extends AcknowledgedRequest<CloseTableRequest> {
     @Nullable
     public String partition() {
         return partition;
-    }
-
-    public boolean ignoreUnavailableIndices() {
-        return ignoreUnavailableIndices;
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/OpenCloseTableOrPartitionRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/OpenCloseTableOrPartitionRequest.java
@@ -21,16 +21,18 @@
 
 package io.crate.execution.ddl.tables;
 
-import io.crate.metadata.RelationName;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import io.crate.metadata.RelationName;
 
 
 public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCloseTableOrPartitionRequest> {
@@ -39,16 +41,11 @@ public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCl
     @Nullable
     private final String partitionIndexName;
     private final boolean openTable;
-    private final boolean ignoreUnavailableIndices;
 
-    public OpenCloseTableOrPartitionRequest(List<RelationName> tables,
-                                            @Nullable String partitionIndexName,
-                                            boolean openTable,
-                                            boolean ignoreUnavailableIndices) {
+    public OpenCloseTableOrPartitionRequest(List<RelationName> tables, @Nullable String partitionIndexName, boolean openTable) {
         this.tables = tables;
         this.partitionIndexName = partitionIndexName;
         this.openTable = openTable;
-        this.ignoreUnavailableIndices = ignoreUnavailableIndices;
     }
 
     @Nullable
@@ -64,14 +61,12 @@ public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCl
         super(in);
         if (in.getVersion().before(Version.V_4_8_0)) {
             tables = List.of(new RelationName(in));
-            ignoreUnavailableIndices = false;
         } else {
             int count = in.readVInt();
             tables = new ArrayList<>(count);
             for (int i = 0; i < count; i++) {
                 tables.add(new RelationName(in));
             }
-            ignoreUnavailableIndices = in.readBoolean();
         }
         partitionIndexName = in.readOptionalString();
         openTable = in.readBoolean();
@@ -90,7 +85,6 @@ public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCl
             for (int i = 0; i < tables.size(); i++) {
                 tables.get(i).writeTo(out);
             }
-            out.writeBoolean(ignoreUnavailableIndices);
         }
         out.writeOptionalString(partitionIndexName);
         out.writeBoolean(openTable);
@@ -98,9 +92,5 @@ public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCl
 
     public List<RelationName> tables() {
         return tables;
-    }
-
-    public boolean ignoreUnavailableIndices() {
-        return ignoreUnavailableIndices;
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -92,6 +92,7 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
 
     private static final Logger LOGGER = LogManager.getLogger(TransportCloseTable.class);
     private static final String ACTION_NAME = "internal:crate:sql/table_or_partition/close";
+    private static final IndicesOptions STRICT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, false);
     public static final int INDEX_CLOSED_BLOCK_ID = 4;
 
     private final TransportVerifyShardBeforeCloseAction verifyShardBeforeClose;
@@ -259,14 +260,12 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
     protected ClusterBlockException checkBlock(CloseTableRequest request, ClusterState state) {
         return checkBlock(
             state,
-            request.ignoreUnavailableIndices(),
             request.tables(),
             request.partition()
         );
     }
 
     public static ClusterBlockException checkBlock(ClusterState state,
-                                                   boolean ignoreUnavailableIndices,
                                                    List<RelationName> relationNames,
                                                    @Nullable String partition) {
         var relationsToCheck = new ArrayList<>(relationNames);
@@ -285,7 +284,7 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
             ClusterBlockLevel.METADATA_WRITE,
             IndexNameExpressionResolver.concreteIndexNames(
                 state.metadata(),
-                ignoreUnavailableIndices ? IndicesOptions.lenientExpandOpen() : IndicesOptions.strictExpandOpen(),
+                STRICT_INDICES_OPTIONS,
                 getIndices(relationsToCheck, partition)
             )
         );

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -81,7 +81,6 @@ public class TransportOpenCloseTableOrPartitionAction extends AbstractDDLTranspo
     protected ClusterBlockException checkBlock(OpenCloseTableOrPartitionRequest request, ClusterState state) {
         return TransportCloseTable.checkBlock(
             state,
-            request.ignoreUnavailableIndices(),
             request.tables(),
             request.partitionIndexName()
         );

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
@@ -75,7 +75,7 @@ public class AlterTableOpenClosePlan implements Plan {
         }
 
         dependencies.alterTableOperation()
-            .executeAlterTableOpenClose(List.of(tableInfo.ident()), analyzedAlterTable.isOpenTable(), false, partitionName)
+            .executeAlterTableOpenClose(List.of(tableInfo.ident()), analyzedAlterTable.isOpenTable(), partitionName)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }


### PR DESCRIPTION
This reverts commit 562abc8a and part of https://github.com/crate/crate/pull/12112 related to close request logic

I kept changes from https://github.com/crate/crate/pull/12280/, https://github.com/crate/crate/pull/12370,  https://github.com/crate/crate/pull/12378, https://github.com/crate/crate/pull/12220/ and https://github.com/crate/crate/pull/12231

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
