### PR TITLE
Make hashjoin work with multiple relations on the right-hand-side

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
@@ -75,6 +75,7 @@ public class SqlParser {
     }
 
     public static List<Statement> createStatements(String sql) {
+        System.out.println("sql = " + sql);
         return ((MultiStatement) INSTANCE.generateStatements(sql)).statements();
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -29,6 +29,7 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.where.WhereClauseAnalyzer;
 import io.crate.common.collections.Lists2;
+import io.crate.common.collections.Sets;
 import io.crate.data.Row;
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
@@ -46,6 +47,7 @@ import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
@@ -326,6 +328,11 @@ public class Collect implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return baseTables;
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(relation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -42,6 +42,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
@@ -135,6 +136,11 @@ public class Count implements LogicalPlan {
     @Override
     public List<LogicalPlan> sources() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(tableRelation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -219,6 +219,11 @@ public class Get implements LogicalPlan {
     }
 
     @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(tableRelation.relationName());
+    }
+
+    @Override
     public List<LogicalPlan> sources() {
         return List.of();
     }

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -305,7 +305,6 @@ public class HashJoin implements LogicalPlan {
                 }
             }
         }
-        assert (!result.isEmpty()) : "Hash Join symbols for Logical Plan must not be empty";
         return result;
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -41,6 +41,7 @@ import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -114,6 +115,11 @@ public class Insert implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -104,6 +104,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -832,6 +833,11 @@ public class InsertFromValues implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -117,7 +117,6 @@ public class JoinPlanBuilder {
             joinType,
             joinCondition,
             lhs,
-            rhs,
             query,
             hashJoinEnabled
         );
@@ -166,15 +165,14 @@ public class JoinPlanBuilder {
                                               JoinType joinType,
                                               Symbol joinCondition,
                                               AnalyzedRelation lhs,
-                                              AnalyzedRelation rhs,
                                               Symbol query,
                                               boolean hashJoinEnabled) {
         if (hashJoinEnabled && isHashJoinPossible(joinType, joinCondition)) {
             return new HashJoin(
                 lhsPlan,
                 rhsPlan,
-                joinCondition,
-                rhs);
+                joinCondition
+            );
         } else {
             return new NestedLoopJoin(
                 lhsPlan,
@@ -232,7 +230,6 @@ public class JoinPlanBuilder {
                 type,
                 condition,
                 leftRelation,
-                nextRel,
                 query,
                 hashJoinEnabled),
             query

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -226,9 +226,7 @@ public interface LogicalPlan extends Plan {
         return StatementType.SELECT;
     }
 
-    default Set<RelationName> getRelationNames() {
-        return baseTables().stream().map(AnalyzedRelation::relationName).collect(Collectors.toSet());
-    }
+    Set<RelationName> getRelationNames();
 
     default void print(PrintContext printContext) {
         printContext

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -35,6 +35,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -119,6 +120,11 @@ public final class TableFunction implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(relation.relationName());
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -245,7 +245,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(HashJoin.class));
-        assertThat(((HashJoin) operator).concreteRelation.toString(), is("DocTableRelation{doc.locations}"));
+        // smaller table must be on the right-hand-side
+        assertThat(((HashJoin) operator).rhs().getRelationNames(), contains(TEST_DOC_LOCATIONS_TABLE_IDENT));
 
         Join join = buildJoin(operator);
         assertThat(((Collect) join.left()).collectPhase().toCollect().get(1), isReference("other_id"));
@@ -265,7 +266,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(HashJoin.class));
-        assertThat(((HashJoin) operator).concreteRelation.toString(), is("DocTableRelation{doc.locations}"));
+        // smaller table must be on the right-hand-side
+        assertThat(((HashJoin) operator).rhs.getRelationNames(), contains(TEST_DOC_LOCATIONS_TABLE_IDENT));
 
         Join join = buildJoin(operator);
         assertThat(((Collect) join.left()).collectPhase().toCollect().get(1), isReference("loc"));

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -83,7 +83,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"), t1Relation);
+        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
         assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Hash-joins are currently depending on a 'concrete relation' which is used to plan the distribution of the execution tasks. The concrete relation is always derived from the right-hand-side in the codebase. This limits the hash-join to handle only a single relations on the right-hand-side. 

This removes the concrete relation, adapts the distribution and makes it work with multiple relations on both sides of the operator.

This is a pre-requisite for the `MoveConstantJoinConditionsBeneathNestedLoop` rule.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
