### PR TITLE
Fix randomization in forRandomMasterOrDataNode

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -92,6 +92,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could cause queries on ``sys.snapshots`` to get stuck and
+  consume a significant amount of resources.
+
 - Fixed an issue with primary key columns that have a ``DEFAULT`` clause. That
   could lead to queries on the primary key column not matching the row.
 

--- a/server/src/main/java/io/crate/metadata/RoutingProvider.java
+++ b/server/src/main/java/io/crate/metadata/RoutingProvider.java
@@ -88,12 +88,13 @@ public final class RoutingProvider {
             return forTableOnSingleNode(relationName, localNode.getId());
         }
         ImmutableOpenMap<String, DiscoveryNode> masterAndDataNodes = nodes.getMasterAndDataNodes();
-        int randomIdx = seed % masterAndDataNodes.size();
+        int randomIdx = Math.abs(seed % masterAndDataNodes.size());
         Iterator<DiscoveryNode> it = masterAndDataNodes.valuesIt();
         int currIdx = 0;
         while (it.hasNext()) {
+            DiscoveryNode next = it.next();
             if (currIdx == randomIdx) {
-                return forTableOnSingleNode(relationName, it.next().getId());
+                return forTableOnSingleNode(relationName, next.getId());
             }
             currIdx++;
         }

--- a/server/src/test/java/io/crate/metadata/RoutingProviderTest.java
+++ b/server/src/test/java/io/crate/metadata/RoutingProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata;
+
+import static org.hamcrest.Matchers.contains;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class RoutingProviderTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_random_master_or_data_node_that_is_not_local_with_negative_seed() {
+        RoutingProvider routingProvider = new RoutingProvider(-3, List.of());
+        Map<String, String> attr = Map.of();
+        var local = new DiscoveryNode("client", buildNewFakeTransportAddress(), attr, Set.of(), Version.CURRENT);
+        var node1 = new DiscoveryNode("master", buildNewFakeTransportAddress(), attr, Set.of(DiscoveryNodeRole.MASTER_ROLE), Version.CURRENT);
+        var node2 = new DiscoveryNode("data", buildNewFakeTransportAddress(), attr, Set.of(DiscoveryNodeRole.DATA_ROLE), Version.CURRENT);
+        DiscoveryNodes nodes = new DiscoveryNodes.Builder()
+            .add(node1)
+            .add(node2)
+            .add(local)
+            .localNodeId(local.getId())
+            .build();
+
+        Routing forRandomMasterOrDataNode = routingProvider.forRandomMasterOrDataNode(new RelationName("doc", "dummy"), nodes);
+        assertThat(forRandomMasterOrDataNode.nodes(), contains(
+            Matchers.oneOf(node1.getId(), node2.getId())
+        ));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes a potential infinite loop.

The `seed` could randomize to a negative value, leading to a negative
`randomIdx`. Due to the loop not correctly advancing the iterator it
kept iterating forever.

Only happened with dedicated client nodes in a cluster.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
