### PR TITLE
alter table fix varchar length info being dropped

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -119,5 +119,10 @@ Fixes
   creating a subscription with bad credentials and ``pg_tunnel`` followed by
   re-creating it second time with the same name and valid credentials.
 
+- Fixed an issue with ``VARCHAR`` and ``BIT`` columns with a length
+  limited used in primary key, generated or default column expression. An
+  ``ALTER TABLE`` statement removed the length limit from such columns.
+
 - Fixed an issue resulting in a broken subscription when a subscription is
   dropped and re-created within a short period of time.
+

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -261,6 +261,13 @@ public class AnalyzedColumnDefinition<T> {
         this.geoProperties = properties;
     }
 
+    /**
+     * Initializes from a given DataType including internal parameters
+     */
+    public void dataType(DataType<?> dataType) {
+        this.dataType = dataType;
+    }
+
     public void dataType(String dataType) {
         dataType(dataType, List.of(), true);
     }

--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -406,9 +406,9 @@ public class AnalyzedTableElements<T> {
         } else {
             if (valueType instanceof ArrayType) {
                 columnDefinitionEvaluated.collectionType(ArrayType.NAME);
-                columnDefinitionEvaluated.dataType(ArrayType.unnest(valueType).getName());
+                columnDefinitionEvaluated.dataType(ArrayType.unnest(valueType));
             } else {
-                columnDefinitionEvaluated.dataType(valueType.getName());
+                columnDefinitionEvaluated.dataType(valueType);
             }
             formattedExpression = function.toString(Style.UNQUALIFIED);
         }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
@@ -185,7 +185,12 @@ public class AlterTableAddColumnPlan implements Plan {
             if (reference.valueType().id() != ObjectType.ID) {
                 columnDef.indexConstraint(reference.indexType());
             }
-            columnDef.dataType(reference.valueType().getName());
+
+            // We are mirroring PK type as is (including type's internal settings if there are any)
+            // We cannot resolve type by name via columnDef.dataType(reference.valueType().getName())
+            // as internal parameters, such as VARCHAR length can be lost.
+            columnDef.dataType(reference.valueType());
+
             if (parentDef != null) {
                 parentDef.addChild(columnDef);
             }


### PR DESCRIPTION
Resolves https://github.com/crate/crate/issues/12492


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
