### PR TITLE
Fix/allow handling of null literals in UNION and GROUP BY

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -111,4 +111,6 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue that caused queries operating on expressions with no defined
+  type to fail. Examples are queries with ``GROUP BY`` on an ignored object
+  column or ``UNION`` on ``NULL`` literals.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -33,7 +33,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 
 import java.util.List;
@@ -102,8 +101,8 @@ public class GroupingProjector implements Projector {
 
     private static void ensureAllTypesSupported(Iterable<? extends Symbol> keys) {
         for (Symbol key : keys) {
-            DataType type = key.valueType();
-            if (type instanceof ArrayType || type.equals(DataTypes.UNDEFINED)) {
+            DataType<?> type = key.valueType();
+            if (type instanceof ArrayType) {
                 throw new UnsupportedOperationException("Cannot GROUP BY type: " + type);
             }
         }

--- a/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
+++ b/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
@@ -87,14 +87,6 @@ public final class GroupAndAggregateSemantics {
         static final EnsureTypedGroupKey INSTANCE = new EnsureTypedGroupKey();
 
         @Override
-        public Void visitSymbol(Symbol symbol, Void context) {
-            if (symbol.valueType() == DataTypes.UNDEFINED) {
-                raiseException(symbol);
-            }
-            return null;
-        }
-
-        @Override
         public Void visitLiteral(Literal symbol, Void context) {
             if (symbol.valueType() == DataTypes.UNDEFINED) {
                 if (symbol.value() == null) {

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -121,14 +121,6 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_group_by_unknown_column() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-                                () -> analyze("select max(age) from foo.users group by details_ignored['lol']"),
-                                "Cannot group or aggregate on 'details_ignored['lol']' with an undefined type." +
-                                " Using an explicit type cast will make this work but adds processing overhead to the query.");
-    }
-
-    @Test
     public void testGroupByScalarAliasedWithRealColumnNameFailsIfScalarColumnIsNotGrouped() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(

--- a/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
@@ -327,4 +327,10 @@ public class UnionIntegrationTest extends SQLIntegrationTestCase {
         execute("select a from x union distinct select a from y order by a");
         assertThat(printedTable(response.rows()), is("1\n2\n3\n5\n"));
     }
+
+    @Test
+    public void test_null_literal_union_null_literal() {
+        execute("select null from unnest([1, 2]) union select null from unnest([1])");
+        assertThat(printedTable(response.rows()), is("NULL\n"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/12578
Alternative solution to https://github.com/crate/crate/pull/12582

Instead of adding more special cases we can allow grouping on undefined
columns. The optimized code paths are only used if there are doc-values
(not available for ignored objects), the regular code path will use
a source lookup. The `UndefinedType` streaming implementation can deal with mixed types/values

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
