### PR TITLE
Fix NPE while writing a ShardResponse with an empty failure message

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -205,8 +205,11 @@ public class SQLExceptions {
     /**
      * Converts a possible ES exception to a Crate one and returns the message.
      * The message will not contain any information about possible nested exceptions.
+     * If the message is null, the exceptions name is used.
      */
     public static String userFriendlyCrateExceptionTopOnly(Throwable e) {
-        return esToCrateException(e).getMessage();
+        var throwable = esToCrateException(e);
+        var message = throwable.getMessage();
+        return message != null ? message : throwable.getClass().getName();
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The ShardUpsertActions uses the userFriendlyCrateExceptionTopOnly helper method to retrieve a friendly error message from an exception.
This method will use the `Throwable.getMessage()` method which mayreturn NULL.
The throwable class name is now used in such a case.

See test failure https://github.com/crate/crate/runs/6520628861?check_suite_focus=true.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
