### PR TITLE
Add extra syntax support for LIMIT & OFFSET

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,6 +74,9 @@ None
 Changes
 =======
 
+- Added support for ``LIMIT NULL``, ``LIMIT ALL``, ``OFFSET NULL``,
+  ``OFFSET 10 ROW`` and ``OFFSET 10 ROWS``.
+
 - Added support for using ``NULL`` literals in a ``UNION`` without requiring an
   explicit cast.
 

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -29,8 +29,8 @@ Synopsis
       [ UNION [ ALL | DISTINCT ] query_specification ]
       [ WINDOW window_name AS ( window_definition ) [, ...] ]
       [ ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
-      [ LIMIT num_results ]
-      [ OFFSET start ]
+      [ LIMIT [num_results | ALL] ]
+      [ OFFSET start [ROW | ROWS] ]
 
 where ``relation`` is::
 
@@ -448,7 +448,8 @@ rows::
     LIMIT number_of_results
 
 :number_of_results:
-  Specifies the maximum number of result rows to return.
+  Specifies the maximum number of result rows to return. Must be a non-negative
+  long or ``null``.
 
 .. NOTE::
 
@@ -456,6 +457,15 @@ rows::
    different subsets of the rows of a table, if there is not an ``ORDER BY`` to
    enforce selection of a deterministic subset.
 
+.. NOTE::
+
+   If ``LIMIT ALL`` is used, then no limit is applied, essentially the query is
+   returning all rows, as if not ``LIMIT`` clause is present.
+
+.. NOTE::
+
+   If ``number_of_results`` is null, then no limit is applied, essentially the
+   query is returning all rows, as if not ``LIMIT`` clause is present.
 
 .. _sql-select-offset:
 
@@ -464,7 +474,19 @@ rows::
 
 The optional ``OFFSET`` clause allows to skip result rows at the beginning::
 
-    OFFSET start
+    OFFSET start [ROW | ROWS]
 
 :start:
-  Specifies the number of rows to skip before starting to return rows.
+  Specifies the number of rows to skip before starting to return rows. Must be a
+  non-negative long or null.
+
+.. NOTE::
+
+   The ``ROW`` or ``ROWS`` is optional and can be omitted, without affecting the
+   behaviour of ``OFFSET`` functionality.
+
+.. NOTE::
+
+   If ``start`` is null, then no offset is applied, essentially the
+   query is returning rows from the 1st one, as if not ``OFFSET`` clause is
+   present.

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -134,8 +134,8 @@ query
 queryNoWith
     : queryTerm
       (ORDER BY sortItem (',' sortItem)*)?
-      (LIMIT limit=parameterOrInteger)?
-      (OFFSET offset=parameterOrInteger)?
+      (LIMIT (limit=parameterOrInteger | ALL))?
+      (OFFSET offset=parameterOrInteger (ROW | ROWS)?)?
     ;
 
 queryTerm
@@ -339,6 +339,7 @@ parameterOrSimpleLiteral
 parameterOrInteger
     : parameterExpr
     | integerLiteral
+    | nullLiteral
     ;
 
 parameterOrIdent

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -929,7 +929,13 @@ public class TestStatementBuilder {
                     " from t1, t2 where t1.a='a' or t2.b='aa') as t)" +
             " as tt order by iiy");
         printStatement("select extract(day from x) from y");
+        printStatement("select * from foo order by 1, 2 limit all offset ?");
+        printStatement("select * from foo order by 1, 2 limit null offset ?");
         printStatement("select * from foo order by 1, 2 limit 1 offset ?");
+        printStatement("select * from foo order by 1, 2 limit 1 offset ? row");
+        printStatement("select * from foo order by 1, 2 limit 1 offset null row");
+        printStatement("select * from foo order by 1, 2 limit all offset ? rows");
+        printStatement("select * from foo order by 1, 2 limit all offset null rows");
         printStatement("select * from foo a (x, y, z)");
         printStatement("select *, 123, * from foo");
         printStatement("select show from foo");
@@ -959,7 +965,15 @@ public class TestStatementBuilder {
         printStatement("select \"TOTALPRICE\" \"my price\" from \"orders\"");
 
         printStatement("select * from foo limit 100 offset 20");
+        printStatement("select * from foo limit null offset 20");
+        printStatement("select * from foo limit all offset 20 row");
+        printStatement("select * from foo limit 100 offset 20 rows");
         printStatement("select * from foo offset 20");
+        printStatement("select * from foo offset null");
+        printStatement("select * from foo offset 20 row");
+        printStatement("select * from foo offset null row");
+        printStatement("select * from foo offset 20 rows");
+        printStatement("select * from foo offset null rows");
 
         printStatement("select * from t where 'value' LIKE ANY (col)");
         printStatement("select * from t where 'value' NOT LIKE ANY (col)");
@@ -1160,11 +1174,17 @@ public class TestStatementBuilder {
         // insert from query
         printStatement("insert into foo (id, name) select id, name from bar order by id");
         printStatement("insert into foo (id, name) select * from bar limit 3 offset 10");
+        printStatement("insert into foo (id, name) select * from bar limit null offset 10");
+        printStatement("insert into foo (id, name) select * from bar limit all offset 10 row");
+        printStatement("insert into foo (id, name) select * from bar limit 3 offset 10 rows");
         printStatement("insert into foo (wealth, name) select sum(money), name from bar group by name");
         printStatement("insert into foo select sum(money), name from bar group by name");
 
         printStatement("insert into foo (id, name) (select id, name from bar order by id)");
-        printStatement("insert into foo (id, name) (select * from bar limit 3 offset 10)");
+        printStatement("insert into foo (id, name) (select * from bar limit all offset 10)");
+        printStatement("insert into foo (id, name) (select * from bar limit 3 offset 10 row)");
+        printStatement("insert into foo (id, name) (select * from bar limit 3 offset 10 rows)");
+        printStatement("insert into foo (id, name) (select * from bar limit 3 offset null rows)");
         printStatement("insert into foo (wealth, name) (select sum(money), name from bar group by name)");
         printStatement("insert into foo (select sum(money), name from bar group by name)");
     }
@@ -1181,6 +1201,8 @@ public class TestStatementBuilder {
     public void testParameterExpressionLimitOffset() {
         // ORMs like SQLAlchemy generate these kind of queries.
         printStatement("select * from foo limit ? offset ?");
+        printStatement("select * from foo limit ? offset ? row");
+        printStatement("select * from foo limit ? offset ? rows");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To improve compatibility with PostgreSQL, add the exact syntax
which is supported by PostgreSQL for `LIMIT` and `OFFSET`:

```
LIMIT ALL
LIMIT NULL
OFFSET 10 ROW
OFFSET 10 ROWS
OFFSET NULL
```
Pre-work for: #11540 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
