### PR TITLE
Fix error handling when subscribing to unknown publication

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -101,4 +101,6 @@ Fixes
 - Fixed an issue with table functions parameter binding in ``SELECT`` queries
   without ``FROM`` clause. Example: ``SELECT unnest(?)``.
 
-
+- Improved error handling when creating a subscription with unknown
+  publications. Instead of successfully creating the subscription, an error
+  is now presented to the user.

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -228,7 +228,7 @@ public final class MetadataTracker implements Closeable {
         );
         CompletableFuture<Response> publicationsState = client.execute(PublicationsStateAction.INSTANCE, request);
         CompletableFuture<Boolean> updatedClusterState = publicationsState.thenCompose(response -> {
-            if (response.droppedPublications().containsAll(subscription.publications())) {
+            if (response.unknownPublications().containsAll(subscription.publications())) {
                 stopTracking(subscriptionName);
                 return CompletableFuture.completedFuture(false);
             }
@@ -319,8 +319,8 @@ public final class MetadataTracker implements Closeable {
                 }
 
                 ArrayList<String> mutablePublications = new ArrayList<>(subscription.publications());
-                if (mutablePublications.removeAll(response.droppedPublications())) {
-                    LOGGER.info("Subscription {} will stop getting updates from publications: {} as they have been dropped.", subscriptionName, response.droppedPublications());
+                if (mutablePublications.removeAll(response.unknownPublications())) {
+                    LOGGER.info("Subscription {} will stop getting updates from publications: {} as they have been dropped.", subscriptionName, response.unknownPublications());
                     localClusterState = UpdateSubscriptionAction.update(
                         localClusterState,
                         subscriptionName,

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
@@ -43,6 +43,7 @@ import org.elasticsearch.transport.TransportService;
 import io.crate.exceptions.Exceptions;
 import io.crate.metadata.RelationName;
 import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.exceptions.PublicationUnknownException;
 import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsException;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
@@ -105,6 +106,9 @@ public class TransportCreateSubscriptionAction extends TransportMasterNodeAction
             )
             .thenCompose(
                 response -> {
+                    if (response.unknownPublications().isEmpty() == false) {
+                        throw new PublicationUnknownException(response.unknownPublications().get(0));
+                    }
                     logicalReplicationService.verifyTablesDoNotExist(request.name(), response);
                     return submitClusterStateTask(request, response);
                 }

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -40,6 +40,7 @@ import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.RelationName;
 import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.replication.logical.exceptions.PublicationUnknownException;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.testing.MoreMatchers;
@@ -229,6 +230,17 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         var response = executeOnSubscriber("SELECT * FROM doc.t1 ORDER BY id");
         assertThat(printedTable(response.rows()), is("1\n" +
                                                      "2\n"));
+    }
+
+    @Test
+    public void test_subscribing_to_unknown_publication_raises_error() throws Exception {
+        createPublication("pub1", true, List.of());
+        assertThrowsMatches(
+            () -> executeOnSubscriber("CREATE SUBSCRIPTION sub1" +
+                " CONNECTION '" + publisherConnectionUrl() + "' publication unknown_pub"),
+            PublicationUnknownException.class,
+            "Publication 'unknown_pub' unknown"
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

An exception must be raised instead of treating the creation as successful and create a non-working subscription.

closes https://github.com/crate/crate/issues/12489

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
