### PR TITLE
Make instance cancellable variable volatile at RetryRunnable

### DIFF
--- a/server/src/main/java/io/crate/execution/support/RetryRunnable.java
+++ b/server/src/main/java/io/crate/execution/support/RetryRunnable.java
@@ -42,7 +42,7 @@ public class RetryRunnable implements Runnable, Scheduler.Cancellable {
     private final Executor executor;
     private final Iterator<TimeValue> delay;
     private final Runnable retryCommand;
-    private Scheduler.Cancellable cancellable;
+    private volatile Scheduler.Cancellable cancellable;
 
     public RetryRunnable(ThreadPool threadPool,
                          String executorName,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The instance could be created (and run) and cancelled by different threads.

Follow up of ee833b3b826.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
