### PR TITLE
Fix ssl documentation for self-signed certifications

### DIFF
--- a/docs/admin/ssl.rst
+++ b/docs/admin/ssl.rst
@@ -349,7 +349,7 @@ Now you can generate a signed cert from our certificate signing request.
 Command::
 
     openssl x509 -req -in server.csr -CA rootCA.crt -CAkey rootCA.key \
-        -CAcreateserial -out server.crt -sha256 -days 36500
+        -CAcreateserial -out server.crt -sha256 -days 36500 -extfile ssl.ext
 
 Output::
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The command for generating a signed cert must use the documented
ssl configuration in order to ensure that the rootCA should be used
for cert verification.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
