### PR TITLE
bp: Fix testRerouteOccursOnDiskPassingHighWatermark

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -209,7 +209,7 @@ should be crossed out as well.
 - [ ] 0286d0a769e Move distance_feature query building into MFT (#60614) (#60846)
 - [ ] f44c28b5951 Deprecate and ignore join timeout (#60872)
 - [ ] e8d9185045b Cut over IPFieldMapper to parametrized form (#60602)
-- [ ] 1f49e0b9d01 Fix testRerouteOccursOnDiskPassingHighWatermark (#60869)
+- [x] 1f49e0b9d01 Fix testRerouteOccursOnDiskPassingHighWatermark (#60869)
 - [ ] 2f76c48ea71 Propagate forceExecution when acquiring permit (#60634)
 - [ ] b4044004aa4 Add recovery state tracking for Searchable Snapshots (#60751)
 - [ ] ebfb93ff264 Improve some BytesStreamOutput Usage (#60730) (#60736)

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -188,7 +188,7 @@ public class DiskThresholdMonitor {
                 nodesOverLowThreshold.add(node);
                 nodesOverHighThreshold.add(node);
 
-                if (lastRunTimeMillis.get() < currentTimeMillis - diskThresholdSettings.getRerouteInterval().millis()) {
+                if (lastRunTimeMillis.get() <= currentTimeMillis - diskThresholdSettings.getRerouteInterval().millis()) {
                     reroute = true;
                     explanation = "high disk watermark exceeded on one or more nodes";
                     usagesOverHighThreshold.add(usage);
@@ -223,7 +223,7 @@ public class DiskThresholdMonitor {
                 if (nodesOverLowThreshold.contains(node)) {
                     // The node has previously been over the low watermark, but is no longer, so it may be possible to allocate more shards
                     // if we reroute now.
-                    if (lastRunTimeMillis.get() < currentTimeMillis - diskThresholdSettings.getRerouteInterval().millis()) {
+                    if (lastRunTimeMillis.get() <= currentTimeMillis - diskThresholdSettings.getRerouteInterval().millis()) {
                         reroute = true;
                         explanation = "one or more nodes has gone under the high or low watermark";
                         nodesOverLowThreshold.remove(node);

--- a/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
@@ -41,7 +41,6 @@ import java.util.stream.StreamSupport;
 
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.MockInternalClusterInfoService;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -143,7 +142,7 @@ public class DiskUsagesITest extends SQLIntegrationTestCase {
             internalCluster().startNode(
                 Settings.builder()
                     .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir())
-                    .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "1ms"));
+                    .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms"));
         }
         List<String> nodeIds = getNodeIds();
 


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/commit/3a803c85a41377c274bcbea58dddfd658ccdd40f

Faced failure of this test multiple times while working on another task and accidentally noticed that there exist a fix for it.

Checked with Repeat and with seed from Jenkins, it seems to help
`./gradlew :server:test -Dtests.seed=F9AE7EA923608E82 -Dtests.class=io.crate.integrationtests.DiskUsagesITest -Dtests.method="testRerouteOccursOnDiskPassingHighWatermark" -Dtests.locale=fur -Dtests.timezone=Europe/Tiraspol `     


[this](https://github.com/elastic/elasticsearch/commit/3a803c85a41377c274bcbea58dddfd658ccdd40f#diff-fd31d583be4f4053c11890df4d243456ba696d7426d0f7e43f5198e0ee9ca729R104) change we already did in https://github.com/crate/crate/pull/12212/commits/c2b4d3189caf48f946e1ac3546f3c37eb9110bf7#diff-27f957a519dc09352d1be5a439fa1da36f9888ef3fa49bfb14a725eac8a4581e (which BTW was not part of original https://github.com/elastic/elasticsearch/pull/59880/files#diff-fd31d583be4f4053c11890df4d243456ba696d7426d0f7e43f5198e0ee9ca729) 


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
