### PR TITLE
Make hashjoin work with multiple relations on the right-hand-side

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -46,6 +46,7 @@ import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
@@ -326,6 +327,11 @@ public class Collect implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return baseTables;
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(relation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -42,6 +42,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
@@ -135,6 +136,11 @@ public class Count implements LogicalPlan {
     @Override
     public List<LogicalPlan> sources() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(tableRelation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -219,6 +219,11 @@ public class Get implements LogicalPlan {
     }
 
     @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(tableRelation.relationName());
+    }
+
+    @Override
     public List<LogicalPlan> sources() {
         return List.of();
     }

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -32,17 +32,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
-import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Sets;
-import io.crate.common.collections.Tuple;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.HashJoinPhase;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -68,20 +64,16 @@ import io.crate.statistics.TableStats;
 public class HashJoin implements LogicalPlan {
 
     private final Symbol joinCondition;
-    @VisibleForTesting
-    final AnalyzedRelation concreteRelation;
     private final List<Symbol> outputs;
     final LogicalPlan rhs;
     final LogicalPlan lhs;
 
     public HashJoin(LogicalPlan lhs,
                     LogicalPlan rhs,
-                    Symbol joinCondition,
-                    AnalyzedRelation concreteRelation) {
+                    Symbol joinCondition) {
         this.outputs = Lists2.concat(lhs.outputs(), rhs.outputs());
         this.lhs = lhs;
         this.rhs = rhs;
-        this.concreteRelation = concreteRelation;
         this.joinCondition = joinCondition;
     }
 
@@ -129,11 +121,9 @@ public class HashJoin implements LogicalPlan {
         LogicalPlan leftLogicalPlan = lhs;
         LogicalPlan rightLogicalPlan = rhs;
 
-        boolean tablesSwitched = false;
         // We move smaller table to the right side since benchmarking
         // revealed that this improves performance in most cases.
         if (lhs.numExpectedRows() < rhs.numExpectedRows()) {
-            tablesSwitched = true;
             leftLogicalPlan = rhs;
             rightLogicalPlan = lhs;
 
@@ -143,8 +133,24 @@ public class HashJoin implements LogicalPlan {
         }
 
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
-        Tuple<List<Symbol>, List<Symbol>> hashSymbols =
-            extractHashJoinSymbolsFromJoinSymbolsAndSplitPerSide(tablesSwitched);
+        var hashSymbols = HashJoinConditionSymbolsExtractor.extract(joinCondition);
+        // First extract the symbols that belong to rhs
+        var rhsHashSymbols = new ArrayList<Symbol>();
+        for (var relationName : rightLogicalPlan.getRelationNames()) {
+            var symbols = hashSymbols.remove(relationName);
+            if (symbols != null) {
+                for (var symbol : symbols) {
+                    rhsHashSymbols.add(paramBinder.apply(symbol));
+                }
+            }
+        }
+        // All leftover extracted symbols belong to the lhs
+        var lhsHashSymbols = new ArrayList<Symbol>();
+        for (var symbols : hashSymbols.values()) {
+            for (Symbol symbol : symbols) {
+                lhsHashSymbols.add(paramBinder.apply(symbol));
+            }
+        }
 
         ResultDescription leftResultDesc = leftExecutionPlan.resultDescription();
         ResultDescription rightResultDesc = rightExecutionPlan.resultDescription();
@@ -180,8 +186,8 @@ public class HashJoin implements LogicalPlan {
         } else {
             if (isDistributed) {
                 // Run the join distributed by modulo distribution algorithm
-                leftOutputs = setModuloDistribution(Lists2.map(hashSymbols.v1(), paramBinder), leftLogicalPlan.outputs(), leftExecutionPlan);
-                rightOutputs = setModuloDistribution(Lists2.map(hashSymbols.v2(), paramBinder), rightLogicalPlan.outputs(), rightExecutionPlan);
+                leftOutputs = setModuloDistribution(lhsHashSymbols, leftLogicalPlan.outputs(), leftExecutionPlan);
+                rightOutputs = setModuloDistribution(rhsHashSymbols, rightLogicalPlan.outputs(), rightExecutionPlan);
             } else {
                 // Run the join non-distributed on the handler node
                 joinExecutionNodes = Collections.singletonList(plannerContext.handlerNode());
@@ -204,8 +210,8 @@ public class HashJoin implements LogicalPlan {
             rightOutputs.size(),
             joinExecutionNodes,
             InputColumns.create(paramBinder.apply(joinCondition), joinOutputs),
-            InputColumns.create(Lists2.map(hashSymbols.v1(), paramBinder), new InputColumns.SourceSymbols(leftOutputs)),
-            InputColumns.create(Lists2.map(hashSymbols.v2(), paramBinder), new InputColumns.SourceSymbols(rightOutputs)),
+            InputColumns.create(lhsHashSymbols, new InputColumns.SourceSymbols(leftOutputs)),
+            InputColumns.create(rhsHashSymbols, new InputColumns.SourceSymbols(rightOutputs)),
             Symbols.typeView(leftOutputs),
             leftLogicalPlan.estimatedRowSize(),
             leftLogicalPlan.numExpectedRows());
@@ -246,8 +252,7 @@ public class HashJoin implements LogicalPlan {
         return new HashJoin(
             sources.get(0),
             sources.get(1),
-            joinCondition,
-            concreteRelation
+            joinCondition
         );
     }
 
@@ -269,8 +274,7 @@ public class HashJoin implements LogicalPlan {
         return new HashJoin(
             newLhs,
             newRhs,
-            joinCondition,
-            concreteRelation
+            joinCondition
         );
     }
 
@@ -298,28 +302,11 @@ public class HashJoin implements LogicalPlan {
             new HashJoin(
                 lhsFetchRewrite == null ? lhs : lhsFetchRewrite.newPlan(),
                 rhsFetchRewrite == null ? rhs : rhsFetchRewrite.newPlan(),
-                joinCondition,
-                concreteRelation
+                joinCondition
             )
         );
     }
 
-    private Tuple<List<Symbol>, List<Symbol>> extractHashJoinSymbolsFromJoinSymbolsAndSplitPerSide(boolean switchedTables) {
-        Map<RelationName, List<Symbol>> hashJoinSymbols = HashJoinConditionSymbolsExtractor.extract(joinCondition);
-
-        // First extract the symbols that belong to the concrete relation
-        List<Symbol> hashJoinSymbolsForConcreteRelation = hashJoinSymbols.remove(concreteRelation.relationName());
-
-        // All leftover extracted symbols belong to the other relation which might be a
-        // "concrete" relation too but can already be a tree of relation.
-        List<Symbol> hashJoinSymbolsForJoinTree =
-            hashJoinSymbols.values().stream().flatMap(List::stream).collect(Collectors.toList());
-
-        if (switchedTables) {
-            return new Tuple<>(hashJoinSymbolsForConcreteRelation, hashJoinSymbolsForJoinTree);
-        }
-        return new Tuple<>(hashJoinSymbolsForJoinTree, hashJoinSymbolsForConcreteRelation);
-    }
 
     @Override
     public long numExpectedRows() {

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -41,6 +41,7 @@ import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -114,6 +115,11 @@ public class Insert implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -104,6 +104,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -832,6 +833,11 @@ public class InsertFromValues implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -117,7 +117,6 @@ public class JoinPlanBuilder {
             joinType,
             joinCondition,
             lhs,
-            rhs,
             query,
             hashJoinEnabled
         );
@@ -166,15 +165,14 @@ public class JoinPlanBuilder {
                                               JoinType joinType,
                                               Symbol joinCondition,
                                               AnalyzedRelation lhs,
-                                              AnalyzedRelation rhs,
                                               Symbol query,
                                               boolean hashJoinEnabled) {
         if (hashJoinEnabled && isHashJoinPossible(joinType, joinCondition)) {
             return new HashJoin(
                 lhsPlan,
                 rhsPlan,
-                joinCondition,
-                rhs);
+                joinCondition
+            );
         } else {
             return new NestedLoopJoin(
                 lhsPlan,
@@ -232,7 +230,6 @@ public class JoinPlanBuilder {
                 type,
                 condition,
                 leftRelation,
-                nextRel,
                 query,
                 hashJoinEnabled),
             query

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
-import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -43,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * LogicalPlan is a tree of "Operators"
@@ -226,9 +224,7 @@ public interface LogicalPlan extends Plan {
         return StatementType.SELECT;
     }
 
-    default Set<RelationName> getRelationNames() {
-        return baseTables().stream().map(AnalyzedRelation::relationName).collect(Collectors.toSet());
-    }
+    Set<RelationName> getRelationNames();
 
     default void print(PrintContext printContext) {
         printContext

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -35,6 +35,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -119,6 +120,11 @@ public final class TableFunction implements LogicalPlan {
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
         return List.of();
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of(relation.relationName());
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -245,7 +245,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(HashJoin.class));
-        assertThat(((HashJoin) operator).concreteRelation.toString(), is("DocTableRelation{doc.locations}"));
+        // smaller table must be on the right-hand-side
+        assertThat(((HashJoin) operator).rhs().getRelationNames(), contains(TEST_DOC_LOCATIONS_TABLE_IDENT));
 
         Join join = buildJoin(operator);
         assertThat(((Collect) join.left()).collectPhase().toCollect().get(1), isReference("other_id"));
@@ -265,7 +266,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
         assertThat(operator, instanceOf(HashJoin.class));
-        assertThat(((HashJoin) operator).concreteRelation.toString(), is("DocTableRelation{doc.locations}"));
+        // smaller table must be on the right-hand-side
+        assertThat(((HashJoin) operator).rhs.getRelationNames(), contains(TEST_DOC_LOCATIONS_TABLE_IDENT));
 
         Join join = buildJoin(operator);
         assertThat(((Collect) join.left()).collectPhase().toCollect().get(1), isReference("loc"));

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -85,7 +85,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"), t1Relation);
+        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
         assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }


### PR DESCRIPTION
Hash-joins are currently depending on a concrete relation which is used to plan
the distribution of the execution task. The concrete relation is always derived
from the right-hand-side in the codebase. This limits the hash-join to handle
only a single relations on the right-hand-side.

This removes the concrete relation, adapts the distribution and make it work
with multiple relations on both sides of the join.

Pre-cursor for https://github.com/crate/crate/pull/12460

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
