### PR TITLE
Enable to alter the setting ``blocks.read_only_allow_delete`` on blob…

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -99,6 +99,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Enabled to alter the setting ``blocks.read_only_allow_delete`` on blob tables
+  to make it possible to drop read-only blob tables.
+
 - Fixed an issue that could cause queries on ``sys.snapshots`` to get stuck and
   consume a significant amount of resources.
 

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -21,6 +21,9 @@
 
 package io.crate.analyze;
 
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -85,7 +88,7 @@ public class TableParameters {
             NUMBER_OF_REPLICAS,
             IndexSettings.INDEX_REFRESH_INTERVAL_SETTING,
             IndexMetadata.INDEX_READ_ONLY_SETTING,
-            IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
+            INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
             IndexMetadata.INDEX_BLOCKS_READ_SETTING,
             IndexMetadata.INDEX_BLOCKS_WRITE_SETTING,
             IndexMetadata.INDEX_BLOCKS_METADATA_SETTING,
@@ -180,9 +183,13 @@ public class TableParameters {
     );
 
     public static final TableParameters ALTER_BLOB_TABLE_PARAMETERS = new TableParameters(
-        Map.of(NUMBER_OF_REPLICAS.getKey(), NUMBER_OF_REPLICAS),
+        Map.of(NUMBER_OF_REPLICAS.getKey(),
+               NUMBER_OF_REPLICAS,
+               stripDotSuffix(stripIndexPrefix(SETTING_READ_ONLY_ALLOW_DELETE)),
+               INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING
+        ),
         Map.of()
-    );
+        );
 
     private final Map<String, Setting<?>> supportedSettings;
     private final Map<String, Setting<?>> supportedMappings;

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -223,6 +223,15 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_alter_setting_block_read_only() {
+        AnalyzedAlterBlobTable analysis = e.analyze("alter blob table blobs set (\"blocks.read_only_allow_delete\"=true)");
+        assertThat(analysis.tableInfo().ident().name(), is("blobs"));
+        AlterTable<Object> alterTable = analysis.alterTable().map(EVAL);
+        TableParameter parameter = getTableParameter(alterTable, TableParameters.ALTER_BLOB_TABLE_PARAMETERS);
+        assertThat(parameter.settings().getAsBoolean(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, false), is(true));
+    }
+
+    @Test
     public void testAlterBlobTableWithPath() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Invalid property \"blobs_path\" passed to [ALTER | CREATE] TABLE statement");


### PR DESCRIPTION
This enables to alter the setting ``blocks.read_only_allow_delete`` on blob
tables to make it possible to drop read-only blob tables.

Resolves https://github.com/crate/crate/issues/12534

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
