### PR TITLE
Support using `null` without explicit cast in UNION

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,9 @@ None
 Changes
 =======
 
+- Added support for using ``NULL`` literals in a ``UNION`` without requiring an
+  explicit cast.
+
 - Added an optimization to push down constant join conditions to the relation
   in an inner join, which results in a more efficient execution plan.
 

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -227,12 +227,18 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         List<Symbol> leftOutputs = left.outputs();
         List<Symbol> rightOutputs = right.outputs();
         for (int i = 0; i < leftOutputs.size(); i++) {
-            var leftType = leftOutputs.get(i).valueType();
-            var rightType = rightOutputs.get(i).valueType();
+            Symbol leftOutput = leftOutputs.get(i);
+            Symbol rightOutput = rightOutputs.get(i);
+            DataType<?> leftType = leftOutput.valueType();
+            DataType<?> rightType = rightOutput.valueType();
             if (!DataTypes.isCompatibleType(leftType, rightType)) {
+                if (Symbol.hasLiteralValue(leftOutput, null) || Symbol.hasLiteralValue(rightOutput, null)) {
+                    continue;
+                }
                 throw new UnsupportedOperationException(
-                    "Corresponding output columns at position: " + (i + 1) +
-                    " must be compatible for all parts of a UNION");
+                    "Output columns at position " + (i + 1) +
+                    " must be compatible for all parts of a UNION. " +
+                    "Got `" + leftType.getName() + "` and `" + rightType.getName() + "`");
             }
         }
     }

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -27,12 +27,22 @@ import io.crate.expression.symbol.format.Style;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+
+import java.util.Objects;
+
 import org.elasticsearch.common.io.stream.Writeable;
 
 public abstract class Symbol implements Writeable {
 
     public static boolean isLiteral(Symbol symbol, DataType<?> expectedType) {
         return symbol.symbolType() == SymbolType.LITERAL && symbol.valueType().equals(expectedType);
+    }
+
+    public static boolean hasLiteralValue(Symbol symbol, Object value) {
+        while (symbol instanceof AliasSymbol alias) {
+            symbol = alias.symbol();
+        }
+        return symbol instanceof Literal<?> literal && Objects.equals(literal.value(), value);
     }
 
     public abstract SymbolType symbolType();

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -102,7 +102,8 @@ public class Union implements LogicalPlan {
         ExecutionPlan right = rhs.build(
             plannerContext, hints, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
 
-        addCastsForIncompatibleObjects(right);
+        addCastsForIncompatibleObjects(lhs, left);
+        addCastsForIncompatibleObjects(rhs, right);
 
         if (left.resultDescription().hasRemainingLimitOrOffset()) {
             left = Merge.ensureOnHandler(left, plannerContext);
@@ -171,10 +172,10 @@ public class Union implements LogicalPlan {
      * using the same type
      * </p>
      **/
-    private void addCastsForIncompatibleObjects(ExecutionPlan right) {
-        EvalProjection castValues = EvalProjection.castValues(Symbols.typeView(lhs.outputs()), rhs.outputs());
+    private void addCastsForIncompatibleObjects(LogicalPlan logicalPlan, ExecutionPlan executionPlan) {
+        EvalProjection castValues = EvalProjection.castValues(Symbols.typeView(outputs), logicalPlan.outputs());
         if (castValues != null) {
-            right.addProjection(castValues);
+            executionPlan.addProjection(castValues);
         }
     }
 


### PR DESCRIPTION
Adds support for cases like `select null union all select x from tbl` (or the other way around)


We could also support implicit casts as requested in  https://github.com/crate/crate/issues/12511 but I'm not sure if it is a good idea.

Would only have to adjust the logic here to check for cast compatibility instead of checking if they're compatible:

https://github.com/crate/crate/blob/76c619b12a5157592d2e6db67c3bafc089568287/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java#L226-L244

The remainder of the logic should then already take care of the rest.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
