### PR TITLE
Make RetryRunnable cancelable 

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -122,11 +122,12 @@ public final class MetadataTracker implements Closeable {
             assert isActive == false : "MetadataTracker is already started";
             assert clusterService.state().getNodes().isLocalNodeElectedMaster() : "MetadataTracker must only be run on the master node";
             runnable = new RetryRunnable(
-                threadPool.executor(ThreadPool.Names.LOGICAL_REPLICATION),
-                threadPool.scheduler(),
+                threadPool,
+                ThreadPool.Names.LOGICAL_REPLICATION,
                 this::run,
                 BackoffPolicy.exponentialBackoff(replicationSettings.pollDelay(), 8)
             );
+            cancellable = runnable;
             isActive = true;
         }
         runnable.run();

--- a/server/src/main/java/io/crate/replication/logical/ShardReplicationChangesTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/ShardReplicationChangesTracker.java
@@ -319,7 +319,7 @@ public class ShardReplicationChangesTracker implements Closeable {
         // has data until then.
         // Method is called inside a transport thread (response listener), so dispatch away
         threadPool.executor(ThreadPool.Names.LOGICAL_REPLICATION).execute(() -> {
-            shardReplicationService.getRemoteClusterClient(shardId.getIndex()).thenAccept(remoteClient -> {
+            shardReplicationService.getRemoteClusterClient(shardId.getIndex()).thenAccept(remoteClient ->
                 RetentionLeaseHelper.renewRetentionLease(
                     shardId,
                     toSeqNoReceived,
@@ -327,15 +327,17 @@ public class ShardReplicationChangesTracker implements Closeable {
                     remoteClient,
                     ActionListener.wrap(
                         r -> {
-                            cancellable = threadPool.scheduleUnlessShuttingDown(
-                                replicationSettings.pollDelay(),
-                                ThreadPool.Names.LOGICAL_REPLICATION,
-                                newRunnable()
-                            );
+                            if (!closed) {
+                                cancellable = threadPool.scheduleUnlessShuttingDown(
+                                    replicationSettings.pollDelay(),
+                                    ThreadPool.Names.LOGICAL_REPLICATION,
+                                    newRunnable()
+                                );
+                            }
                         },
                         e -> {
                             var t = SQLExceptions.unwrap(e);
-                            if (SQLExceptions.maybeTemporary(t) && !closed) {
+                            if (!closed && SQLExceptions.maybeTemporary(t)) {
                                 LOGGER.info(
                                     "[{}] Temporary error during renewal of retention leases for subscription '{}'. Retrying: {}:{}",
                                     shardId,
@@ -349,32 +351,30 @@ public class ShardReplicationChangesTracker implements Closeable {
                                     () -> renewLeasesThenReschedule(toSeqNoReceived)
                                 );
                             } else {
-                                LOGGER.warn("Exception renewing retention lease. Stopping tracking (closed={})", e, closed);
+                                LOGGER.warn("Exception renewing retention lease. Stopping tracking (closed=" + closed + ")", e);
                             }
                         }
                     )
-                );
-            });
+                )
+            );
         });
     }
 
     @Override
     public void close() throws IOException {
+        closed = true;
         Cancellable currentCancellable = cancellable;
         if (currentCancellable != null) {
             currentCancellable.cancel();
             cancellable = null;
         }
-        closed = true;
         shardReplicationService.getRemoteClusterClient(shardId.getIndex())
-            .thenAccept(client -> {
-                RetentionLeaseHelper.attemptRetentionLeaseRemoval(
-                    shardId,
-                    clusterName,
-                    client,
-                    ActionListener.wrap(() -> {})
-                );
-            });
+            .thenAccept(client -> RetentionLeaseHelper.attemptRetentionLeaseRemoval(
+                shardId,
+                clusterName,
+                client,
+                ActionListener.wrap(() -> {})
+            ));
     }
 
     private static class ReplayChangesRetryListener<TResp> extends RetryListener<TResp> {

--- a/server/src/main/java/io/crate/replication/logical/ShardReplicationChangesTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/ShardReplicationChangesTracker.java
@@ -106,13 +106,15 @@ public class ShardReplicationChangesTracker implements Closeable {
 
     public void start() {
         LOGGER.debug("[{}] Spawning the shard changes reader", shardId);
-        newRunnable().run();
+        var retryRunnable = newRunnable();
+        cancellable = retryRunnable;
+        retryRunnable.run();
     }
 
     private RetryRunnable newRunnable() {
         return new RetryRunnable(
-            threadPool.executor(ThreadPool.Names.LOGICAL_REPLICATION),
-            threadPool.scheduler(),
+            threadPool,
+            ThreadPool.Names.LOGICAL_REPLICATION,
             this::pollAndProcessPendingChanges,
             BackoffPolicy.exponentialBackoff()
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This should fix some thread leaks when components using the `RetryRunnable` (like e.g. `MetadataTracker`) are closed while its still running, e.g. caused by retries.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
