### PR TITLE
Move characterMaximumLength to DataType

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/information/ColumnContext.java
+++ b/server/src/main/java/io/crate/expression/reference/information/ColumnContext.java
@@ -23,32 +23,6 @@ package io.crate.expression.reference.information;
 
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationInfo;
-import io.crate.types.BitStringType;
-import io.crate.types.DataType;
-import io.crate.types.StringType;
 
-public class ColumnContext {
-
-    public final RelationInfo tableInfo;
-    public final Reference info;
-
-    public ColumnContext(RelationInfo tableInfo, Reference ref) {
-        this.tableInfo = tableInfo;
-        this.info = ref;
-    }
-
-    public Integer characterMaximumLength() {
-        DataType<?> type = info.valueType();
-        if (type instanceof StringType stringType) {
-            if (stringType.unbound()) {
-                return null;
-            } else {
-                return stringType.lengthLimit();
-            }
-        } else if (type instanceof BitStringType bitStringType) {
-            return bitStringType.length();
-        } else {
-            return null;
-        }
-    }
+public record ColumnContext(RelationInfo relation, Reference ref) {
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -55,45 +55,45 @@ public class InformationColumnsTableInfo {
 
     public static SystemTable<ColumnContext> create() {
         return SystemTable.<ColumnContext>builder(IDENT)
-            .addNonNull("table_schema", STRING, r -> r.info.ident().tableIdent().schema())
-            .addNonNull("table_name", STRING, r -> r.info.ident().tableIdent().name())
-            .addNonNull("table_catalog", STRING, r -> r.info.ident().tableIdent().schema())
-            .addNonNull("column_name", STRING, r -> r.info.column().sqlFqn())
-            .addNonNull("ordinal_position", INTEGER, r -> r.info.position())
-            .addNonNull("data_type", STRING, r -> r.info.valueType().getName())
+            .addNonNull("table_schema", STRING, r -> r.ref().ident().tableIdent().schema())
+            .addNonNull("table_name", STRING, r -> r.ref().ident().tableIdent().name())
+            .addNonNull("table_catalog", STRING, r -> r.ref().ident().tableIdent().schema())
+            .addNonNull("column_name", STRING, r -> r.ref().column().sqlFqn())
+            .addNonNull("ordinal_position", INTEGER, r -> r.ref().position())
+            .addNonNull("data_type", STRING, r -> r.ref().valueType().getName())
             .addNonNull("is_generated", STRING, r -> {
-                if (r.info instanceof GeneratedReference) {
+                if (r.ref() instanceof GeneratedReference) {
                     return IS_GENERATED_ALWAYS;
                 }
                 return IS_GENERATED_NEVER;
             })
-            .addNonNull("is_nullable", BOOLEAN, r -> !r.tableInfo.primaryKey().contains(r.info.column()) && r.info.isNullable())
+            .addNonNull("is_nullable", BOOLEAN, r -> !r.relation().primaryKey().contains(r.ref().column()) && r.ref().isNullable())
             .add("generation_expression", STRING, r -> {
-                if (r.info instanceof GeneratedReference) {
-                    return ((GeneratedReference) r.info).formattedGeneratedExpression();
+                if (r.ref() instanceof GeneratedReference) {
+                    return ((GeneratedReference) r.ref()).formattedGeneratedExpression();
                 }
                 return null;
             })
             .add("column_default", STRING, r -> {
-                Symbol defaultExpression = r.info.defaultExpression();
+                Symbol defaultExpression = r.ref().defaultExpression();
                 if (defaultExpression != null) {
                     return defaultExpression.toString();
                 } else {
                     return null;
                 }
             })
-            .add("character_maximum_length", INTEGER, ColumnContext::characterMaximumLength)
+            .add("character_maximum_length", INTEGER, r -> r.ref().valueType().characterMaximumLength())
             .add("character_octet_length", INTEGER, ignored -> null)
-            .add("numeric_precision", INTEGER, r -> PRECISION_BY_TYPE_ID.get(r.info.valueType().id()))
+            .add("numeric_precision", INTEGER, r -> PRECISION_BY_TYPE_ID.get(r.ref().valueType().id()))
             .add("numeric_precision_radix", INTEGER, r -> {
-                if (DataTypes.isNumericPrimitive(r.info.valueType())) {
+                if (DataTypes.isNumericPrimitive(r.ref().valueType())) {
                     return NUMERIC_PRECISION_RADIX;
                 }
                 return null;
             })
             .add("numeric_scale", INTEGER, ignored -> null)
             .add("datetime_precision", INTEGER, r -> {
-                if (r.info.valueType() == TIMESTAMPZ || r.info.valueType() == TIMESTAMP) {
+                if (r.ref().valueType() == TIMESTAMPZ || r.ref().valueType() == TIMESTAMP) {
                     return DATETIME_PRECISION;
                 }
                 return null;
@@ -115,8 +115,8 @@ public class InformationColumnsTableInfo {
             .add("check_references", STRING, ignored -> null)
             .add("check_action", INTEGER, ignored -> null)
             .startObject("column_details")
-                .add("name", STRING , r -> r.info.column().name())
-                .add("path", STRING_ARRAY, r -> r.info.column().path())
+                .add("name", STRING , r -> r.ref().column().name())
+                .add("path", STRING_ARRAY, r -> r.ref().column().path())
             .endObject()
             .setPrimaryKeys(
                 new ColumnIdent("table_catalog"),

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -67,9 +67,9 @@ public class InformationSchemaTableDefinitions {
         ));
         tableDefinitions.put(InformationColumnsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::columns,
-            (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.tableInfo.ident().fqn())
+            (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.relation().ident().fqn())
                          // we also need to check for views which have privileges set
-                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.tableInfo.ident().fqn()),
+                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.relation().ident().fqn()),
             InformationColumnsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationTableConstraintsTableInfo.IDENT, new StaticTableDefinition<>(

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -43,19 +43,19 @@ public class PgAttributeTable {
 
     public static SystemTable<ColumnContext> create() {
         return SystemTable.<ColumnContext>builder(IDENT)
-            .add("attrelid", REGCLASS, c -> Regclass.relationOid(c.tableInfo))
-            .add("attname", STRING, c -> c.info.column().sqlFqn())
-            .add("atttypid", INTEGER, c -> PGTypes.get(c.info.valueType()).oid())
+            .add("attrelid", REGCLASS, c -> Regclass.relationOid(c.relation()))
+            .add("attname", STRING, c -> c.ref().column().sqlFqn())
+            .add("atttypid", INTEGER, c -> PGTypes.get(c.ref().valueType()).oid())
             .add("attstattarget", INTEGER, c -> 0)
-            .add("attlen", SHORT, c -> PGTypes.get(c.info.valueType()).typeLen())
-            .add("attnum", INTEGER, c -> c.info.position())
-            .add("attndims", INTEGER, c -> isArray(c.info.valueType()) ? 1 : 0)
+            .add("attlen", SHORT, c -> PGTypes.get(c.ref().valueType()).typeLen())
+            .add("attnum", INTEGER, c -> c.ref().position())
+            .add("attndims", INTEGER, c -> isArray(c.ref().valueType()) ? 1 : 0)
             .add("attcacheoff", INTEGER, c -> -1)
-            .add("atttypmod", INTEGER, c -> PGTypes.get(c.info.valueType()).typeMod())
+            .add("atttypmod", INTEGER, c -> PGTypes.get(c.ref().valueType()).typeMod())
             .add("attbyval", BOOLEAN, c -> false)
             .add("attstorage", STRING, c -> null)
             .add("attalign", STRING, c -> null)
-            .add("attnotnull", BOOLEAN, c -> !c.info.isNullable())
+            .add("attnotnull", BOOLEAN, c -> !c.ref().isNullable())
             .add("atthasdef", BOOLEAN, c -> false) // don't support default values
             .add("attidentity", STRING, c -> "")
             .add("attisdropped", BOOLEAN, c -> false) // don't support dropping columns

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -99,9 +99,9 @@ public class PgCatalogTableDefinitions {
             false));
         tableDefinitions.put(PgAttributeTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::columns,
-            (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.tableInfo.ident().fqn())
-                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.tableInfo.ident().fqn())
-                         || isPgCatalogOrInformationSchema(c.tableInfo.ident().schema()),
+            (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.relation().ident().fqn())
+                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.relation().ident().fqn())
+                         || isPgCatalogOrInformationSchema(c.relation().ident().schema()),
             PgAttributeTable.create().expressions()
         ));
         tableDefinitions.put(PgIndexTable.IDENT, new StaticTableDefinition<>(

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -234,4 +234,9 @@ public final class BitStringType extends DataType<BitString> implements Streamer
     public StorageSupport<BitString> storageSupport() {
         return STORAGE;
     }
+
+    @Override
+    public Integer characterMaximumLength() {
+        return length();
+    }
 }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -227,4 +227,8 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
             : "If the type parameters aren't empty, `" + getClass().getSimpleName() + "` must override `toColumnType`";
         return new ColumnType<>(getName());
     }
+
+    public Integer characterMaximumLength() {
+        return null;
+    }
 }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -328,4 +328,13 @@ public class StringType extends DataType<String> implements Streamer<String> {
     public StorageSupport<String> storageSupport() {
         return STORAGE;
     }
+
+    @Override
+    public Integer characterMaximumLength() {
+        if (unbound()) {
+            return null;
+        } else {
+            return lengthLimit();
+        }
+    }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/ColumnsIterableTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/ColumnsIterableTest.java
@@ -62,7 +62,7 @@ public class ColumnsIterableTest extends CrateDummyClusterServiceUnitTest {
             .collect(Collectors.toList());
 
         assertThat(
-            contexts.stream().map(c -> c.info.column().name()).collect(Collectors.toList()),
+            contexts.stream().map(c -> c.ref().column().name()).collect(Collectors.toList()),
             Matchers.contains("a", "x", "i"));
     }
 
@@ -71,10 +71,10 @@ public class ColumnsIterableTest extends CrateDummyClusterServiceUnitTest {
         List<String> names = new ArrayList<>(6);
         InformationSchemaIterables.ColumnsIterable columns = new InformationSchemaIterables.ColumnsIterable(t1Info);
         for (ColumnContext column : columns) {
-            names.add(column.info.column().name());
+            names.add(column.ref().column().name());
         }
         for (ColumnContext column : columns) {
-            names.add(column.info.column().name());
+            names.add(column.ref().column().name());
         }
         assertThat(names, Matchers.contains("a", "x", "i", "a", "x", "i"));
     }
@@ -86,12 +86,12 @@ public class ColumnsIterableTest extends CrateDummyClusterServiceUnitTest {
             .collect(Collectors.toList());
 
         // sub columns must have NON-NULL ordinal value
-        assertThat(contexts.get(1).info.position(), is(2));
-        assertThat(contexts.get(2).info.position(), is(3));
+        assertThat(contexts.get(1).ref().position(), is(2));
+        assertThat(contexts.get(2).ref().position(), is(3));
 
         // array of object sub columns also
-        assertThat(contexts.get(3).info.position(), is(4));
-        assertThat(contexts.get(4).info.position(), is(5));
+        assertThat(contexts.get(3).ref().position(), is(4));
+        assertThat(contexts.get(4).ref().position(), is(5));
     }
 
     @Test
@@ -102,6 +102,6 @@ public class ColumnsIterableTest extends CrateDummyClusterServiceUnitTest {
         var columns = new InformationSchemaIterables.ColumnsIterable(e.resolveTableInfo("bit_table"));
         var contexts = StreamSupport.stream(columns.spliterator(), false).toList();
 
-        assertThat(contexts.get(0).characterMaximumLength(), is(12));
+        assertThat(contexts.get(0).ref().valueType().characterMaximumLength(), is(12));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Components like the `ColumnContext` shouldn't be aware of concrete type
implementations.
It makes it more difficult to add new types and would also make it harder to add something like user defined types.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
