### PR TITLE
Remove unused MultiFields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
@@ -83,9 +83,8 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
                 FieldType fieldType,
                 MappedFieldType defaultFieldType,
                 Settings indexSettings,
-                MultiFields multiFields,
                 Mapper innerMapper) {
-        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, CopyTo.empty());
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, CopyTo.empty());
         this.innerMapper = innerMapper;
     }
 
@@ -119,7 +118,6 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
                 fieldType,
                 mappedFieldType,
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 innerMapper
             );
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
@@ -48,7 +48,6 @@ public class BitStringFieldMapper extends FieldMapper {
                                    FieldType fieldType,
                                    MappedFieldType mappedFieldType,
                                    Settings indexSettings,
-                                   MultiFields multiFields,
                                    CopyTo copyTo) {
         super(
             simpleName,
@@ -57,7 +56,6 @@ public class BitStringFieldMapper extends FieldMapper {
             fieldType,
             mappedFieldType,
             indexSettings,
-            multiFields,
             copyTo
         );
         this.length = length;
@@ -108,7 +106,6 @@ public class BitStringFieldMapper extends FieldMapper {
                 fieldType,
                 new BitStringFieldType(name, true, true),
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -85,7 +85,6 @@ public class BooleanFieldMapper extends FieldMapper {
                 fieldType,
                 new BooleanFieldType(buildFullName(context), indexed, hasDocValues),
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo,
                 nullValue);
         }
@@ -136,10 +135,9 @@ public class BooleanFieldMapper extends FieldMapper {
                                  FieldType fieldType,
                                  MappedFieldType defaultFieldType,
                                  Settings indexSettings,
-                                 MultiFields multiFields,
                                  CopyTo copyTo,
                                  Boolean nullValue) {
-        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, copyTo);
         this.nullValue = nullValue;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
@@ -54,7 +54,6 @@ public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
                 innerFieldMapper.fieldType,
                 mappedFieldType,
                 context.indexSettings().getSettings(),
-                FieldMapper.MultiFields.empty(),
                 innerMapper);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -126,7 +126,6 @@ public class DateFieldMapper extends FieldMapper {
                 nullValue,
                 ignoreTimezone,
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo);
         }
     }
@@ -203,9 +202,8 @@ public class DateFieldMapper extends FieldMapper {
             String nullValueAsString,
             Boolean ignoreTimezone,
             Settings indexSettings,
-            MultiFields multiFields,
             CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, copyTo);
         this.ignoreTimezone = ignoreTimezone;
         this.nullValue = nullValue;
         this.nullValueAsString = nullValueAsString;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -75,7 +75,6 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
                 fieldType,
                 ft,
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo);
         }
     }
@@ -97,9 +96,8 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
                                FieldType fieldType,
                                MappedFieldType defaultFieldType,
                                Settings indexSettings,
-                               MultiFields multiFields,
                                CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, indexSettings, copyTo);
     }
 
     @Override
@@ -151,10 +149,6 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
             for (IndexableField field : fields) {
                 context.doc().add(field);
             }
-        }
-        // if the mapping contains multifields then use the geohash string
-        if (multiFields.iterator().hasNext()) {
-            multiFields.parse(this, context.createExternalValueContext(point.geohash()));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -146,7 +146,6 @@ public class GeoShapeFieldMapper extends FieldMapper {
                 fieldType,
                 ft,
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo
             );
         }
@@ -366,9 +365,8 @@ public class GeoShapeFieldMapper extends FieldMapper {
                                FieldType fieldType,
                                MappedFieldType mappedFieldType,
                                Settings indexSettings,
-                               MultiFields multiFields,
                                CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, copyTo);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -77,7 +77,6 @@ public class IpFieldMapper extends FieldMapper {
                 new IpFieldType(buildFullName(context), indexed, hasDocValues),
                 nullValue,
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo);
         }
     }
@@ -133,9 +132,8 @@ public class IpFieldMapper extends FieldMapper {
             MappedFieldType mappedFieldType,
             InetAddress nullValue,
             Settings indexSettings,
-            MultiFields multiFields,
             CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, copyTo);
         this.nullValue = nullValue;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -135,7 +135,6 @@ public final class KeywordFieldMapper extends FieldMapper {
                 nullValue,
                 lengthLimit,
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo
             );
         }
@@ -205,9 +204,8 @@ public final class KeywordFieldMapper extends FieldMapper {
                                  String nullValue,
                                  Integer lengthLimit,
                                  Settings indexSettings,
-                                 MultiFields multiFields,
                                  CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, copyTo);
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         this.ignoreAbove = ignoreAbove;
         this.lengthLimit = lengthLimit;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -73,7 +73,6 @@ public abstract class MetadataFieldMapper extends FieldMapper {
             fieldType,
             mappedFieldType,
             indexSettings,
-            MultiFields.empty(),
             CopyTo.empty()
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -80,7 +80,6 @@ public class NumberFieldMapper extends FieldMapper {
                 fieldType,
                 new NumberFieldType(buildFullName(context), type, indexed, hasDocValues),
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo
             );
         }
@@ -459,9 +458,8 @@ public class NumberFieldMapper extends FieldMapper {
             FieldType fieldType,
             MappedFieldType mappedFieldType,
             Settings indexSettings,
-            MultiFields multiFields,
             CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, copyTo);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -465,24 +465,6 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
 
     public abstract void seqID(SeqNoFieldMapper.SequenceIDFields seqID);
 
-    /**
-     * Return a new context that will have the external value set.
-     */
-    public final ParseContext createExternalValueContext(final Object externalValue) {
-        return new FilterParseContext(this) {
-
-            @Override
-            public boolean externalValueSet() {
-                return true;
-            }
-
-            @Override
-            public Object externalValue() {
-                return externalValue;
-            }
-        };
-    }
-
     public boolean externalValueSet() {
         return false;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -100,7 +100,6 @@ public class TextFieldMapper extends FieldMapper {
                 fieldType,
                 tft,
                 context.indexSettings(),
-                multiFieldsBuilder.build(this, context),
                 copyTo
             );
         }
@@ -144,9 +143,8 @@ public class TextFieldMapper extends FieldMapper {
                               FieldType fieldType,
                               TextFieldType mappedFieldType,
                               Settings indexSettings,
-                              MultiFields multiFields,
                               CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, multiFields, copyTo);
+        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, indexSettings, copyTo);
         assert mappedFieldType.hasDocValues() == false;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

CrateDB only uses `copy_to`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
