### PR TITLE
Change timestamp alias to timestamp without time zone

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Changed the type of :ref:`TIMESTAMP <type-timestamp>` from :ref:`TIMESTAMP WITH
+  TIME ZONE <type-timestamp-with-tz>` to :ref:`TIMESTAMP WITHOUT TIME ZONE
+  <type-timestamp-without-tz>` to be compatible with the SQL standard.
+
 - Creating tables with soft deletes disabled is no longer supported.
   The setting :ref:`sql-create-table-soft-deletes-enabled` will
   always be set to ``true`` and removed in CrateDB 6.0.

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -1121,6 +1121,15 @@ With a few exceptions (noted below), the ``+`` and ``-`` :ref:`operators
 A timestamp expresses a specific date and time as the number of milliseconds
 since the `Unix epoch`_ (i.e., ``1970-01-01T00:00:00Z``).
 
+``TIMESTAMP`` has two variants:
+    - :ref:`TIMESTAMP WITHOUT TIME ZONE <type-timestamp-without-tz>` which
+       presents all values in UTC.
+    - :ref:`TIMESTAMP WITH TIME ZONE <type-timestamp-with-tz>`  which presents
+      all values in UTC in respect to the ``TIME ZONE`` related offset.
+
+By default a ``TIMESTAMP`` is an alias for :ref:`TIMESTAMP WITHOUT TIME ZONE
+<type-timestamp-without-tz>`.
+
 Timestamps can be expressed as string literals (e.g.,
 ``'1970-01-02T00:00:00'``) with the following syntax:
 
@@ -1276,19 +1285,6 @@ timestamp into UTC prior to insertion. Contrast this with the behavior of
 
     ``TIMESTAMPTZ`` is an alias for ``TIMESTAMP WITH TIME ZONE``.
 
-.. CAUTION::
-
-    In the absence of an explicit :ref:`WITH TIME ZONE
-    <type-timestamp-with-tz>` or :ref:`WITHOUT TIME ZONE
-    <type-timestamp-without-tz>`, CrateDB will interpret ``TIMEZONE`` as an
-    alias for ``TIMESTAMP WITH TIME ZONE``.
-
-    This behaviour does not comply with standard SQL and is incompatible with
-    PostgreSQL. CrateDB 4.0 :ref:`deprecated this alias <v4.0.0-deprecations>`
-    and behavior may change in a future version of CrateDB (see `tracking issue
-    #11491`_). To avoid issues, we recommend that you always specify ``WITH
-    TIME ZONE`` or ``WITHOUT TIME ZONE``.
-
 
 .. _type-timestamp-without-tz:
 
@@ -1346,20 +1342,6 @@ literal. Contrast this with the behavior of :ref:`WITH TIME ZONE
 
     cr> DROP TABLE my_table;
     DROP OK, 1 row affected (... sec)
-
-.. CAUTION::
-
-    In the absence of an explicit :ref:`WITH TIME ZONE
-    <type-timestamp-with-tz>` or :ref:`WITHOUT TIME ZONE
-    <type-timestamp-without-tz>`, CrateDB will interpret ``TIMEZONE`` as an
-    alias for ``TIMESTAMP WITH TIME ZONE``.
-
-    This behaviour does not comply with standard SQL and is incompatible with
-    PostgreSQL. CrateDB 4.0 :ref:`deprecated this alias <v4.0.0-deprecations>`
-    and behavior may change in a future version of CrateDB (see `tracking issue
-    #11491`_). To avoid issues, we recommend that you always specify ``WITH
-    TIME ZONE`` or ``WITHOUT TIME ZONE``.
-
 
 .. _type-timestamp-at-tz:
 
@@ -3275,47 +3257,47 @@ For example, in a type cast::
 
 See the table below for a full list of aliases:
 
-+-----------------------+------------------------------+
-| Alias                 | CrateDB Type                 |
-+=======================+==============================+
-| ``SHORT``             | ``SMALLINT``                 |
-+-----------------------+------------------------------+
-| ``INT``               | ``INTEGER``                  |
-+-----------------------+------------------------------+
-| ``INT2``              | ``SMALLINT``                 |
-+-----------------------+------------------------------+
-| ``INT4``              | ``INTEGER``                  |
-+-----------------------+------------------------------+
-| ``INT8``              | ``BIGINT``                   |
-+-----------------------+------------------------------+
-| ``LONG``              | ``BIGINT``                   |
-+-----------------------+------------------------------+
-| ``STRING``            | ``TEXT``                     |
-+-----------------------+------------------------------+
-| ``VARCHAR``           | ``TEXT``                     |
-+-----------------------+------------------------------+
-| ``CHARACTER VARYING`` | ``TEXT``                     |
-+-----------------------+------------------------------+
-| ``NAME``              | ``TEXT``                     |
-+-----------------------+------------------------------+
-| ``REGPROC``           | ``TEXT``                     |
-+-----------------------+------------------------------+
-| ``BYTE``              | ``CHAR``                     |
-+-----------------------+------------------------------+
-| ``FLOAT``             | ``REAL``                     |
-+-----------------------+------------------------------+
-| ``FLOAT4``            | ``REAL``                     |
-+-----------------------+------------------------------+
-| ``FLOAT8``            | ``DOUBLE PRECISION``         |
-+-----------------------+------------------------------+
-| ``DOUBLE``            | ``DOUBLE PRECISION``         |
-+-----------------------+------------------------------+
-| ``DECIMAL``           | ``NUMERIC``                  |
-+-----------------------+------------------------------+
-| ``TIMESTAMP``         | ``TIMESTAMP WITH TIME ZONE`` |
-+-----------------------+------------------------------+
-| ``TIMESTAMPTZ``       | ``TIMESTAMP WITH TIME ZONE`` |
-+-----------------------+------------------------------+
++-----------------------+---------------------------------+
+| Alias                 | CrateDB Type                    |
++=======================+=================================+
+| ``SHORT``             | ``SMALLINT``                    |
++-----------------------+---------------------------------+
+| ``INT``               | ``INTEGER``                     |
++-----------------------+---------------------------------+
+| ``INT2``              | ``SMALLINT``                    |
++-----------------------+---------------------------------+
+| ``INT4``              | ``INTEGER``                     |
++-----------------------+---------------------------------+
+| ``INT8``              | ``BIGINT``                      |
++-----------------------+---------------------------------+
+| ``LONG``              | ``BIGINT``                      |
++-----------------------+---------------------------------+
+| ``STRING``            | ``TEXT``                        |
++-----------------------+---------------------------------+
+| ``VARCHAR``           | ``TEXT``                        |
++-----------------------+---------------------------------+
+| ``CHARACTER VARYING`` | ``TEXT``                        |
++-----------------------+---------------------------------+
+| ``NAME``              | ``TEXT``                        |
++-----------------------+---------------------------------+
+| ``REGPROC``           | ``TEXT``                        |
++-----------------------+---------------------------------+
+| ``BYTE``              | ``CHAR``                        |
++-----------------------+---------------------------------+
+| ``FLOAT``             | ``REAL``                        |
++-----------------------+---------------------------------+
+| ``FLOAT4``            | ``REAL``                        |
++-----------------------+---------------------------------+
+| ``FLOAT8``            | ``DOUBLE PRECISION``            |
++-----------------------+---------------------------------+
+| ``DOUBLE``            | ``DOUBLE PRECISION``            |
++-----------------------+---------------------------------+
+| ``DECIMAL``           | ``NUMERIC``                     |
++-----------------------+---------------------------------+
+| ``TIMESTAMP``         | ``TIMESTAMP WITHOUT TIME ZONE`` |
++-----------------------+---------------------------------+
+| ``TIMESTAMPTZ``       | ``TIMESTAMP WITH TIME ZONE``    |
++-----------------------+---------------------------------+
 
 .. NOTE::
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -37,8 +37,6 @@ import io.crate.types.GeoShapeType;
 import io.crate.types.ObjectType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
-import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -54,9 +52,6 @@ import java.util.function.Function;
 import static org.elasticsearch.index.mapper.TypeParsers.DOC_VALUES;
 
 public class AnalyzedColumnDefinition<T> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER =
-        new DeprecationLogger(LogManager.getLogger(AnalyzedColumnDefinition.class));
 
     private static final Set<Integer> UNSUPPORTED_PK_TYPE_IDS = Set.of(
         ObjectType.ID,
@@ -273,13 +268,6 @@ public class AnalyzedColumnDefinition<T> {
     }
 
     public void dataType(String typeName, List<Integer> parameters, boolean logWarnings) {
-        if ("timestamp".equals(typeName) && logWarnings) {
-            DEPRECATION_LOGGER.deprecated(
-                "Column [{}]: Usage of the `TIMESTAMP` data type as a timestamp with zone " +
-                "is deprecated, use the `TIMESTAMPTZ` or `TIMESTAMP WITH TIME ZONE` data type instead.",
-                ident.fqn()
-            );
-        }
         this.dataType = DataTypes.of(typeName, parameters);
     }
 

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -401,14 +401,7 @@ public final class DataTypes {
         entry("character varying", STRING),
         entry("timetz", TIMETZ),
         entry("timestamptz", TIMESTAMPZ),
-        // The usage of the `timestamp` data type as a data type with time
-        // zone is deprecate, use `timestamp with time zone` or `timestamptz`
-        // instead. In future releases the `timestamp` data type will be changed
-        // to behave as a timestamp without time zone. For now, we use the
-        // `timestamp` as an alias for the `timestamp with time zone` data type
-        // to warn users about the data type semantic change and give a time
-        // to adjust to the change.
-        entry("timestamp", TIMESTAMPZ),
+        entry("timestamp", TIMESTAMP),
         entry("interval", INTERVAL),
         entry(DATE.getName(), DATE),
         entry(BitStringType.INSTANCE_ONE.getName(), BitStringType.INSTANCE_ONE),

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -151,15 +151,6 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     }
 
     @Test
-    public void testTimestampDataTypeDeprecationWarning() {
-        analyze("create table t (ts timestamp)");
-        assertWarnings(
-            "Column [ts]: Usage of the `TIMESTAMP` data type as a timestamp with zone is deprecated," +
-            " use the `TIMESTAMPTZ` or `TIMESTAMP WITH TIME ZONE` data type instead."
-        );
-    }
-
-    @Test
     public void test_cannot_create_table_that_contains_a_column_definition_of_type_time () {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot use the type `time with time zone` for column: ts");

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -82,7 +82,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDeleteWherePartitionedByColumn() throws Exception {
-        AnalyzedDeleteStatement delete = e.analyze("delete from parted where date = 1395874800000::timestamp");
+        AnalyzedDeleteStatement delete = e.analyze("delete from parted where date = 1395874800000::timestamptz");
         assertThat(delete.query(), isFunction(EqOperator.NAME, isReference("date"), isLiteral(1395874800000L)));
     }
 

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2429,7 +2429,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var executor = SQLExecutor.builder(clusterService)
             .build();
         AnalyzedRelation relation = executor.analyze("select timestamp '2018-12-12T00:00:00'");
-        assertThat(relation.outputs().get(0).valueType(), is(DataTypes.TIMESTAMPZ));
+        assertThat(relation.outputs().get(0).valueType(), is(DataTypes.TIMESTAMP));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -174,7 +174,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testUpdateWherePartitionedByColumn() throws Exception {
-        AnalyzedUpdateStatement update = analyzeUpdate("update parted set id = 2 where date = 1395874800000::timestamp");
+        AnalyzedUpdateStatement update = analyzeUpdate("update parted set id = 2 where date = 1395874800000::timestamptz");
         assertThat(update.query(), isFunction(EqOperator.NAME, isReference("date"), isLiteral(1395874800000L)));
     }
 
@@ -265,7 +265,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_where_on_date_with_null_partition_or_id_can_match_all_partitions() throws Exception {
         WhereClause whereClause = analyzeSelectWhere(
-            "select id, name from parted where date = 1395961200000::timestamp or id = 1");
+            "select id, name from parted where date = 1395961200000::timestamptz or id = 1");
         assertThat(whereClause.partitions(), containsInAnyOrder(
             ".partitioned.parted.0400",
             ".partitioned.parted.04732cpp6ksjcc9i60o30c1g",

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import static io.crate.testing.Asserts.assertThrowsMatches;
+
 import io.crate.expression.scalar.ScalarTestCase;
 import org.hamcrest.Matchers;
 import org.joda.time.Period;
@@ -73,9 +75,10 @@ public class IntervalFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_unallowed_operations() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unknown function: (cast('1 second' AS interval) - cast('86401000' AS timestamp with time zone))," +
-                                        " no overload found for matching argument types: (interval, timestamp with time zone).");
-        assertEvaluate("interval '1 second' - '86401000'::timestamp", Matchers.is(86400000L));
+        assertThrowsMatches(
+            () -> assertEvaluate("interval '1 second' - '86401000'::timestamptz", Matchers.is(86400000L)),
+            UnsupportedOperationException.class,
+            "Unknown function: (cast('1 second' AS interval) - cast('86401000' AS timestamp with time zone)), "
+        );
     }
 }

--- a/server/src/test/java/io/crate/expression/tablefunctions/GenerateSeriesTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/GenerateSeriesTest.java
@@ -21,6 +21,9 @@
 
 package io.crate.expression.tablefunctions;
 
+import static io.crate.testing.Asserts.assertThrowsMatches;
+
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class GenerateSeriesTest extends AbstractTableFunctionsTest {
@@ -152,8 +155,10 @@ public class GenerateSeriesTest extends AbstractTableFunctionsTest {
 
     @Test
     public void test_step_is_mandatory_for_timestamps() {
-        expectedException.expectMessage(
-            "generate_series(start, stop) has type `timestamp with time zone` for start, but requires long/int values for start and stop, or if used with timestamps, it requires a third argument for the step (interval)");
-        assertExecute("generate_series(null::timestamp, '2019-03-04'::timestamp)", "");
+        assertThrowsMatches(
+            () -> assertExecute("generate_series(null::timestamptz, '2019-03-04'::timestamptz)", ""),
+            IllegalArgumentException.class,
+            "generate_series(start, stop) has type `timestamp with time zone` for start, but requires long/int values for start and stop, or if used with timestamps, it requires a third argument for the step (interval)"
+        );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -863,7 +863,7 @@ public class DDLIntegrationTest extends SQLIntegrationTestCase {
             "create table test (" +
             "   ts timestamp with time zone," +
             "   day as date_trunc('day', ts)) with (number_of_replicas=0)");
-        execute("alter table test add column added timestamp generated always as date_trunc('day', ts)");
+        execute("alter table test add column added timestamp with time zone generated always as date_trunc('day', ts)");
         ensureYellow();
         String expectedMapping = "{\"default\":" +
                                  "{\"dynamic\":\"strict\"," +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Resolves https://github.com/crate/crate/issues/11509

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
