### PR TITLE
Add documentation when using self-signed cert for node2node enc

### DIFF
--- a/docs/admin/ssl.rst
+++ b/docs/admin/ssl.rst
@@ -468,6 +468,29 @@ Output::
     Trust this certificate? [no]:  yes
     Certificate was added to keystore
 
+Optional: Import each node's signed certificate into the truststore
+...................................................................
+
+.. NOTE::
+
+    This step is only needed if communication between nodes or clusters should
+    be encrypted (:ref:`ssl.transport.mode` is set to ``on``).
+
+When self-signed certificates are used, the truststore must contain
+the (self-)signed certificate of each node inside the cluster
+(or remote cluster) as each node also act as a *client* and need to validate
+the remote side's identity.
+
+Command::
+
+    keytool -import -keystore truststore -file node_<N>.crt -alias node_<N>
+
+Output::
+
+    Enter keystore password:
+    Certificate was added to keystore
+
+Repeat this N times on every node inside the cluster.
 
 Import the signed certificate
 -----------------------------


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add missing SSL documentation section for self-signed certificates when used to encrypt connections between nodes (or cluster).


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
