### PR TITLE
add object_keys function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,9 @@ Changes
 
 - Added ``typsend`` column to ``pg_catalog.pgtype`` table for improved
   compatibility with PostgreSQL.
+  
+- Added the :ref:`object_keys <scalar-object_keys>` scalar function which returns
+  the set of first level keys of an ``object``.
 
 
 Fixes

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2945,6 +2945,32 @@ arguments, the return type is ``numeric``.
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-objects:
+
+Object functions
+================
+
+.. _scalar-object_keys:
+
+``object_keys(object)``
+-----------------------
+
+The ``object_keys`` function returns the set of first level keys of an ``object``.
+
+Returns: ``array(text)``
+
+::
+
+    cr> select
+    ...     object_keys({a = 1, b = { c = 2 }}) AS object_keys;
+    +-------------+
+    | object_keys |
+    +-------------+
+    | ["a", "b"]  |
+    +-------------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-conditional-fn-exp:
 
 Conditional functions and expressions

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -54,6 +54,7 @@ import io.crate.expression.scalar.geo.DistanceFunction;
 import io.crate.expression.scalar.geo.GeoHashFunction;
 import io.crate.expression.scalar.geo.IntersectsFunction;
 import io.crate.expression.scalar.geo.WithinFunction;
+import io.crate.expression.scalar.object.ObjectKeysFunction;
 import io.crate.expression.scalar.postgres.CurrentSettingFunction;
 import io.crate.expression.scalar.postgres.PgBackendPidFunction;
 import io.crate.expression.scalar.postgres.PgEncodingToCharFunction;
@@ -212,5 +213,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         PgFunctionIsVisibleFunction.register(this);
         PgGetFunctionResultFunction.register(this);
         PgPostmasterStartTime.register(this);
+
+        ObjectKeysFunction.register(this);
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.object;
+
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+import java.util.ArrayList;
+
+public final class ObjectKeysFunction {
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                "object_keys",
+                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                DataTypes.STRING_ARRAY.getTypeSignature()
+            ),
+            (signature, boundSignature) ->
+            new UnaryScalar<>(
+                signature,
+                boundSignature,
+                DataTypes.UNTYPED_OBJECT,
+                obj -> new ArrayList<>(obj.keySet())
+            )
+        );
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.object;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import org.junit.Test;
+import java.util.List;
+
+public class ObjectKeysFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_input() {
+        assertEvaluate("object_keys(null)", null);
+    }
+
+    @Test
+    public void test_array_input() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Unknown function: object_keys(_array(1)), no overload found for"+
+                                        " matching argument types: (integer_array). Possible candidates:"+
+                                        " object_keys(object):array(text)");
+        assertEvaluate("object_keys([1])", null);
+    }
+
+    @Test
+    public void test_empty_object() {
+        assertEvaluate("object_keys({})", List.of());
+    }
+
+    @Test
+    public void test_flat_object() {
+        assertEvaluate("object_keys({a=1, b=2})", List.of("a","b"));
+    }
+
+    @Test
+    public void test_nested_object() {
+        assertEvaluate("object_keys({a=1, b={c=2}})", List.of("a","b"));
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
- Add the object_keys scalar function which returns the set of first level keys of an ``object`` as ``array(text)``

closes https://github.com/crate/crate/issues/11942

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
