### PR TITLE
Implement support for non-recursive, DQL WITH sql statements

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -84,6 +84,7 @@ Changes
 - Added the :ref:`object_keys <scalar-object_keys>` scalar function which returns
   the set of first level keys of an ``object``.
 
+- Added support for non-recursive :ref:`sql_dql_with`.
 
 Fixes
 =====

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -64,3 +64,4 @@ SQL Statements
     show
     update
     values
+    with

--- a/docs/sql/statements/with.rst
+++ b/docs/sql/statements/with.rst
@@ -1,0 +1,42 @@
+.. highlight:: psql
+
+.. _sql_with:
+
+========
+``WITH``
+========
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+Synopsis
+========
+
+::
+
+    WITH with_query [, ...] select_query
+
+
+where ``with_query`` is:
+
+::
+
+    with_query_name [ ( column_name [, ...] ) ] AS (select_query)
+
+and ``select_query`` any :ref:`SELECT <sql-select>` clause.
+
+Description
+===========
+
+The ``WITH`` clause allows you to specify one or more subqueries that can be
+referenced by name in the primary query. The subqueries effectively act as
+temporary tables or views for the duration of the primary query.
+
+A name (without schema qualification) must be specified for each ``WITH`` query.
+Optionally, a list of column names can be specified; if this is omitted, the
+column names are inferred from the subquery.
+
+.. seealso:: :ref:`sql_dql_with`

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -126,8 +126,13 @@ alterStmt
     | ALTER SUBSCRIPTION name=ident alterSubscriptionMode                            #alterSubscription
     ;
 
-query:
-      queryTerm
+
+query
+    : with? queryNoWith
+    ;
+
+queryNoWith
+    : queryTerm
       (ORDER BY sortItem (',' sortItem)*)?
       (LIMIT limit=parameterOrInteger)?
       (OFFSET offset=parameterOrInteger)?
@@ -218,6 +223,14 @@ table
 
 aliasedColumns
     : '(' ident (',' ident)* ')'
+    ;
+
+with
+    : WITH namedQuery (',' namedQuery)*
+    ;
+
+namedQuery
+    : name=ident (aliasedColumns)? AS '(' query ')'
     ;
 
 expr

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -667,4 +667,12 @@ public abstract class AstVisitor<R, C> {
     public R visitAlterSubscription(AlterSubscription alterSubscription, C context) {
         return visitStatement(alterSubscription, context);
     }
+
+    public R visitWithQuery(WithQuery withQuery, C context) {
+        return visitNode(withQuery, context);
+    }
+
+    public R visitWith(With with, C context) {
+        return visitStatement(with, context);
+    }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Query.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Query.java
@@ -21,27 +21,34 @@
 
 package io.crate.sql.tree;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.util.Objects.requireNonNull;
-
 public class Query extends Statement {
 
+    private final Optional<With> with;
     private final QueryBody queryBody;
     private final List<SortItem> orderBy;
     private final Optional<Expression> limit;
     private final Optional<Expression> offset;
 
-    public Query(QueryBody queryBody,
+    public Query(Optional<With> with,
+                 QueryBody queryBody,
                  List<SortItem> orderBy,
                  Optional<Expression> limit,
                  Optional<Expression> offset) {
+        this.with = requireNonNull(with, "with is null");
         this.queryBody = requireNonNull(queryBody, "queryBody is null");
         this.orderBy = orderBy;
         this.limit = limit;
         this.offset = offset;
+    }
+
+    public Optional<With> getWith() {
+        return with;
     }
 
     public QueryBody getQueryBody() {
@@ -74,7 +81,8 @@ public class Query extends Statement {
             return false;
         }
         Query query = (Query) o;
-        return Objects.equals(queryBody, query.queryBody) &&
+        return Objects.equals(with, query.with) &&
+               Objects.equals(queryBody, query.queryBody) &&
                Objects.equals(orderBy, query.orderBy) &&
                Objects.equals(limit, query.limit) &&
                Objects.equals(offset, query.offset);
@@ -82,12 +90,13 @@ public class Query extends Statement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(queryBody, orderBy, limit, offset);
+        return Objects.hash(with, queryBody, orderBy, limit, offset);
     }
 
     @Override
     public String toString() {
         return "Query{" +
+               "with=" + with +
                "queryBody=" + queryBody +
                ", orderBy=" + orderBy +
                ", limit=" + limit +

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/With.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/With.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.List;
+import java.util.Objects;
+
+public class With extends Statement {
+
+    private final List<WithQuery> withQueries;
+
+    public With(List<WithQuery> withQueries) {
+        this.withQueries = withQueries;
+    }
+
+    public List<WithQuery> withQueries() {
+        return withQueries;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitWith(this, context);
+    }
+
+    @Override
+    public String toString() {
+        return "With{" +
+            "withQueries=" + withQueries +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        With with = (With) o;
+        return withQueries.equals(with.withQueries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(withQueries);
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/WithQuery.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/WithQuery.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.List;
+import java.util.Objects;
+
+public class WithQuery extends Node {
+
+    private final String name;
+    private final Query query;
+    private final List<String> columnNames;
+
+    public WithQuery(String name, Query query, List<String> columnNames) {
+        this.name = name;
+        this.query = Objects.requireNonNull(query, "query is null");
+        this.columnNames = columnNames;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Query query() {
+        return query;
+    }
+
+    public List<String> columnNames() {
+        return columnNames;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitWithQuery(this, context);
+    }
+
+    @Override
+    public String toString() {
+        return "WithQuery{" +
+            "name=" + name +
+            ", query=" + query +
+            ", columnNames=" + columnNames +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WithQuery withQuery = (WithQuery) o;
+        return name.equals(withQuery.name)
+            && query.equals(withQuery.query)
+            && Objects.equals(columnNames, withQuery.columnNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, query, columnNames);
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -21,6 +21,25 @@
 
 package io.crate.sql.parser;
 
+import static io.crate.sql.SqlFormatter.formatSql;
+import static io.crate.sql.tree.QueryUtil.selectList;
+import static io.crate.sql.tree.QueryUtil.table;
+import static java.lang.String.format;
+import static java.util.Collections.nCopies;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Test;
+
 import io.crate.common.collections.Lists2;
 import io.crate.sql.tree.Cast;
 import io.crate.sql.tree.ColumnType;
@@ -37,24 +56,6 @@ import io.crate.sql.tree.Query;
 import io.crate.sql.tree.QuerySpecification;
 import io.crate.sql.tree.Statement;
 import io.crate.sql.tree.StringLiteral;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-
-import static io.crate.sql.SqlFormatter.formatSql;
-import static io.crate.sql.tree.QueryUtil.selectList;
-import static io.crate.sql.tree.QueryUtil.table;
-import static java.lang.String.format;
-import static java.util.Collections.nCopies;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestSqlParser {
 
@@ -164,6 +165,7 @@ public class TestSqlParser {
     public void testDoubleInQuery() {
         assertStatement("SELECT 123.456E7 FROM DUAL",
             new Query(
+                Optional.empty(),
                 new QuerySpecification(
                     selectList(new DoubleLiteral("123.456E7")),
                     table(QualifiedName.of("dual")),

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -98,6 +98,7 @@ import io.crate.sql.tree.SubscriptExpression;
 import io.crate.sql.tree.SwapTable;
 import io.crate.sql.tree.Update;
 import io.crate.sql.tree.Window;
+import io.crate.sql.tree.With;
 
 public class TestStatementBuilder {
 
@@ -1808,6 +1809,18 @@ public class TestStatementBuilder {
         printStatement("ALTER SUBSCRIPTION \"mySub\" DISABLE");
     }
 
+    @Test
+    public void test_with_statement() {
+        printStatement("WITH r AS (SELECT * FROM t1)\n" +
+            "SELECT * FROM t2, r");
+        printStatement("WITH r AS (SELECT * FROM t1)," +
+            " s AS (SELECT * FROM t2)\n" +
+            "SELECT * FROM t2, r");
+        printStatement("WITH r AS (SELECT * FROM t1)," +
+            " s AS (WITH r AS (SELECT * FROM t2) SELECT * FROM r)\n" +
+            "SELECT * FROM t2, r");
+    }
+
     private static void printStatement(String sql) {
         println(sql.trim());
         println("");
@@ -1844,7 +1857,8 @@ public class TestStatementBuilder {
             statement instanceof AlterPublication ||
             statement instanceof CreateSubscription ||
             statement instanceof DropSubscription ||
-            statement instanceof AlterSubscription) {
+            statement instanceof AlterSubscription ||
+            statement instanceof With) {
                 println(SqlFormatter.formatSql(statement));
                 println("");
                 assertFormattedSql(statement);

--- a/server/src/main/java/io/crate/analyze/relations/ParentRelations.java
+++ b/server/src/main/java/io/crate/analyze/relations/ParentRelations.java
@@ -21,12 +21,14 @@
 
 package io.crate.analyze.relations;
 
-import io.crate.metadata.RelationName;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import io.crate.metadata.RelationName;
 
 public class ParentRelations {
 
@@ -49,11 +51,18 @@ public class ParentRelations {
     }
 
     public boolean containsRelation(RelationName qualifiedName) {
+        return relation(qualifiedName) != null;
+    }
+
+    @Nullable
+    public AnalyzedRelation relation(RelationName relationName) {
+        AnalyzedRelation relation = null;
         for (int i = sourcesTree.size() - 1; i >= 0; i--) {
-            if (sourcesTree.get(i).containsKey(qualifiedName)) {
-                return true;
+            relation = sourcesTree.get(i).get(relationName);
+            if (relation != null) {
+                break;
             }
         }
-        return false;
+        return relation;
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -21,24 +21,8 @@
 
 package io.crate.integrationtests;
 
-import io.crate.data.Paging;
-import io.crate.execution.engine.sort.OrderingByPosition;
-import io.crate.metadata.RelationName;
-import io.crate.statistics.Stats;
-import io.crate.statistics.TableStats;
-import io.crate.testing.TestingHelpers;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
-
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
@@ -46,6 +30,22 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import io.crate.data.Paging;
+import io.crate.execution.engine.sort.OrderingByPosition;
+import io.crate.metadata.RelationName;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.testing.TestingHelpers;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class SubSelectIntegrationTest extends SQLIntegrationTestCase {
@@ -764,5 +764,17 @@ public class SubSelectIntegrationTest extends SQLIntegrationTestCase {
                 "select o, o['a']['b']['c'] from nested_obj" +
                 ") nobj");
         assertThat(printedTable(response.rows()), is("1\n"));
+    }
+
+    @Test
+    public void test_non_recursive_with_query() {
+        setup.setUpCharacters();
+
+        execute("WITH ch AS (SELECT * FROM characters WHERE female = true) " +
+            "SELECT id, name " +
+            "FROM ch " +
+            "WHERE name LIKE 'Arthur'");
+        assertThat(printedTable(response.rows()),
+            is("4| Arthur\n"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Non-recursive WITH statements, which only contain DQL statements, can be simply rewritten to (nested) sub-select queries.
Recursive or materialized WITH and the usage of DML statements is not supported.

Relates #11757.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
