### PR TITLE
Set final newline for all filetypes in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,9 @@
 
 root = true
 
+[*]
+insert_final_newline = true
+
 [*.txt]
 charset = utf-8
 
@@ -10,7 +13,6 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
-insert_final_newline = true
 
 [*.gradle]
 charset = utf-8


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Got some conflicts in the unreleased.rst due to different final newline
settings.
Might help prevent that in the future


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
