### PR TITLE
add decimal type as alias to numeric type

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,8 +54,7 @@ None
 Changes
 =======
 
-None
-
+- Added ``decimal`` type as alias to ``numeric``
 
 Fixes
 =====

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -3310,6 +3310,8 @@ See the table below for a full list of aliases:
 +-----------------------+------------------------------+
 | ``DOUBLE``            | ``DOUBLE PRECISION``         |
 +-----------------------+------------------------------+
+| ``DECIMAL``           | ``NUMERIC``                  |
++-----------------------+------------------------------+
 | ``TIMESTAMP``         | ``TIMESTAMP WITH TIME ZONE`` |
 +-----------------------+------------------------------+
 | ``TIMESTAMPTZ``       | ``TIMESTAMP WITH TIME ZONE`` |

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -412,7 +412,8 @@ public final class DataTypes {
         entry("interval", INTERVAL),
         entry(DATE.getName(), DATE),
         entry(BitStringType.INSTANCE_ONE.getName(), BitStringType.INSTANCE_ONE),
-        entry(JsonType.INSTANCE.getName(), JsonType.INSTANCE)
+        entry(JsonType.INSTANCE.getName(), JsonType.INSTANCE),
+        entry("decimal", NUMERIC)
     );
 
     public static DataType<?> ofName(String typeName) {

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -171,6 +171,11 @@ public class DataTypesTest extends ESTestCase {
     }
 
     @Test
+    public void testDecimalIsAliasedToNumeric() {
+        assertThat(DataTypes.ofName("decimal"), is(DataTypes.NUMERIC));
+    }
+
+    @Test
     public void test_is_same_type_on_primitive_types() {
         assertThat(DataTypes.isCompatibleType(DataTypes.STRING, DataTypes.STRING), is(true));
         assertThat(DataTypes.isCompatibleType(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Add decimal type as alias to numeric type.

closes #12359 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
