### PR TITLE
Fix more relation names retrieval in logical plan operators

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -46,6 +46,7 @@ import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
@@ -326,6 +327,11 @@ public class Collect implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return baseTables;
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(relation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -42,6 +42,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
@@ -135,6 +136,11 @@ public class Count implements LogicalPlan {
     @Override
     public List<LogicalPlan> sources() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(tableRelation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -219,6 +219,11 @@ public class Get implements LogicalPlan {
     }
 
     @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(tableRelation.relationName());
+    }
+
+    @Override
     public List<LogicalPlan> sources() {
         return List.of();
     }

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -41,6 +41,7 @@ import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -114,6 +115,11 @@ public class Insert implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -104,6 +104,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -832,6 +833,11 @@ public class InsertFromValues implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
-import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -43,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * LogicalPlan is a tree of "Operators"
@@ -226,9 +224,7 @@ public interface LogicalPlan extends Plan {
         return StatementType.SELECT;
     }
 
-    default Set<RelationName> getRelationNames() {
-        return baseTables().stream().map(AnalyzedRelation::relationName).collect(Collectors.toSet());
-    }
+    Set<RelationName> getRelationNames();
 
     default void print(PrintContext printContext) {
         printContext

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -35,6 +35,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -119,6 +120,11 @@ public final class TableFunction implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(relation.relationName());
     }
 
     @Override


### PR DESCRIPTION
Follow up, see https://github.com/crate/crate/commit/ff83c3f15efc571aab8d4b4349e58283c018298d for the details.

Precursor for https://github.com/crate/crate/pull/12459

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
