### PR TITLE
Use VarHandle for long decoding in MurmurHash3

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
+++ b/server/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.common.hash;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
 import org.elasticsearch.common.util.ByteUtils;
 
 
@@ -48,6 +52,8 @@ public enum MurmurHash3 {
     private static final int M = 5;
     private static final int N1 = 0x52dce729;
     private static final int DEFAULT_SEED = 123;
+    private static final VarHandle VH_LE_LONG = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+
 
     protected static long fmix(long k) {
         k ^= k >>> 33;
@@ -86,14 +92,7 @@ public enum MurmurHash3 {
         // body
         for (int i = 0; i < nblocks; i++) {
             final int i8 = (i << 3) + offset;
-            long k = ((long) data[i8] & 0xff)
-                | (((long) data[i8 + 1] & 0xff) << 8)
-                | (((long) data[i8 + 2] & 0xff) << 16)
-                | (((long) data[i8 + 3] & 0xff) << 24)
-                | (((long) data[i8 + 4] & 0xff) << 32)
-                | (((long) data[i8 + 5] & 0xff) << 40)
-                | (((long) data[i8 + 6] & 0xff) << 48)
-                | (((long) data[i8 + 7] & 0xff) << 56);
+            long k = (long) VH_LE_LONG.get(data, i8);
 
             // mix functions
             k *= C1;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Tiny performance improvement:

    Benchmark                              (length)  Mode  Cnt   Score   Error  Units
    MurmurHash3Benchmark.measureNewHash64        10  avgt    6  11.821 ± 0.102  ns/op
    MurmurHash3Benchmark.measureNewHash64        30  avgt    6  15.897 ± 0.058  ns/op
    MurmurHash3Benchmark.measureOldHash64        10  avgt    6  14.451 ± 0.369  ns/op
    MurmurHash3Benchmark.measureOldHash64        30  avgt    6  24.788 ± 0.434  ns/op

Will squash the second commit. Kept it separate so the intermediate test/benchmark can be checked.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
