### PR TITLE
Enable to alter settings in subscribed tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -99,6 +99,8 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Enabled users to alter settings on tables subscribed in a logical replication.
+
 - Enabled to alter the setting ``blocks.read_only_allow_delete`` on blob tables
   to make it possible to drop read-only blob tables.
 

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -161,8 +161,16 @@ public class TableParameters {
 
     private static final Map<String, Setting<?>> SUPPORTED_MAPPINGS_DEFAULT = Map.of("column_policy", COLUMN_POLICY);
 
+    private static final Map<String, Setting<?>> SUPPORTED_SETTINGS_FOR_REPLICATED_TABLES = SUPPORTED_SETTINGS
+        .stream()
+        .filter(Setting::isReplicatedIndexScope)
+        .collect(Collectors.toMap(s -> stripDotSuffix(stripIndexPrefix(s.getKey())), s -> s));
+
     public static final TableParameters TABLE_CREATE_PARAMETER_INFO
         = new TableParameters(SUPPORTED_SETTINGS_DEFAULT, SUPPORTED_MAPPINGS_DEFAULT);
+
+    public static final TableParameters REPLICATED_TABLE_ALTER_PARAMETER_INFO
+        = new TableParameters(SUPPORTED_SETTINGS_FOR_REPLICATED_TABLES, Map.of());
 
     public static final TableParameters TABLE_ALTER_PARAMETER_INFO
         = new TableParameters(SUPPORTED_SETTINGS_INCL_SHARDS, SUPPORTED_MAPPINGS_DEFAULT);

--- a/server/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
+++ b/server/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
@@ -44,7 +44,7 @@ public class NumberOfReplicasSetting extends Setting<Settings> {
         .build();
 
     public NumberOfReplicasSetting() {
-        this(new SimpleKey(NAME), (s) -> "0-1", NumberOfReplicasSetting::parseValue);
+        this(new SimpleKey(NAME), (s) -> "0-1", NumberOfReplicasSetting::parseValue, Property.ReplicatedIndexScope);
     }
 
     private NumberOfReplicasSetting(Key key, Function<Settings, String> defaultValue, Function<String, Settings> parser, Property... properties) {

--- a/server/src/main/java/io/crate/metadata/table/Operation.java
+++ b/server/src/main/java/io/crate/metadata/table/Operation.java
@@ -65,7 +65,7 @@ public enum Operation {
     public static final EnumSet<Operation> METADATA_DISABLED_OPERATIONS = EnumSet.of(READ, UPDATE, INSERT, DELETE,
         ALTER_BLOCKS, ALTER_OPEN, ALTER_CLOSE, ALTER_REROUTE, REFRESH, SHOW_CREATE, OPTIMIZE);
     public static final EnumSet<Operation> SUBSCRIBED_IN_LOGICAL_REPLICATION = EnumSet.of(
-        READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE);
+        READ, ALTER, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE);
     public static final EnumSet<Operation> PUBLISHED_IN_LOGICAL_REPLICATION = EnumSet.of(
         READ, UPDATE, INSERT, DELETE, DROP, ALTER, ALTER_BLOCKS, ALTER_CLOSE, ALTER_REROUTE, REFRESH,
         SHOW_CREATE, COPY_TO, OPTIMIZE, RESTORE_SNAPSHOT, CREATE_SNAPSHOT);
@@ -92,9 +92,7 @@ public enum Operation {
         }
         Set<Operation> operations = ALL;
 
-        var subscriptionName = REPLICATION_SUBSCRIPTION_NAME.get(settings);
-        var isSubscribed = subscriptionName != null && subscriptionName.isEmpty() == false;
-
+        var isSubscribed = isReplicated(settings);
         if (isSubscribed && isPublished) {
             // if the table is subscribed and published use the more restrictive operation set
             operations = SUBSCRIBED_IN_LOGICAL_REPLICATION;
@@ -111,6 +109,11 @@ public enum Operation {
             operations = Sets.intersection(entry.getValue(), operations);
         }
         return EnumSet.copyOf(operations);
+    }
+
+    public static boolean isReplicated(Settings settings) {
+        var subscriptionName = REPLICATION_SUBSCRIPTION_NAME.get(settings);
+        return subscriptionName != null && subscriptionName.isEmpty() == false;
     }
 
     public static void blockedRaiseException(TableInfo tableInfo, Operation operation) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -138,7 +138,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final Setting<Integer> INDEX_NUMBER_OF_SHARDS_SETTING = buildNumberOfShardsSetting();
     public static final String SETTING_NUMBER_OF_REPLICAS = "index.number_of_replicas";
     public static final Setting<Integer> INDEX_NUMBER_OF_REPLICAS_SETTING =
-        Setting.intSetting(SETTING_NUMBER_OF_REPLICAS, 1, 0, Property.Dynamic, Property.IndexScope);
+        Setting.intSetting(SETTING_NUMBER_OF_REPLICAS, 1, 0, Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
 
     public static final String SETTING_ROUTING_PARTITION_SIZE = "index.routing_partition_size";
     public static final Setting<Integer> INDEX_ROUTING_PARTITION_SIZE_SETTING =
@@ -192,7 +192,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public static final String SETTING_READ_ONLY_ALLOW_DELETE = "index.blocks.read_only_allow_delete";
     public static final Setting<Boolean> INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING =
-        Setting.boolSetting(SETTING_READ_ONLY_ALLOW_DELETE, false, Property.Dynamic, Property.IndexScope);
+        Setting.boolSetting(SETTING_READ_ONLY_ALLOW_DELETE, false, Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
 
     public static final String SETTING_VERSION_CREATED = "index.version.created";
 
@@ -223,13 +223,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final String INDEX_ROUTING_EXCLUDE_GROUP_PREFIX = "index.routing.allocation.exclude";
     public static final Setting.AffixSetting<String> INDEX_ROUTING_REQUIRE_GROUP_SETTING =
         Setting.prefixKeySetting(INDEX_ROUTING_REQUIRE_GROUP_PREFIX + ".", key ->
-            Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.IndexScope));
+            Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope));
     public static final Setting.AffixSetting<String> INDEX_ROUTING_INCLUDE_GROUP_SETTING =
         Setting.prefixKeySetting(INDEX_ROUTING_INCLUDE_GROUP_PREFIX + ".", key ->
-            Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.IndexScope));
+            Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope));
     public static final Setting.AffixSetting<String> INDEX_ROUTING_EXCLUDE_GROUP_SETTING =
         Setting.prefixKeySetting(INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + ".", key ->
-            Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.IndexScope));
+            Setting.simpleString(key, value -> IP_VALIDATOR.accept(key, value), Property.Dynamic, Property.IndexScope,Property.ReplicatedIndexScope));
 
     // this is only setable internally not a registered setting!!
     public static final Setting.AffixSetting<String> INDEX_ROUTING_INITIAL_RECOVERY_GROUP_SETTING =
@@ -244,7 +244,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                       ActiveShardCount::parseString,
                       DataTypes.STRING,
                       Setting.Property.Dynamic,
-                      Setting.Property.IndexScope);
+                      Setting.Property.IndexScope,
+                      Property.ReplicatedIndexScope);
 
     /**
      * an internal index format description, allowing us to find out if this index is upgraded or needs upgrading

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -55,10 +55,11 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     public static final DateFormatter DATE_TIME_FORMATTER = DateFormatters.forPattern("dateOptionalTime").withZone(ZoneOffset.UTC);
 
     public static final Setting<TimeValue> INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING = Setting.positiveTimeSetting(
-            "index.unassigned.node_left.delayed_timeout",
+        "index.unassigned.node_left.delayed_timeout",
         TimeValue.timeValueMinutes(1),
         Property.Dynamic,
-        Property.IndexScope
+        Property.IndexScope,
+        Property.ReplicatedIndexScope
     );
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -70,7 +70,7 @@ public class EnableAllocationDecider extends AllocationDecider {
             DataTypes.STRING, Property.Dynamic, Property.NodeScope);
     public static final Setting<Allocation> INDEX_ROUTING_ALLOCATION_ENABLE_SETTING =
         new Setting<>("index.routing.allocation.enable", Allocation.ALL.toString(), Allocation::parse,
-            DataTypes.STRING, Property.Dynamic, Property.IndexScope);
+            DataTypes.STRING, Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
 
     public static final Setting<Rebalance> CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING = new Setting<>(
         "cluster.routing.rebalance.enable",

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -37,7 +37,7 @@ import org.elasticsearch.common.settings.Setting;
 public class MaxRetryAllocationDecider extends AllocationDecider {
 
     public static final Setting<Integer> SETTING_ALLOCATION_MAX_RETRY = Setting.intSetting("index.allocation.max_retries", 5, 0,
-        Setting.Property.Dynamic, Setting.Property.IndexScope, Setting.Property.NotCopyableOnResize);
+        Setting.Property.Dynamic, Setting.Property.IndexScope, Setting.Property.ReplicatedIndexScope, Setting.Property.NotCopyableOnResize);
 
     public static final String NAME = "max_retry";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
@@ -68,7 +68,8 @@ public class ShardsLimitAllocationDecider extends AllocationDecider {
             -1,
             -1,
             Property.Dynamic,
-            Property.IndexScope
+            Property.IndexScope,
+            Property.ReplicatedIndexScope
         );
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -118,6 +118,11 @@ public class Setting<T> implements ToXContentObject {
         IndexScope,
 
         /**
+         * Indicates an index-level setting that is allowed to be changed on a replicated index.
+         */
+        ReplicatedIndexScope,
+
+        /**
          * Mark this setting as not copyable during an index resize (shrink or split). This property can only be applied to settings that
          * also have {@link Property#IndexScope}.
          */
@@ -309,6 +314,10 @@ public class Setting<T> implements ToXContentObject {
      */
     public final boolean isDynamic() {
         return properties.contains(Property.Dynamic);
+    }
+
+    public final boolean isReplicatedIndexScope() {
+        return properties.contains(Property.ReplicatedIndexScope);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -841,7 +841,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     new TimeValue(30, TimeUnit.SECONDS),
                     new TimeValue(0, TimeUnit.MILLISECONDS),
                     Property.Dynamic,
-                    Property.IndexScope);
+                    Property.IndexScope,
+                    Property.ReplicatedIndexScope);
 
     // this setting is intentionally not registered, it is only used in tests
     public static final Setting<TimeValue> RETENTION_LEASE_SYNC_INTERVAL_SETTING =
@@ -850,7 +851,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     new TimeValue(5, TimeUnit.MINUTES),
                     new TimeValue(0, TimeUnit.MILLISECONDS),
                     Property.Dynamic,
-                    Property.IndexScope);
+                    Property.IndexScope,
+                    Property.ReplicatedIndexScope);
 
     /**
      * Background task that syncs the global checkpoint to replicas.

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -69,13 +69,18 @@ public final class IndexSettings {
         Setting.boolSetting("index.query.parse.allow_unmapped_fields", true, Property.IndexScope);
     public static final Setting<TimeValue> INDEX_TRANSLOG_SYNC_INTERVAL_SETTING =
         Setting.timeSetting("index.translog.sync_interval", TimeValue.timeValueSeconds(5), TimeValue.timeValueMillis(100),
-            Property.Dynamic, Property.IndexScope);
+            Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
     public static final Setting<TimeValue> INDEX_SEARCH_IDLE_AFTER =
         Setting.timeSetting("index.search.idle.after", TimeValue.timeValueSeconds(30),
             TimeValue.timeValueMinutes(0), Property.IndexScope, Property.Dynamic);
     public static final Setting<Translog.Durability> INDEX_TRANSLOG_DURABILITY_SETTING =
-        new Setting<>("index.translog.durability", Translog.Durability.REQUEST.name(),
-            (value) -> Translog.Durability.valueOf(value.toUpperCase(Locale.ROOT)), DataTypes.STRING, Property.Dynamic, Property.IndexScope);
+        new Setting<>("index.translog.durability",
+                      Translog.Durability.REQUEST.name(),
+                      (value) -> Translog.Durability.valueOf(value.toUpperCase(Locale.ROOT)),
+                      DataTypes.STRING,
+                      Property.Dynamic,
+                      Property.IndexScope,
+                      Property.ReplicatedIndexScope);
 
     public static final Setting<Boolean> INDEX_WARMER_ENABLED_SETTING =
         Setting.boolSetting("index.warmer.enabled", true, Property.Dynamic, Property.IndexScope, Property.Deprecated);
@@ -101,7 +106,7 @@ public final class IndexSettings {
      * and is defensive as it prevents generating too many index terms.
      */
     public static final Setting<Integer> MAX_NGRAM_DIFF_SETTING =
-        Setting.intSetting("index.max_ngram_diff", 1, 0, Property.Dynamic, Property.IndexScope);
+        Setting.intSetting("index.max_ngram_diff", 1, 0, Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
 
     /**
      * Index setting describing for ShingleTokenFilter
@@ -110,12 +115,12 @@ public final class IndexSettings {
      * The default value is 3 is defensive as it prevents generating too many tokens.
      */
     public static final Setting<Integer> MAX_SHINGLE_DIFF_SETTING =
-        Setting.intSetting("index.max_shingle_diff", 3, 0, Property.Dynamic, Property.IndexScope);
+        Setting.intSetting("index.max_shingle_diff", 3, 0, Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
 
     public static final TimeValue DEFAULT_REFRESH_INTERVAL = new TimeValue(1, TimeUnit.SECONDS);
     public static final Setting<TimeValue> INDEX_REFRESH_INTERVAL_SETTING =
         Setting.timeSetting("index.refresh_interval", DEFAULT_REFRESH_INTERVAL, new TimeValue(-1, TimeUnit.MILLISECONDS),
-            Property.Dynamic, Property.IndexScope);
+            Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
     public static final Setting<ByteSizeValue> INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING =
         Setting.byteSizeSetting("index.translog.flush_threshold_size", new ByteSizeValue(512, ByteSizeUnit.MB),
             /*
@@ -125,7 +130,7 @@ public final class IndexSettings {
              */
             new ByteSizeValue(Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1, ByteSizeUnit.BYTES),
             new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-            Property.Dynamic, Property.IndexScope);
+            Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
 
 
     /**
@@ -224,7 +229,8 @@ public final class IndexSettings {
             TimeValue.timeValueHours(12),
             TimeValue.ZERO,
             Property.Dynamic,
-            Property.IndexScope
+            Property.IndexScope,
+            Property.ReplicatedIndexScope
         );
 
 

--- a/server/src/main/java/org/elasticsearch/index/MergeSchedulerConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergeSchedulerConfig.java
@@ -56,11 +56,12 @@ public final class MergeSchedulerConfig {
 
     public static final Setting<Integer> MAX_THREAD_COUNT_SETTING =
         new Setting<>("index.merge.scheduler.max_thread_count",
-            (s) -> Integer.toString(Math.max(1, Math.min(4, EsExecutors.numberOfProcessors(s) / 2))),
-            (s) -> Setting.parseInt(s, 1, "index.merge.scheduler.max_thread_count"),
-            DataTypes.INTEGER,
-            Property.Dynamic,
-            Property.IndexScope);
+                      (s) -> Integer.toString(Math.max(1, Math.min(4, EsExecutors.numberOfProcessors(s) / 2))),
+                      (s) -> Setting.parseInt(s, 1, "index.merge.scheduler.max_thread_count"),
+                      DataTypes.INTEGER,
+                      Property.Dynamic,
+                      Property.IndexScope,
+                      Property.ReplicatedIndexScope);
     public static final Setting<Integer> MAX_MERGE_COUNT_SETTING =
         new Setting<>("index.merge.scheduler.max_merge_count",
             (s) -> Integer.toString(MAX_THREAD_COUNT_SETTING.get(s) + 5),

--- a/server/src/test/java/io/crate/metadata/table/OperationTest.java
+++ b/server/src/test/java/io/crate/metadata/table/OperationTest.java
@@ -103,7 +103,7 @@ public class OperationTest extends ESTestCase {
         var replicatedIndexSettings = Settings.builder().put(REPLICATION_SUBSCRIPTION_NAME.getKey(), "sub1").build();
         assertThat(
             Operation.buildFromIndexSettingsAndState(replicatedIndexSettings, IndexMetadata.State.OPEN, false),
-            containsInAnyOrder(READ, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE)
+            containsInAnyOrder(READ, ALTER, ALTER_BLOCKS, ALTER_REROUTE, OPTIMIZE, REFRESH, COPY_TO, SHOW_CREATE)
         );
     }
 

--- a/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+import static io.crate.testing.Asserts.assertThrowsMatches;
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.analyze.BoundAlterTable;
+import io.crate.data.Row;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class AlterTablePlanTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() throws IOException {
+        e = SQLExecutor.builder(clusterService).addTable("create table doc.test(i int)", Settings.builder()
+            .put(REPLICATION_SUBSCRIPTION_NAME.getKey(), "sub1").build()).build();
+    }
+
+    /**
+     * https://github.com/crate/crate/issues/12478
+     */
+    @Test
+    public void test_alter_allowed_settings_on_a_replicated_table() throws IOException {
+
+        assertThat(analyze("Alter table doc.test set(number_of_replicas = 1)"), is(notNullValue()));
+
+        assertThat(analyze("Alter table doc.test set(refresh_interval = 523)"), is(notNullValue()));
+
+    }
+
+    @Test
+    public void test_alter_forbidden_settings_on_a_replicated_table() throws IOException {
+        assertThrowsMatches(
+            () -> analyze("Alter table doc.test set(number_of_shards = 1)"),
+            IllegalArgumentException.class,
+            "Invalid property \"number_of_shards\" passed to [ALTER | CREATE] TABLE statement"
+        );
+    }
+
+    private BoundAlterTable analyze(String stmt) {
+        AlterTablePlan plan = e.plan(stmt);
+        return AlterTablePlan.bind(plan.alterTable,
+                                   CoordinatorTxnCtx.systemTransactionContext(),
+                                   createNodeContext(),
+                                   Row.EMPTY,
+                                   SubQueryResults.EMPTY);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This enables to alter settings in subscribed tables except ``number_of_shards`` and ``mapping.total_fields.limit``.

Resolves https://github.com/crate/crate/issues/12478


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
