### PR TITLE
Don't evaluate primary key defaults multiple times

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,4 +68,5 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue with primary key columns that have a ``DEFAULT`` clause. That
+  could lead to queries on the primary key column not matching the row.

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -21,6 +21,13 @@
 
 package io.crate.execution.dml.upsert;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Maps;
 import io.crate.data.BiArrayRow;
@@ -39,13 +46,6 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.common.collections.Tuple;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public final class InsertSourceFromCells implements InsertSourceGen {
 
@@ -57,9 +57,11 @@ public final class InsertSourceFromCells implements InsertSourceGen {
     private final GeneratedColumns<Row> generatedColumns;
     private final List<Input<?>> defaultValues;
     private final List<Reference> partitionedByColumns;
+    private final DocTableInfo table;
 
     // This is re-used per document to hold the default values
     private final Object[] defaultValuesCells;
+
 
     public InsertSourceFromCells(TransactionContext txnCtx,
                                  NodeContext nodeCtx,
@@ -67,9 +69,10 @@ public final class InsertSourceFromCells implements InsertSourceGen {
                                  String indexName,
                                  boolean validation,
                                  List<Reference> targets) {
-        Tuple<List<Reference>, List<Input<?>>> allTargetColumnsAndDefaults = addDefaults(targets, table, txnCtx, nodeCtx);
-        this.targets = allTargetColumnsAndDefaults.v1();
-        this.defaultValues = allTargetColumnsAndDefaults.v2();
+        Defaults allTargetColumnsAndDefaults = addDefaults(targets, table, txnCtx, nodeCtx);
+        this.table = table;
+        this.targets = allTargetColumnsAndDefaults.allColumns;
+        this.defaultValues = allTargetColumnsAndDefaults.defaults;
         this.defaultValuesCells = defaultValues.isEmpty() ? EMPTY_ARRAY : new Object[defaultValues.size()];
         this.partitionedByColumns = table.partitionedByColumns();
         this.row.secondCells(defaultValuesCells);
@@ -101,7 +104,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
     }
 
     @Override
-    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) {
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values, List<String> pkValues) {
         row.firstCells(values);
         evaluateDefaultValues();
 
@@ -115,6 +118,12 @@ public final class InsertSourceFromCells implements InsertSourceGen {
             if (valueForInsert != null) {
                 Maps.mergeInto(source, column.name(), column.path(), valueForInsert, Map::putIfAbsent);
             }
+        }
+
+        for (int i = 0; i < pkValues.size(); i++) {
+            String pkValue = pkValues.get(i);
+            ColumnIdent column = table.primaryKey().get(i);
+            Maps.mergeInto(source, column.name(), column.path(), pkValue, Map::putIfAbsent);
         }
 
         generatedColumns.setNextRow(row);
@@ -146,18 +155,25 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         }
     }
 
-    private static Tuple<List<Reference>, List<Input<?>>> addDefaults(List<Reference> targets,
-                                                                      DocTableInfo table,
-                                                                      TransactionContext txnCtx,
-                                                                      NodeContext nodeCtx) {
+    record Defaults(List<Reference> allColumns, List<Input<?>> defaults) {
+    }
+
+    private static Defaults addDefaults(List<Reference> targets,
+                                        DocTableInfo table,
+                                        TransactionContext txnCtx,
+                                        NodeContext nodeCtx) {
         if (table.defaultExpressionColumns().isEmpty()) {
-            return new Tuple<>(targets, List.of());
+            return new Defaults(targets, List.of());
         }
         InputFactory inputFactory = new InputFactory(nodeCtx);
         Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         ArrayList<Reference> defaultColumns = new ArrayList<>(table.defaultExpressionColumns().size());
         ArrayList<Input<?>> defaultValues = new ArrayList<>();
         for (Reference ref : table.defaultExpressionColumns()) {
+            // Generated primary key values are generated up-front as they are required for sharding.
+            if (table.primaryKey().contains(ref.column())) {
+                continue;
+            }
             if (targets.contains(ref) == false) {
                 defaultColumns.add(ref);
                 defaultValues.add(ctx.add(ref.defaultExpression()));
@@ -169,7 +185,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         } else {
             allColumns = Lists2.concat(targets, defaultColumns);
         }
-        return new Tuple<>(allColumns, defaultValues);
+        return new Defaults(allColumns, defaultValues);
     }
 
     private static class ReferencesFromInputRow implements ReferenceResolver<CollectExpression<Row, ?>> {

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceGen.java
@@ -48,10 +48,10 @@ public interface InsertSourceGen {
 
 
     default BytesReference generateSourceAndCheckConstraintsAsBytesReference(Object[] values) throws IOException {
-        return BytesReference.bytes(XContentFactory.jsonBuilder().map(generateSourceAndCheckConstraints(values), SOURCE_WRITERS));
+        return BytesReference.bytes(XContentFactory.jsonBuilder().map(generateSourceAndCheckConstraints(values, List.of()), SOURCE_WRITERS));
     }
 
-    Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException;
+    Map<String, Object> generateSourceAndCheckConstraints(Object[] values, List<String> pkValues) throws IOException;
 
     static InsertSourceGen of(TransactionContext txnCtx,
                               NodeContext nodeCtx,

--- a/server/src/main/java/io/crate/execution/dml/upsert/RawInsertSource.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/RawInsertSource.java
@@ -21,14 +21,15 @@
 
 package io.crate.execution.dml.upsert;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-
-import java.io.IOException;
-import java.util.Map;
 
 public class RawInsertSource implements InsertSourceGen {
 
@@ -37,7 +38,7 @@ public class RawInsertSource implements InsertSourceGen {
     }
 
     @Override
-    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values, List<String> pkValues) throws IOException {
         return JsonXContent.JSON_XCONTENT.createParser(
             NamedXContentRegistry.EMPTY,
             DeprecationHandler.THROW_UNSUPPORTED_OPERATION,

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -21,28 +21,30 @@
 
 package io.crate.execution.dml.upsert;
 
-import io.crate.Streamer;
-import io.crate.execution.dml.ShardRequest;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Reference;
-import io.crate.metadata.settings.SessionSettings;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.uid.Versions;
-import io.crate.common.unit.TimeValue;
-import org.elasticsearch.index.seqno.SequenceNumbers;
-import org.elasticsearch.index.shard.ShardId;
-
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.shard.ShardId;
+
+import io.crate.Streamer;
+import io.crate.common.unit.TimeValue;
+import io.crate.execution.dml.ShardRequest;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.Reference;
+import io.crate.metadata.settings.SessionSettings;
 
 public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUpsertRequest.Item> {
 
@@ -285,12 +287,18 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
         @Nullable
         private Object[] insertValues;
 
+        /**
+         * Values that make up the primary key.
+         */
+        private List<String> pkValues;
+
         public Item(String id,
                     @Nullable Symbol[] updateAssignments,
                     @Nullable Object[] insertValues,
                     @Nullable Long version,
                     @Nullable Long seqNo,
-                    @Nullable Long primaryTerm
+                    @Nullable Long primaryTerm,
+                    List<String> pkValues
         ) {
             super(id);
             this.updateAssignments = updateAssignments;
@@ -304,6 +312,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
                 this.primaryTerm = primaryTerm;
             }
             this.insertValues = insertValues;
+            this.pkValues = pkValues;
         }
 
         @Nullable
@@ -329,6 +338,10 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             return insertValues;
         }
 
+        public List<String> pkValues() {
+            return pkValues;
+        }
+
         public Item(StreamInput in, @Nullable Streamer[] insertValueStreamers) throws IOException {
             super(in);
             if (in.readBoolean()) {
@@ -349,6 +362,11 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             }
             if (in.readBoolean()) {
                 source = in.readBytesReference();
+            }
+            if (in.getVersion().after(Version.V_4_8_0)) {
+                pkValues = in.readList(StreamInput::readString);
+            } else {
+                pkValues = List.of();
             }
         }
 
@@ -377,6 +395,9 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             out.writeBoolean(sourceAvailable);
             if (sourceAvailable) {
                 out.writeBytesReference(source);
+            }
+            if (out.getVersion().after(Version.V_4_8_0)) {
+                out.writeStringCollection(pkValues);
             }
         }
 

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -320,7 +320,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             if (insertSourceGen instanceof RawInsertSource) {
                 rawSource = insertSourceGen.generateSourceAndCheckConstraintsAsBytesReference(item.insertValues());
             } else {
-                source = insertSourceGen.generateSourceAndCheckConstraints(item.insertValues());
+                source = insertSourceGen.generateSourceAndCheckConstraints(item.insertValues(), item.pkValues());
                 rawSource = BytesReference.bytes(XContentFactory.jsonBuilder().map(source, SOURCE_WRITERS));
             }
         } catch (IOException e) {

--- a/server/src/main/java/io/crate/execution/dml/upsert/ValidatedRawInsertSource.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ValidatedRawInsertSource.java
@@ -79,7 +79,7 @@ public class ValidatedRawInsertSource implements InsertSourceGen, ParameterizedX
     }
 
     @Override
-    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values) throws IOException {
+    public Map<String, Object> generateSourceAndCheckConstraints(Object[] values, List<String> pkValues) throws IOException {
         try {
             String src = (String) values[0];
             Map<String, Object> validatedSource;

--- a/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
@@ -49,6 +49,7 @@ public class RowShardResolver {
 
     private String id;
     private String routing;
+    private List<String> pkValues;
 
 
     public RowShardResolver(TransactionContext txnCtx,
@@ -77,7 +78,8 @@ public class RowShardResolver {
         for (CollectExpression<Row, ?> expression : expressions) {
             expression.setNextRow(row);
         }
-        id = idFunction.apply(pkValues(primaryKeyInputs));
+        pkValues = pkValues(primaryKeyInputs);
+        id = idFunction.apply(pkValues);
         if (routingInput == null) {
             routing = null;
         } else {
@@ -87,6 +89,10 @@ public class RowShardResolver {
 
     private static List<String> pkValues(List<Input<?>> primaryKeyInputs) {
         return Lists2.map(primaryKeyInputs, input -> nullOrString(input.value()));
+    }
+
+    public List<String> pkValues() {
+        return pkValues;
     }
 
     /**

--- a/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class ColumnIndexWriterProjector implements Projector {
@@ -112,14 +111,16 @@ public class ColumnIndexWriterProjector implements Projector {
             true);
 
         InputRow insertValues = new InputRow(insertInputs);
-        Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id,
-                                              assignments,
-                                              insertValues.materialize(),
-                                              null,
-                                              null,
-                                              null
-                                              );
+        ItemFactory<ShardUpsertRequest.Item> itemFactory = (id, values) ->
+            new ShardUpsertRequest.Item(
+                id,
+                assignments,
+                insertValues.materialize(),
+                null,
+                null,
+                null,
+                values
+            );
 
         var upsertResultContext = returnValues.isEmpty() ? UpsertResultContext.forRowCount() : UpsertResultContext.forResultRows();
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
@@ -55,7 +54,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
     private final RowShardResolver rowShardResolver;
     private final List<? extends CollectExpression<Row, ?>> expressions;
     private final List<? extends CollectExpression<Row, ?>> sourceInfoExpressions;
-    private final Function<String, TItem> itemFactory;
+    private final ItemFactory<TItem> itemFactory;
     private final Supplier<String> indexNameResolver;
     private final ClusterService clusterService;
     private final boolean autoCreateIndices;
@@ -70,7 +69,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
                             ToLongFunction<Row> estimateRowSize,
                             Supplier<String> indexNameResolver,
                             List<? extends CollectExpression<Row, ?>> expressions,
-                            Function<String, TItem> itemFactory,
+                            ItemFactory<TItem> itemFactory,
                             boolean autoCreateIndices,
                             UpsertResultContext upsertContext) {
         this.estimateRowSize = estimateRowSize;
@@ -95,7 +94,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
                             ToLongFunction<Row> estimateRowSize,
                             Supplier<String> indexNameResolver,
                             List<? extends CollectExpression<Row, ?>> expressions,
-                            Function<String, TItem> itemFactory,
+                            ItemFactory<TItem> itemFactory,
                             boolean autoCreateIndices) {
         this(clusterService,
              rowShardResolver,
@@ -124,7 +123,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
             }
 
             String id = rowShardResolver.id();
-            TItem item = itemFactory.apply(id);
+            TItem item = itemFactory.create(id, rowShardResolver.pkValues());
             String indexName = indexNameResolver.get();
             String routing = rowShardResolver.routing();
             String sourceUri = sourceUriInput.value();

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -21,6 +21,31 @@
 
 package io.crate.execution.engine.indexing;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
@@ -37,29 +62,6 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.PageCacheRecycler;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 public class IndexWriterProjector implements Projector {
 
@@ -115,8 +117,15 @@ public class IndexWriterProjector implements Projector {
             jobId,
             validation);
 
-        Function<String, ShardUpsertRequest.Item> itemFactory =
-            id -> new ShardUpsertRequest.Item(id, null, new Object[]{source.value()}, null, null, null);
+        ItemFactory<ShardUpsertRequest.Item> itemFactory = (id, pkValues) -> new ShardUpsertRequest.Item(
+            id,
+            null,
+            new Object[]{source.value()},
+            null,
+            null,
+            null,
+            pkValues
+        );
 
         Predicate<UpsertResults> earlyTerminationCondition = results -> failFast && results.containsErrors();
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/ItemFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ItemFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.indexing;
+
+import java.util.List;
+
+public interface ItemFactory<T> {
+    T create(String id, List<String> pkValues);
+}

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -111,7 +111,7 @@ public class ShardingUpsertExecutor
                            int bulkSize,
                            UUID jobId,
                            RowShardResolver rowShardResolver,
-                           Function<String, ShardUpsertRequest.Item> itemFactory,
+                           ItemFactory<ShardUpsertRequest.Item> itemFactory,
                            Function<ShardId, ShardUpsertRequest> requestFactory,
                            List<? extends CollectExpression<Row, ?>> expressions,
                            Supplier<String> indexNameResolver,

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -568,7 +568,8 @@ public class ProjectionToProjectorVisitor
                                               null,
                                               projection.requiredVersion(),
                                               null,
-                                              null),
+                                              null,
+                                              List.of()),
             (req, resp) -> elasticsearchClient.execute(ShardUpsertAction.INSTANCE, req)
                 .whenComplete(ActionListener.toBiConsumer(resp)),
             collector);

--- a/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -169,12 +169,15 @@ public final class UpdateById implements Plan {
                             Long version,
                             Long seqNo,
                             Long primaryTerm) {
-            ShardUpsertRequest.Item item = new ShardUpsertRequest.Item(id,
-                                                                       assignmentSources,
-                                                                       null,
-                                                                       version,
-                                                                       seqNo,
-                                                                       primaryTerm);
+            ShardUpsertRequest.Item item = new ShardUpsertRequest.Item(
+                id,
+                assignmentSources,
+                null,
+                version,
+                seqNo,
+                primaryTerm,
+                List.of()
+            );
             request.add(location, item);
         }
     }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -92,6 +92,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;
 import io.crate.execution.engine.indexing.GroupRowsByShard;
 import io.crate.execution.engine.indexing.IndexNameResolver;
+import io.crate.execution.engine.indexing.ItemFactory;
 import io.crate.execution.engine.indexing.ShardLocation;
 import io.crate.execution.engine.indexing.ShardedRequests;
 import io.crate.execution.jobs.NodeLimits;
@@ -463,12 +464,16 @@ public class InsertFromValues implements LogicalPlan {
                                  PlannerContext plannerContext,
                                  ClusterService clusterService) {
         InputRow insertValues = new InputRow(insertInputs);
-        Function<String, ShardUpsertRequest.Item> itemFactory = id ->
+        ItemFactory<ShardUpsertRequest.Item> itemFactory = (id, pkValues) ->
             new ShardUpsertRequest.Item(
                 id,
                 assignmentSources,
                 insertValues.materialize(),
-                null, null, null);
+                null,
+                null,
+                null,
+                pkValues
+            );
 
         var rowShardResolver = new RowShardResolver(
             plannerContext.transactionContext(),
@@ -517,7 +522,7 @@ public class InsertFromValues implements LogicalPlan {
                 index,
                 true,
                 writerProjection.allTargetColumns()));
-        validator.generateSourceAndCheckConstraints(cells);
+        validator.generateSourceAndCheckConstraints(cells, List.of());
     }
 
     private static Iterator<Row> evaluateValueTableFunction(TableFunctionImplementation<?> funcImplementation,

--- a/server/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -21,6 +21,19 @@
 
 package io.crate.execution.dml.upsert;
 
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import io.crate.common.unit.TimeValue;
 import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -31,18 +44,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
-import org.elasticsearch.test.ESTestCase;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import io.crate.common.unit.TimeValue;
-import org.elasticsearch.index.shard.ShardId;
-import org.junit.Test;
-
-import java.util.UUID;
-
-import static org.hamcrest.Matchers.equalTo;
 
 public class ShardUpsertRequestTest extends ESTestCase {
 
@@ -85,21 +87,24 @@ public class ShardUpsertRequestTest extends ESTestCase {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null));
+            null,
+            List.of()));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
             null,
             null,
-            null));
+            null,
+            List.of()));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
             new Symbol[]{Literal.of(42), Literal.of("Deep Thought")},
             null,
             2L,
             1L,
-            5L
+            5L,
+            List.of()
             ));
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -135,21 +140,24 @@ public class ShardUpsertRequestTest extends ESTestCase {
             new Object[]{99, "Marvin"},
             null,
             null,
-            null));
+            null,
+            List.of()));
         request.add(42, new ShardUpsertRequest.Item(
             "99",
             new Symbol[0],
             new Object[]{99, "Marvin"},
             null,
             null,
-            null));
+            null,
+            List.of()));
         request.add(5, new ShardUpsertRequest.Item(
             "42",
             new Symbol[]{Literal.of(42), Literal.of("Deep Thought")},
             null,
             2L,
             1L,
-            5L));
+            5L,
+            List.of()));
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);

--- a/server/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/SourceFromCellsTest.java
@@ -86,7 +86,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
     public void testGeneratedSourceBytesRef() throws IOException {
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.nodeCtx, t1, "t1", true, Arrays.asList(x, y));
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2}, List.of());
         assertThat(source, is(Map.of("x", 1, "y", 2, "z", 3)));
     }
 
@@ -96,7 +96,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t1, "t1", true, Arrays.asList(x, y, z));
 
         expectedException.expectMessage("Given value 8 for generated column z does not match calculation (x + y) = 3");
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2, 8});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1, 2, 8}, List.of());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t2, "t2", true, Collections.singletonList(obj));
         HashMap<Object, Object> m = new HashMap<>();
         m.put("a", 10);
-        var map = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m});
+        var map = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{m}, List.of());
         assertThat(map.get("b"), is(11));
         assertThat(Maps.getByPath(map, "obj.a"), is(10));
         assertThat(Maps.getByPath(map, "obj.c"), is(13));
@@ -121,7 +121,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t3, partitionName.asIndexName(), true, emptyList());
 
         expectedException.expectMessage("\"p\" must not be null");
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[0], List.of());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t3, partitionName.asIndexName(), true, emptyList());
 
         // this must pass without error
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[0], List.of());
     }
 
     @Test
@@ -147,7 +147,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t4, "t4", true, Arrays.asList(x));
 
         Object[] input = new Object[]{1};
-        var source = sourceFromCells.generateSourceAndCheckConstraints(input);
+        var source = sourceFromCells.generateSourceAndCheckConstraints(input, List.of());
         assertThat(source, is(Map.of("x", 1, "y", "crate")));
     }
 
@@ -162,7 +162,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t4, "t4", true, Arrays.asList(x, y));
 
         Object[] input = {1, "cr8"};
-        var source = sourceFromCells.generateSourceAndCheckConstraints(input);
+        var source = sourceFromCells.generateSourceAndCheckConstraints(input, List.of());
         assertThat(source, is(Map.of("x", 1, "y", "cr8")));
     }
 
@@ -178,7 +178,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         providedValueForObj.put("a", 10);
         providedValueForObj.put("c", 13);
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj}, List.of());
 
         assertThat(Maps.getByPath(source, "obj.a"), is(10));
         assertThat(Maps.getByPath(source, "b"), is(11));
@@ -198,7 +198,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         providedValueForObj.put("c", 14);
 
         expectedException.expectMessage("Given value 14 for generated column obj['c'] does not match calculation (obj['a'] + 3) = 13");
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj}, List.of());
     }
 
     @Test
@@ -212,7 +212,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t5, "t4", true, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("y", 2);
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj}, List.of());
         assertThat(Maps.getByPath(source, "obj.x"), is(0));
         assertThat(Maps.getByPath(source, "obj.y"), is(2));
     }
@@ -228,7 +228,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             txnCtx, e.nodeCtx, t5, "t5", true, targets);
         HashMap<String, Object> providedValueForObj = new HashMap<>();
         providedValueForObj.put("x", 2);
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{providedValueForObj}, List.of());
         assertThat(Maps.getByPath(source, "obj.x"), is(2));
     }
 
@@ -237,7 +237,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo t6 = e.resolveTableInfo("t6");
         InsertSourceFromCells sourceFromCells = new InsertSourceFromCells(
             txnCtx, e.nodeCtx, t6, "t6", true, List.of());
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0]);
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[0], List.of());
         assertThat(Maps.getByPath(source, "x"), is(1));
         assertThat(Maps.getByPath(source, "y"), is(2));
     }
@@ -256,7 +256,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             true,
             List.of(Objects.requireNonNull(tableInfo.getReference(new ColumnIdent("x")))));
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{1}, List.of());
 
         assertThat(source, is(Map.of("x", 1, "y", 1)));
     }
@@ -278,7 +278,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             true,
             List.of());
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{}, List.of());
 
         assertThat(source, is(Map.of("x", "test")));
     }
@@ -298,7 +298,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             List.copyOf(tableInfo.columns())
         );
         var payloads = List.of(Map.of("x", 10), Map.of("x", 20));
-        var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { payloads });
+        var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { payloads }, List.of());
         assertThat(source, is(Map.of("payloads", List.of(Map.of("x", 10), Map.of("x", 20)))));
     }
 
@@ -322,7 +322,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> obj = new HashMap<>();
         obj.put("x", 10);
         obj.put("p", 1);
-        var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { obj });
+        var source = sourceGen.generateSourceAndCheckConstraints(new Object[] { obj }, List.of());
         assertThat(source, is(Map.of("obj", Map.of("x", 10))));
     }
 
@@ -340,7 +340,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             true,
             List.of()
         );
-        var source = sourceGen.generateSourceAndCheckConstraints(new Object[]{});
+        var source = sourceGen.generateSourceAndCheckConstraints(new Object[]{}, List.of());
         assertThat(source, is(Map.of("str", "ab")));
     }
 
@@ -360,7 +360,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         );
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("'ab' is too long for the text type of length: 1");
-        sourceGen.generateSourceAndCheckConstraints(new Object[]{});
+        sourceGen.generateSourceAndCheckConstraints(new Object[]{}, List.of());
     }
 
     @Test
@@ -379,7 +379,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
         );
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("'ab ' is too long for the text type of length: 1");
-        sourceGen.generateSourceAndCheckConstraints(new Object[]{});
+        sourceGen.generateSourceAndCheckConstraints(new Object[]{}, List.of());
     }
 
     @Test
@@ -398,7 +398,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             true,
             List.of(name, model)
         );
-        Map<String, Object> source = sourceGen.generateSourceAndCheckConstraints(new Object[] { "foo", null });
+        Map<String, Object> source = sourceGen.generateSourceAndCheckConstraints(new Object[] { "foo", null }, List.of());
         assertThat(source, not(Matchers.hasKey("model")));
     }
 
@@ -418,9 +418,9 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             List.of(x)
         );
         Map<String, Object> result;
-        result = sourceGen.generateSourceAndCheckConstraints(new Object[] { 10 });
+        result = sourceGen.generateSourceAndCheckConstraints(new Object[] { 10 }, List.of());
         var id1 = result.get("id");
-        result = sourceGen.generateSourceAndCheckConstraints(new Object[] { 20 });
+        result = sourceGen.generateSourceAndCheckConstraints(new Object[] { 20 }, List.of());
         var id2 = result.get("id");
         assertThat(id1, Matchers.notNullValue());
         assertThat(id1, Matchers.not(is(id2)));
@@ -448,7 +448,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             List.of(ts, g_ts_month)
         );
         Map<String, Object> generateSourceAndCheckConstraints =
-            sourceGen.generateSourceAndCheckConstraints(new Object[] { 1631628823105L, 1630454400000L });
+            sourceGen.generateSourceAndCheckConstraints(new Object[] { 1631628823105L, 1630454400000L }, List.of());
         assertThat(generateSourceAndCheckConstraints, Matchers.hasEntry("ts", 1631628823105L));
         assertThat("partition value must not become part of the source", generateSourceAndCheckConstraints.size(), is(1));
     }
@@ -475,7 +475,7 @@ public class SourceFromCellsTest extends CrateDummyClusterServiceUnitTest {
             List.of(ts, g_ts_month)
         );
         assertThrows(IllegalArgumentException.class, () -> {
-            sourceGen.generateSourceAndCheckConstraints(new Object[] { 1631628823105L, 2630454400000L });
+            sourceGen.generateSourceAndCheckConstraints(new Object[] { 1631628823105L, 2630454400000L }, List.of());
         });
     }
 }

--- a/server/src/test/java/io/crate/execution/dml/upsert/ValidatedRawInsertSourceTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/ValidatedRawInsertSourceTest.java
@@ -83,7 +83,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         DocTableInfo t = e.resolveTableInfo("t");
         ValidatedRawInsertSource insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "t");
         Asserts.assertThrowsMatches(
-            () -> insertSource.generateSourceAndCheckConstraints(new Object[]{"{}}"}), // trailing '}'
+            () -> insertSource.generateSourceAndCheckConstraints(new Object[]{"{}}"}, List.of()), // trailing '}'
             IllegalArgumentException.class,
             "failed to parse `}`"
         );
@@ -97,7 +97,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         DocTableInfo t = e.resolveTableInfo("t");
         ValidatedRawInsertSource insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "t");
         Asserts.assertThrowsMatches(
-            () -> insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"b\": \"\"}"}),
+            () -> insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"b\": \"\"}"}, List.of()),
             IllegalArgumentException.class,
             "Cannot cast value `` to type `boolean`"
         );
@@ -111,7 +111,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         DocTableInfo t = e.resolveTableInfo("t");
         ValidatedRawInsertSource insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "t");
         Asserts.assertThrowsMatches(
-            () -> insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"b\": \"\"}"}),
+            () -> insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"b\": \"\"}"}, List.of()),
             StrictDynamicMappingException.class,
             "mapping set to strict, dynamic introduction of [b] within [doc.t] is not allowed"
         );
@@ -126,7 +126,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         ValidatedRawInsertSource insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "t");
 
         // iteration 1
-        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":1, \"y\":2}"});
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":1, \"y\":2}"}, List.of());
         assertThat(Maps.getByPath(map, "x"), is(1));
         assertThat(Maps.getByPath(map, "y"), is(2));
         assertThat(Maps.getByPath(map, "z"), is(3));
@@ -136,7 +136,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         assertThat(insertSource.refLookUpCache.presentColumns.size(), is(0)); // check that it is cleared
 
         // iteration 2
-        map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":10}"});
+        map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":10}"}, List.of());
         assertThat(Maps.getByPath(map, "x"), is(10));
         assertThat(Maps.getByPath(map, "y"), is(11));
         assertThat(Maps.getByPath(map, "z"), is(12));
@@ -146,7 +146,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         assertThat(insertSource.refLookUpCache.presentColumns.size(), is(0)); // check that it is cleared
 
         // iteration 3
-        map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":20, \"newCol\":\"hello\"}"});
+        map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":20, \"newCol\":\"hello\"}"}, List.of());
         assertThat(Maps.getByPath(map, "x"), is(20));
         assertThat(Maps.getByPath(map, "y"), is(21));
         assertThat(Maps.getByPath(map, "z"), is(22));
@@ -158,7 +158,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         assertThat(insertSource.refLookUpCache.presentColumns.size(), is(0)); // check that it is cleared
 
         // iteration 4
-        map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":100, \"y\":101, \"z\":102}"});
+        map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":100, \"y\":101, \"z\":102}"}, List.of());
         assertThat(Maps.getByPath(map, "x"), is(100));
         assertThat(Maps.getByPath(map, "y"), is(101));
         assertThat(Maps.getByPath(map, "z"), is(102));
@@ -214,7 +214,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             .build();
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         ValidatedRawInsertSource insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "generated_based_on_default");
-        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"}, List.of());
         assertThat(Maps.getByPath(map, "x"), is(1));
         assertThat(Maps.getByPath(map, "y"), is(2));
     }
@@ -226,7 +226,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             .build();
         DocTableInfo t = e.resolveTableInfo("generated_based_on_default");
         ValidatedRawInsertSource insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "generated_based_on_default");
-        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"});
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{\"x\":2}"}, List.of());
         assertThat(Maps.getByPath(map, "x"), is(2));
         assertThat(Maps.getByPath(map, "y"), is(3));
     }
@@ -238,7 +238,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             .build();
         DocTableInfo t = e.resolveTableInfo("t");
         var insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "t");
-        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
+        Map<String, Object> map = insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"}, List.of());
         assertThat(Maps.getByPath(map, "x"), is("ab"));
     }
 
@@ -251,7 +251,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         var insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "t");
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("'abc' is too long for the text type of length: 2");
-        insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
+        insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"}, List.of());
     }
 
     @Test
@@ -263,7 +263,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         var insertSource = new ValidatedRawInsertSource(t, txnCtx, e.nodeCtx, "t");
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("'abc' is too long for the text type of length: 2");
-        insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"});
+        insertSource.generateSourceAndCheckConstraints(new Object[]{"{}"}, List.of());
     }
 
     @Test
@@ -271,13 +271,13 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t1, txnCtx, e.nodeCtx, "t1");
 
         expectedException.expectMessage("Given value 8 for generated column z does not match calculation (x + y) = 3");
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"x\":1, \"y\":2, \"z\":8}"});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"x\":1, \"y\":2, \"z\":8}"}, List.of());
     }
 
     @Test
     public void testGeneratedColumnGenerationThatDependsOnNestedColumnOfObject() throws IOException {
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t2, txnCtx, e.nodeCtx, "t2");
-        var map = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"a\":10}}"});
+        var map = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"a\":10}}"}, List.of());
         assertThat(map.get("b"), is(11));
         assertThat(Maps.getByPath(map, "obj.a"), is(10));
         assertThat(Maps.getByPath(map, "obj.c"), is(13));
@@ -292,7 +292,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t3, txnCtx, e.nodeCtx, partitionName.asIndexName());
 
         expectedException.expectMessage("\"p\" must not be null");
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{}"});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{}"}, List.of());
     }
 
     @Test
@@ -304,7 +304,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t3, txnCtx, e.nodeCtx, partitionName.asIndexName());
 
         // this must pass without error
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{}"});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{}"}, List.of());
     }
 
     @Test
@@ -314,7 +314,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
 
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t4, txnCtx, e.nodeCtx, "t4");
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[] {"{\"x\":1}"});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[] {"{\"x\":1}"}, List.of());
         assertThat(source, is(Map.of("x", 1, "y", "crate")));
     }
 
@@ -325,7 +325,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
 
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t4, txnCtx, e.nodeCtx, "t4");
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[] {"{\"x\":1, \"y\": \"cr8\"}"});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[] {"{\"x\":1, \"y\": \"cr8\"}"}, List.of());
         assertThat(source, is(Map.of("x", 1, "y", "cr8")));
     }
 
@@ -336,7 +336,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         // b as obj['a'] + 1
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t2, txnCtx, e.nodeCtx, "t2");
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[] {"{\"obj\":{\"a\":10, \"c\":13}}"});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[] {"{\"obj\":{\"a\":10, \"c\":13}}"}, List.of());
 
         assertThat(Maps.getByPath(source, "obj.a"), is(10));
         assertThat(Maps.getByPath(source, "b"), is(11));
@@ -351,7 +351,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t2, txnCtx, e.nodeCtx, "t2");
 
         expectedException.expectMessage("Given value 14 for generated column obj['c'] does not match calculation (obj['a'] + 3) = 13");
-        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"a\":10, \"c\":14}}"});
+        sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"a\":10, \"c\":14}}"}, List.of());
     }
 
     @Test
@@ -362,7 +362,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         assertThat(obj, Matchers.notNullValue());
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t5, txnCtx, e.nodeCtx, "t4");
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"y\":2}}"});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"y\":2}}"}, List.of());
         assertThat(Maps.getByPath(source, "obj.x"), is(0));
         assertThat(Maps.getByPath(source, "obj.y"), is(2));
     }
@@ -375,7 +375,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
         assertThat(obj, Matchers.notNullValue());
         ValidatedRawInsertSource sourceFromCells = new ValidatedRawInsertSource(t5, txnCtx, e.nodeCtx, "t5");
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"x\":2}}"});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"obj\":{\"x\":2}}"}, List.of());
         assertThat(Maps.getByPath(source, "obj.x"), is(2));
     }
 
@@ -391,7 +391,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             e.nodeCtx,
             "t");
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"x\":1}"});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{\"x\":1}"}, List.of());
 
         assertThat(source, is(Map.of("x", 1, "y", 1)));
     }
@@ -411,7 +411,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             e.nodeCtx,
             partition.asIndexName());
 
-        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{}"});
+        var source = sourceFromCells.generateSourceAndCheckConstraints(new Object[]{"{}"}, List.of());
 
         assertThat(source, is(Map.of("x", "test")));
     }
@@ -429,9 +429,9 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             tbl.concreteIndices()[0]
         );
         Map<String, Object> result;
-        result = sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"x\":10}"});
+        result = sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"x\":10}"}, List.of());
         var id1 = result.get("id");
-        result = sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"x\":20}"});
+        result = sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"x\":20}"}, List.of());
         var id2 = result.get("id");
         assertThat(id1, Matchers.notNullValue());
         assertThat(id1, Matchers.not(is(id2)));
@@ -455,7 +455,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             new PartitionName(tbl.ident(), List.of("1630454400000")).asIndexName()
         );
         Map<String, Object> generateSourceAndCheckConstraints =
-            sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"ts\": 1631628823105, \"g_ts_month\": 1630454400000}"});
+            sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"ts\": 1631628823105, \"g_ts_month\": 1630454400000}"}, List.of());
         assertThat(generateSourceAndCheckConstraints, Matchers.hasEntry("ts", 1631628823105L));
         assertThat(generateSourceAndCheckConstraints, Matchers.hasEntry("g_ts_month", 1630454400000L));
         assertThat(generateSourceAndCheckConstraints.size(), is(2));
@@ -479,7 +479,7 @@ public class ValidatedRawInsertSourceTest extends CrateDummyClusterServiceUnitTe
             new PartitionName(tbl.ident(), List.of("1630454400000")).asIndexName()
         );
         assertThrows(IllegalArgumentException.class, () -> {
-            sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"ts\": 1631628823105, \"g_ts_month\": 2630454400000}"});
+            sourceGen.generateSourceAndCheckConstraints(new Object[] {"{\"ts\": 1631628823105, \"g_ts_month\": 2630454400000}"}, List.of());
         });
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1636,4 +1636,19 @@ public class InsertIntoIntegrationTest extends SQLIntegrationTestCase {
             "{x=10, y=20}| {\"x\":10,\"y\":20}\n"
         ));
     }
+
+    @Test
+    public void test_insert_into_table_with_primary_key_with_default_clause_sets_right_id() {
+        execute("create table tbl (id text default gen_random_text_uuid() primary key, x int)");
+        execute("insert into tbl (x) values (1)");
+        execute("refresh table tbl");
+        execute("select _id, id from tbl");
+        assertThat("_id and id must match", response.rows()[0][0], is(response.rows()[0][1]));
+
+        String id = (String) response.rows()[0][1];
+        execute("select x from tbl where id = ?", new Object[] { id });
+        assertThat(printedTable(response.rows()), is(
+            "1\n"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We compute the primary key value early because it is needed for sharding.
This led to a problem with nondeterministic `DEFAULT` functions
because those got computed a second time when the source gets generated.

We ended up using the `_id` of the first computation and the primary key column
values from the second generation. Leading to a mismatch.

Closes https://github.com/crate/crate/issues/12427

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
