### PR TITLE
Remove reference to removed HDFS repository from old release notes

### DIFF
--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -180,8 +180,8 @@ Removed Settings
   ``crate.yaml`` configuration file and command line arguments. Please, use the
   :ref:`sql-create-repository` statement parameters for this purpose.
 
-- Removed :ref:`HDFS repository <sql-create-repo-hdfs>` setting:
-  ``concurrent_streams`` as it is no longer supported.
+- Removed HDFS repository setting: ``concurrent_streams`` as it is no longer
+  supported.
 
 - The ``zen1`` related discovery settings mentioned in
   :ref:`v4.0.0-discovery-changes`.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The reference doesn't exists anymore and such sphinx will fail.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
