### PR TITLE
Account for 4.7.3 release in ShardUpsertRequest.Item streaming

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -342,6 +342,10 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             return pkValues;
         }
 
+        private static boolean streamPkValues(Version version) {
+            return version.after(Version.V_4_7_2) && !version.equals(Version.V_4_8_0);
+        }
+
         public Item(StreamInput in, @Nullable Streamer[] insertValueStreamers) throws IOException {
             super(in);
             if (in.readBoolean()) {
@@ -363,7 +367,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             if (in.readBoolean()) {
                 source = in.readBytesReference();
             }
-            if (in.getVersion().after(Version.V_4_8_0)) {
+            if (streamPkValues(in.getVersion())) {
                 pkValues = in.readList(StreamInput::readString);
             } else {
                 pkValues = List.of();
@@ -396,7 +400,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             if (sourceAvailable) {
                 out.writeBytesReference(source);
             }
-            if (out.getVersion().after(Version.V_4_8_0)) {
+            if (streamPkValues(out.getVersion())) {
                 out.writeStringCollection(pkValues);
             }
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The streaming change is also backported to 4.7, so we need to include
the pkValues in >= 4.7.3 and in >= 4.8.1 but not 4.8.0

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
