### PR TITLE
Handle send failures eagerly

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -95,8 +95,18 @@ public final class OutboundHandler {
             isHandshake,
             compressRequest
         );
-        ActionListener<Void> listener = ActionListener.wrap(() ->
-            messageListener.onRequestSent(node, requestId, action, request, options));
+        ActionListener<Void> listener = new ActionListener<Void>() {
+
+            @Override
+            public void onResponse(Void response) {
+                messageListener.onRequestSent(node, requestId, action, request, options);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                messageListener.onRequestFailed(node, requestId, action, request, e);
+            }
+        };
         sendMessage(channel, message, listener);
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
@@ -77,4 +77,13 @@ public interface TransportMessageListener {
     default void onResponseReceived(long requestId, Transport.ResponseContext context) {
     }
 
+    /**
+     * Invoked if sending the request fails
+     **/
+    default void onRequestFailed(DiscoveryNode node,
+                                 long requestId,
+                                 String action,
+                                 TransportRequest request,
+                                 Exception exception) {
+    }
 }


### PR DESCRIPTION
In tests we sometimes see Broken pipe errors because the connection was
closed on the remote site:

    [2022-05-16T15:02:27,444][WARN ][o.e.t.OutboundHandler    ] [[cratedb[node_sc5][netty-worker][T#3]]] send message failed [channel: Netty4TcpChannel{localAddress=/127.0.0.1:41149, remoteAddress=/127.0.0.1:50668}]
    io.netty.channel.StacklessClosedChannelException: null
            at io.netty.channel.AbstractChannel$AbstractUnsafe.write(Object, ChannelPromise)(Unknown Source) ~[netty-transport-4.1.76.Final.jar:4.1.76.Final]
    Caused by: io.netty.channel.unix.Errors$NativeIoException: writeAddress(..) failed: Broken pipe

This commit ensures these errors are bubbled up and trigger response
handlers. So far only a warning got logged and components relied
on either a timeout or a node-disconnected event.

This doesn't fix anything but should help reduce the time required to
react to connection errors.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
