### PR TITLE
Fix authentication error when creating subscription second time with valid credentials

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -104,3 +104,7 @@ Fixes
 - Improved error handling when creating a subscription with unknown
   publications. Instead of successfully creating the subscription, an error
   is now presented to the user.
+
+- Fixed an issue with client caching which lead to authentication error when
+  creating a subscription with bad credentials and ``pg_tunnel`` followed by
+  re-creating it second time with the same name and valid credentials.

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusters.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusters.java
@@ -97,7 +97,12 @@ public class RemoteClusters implements Closeable {
             );
             remoteClusters.put(name, remoteCluster);
         }
-        return remoteCluster.connectAndGetClient();
+        var clientFuture = remoteCluster.connectAndGetClient();
+        return clientFuture.whenComplete((c, err) -> {
+            if (err != null) {
+                remove(name);
+            }
+        });
     }
 
     public synchronized void remove(String subscriptionName) {

--- a/server/src/test/java/io/crate/integrationtests/PgTunnelLogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgTunnelLogicalReplicationITest.java
@@ -180,7 +180,7 @@ public class PgTunnelLogicalReplicationITest extends ESTestCase {
     }
 
     @Test
-    public void test_cannot_create_subscription_with_invalid_user_password_and_can_create_with_same_name_and_valid_credentials() throws Exception {
+    public void test_cannot_create_subscription_with_invalid_user_password() throws Exception {
         publisherCluster = newCluster("publisher", Settings.builder()
             .put("auth.host_based.enabled", true)
             .put("auth.host_based.config.0.user", "marvin")
@@ -214,20 +214,6 @@ public class PgTunnelLogicalReplicationITest extends ESTestCase {
                 PGErrorStatus.EXCLUSION_VIOLATION,
                 HttpResponseStatus.INTERNAL_SERVER_ERROR,
                 5000));
-
-        // Check that later can re-create a subscription with the same name but with valid credentials.
-        // Used to reuse RemoteCluster with old ConnectionInfo and fail with auth failed, see https://github.com/crate/crate/issues/12462
-        subscriber.exec(String.format(Locale.ENGLISH, """
-                    CREATE SUBSCRIPTION sub1
-                        CONNECTION 'crate://%s:%d?user=marvin&password=secret&mode=pg_tunnel'
-                        PUBLICATION pub1
-                    """,
-            postgresAddress.getHostName(),
-            postgresAddress.getPort())
-        );
-        assertThat(TestingHelpers.printedTable(subscriber.exec("select subname from pg_subscription").rows()), is(
-            "sub1\n"
-        ));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgTunnelLogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgTunnelLogicalReplicationITest.java
@@ -180,7 +180,7 @@ public class PgTunnelLogicalReplicationITest extends ESTestCase {
     }
 
     @Test
-    public void test_cannot_create_subscription_with_invalid_user_password() throws Exception {
+    public void test_cannot_create_subscription_with_invalid_user_password_and_can_create_with_same_name_and_valid_credentials() throws Exception {
         publisherCluster = newCluster("publisher", Settings.builder()
             .put("auth.host_based.enabled", true)
             .put("auth.host_based.config.0.user", "marvin")
@@ -214,6 +214,20 @@ public class PgTunnelLogicalReplicationITest extends ESTestCase {
                 PGErrorStatus.EXCLUSION_VIOLATION,
                 HttpResponseStatus.INTERNAL_SERVER_ERROR,
                 5000));
+
+        // Check that later can re-create a subscription with the same name but with valid credentials.
+        // Used to reuse RemoteCluster with old ConnectionInfo and fail with auth failed, see https://github.com/crate/crate/issues/12462
+        subscriber.exec(String.format(Locale.ENGLISH, """
+                    CREATE SUBSCRIPTION sub1
+                        CONNECTION 'crate://%s:%d?user=marvin&password=secret&mode=pg_tunnel'
+                        PUBLICATION pub1
+                    """,
+            postgresAddress.getHostName(),
+            postgresAddress.getPort())
+        );
+        assertThat(TestingHelpers.printedTable(subscriber.exec("select subname from pg_subscription").rows()), is(
+            "sub1\n"
+        ));
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClustersTest.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClustersTest.java
@@ -25,9 +25,9 @@ import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import io.crate.protocols.postgres.PgClient;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -39,8 +39,6 @@ import io.crate.netty.NettyBootstrap;
 import io.crate.protocols.postgres.PgClientFactory;
 import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-
-import java.util.concurrent.CompletableFuture;
 
 public class RemoteClustersTest extends CrateDummyClusterServiceUnitTest {
 


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/12462


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
