### PR TITLE
Add alias target symbol evaluation in the EvaluationNormalizer

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -79,3 +79,7 @@ Fixes
 
 - Fixed an issue with the logical replication of tables metadata which caused
   to stop if the master node of the subscriber changed.
+
+- Fixed an issue with aliased sub-relation outputs when used inside the outer
+  where clause expression, resulting in a planner error. Example:
+  ``SELECT * FROM (SELECT id, true AS a FROM t1) WHERE a``

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -21,6 +21,13 @@
 
 package io.crate.analyze;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.RandomAccess;
+import java.util.function.Predicate;
+
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.SubqueryAnalyzer;
@@ -34,7 +41,6 @@ import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.analyze.relations.select.SelectAnalysis;
 import io.crate.analyze.relations.select.SelectAnalyzer;
-import io.crate.common.collections.Lists2;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -54,13 +60,6 @@ import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.Update;
 import io.crate.types.ArrayType;
 import io.crate.types.ObjectType;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.RandomAccess;
-import java.util.function.Predicate;
 
 /**
  * Used to analyze statements like: `UPDATE t1 SET col1 = ? WHERE id = ?`
@@ -134,7 +133,7 @@ public final class UpdateAnalyzer {
             sourceExprAnalyzer,
             exprCtx
         );
-        List<Symbol> outputSymbol = Lists2.map(selectAnalysis.outputSymbols(), x -> normalizer.normalize(x, txnCtx));
+        List<Symbol> outputSymbol = selectAnalysis.outputSymbols();
         return new AnalyzedUpdateStatement(
             table,
             assignmentByTargetCol,

--- a/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -41,6 +41,7 @@ import io.crate.data.Input;
 import io.crate.expression.NestableInput;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.scalar.arithmetic.MapFunction;
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.Literal;
@@ -251,6 +252,11 @@ public class EvaluatingNormalizer {
                 function.windowDefinition().map(s -> s.accept(this, context)),
                 function.ignoreNulls()
             );
+        }
+
+        @Override
+        public Symbol visitAlias(AliasSymbol aliasSymbol, TransactionContext context) {
+            return aliasSymbol.symbol().accept(this, context);
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The target symbol of an AliasSymbol must be processed on normalization in order to correctly process e.g. query symbols.

Fixes #12448.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
