### PR TITLE
Allow users with AL privileges to run ANALYZE

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -56,6 +56,8 @@ Changes
 
 - Added ``decimal`` type as alias to ``numeric``
 
+- Users with AL privileges can now run ``ANALYZE``
+
 Fixes
 =====
 

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -29,6 +29,7 @@ import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
 import io.crate.analyze.AnalyzedAlterTableRename;
 import io.crate.analyze.AnalyzedAlterUser;
+import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedCommit;
 import io.crate.analyze.AnalyzedCopyFrom;
@@ -843,6 +844,17 @@ public final class AccessControlImpl implements AccessControl {
                 user,
                 defaultSchema
             );
+            return null;
+        }
+
+        @Override
+        public Void visitAnalyze(AnalyzedAnalyze analyzedAnalyze, User user) {
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.AL,
+                Privilege.Clazz.CLUSTER,
+                null,
+                user,
+                defaultSchema);
             return null;
         }
     }

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -681,4 +681,10 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         analyze("ALTER SUBSCRIPTION sub1 DISABLE", user);
         assertAskedForCluster(Privilege.Type.AL);
     }
+
+    @Test
+    public void test_anaylze_works_for_normal_user_with_AL_privileges() {
+        analyze("ANALYZE", user);
+        assertAskedForCluster(Privilege.Type.AL);
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Allow users with AL privileges to run `ANALYZE`

closes https://github.com/crate/crate/issues/12383

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
