### PR TITLE
Remove .add from GenericProperties

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1103,9 +1103,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitGenericProperties(SqlBaseParser.GenericPropertiesContext context) {
-        GenericProperties<Expression> properties = new GenericProperties<>();
-        context.genericProperty().forEach(p -> properties.add((GenericProperty<Expression>) visit(p)));
-        return properties;
+        Map<String, Expression> properties = new HashMap<>();
+        for (var property : context.genericProperty()) {
+            String key = getIdentText(property.ident());
+            Expression value = (Expression) visit(property.expr());
+            properties.put(key, value);
+        }
+        return new GenericProperties<>(properties);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
@@ -49,35 +49,23 @@ public class GenericProperties<T> extends Node {
 
     private static final GenericProperties<?> EMPTY = new GenericProperties<>(Map.of());
 
+    @SuppressWarnings("unchecked")
     public static <T> GenericProperties<T> empty() {
         return (GenericProperties<T>) EMPTY;
     }
 
     private final Map<String, T> properties;
 
-    public GenericProperties() {
-        properties = new HashMap<>();
-    }
-
     public GenericProperties(Map<String, T> map) {
-        this.properties = map;
+        this.properties = Collections.unmodifiableMap(map);
     }
 
     public Map<String, T> properties() {
-        return Collections.unmodifiableMap(properties);
+        return properties;
     }
 
     public T get(String key) {
         return properties.get(key);
-    }
-
-    /**
-     * merge the given {@linkplain io.crate.sql.tree.GenericProperty} into the contained map.
-     *
-     * @param property
-     */
-    public void add(GenericProperty<T> property) {
-        properties.put(property.key(), property.value());
     }
 
     public boolean isEmpty() {

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
@@ -24,6 +24,7 @@ package org.elasticsearch.repositories.s3;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -102,19 +103,20 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testValidateS3ConfigParams() {
-        GenericProperties<Expression> genericProperties = new GenericProperties<>();
-        genericProperties.add(new GenericProperty<>("access_key", new StringLiteral("foobar")));
-        genericProperties.add(new GenericProperty<>("base_path", new StringLiteral("/data")));
-        genericProperties.add(new GenericProperty<>("bucket", new StringLiteral("myBucket")));
-        genericProperties.add(new GenericProperty<>("buffer_size", new StringLiteral("5mb")));
-        genericProperties.add(new GenericProperty<>("canned_acl", new StringLiteral("cannedACL")));
-        genericProperties.add(new GenericProperty<>("chunk_size", new StringLiteral("4g")));
-        genericProperties.add(new GenericProperty<>("compress", new StringLiteral("true")));
-        genericProperties.add(new GenericProperty<>("endpoint", new StringLiteral("myEndpoint")));
-        genericProperties.add(new GenericProperty<>("max_retries", new StringLiteral("8")));
-        genericProperties.add(new GenericProperty<>("protocol", new StringLiteral("http")));
-        genericProperties.add(new GenericProperty<>("secret_key", new StringLiteral("thisIsASecretKey")));
-        genericProperties.add(new GenericProperty<>("server_side_encryption", new StringLiteral("false")));
+        Map<String, Expression> properties = new HashMap<>();
+        properties.put("access_key", new StringLiteral("foobar"));
+        properties.put("base_path", new StringLiteral("/data"));
+        properties.put("bucket", new StringLiteral("myBucket"));
+        properties.put("buffer_size", new StringLiteral("5mb"));
+        properties.put("canned_acl", new StringLiteral("cannedACL"));
+        properties.put("chunk_size", new StringLiteral("4g"));
+        properties.put("compress", new StringLiteral("true"));
+        properties.put("endpoint", new StringLiteral("myEndpoint"));
+        properties.put("max_retries", new StringLiteral("8"));
+        properties.put("protocol", new StringLiteral("http"));
+        properties.put("secret_key", new StringLiteral("thisIsASecretKey"));
+        properties.put("server_side_encryption", new StringLiteral("false"));
+        GenericProperties<Expression> genericProperties = new GenericProperties<>(properties);
         repositoryParamValidator.validate(
             "s3",
             genericProperties,

--- a/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -60,7 +60,7 @@ class CreateAnalyzerStatementAnalyzer {
 
         @Nullable
         private Tuple<String, GenericProperties<Symbol>> tokenizer;
-        private final GenericProperties<Symbol> genericAnalyzerProperties;
+        private final Map<String, Symbol> genericAnalyzerProperties;
         private final Map<String, GenericProperties<Symbol>> charFilters;
         private final Map<String, GenericProperties<Symbol>> tokenFilters;
 
@@ -70,7 +70,7 @@ class CreateAnalyzerStatementAnalyzer {
         Context(CoordinatorTxnCtx transactionContext,
                 NodeContext nodeCtx,
                 ParamTypeHints paramTypeHints) {
-            this.genericAnalyzerProperties = new GenericProperties<>();
+            this.genericAnalyzerProperties = new HashMap<>();
             this.charFilters = new HashMap<>();
             this.tokenFilters = new HashMap<>();
 
@@ -121,7 +121,7 @@ class CreateAnalyzerStatementAnalyzer {
             analyzerIdent,
             extendedAnalyzerName,
             context.tokenizer,
-            context.genericAnalyzerProperties,
+            new GenericProperties<>(context.genericAnalyzerProperties),
             context.tokenFilters,
             context.charFilters);
     }
@@ -151,12 +151,11 @@ class CreateAnalyzerStatementAnalyzer {
         public Void visitGenericProperty(GenericProperty<?> node, Context context) {
             var property = (GenericProperty<Expression>) node;
 
-            context.genericAnalyzerProperties.add(
-                new GenericProperty<>(
-                    property.key(),
-                    context.exprAnalyzerWithFieldsAsString.convert(
-                        property.value(),
-                        context.exprContext))
+            context.genericAnalyzerProperties.put(
+                property.key(),
+                context.exprAnalyzerWithFieldsAsString.convert(
+                    property.value(),
+                    context.exprContext)
             );
             return null;
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Nodes from the Statement AST must not get mutated because the statement
gets cached and re-used when using prepared statements.

This removes the `add` method to avoid accidental mutation.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
