### PR TITLE
Move `quote_ident()` function to `pg_catalog`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,9 @@ None
 Changes
 =======
 
+- Moved the :ref:`scalar-quote_ident` function to `pg_catalog` for improved
+  compatibility with PostgreSQL.
+
 - Added ``decimal`` type as alias to ``numeric``
 
 - Users with AL privileges can now run ``ANALYZE``

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -508,7 +508,7 @@ The quoted string can be used as an identifier in an SQL statement.
 
 ::
 
-    cr> select quote_ident('Column name') AS quoted;
+    cr> select pg_catalog.quote_ident('Column name') AS quoted;
     +---------------+
     | quoted        |
     +---------------+

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -23,17 +23,21 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.sql.Identifiers;
 import io.crate.types.DataTypes;
 
 
 public final class QuoteIdentFunction {
 
+    private static final FunctionName FQNAME = new FunctionName(PgCatalogSchemaInfo.NAME, "quote_ident");
+
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                "quote_ident",
+                FQNAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),

--- a/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
@@ -37,7 +37,7 @@ public class QuoteIdentFunctionTest extends ScalarTestCase {
     public void testZeroArguments() {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Unknown function: quote_ident()." +
-                                        " Possible candidates: quote_ident(text):text");
+                                        " Possible candidates: pg_catalog.quote_ident(text):text");
         assertEvaluate("quote_ident()", null);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Moved the `quote_ident()` function to `pg_catalog` for improved compatibility with PostgreSQL. 

```SQL
SELECT pg_catalog.quote_ident('myTable') = quote_ident('myTable');
-- true
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
