### PR TITLE
Make soft-deletes mandatory for newly created tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Creating tables with soft deletes disabled is no longer supported.
+  The setting :ref:`sql-create-table-soft-deletes-enabled` will
+  always be set to ``true`` and removed in CrateDB 6.0.
+
 - Removed deprecated ``node.max_local_storage_nodes`` setting. Set different
   :ref:`path.data <path.data>` values to run multiple CrateDB processes on the
   same machine.

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -559,15 +559,10 @@ Before the introduction of soft deletes, CrateDB had to retain the information
 in the :ref:`Translog <concept-durability>`. Using soft deletes uses less
 storage than the Translog equivalent and is faster.
 
-Soft deletes can only be configured when a table is created. This setting
-cannot be changed using ``ALTER TABLE``.
+Soft deletes are mandatory in CrateDB 5.0, therefore this setting can no
+longer be modified. It will always be set to ``true``.
 
-This setting is deprecated and soft deletes will become mandatory in CrateDB
-5.0.
-
-:value:
-  Defaults to ``true``. Set to ``false`` to disable soft deletes.
-
+The setting will be removed in CrateDB 6.0.
 
 .. _sql-create-table-soft-deletes-retention-lease-period:
 

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -167,10 +167,11 @@ public final class IndexSettings {
 
     /**
      * Specifies if the index should use soft-delete instead of hard-delete for update/delete operations.
+     * Soft-deletes are enabled by default for 4.3+ indices and mandatory for 5.0+ indices.
      */
     public static final Setting<Boolean> INDEX_SOFT_DELETES_SETTING = Setting.boolSetting(
         "index.soft_deletes.enabled",
-        settings -> Boolean.toString(IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings).onOrAfter(Version.V_4_3_0)),
+        true,
         Property.IndexScope,
         Property.Final,
         Property.Deprecated

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -21,20 +21,23 @@
 
 package io.crate.integrationtests;
 
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.junit.Test;
-
+import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.testing.Asserts.assertThrowsMatches;
+import static io.crate.testing.SQLErrorMatcher.isSQLError;
+import static io.crate.testing.TestingHelpers.printedTable;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.junit.Test;
 
 public class CreateTableIntegrationTest extends SQLIntegrationTestCase {
 
@@ -118,5 +121,16 @@ public class CreateTableIntegrationTest extends SQLIntegrationTestCase {
         refresh();
         execute("select date_format('%Y-%m-%d %H:%i:%s', calculated) from test");
         assertThat(printedTable(response.rows()), is("2020-02-11 15:30:00\n"));
+    }
+
+    @Test
+    public void test_enforce_soft_deletes() {
+        assertThrowsMatches(
+            () -> execute("create table test(t timestamp) with (\"soft_deletes.enabled\" = false)"),
+            isSQLError(startsWith("Creating tables with soft-deletes disabled is no longer supported."),
+                       INTERNAL_ERROR,
+                       BAD_REQUEST,
+                       4000));
+
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -30,8 +30,10 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.test.MockLogAppender;
 import org.junit.After;
 import org.junit.Before;
@@ -74,6 +76,10 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
                 return true; // This test case doesn't check privileges.
             }
         };
+        // Soft-deletes are mandatory from 5.0, so let's use 4.8 to create a table with soft-deletes disabled
+        clusterService = createClusterService(additionalClusterSettings().stream().filter(Setting::hasNodeScope).toList(),
+                                                  Metadata.EMPTY_METADATA,
+                                                  Version.V_4_8_0);
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
             .addTable("CREATE TABLE doc.t2 (id int) with (\"soft_deletes.enabled\" = false)")

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.flush.SyncedFlushAction;
 import org.elasticsearch.action.admin.indices.flush.SyncedFlushRequest;
 import org.elasticsearch.action.admin.indices.flush.SyncedFlushResponse;
@@ -77,15 +78,13 @@ public class ReplicaShardAllocatorIT extends SQLIntegrationTestCase {
         execute("""
             create table doc.test (x int)
             clustered into 1 shards with (
-                "soft_deletes.enabled" = ?,
                 number_of_replicas = 1,
                 "recovery.file_based_threshold" = 1.0,
                 "global_checkpoint_sync.interval" = '100ms',
                 "soft_deletes.retention_lease.sync_interval" = '100ms',
                 "unassigned.node_left.delayed_timeout" = '1ms'
             )
-        """, new Object[] { randomBoolean() } );
-
+        """);
 
         String nodeWithReplica = internalCluster().startDataOnlyNode();
         Settings nodeWithReplicaSettings = internalCluster().dataPathSettings(nodeWithReplica);
@@ -241,13 +240,12 @@ public class ReplicaShardAllocatorIT extends SQLIntegrationTestCase {
             create table doc.test (x int)
             clustered into 1 shards with (
                 number_of_replicas = ?,
-                "soft_deletes.enabled" = ?,
                 "translog.flush_threshold_size" = ?,
                 "recovery.file_based_threshold" = '0.5',
                 "global_checkpoint_sync.interval" = '100ms',
                 "soft_deletes.retention_lease.sync_interval" = '100ms'
             )
-                """, new Object[] {numOfReplicas, randomBoolean(), randomIntBetween(10, 100) + "kb",  });
+                """, new Object[] {numOfReplicas, randomIntBetween(10, 100) + "kb",  });
 
         ensureGreen(indexName);
 

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -610,22 +610,6 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     @Test
-    public void testSoftDeletesDefaultSetting() {
-        Version createdVersion = VersionUtils.randomVersionBetween(
-            random(),
-            Version.CURRENT.minimumIndexCompatibilityVersion(),
-            Version.CURRENT
-        );
-
-        Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), createdVersion)
-            .build();
-
-        boolean isEnabled = createdVersion.onOrAfter(Version.V_4_3_0);
-        assertThat(IndexSettings.INDEX_SOFT_DELETES_SETTING.get(settings), is(isEnabled));
-    }
-
-    @Test
     public void testUpdateTranslogRetentionSettingsWithSoftDeletesDisabled() {
         Settings.Builder settings = Settings.builder()
             .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), false)

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -558,7 +558,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
         builder.put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), 0);
         builder.put(SETTING_AUTO_EXPAND_REPLICAS, "false");
         builder.put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE.toString());
-        builder.put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), randomBoolean());
         if (randomBoolean()) {
             builder.put(IndexSettings.INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING.getKey(), between(0, 1000));
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Creating tables with soft deletes disabled is no longer supported.
The setting ``soft_deletes.enabled`` will always be set to ``true``.

The behavior of the setting is depending on the index version of the created table.
If the index version >= 5.0 the change of the setting will be rejected.

For previously created tables with index version < 5.0 the setting remains the state once the table was created.

In case of a mixed cluster for the rolling upgrade use-case, the index version is determined 
by the lowest version of nodes in the cluster. 

Therefore this behavior only applies once all nodes in a cluster are upgraded to 5.0+.



Relates to https://github.com/crate/crate/issues/11142

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
