### PR TITLE
Remove caching in table parameters

### DIFF
--- a/server/src/main/java/io/crate/analyze/TableParameter.java
+++ b/server/src/main/java/io/crate/analyze/TableParameter.java
@@ -30,9 +30,6 @@ public class TableParameter {
     private final Settings.Builder settingsBuilder;
     private final Settings.Builder mappingsBuilder;
 
-    private Settings settings;
-    private Map<String, Object> mappings;
-
     public TableParameter() {
         settingsBuilder = Settings.builder();
         mappingsBuilder = Settings.builder();
@@ -43,10 +40,7 @@ public class TableParameter {
     }
 
     public Settings settings() {
-        if (settings == null) {
-            settings = settingsBuilder.build();
-        }
-        return settings;
+        return settingsBuilder.build();
     }
 
     public Settings.Builder mappingsBuilder() {
@@ -54,9 +48,6 @@ public class TableParameter {
     }
 
     public Map<String, Object> mappings() {
-        if (mappings == null) {
-            mappings = mappingsBuilder.build().getAsStructuredMap();
-        }
-        return mappings;
+        return mappingsBuilder.build().getAsStructuredMap();
     }
 }


### PR DESCRIPTION
This removes the caching of settings and mappings in table parameters.
If the settings/mappings methods are called and the builders are afterwards
mutated, then settings/mappings will be cached and not reflecting the latest state.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
