### PR TITLE
Don't set analyzers on NumberFieldType

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -299,10 +299,6 @@ public class XContentMapValues {
         return filtered;
     }
 
-    public static boolean isArray(Object node) {
-        return node instanceof List;
-    }
-
     public static String nodeStringValue(Object node, String defaultValue) {
         if (node == null) {
             return defaultValue;
@@ -385,11 +381,10 @@ public class XContentMapValues {
      * Otherwise the node is treated as a comma-separated string.
      */
     public static String[] nodeStringArrayValue(Object node) {
-        if (isArray(node)) {
-            List list = (List) node;
-            String[] arr = new String[list.size()];
+        if (node instanceof List<?> nodes) {
+            String[] arr = new String[nodes.size()];
             for (int i = 0; i < arr.length; i++) {
-                arr[i] = nodeStringValue(list.get(i), null);
+                arr[i] = nodeStringValue(nodes.get(i), null);
             }
             return arr;
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.analysis.Analyzer;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,25 +30,11 @@ public final class DocumentFieldMappers implements Iterable<Mapper> {
     /** Full field name to mapper */
     private final Map<String, Mapper> fieldMappers;
 
-    private static void put(Map<String, Analyzer> analyzers, String key, Analyzer value, Analyzer defaultValue) {
-        if (value == null) {
-            value = defaultValue;
-        }
-        analyzers.put(key, value);
-    }
-
-    public DocumentFieldMappers(Collection<FieldMapper> mappers,
-                                Analyzer defaultIndex,
-                                Analyzer defaultSearch,
-                                Analyzer defaultSearchQuote) {
+    public DocumentFieldMappers(Collection<FieldMapper> mappers) {
         Map<String, Mapper> fieldMappers = new HashMap<>();
-        Map<String, Analyzer> indexAnalyzers = new HashMap<>();
         for (FieldMapper mapper : mappers) {
             fieldMappers.put(mapper.name(), mapper);
-            MappedFieldType fieldType = mapper.fieldType();
-            put(indexAnalyzers, fieldType.name(), fieldType.indexAnalyzer(), defaultIndex);
         }
-
         this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -19,20 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.document.StoredField;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchGenerationException;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.ToXContentFragment;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.analysis.IndexAnalyzers;
-import org.elasticsearch.index.mapper.MetadataFieldMapper.TypeParser;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,6 +30,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchGenerationException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MetadataFieldMapper.TypeParser;
 
 
 public class DocumentMapper implements ToXContentFragment {
@@ -136,14 +135,7 @@ public class DocumentMapper implements ToXContentFragment {
         }
         MapperUtils.collect(this.mapping.root, newObjectMappers, newFieldMappers);
 
-        final IndexAnalyzers indexAnalyzers = mapperService.getIndexAnalyzers();
-        this.fieldMappers = new DocumentFieldMappers(
-            newFieldMappers,
-            indexAnalyzers.getDefaultIndexAnalyzer(),
-            indexAnalyzers.getDefaultSearchAnalyzer(),
-            indexAnalyzers.getDefaultSearchQuoteAnalyzer()
-        );
-
+        this.fieldMappers = new DocumentFieldMappers(newFieldMappers);
         Map<String, ObjectMapper> builder = new HashMap<>();
         for (ObjectMapper objectMapper : newObjectMappers) {
             ObjectMapper previous = builder.put(objectMapper.fullPath(), objectMapper);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -35,7 +35,6 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
 
 public abstract class FieldMapper extends Mapper implements Cloneable {
@@ -51,10 +50,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         protected Integer position;
         @Nullable
         protected String defaultExpression;
-        // TODO move to text-specific builder base class
-        protected NamedAnalyzer indexAnalyzer;
-        protected NamedAnalyzer searchAnalyzer;
-        protected NamedAnalyzer searchQuoteAnalyzer;
 
         protected Builder(String name, FieldType fieldType) {
             super(name);
@@ -119,21 +114,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         public T indexOptions(IndexOptions indexOptions) {
             this.fieldType.setIndexOptions(indexOptions);
             this.indexOptionsSet = true;
-            return builder;
-        }
-
-        public T indexAnalyzer(NamedAnalyzer indexAnalyzer) {
-            this.indexAnalyzer = indexAnalyzer;
-            return builder;
-        }
-
-        public T searchAnalyzer(NamedAnalyzer searchAnalyzer) {
-            this.searchAnalyzer = searchAnalyzer;
-            return builder;
-        }
-
-        public T searchQuoteAnalyzer(NamedAnalyzer searchQuoteAnalyzer) {
-            this.searchQuoteAnalyzer = searchQuoteAnalyzer;
             return builder;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -40,7 +40,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Numbers;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
@@ -436,8 +435,6 @@ public class NumberFieldMapper extends FieldMapper {
         public NumberFieldType(String name, NumberType type, boolean isSearchable, boolean hasDocValues) {
             super(name, isSearchable, hasDocValues);
             this.type = Objects.requireNonNull(type);
-            this.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);     // allows number fields in significant text aggs - do we need this?
-            this.setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);    // allows match queries on number fields
         }
 
         public NumberFieldType(String name, NumberType type) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 
 /** A {@link FieldMapper} for full-text fields. */
 public class TextFieldMapper extends FieldMapper {
@@ -64,6 +65,10 @@ public class TextFieldMapper extends FieldMapper {
 
     public static class Builder extends FieldMapper.Builder<Builder> {
 
+        protected NamedAnalyzer indexAnalyzer;
+        protected NamedAnalyzer searchAnalyzer;
+        protected NamedAnalyzer searchQuoteAnalyzer;
+
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
             builder = this;
@@ -77,6 +82,20 @@ public class TextFieldMapper extends FieldMapper {
             return super.docValues(docValues);
         }
 
+        public Builder indexAnalyzer(NamedAnalyzer indexAnalyzer) {
+            this.indexAnalyzer = indexAnalyzer;
+            return builder;
+        }
+
+        public Builder searchAnalyzer(NamedAnalyzer searchAnalyzer) {
+            this.searchAnalyzer = searchAnalyzer;
+            return builder;
+        }
+
+        public Builder searchQuoteAnalyzer(NamedAnalyzer searchQuoteAnalyzer) {
+            this.searchQuoteAnalyzer = searchQuoteAnalyzer;
+            return builder;
+        }
 
         private TextFieldType buildFieldType(BuilderContext context) {
             TextFieldType ft = new TextFieldType(
@@ -109,7 +128,7 @@ public class TextFieldMapper extends FieldMapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder<?> parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             TextFieldMapper.Builder builder = new TextFieldMapper.Builder(fieldName);
             builder.indexAnalyzer(parserContext.getIndexAnalyzers().getDefaultIndexAnalyzer());
             builder.searchAnalyzer(parserContext.getIndexAnalyzers().getDefaultSearchAnalyzer());
@@ -134,7 +153,6 @@ public class TextFieldMapper extends FieldMapper {
         public String typeName() {
             return CONTENT_TYPE;
         }
-
     }
 
     protected TextFieldMapper(String simpleName,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`WHERE MATCH(numericColumn, ...)` is not supported, no need to set an
analyzer on the `FieldMapper`

(As far as I can tell this didn't have an impact on indexing. None of
the `createFields` methods used the indexAnalazyer information)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
