### PR TITLE
Fix retrieval of relation names in logical plan operators

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -41,6 +41,7 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
+import io.crate.common.collections.Sets;
 import io.crate.common.collections.Tuple;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.HashJoinPhase;
@@ -228,6 +229,11 @@ public class HashJoin implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return Lists2.concat(lhs.baseTables(), rhs.baseTables());
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Sets.union(lhs.getRelationNames(), rhs.getRelationNames());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -27,6 +27,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Maps;
+import io.crate.common.collections.Sets;
 import io.crate.common.collections.Tuple;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -39,6 +40,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.RelationName;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
@@ -108,6 +110,11 @@ public class NestedLoopJoin implements LogicalPlan {
         this(lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation);
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Sets.union(lhs.getRelationNames(), rhs.getRelationNames());
     }
 
     public boolean isRewriteFilterOnOuterJoinToInnerJoinDone() {

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -39,6 +39,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Maps;
+import io.crate.common.collections.Sets;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.projection.EvalProjection;
@@ -48,6 +49,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.RelationName;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -184,6 +186,11 @@ public class Union implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return Lists2.concat(lhs.baseTables(), rhs.baseTables());
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Sets.union(lhs.getRelationNames(), rhs.getRelationNames());
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.util.List;
+
+import org.elasticsearch.common.Randomness;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.relations.AliasedAnalyzedRelation;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
+import io.crate.planner.node.dql.join.JoinType;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
+import io.crate.types.DataTypes;
+
+public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+    private AbstractTableRelation<?> t1Relation;
+    private AbstractTableRelation<?> t2Relation;
+    private RelationName t1RenamedRelationName;
+    private RelationName t2RenamedRelationName;
+    private Rename t1Rename;
+    private Rename t2Rename;
+
+    @Before
+    public void setup() throws Exception {
+        e = SQLExecutor.builder(clusterService, 2, Randomness.get(), List.of())
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
+            .addTable(T3.T3_DEFINITION)
+            .build();
+
+        DocTableInfo t1 = e.resolveTableInfo("t1");
+        Reference x = (Reference) e.asSymbol("x");
+        t1Relation = new DocTableRelation(t1);
+        t1RenamedRelationName = new RelationName("doc", "t1_renamed");
+        var t1Alias = new AliasedAnalyzedRelation(t1Relation, t1RenamedRelationName);
+        var t1Collect = new Collect(t1Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        Symbol t1Output = t1Alias.getField(x.column(), Operation.READ, true);
+        t1Rename = new Rename(List.of(t1Output), t1Alias.relationName(), t1Alias, t1Collect);
+
+        DocTableInfo t2 = e.resolveTableInfo("t2");
+        Reference y = (Reference) e.asSymbol("y");
+        t2Relation = new DocTableRelation(t2);
+        t2RenamedRelationName = new RelationName("doc", "t2_renamed");
+        var t2Alias = new AliasedAnalyzedRelation(t2Relation, t2RenamedRelationName);
+        var t2Collect = new Collect(t2Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        Symbol t2Output = t2Alias.getField(y.column(), Operation.READ, true);
+        t2Rename = new Rename(List.of(t2Output), t2Alias.relationName(), t2Alias, t2Collect);
+    }
+
+    @Test
+    public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
+        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"), t1Relation);
+        assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
+        assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
+    }
+
+    @Test
+    public void test_relationnames_are_based_on_sources_in_nestedloopjoin() {
+        var nestedLoopJoin = new NestedLoopJoin(t1Rename, t2Rename, JoinType.INNER, e.asSymbol("x = y"), false, t1Relation);
+        assertThat(nestedLoopJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
+        assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
+    }
+
+    @Test
+    public void test_relationnames_are_based_on_sources_in_union() {
+        var union = new Union(t1Rename, t2Rename, List.of());
+        assertThat(union.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
+        assertThat(union.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Currently the relation names in a logical plan operator are retrieved from the base tables of the operator. However, the relation names of an operator can be different to its base tables. 

See https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/planner/operators/Rename.java#L215 

Therefore operators which internally use other operators as sources must retrieve the relation names directly.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
