### PR TITLE
tests: Fix sql-parser tests regarding assertThrows

### DIFF
--- a/libs/sql-parser/src/test/java/io/crate/sql/IntervalLiteralTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/IntervalLiteralTest.java
@@ -26,10 +26,10 @@ import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.IntervalLiteral;
 import org.junit.Test;
 
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IntervalLiteralTest {
 
@@ -107,22 +107,25 @@ public class IntervalLiteralTest {
 
     @Test
     public void testSecondToHour() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> SqlParser.createExpression("INTERVAL '1' SECOND TO HOUR"),
-                     "Startfield must be less significant than Endfield");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression("INTERVAL '1' SECOND TO HOUR"),
+            IllegalArgumentException.class,
+            "Startfield must be less significant than Endfield");
     }
 
     @Test
     public void testSecondToYear() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> SqlParser.createExpression("INTERVAL '1' SECOND TO YEAR"),
-                     "Startfield must be less significant than Endfield");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression("INTERVAL '1' SECOND TO YEAR"),
+            IllegalArgumentException.class,
+            "Startfield must be less significant than Endfield");
     }
 
     @Test
     public void testDayToYear() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> SqlParser.createExpression("INTERVAL '1' DAY TO YEAR"),
-                     "Startfield must be less significant than Endfield");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression("INTERVAL '1' DAY TO YEAR"),
+            IllegalArgumentException.class,
+            "Startfield must be less significant than Endfield");
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -26,9 +26,9 @@ import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.IntegerLiteral;
 import org.junit.Test;
 
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LiteralsTest {
 
@@ -230,16 +230,18 @@ public class LiteralsTest {
 
     @Test
     public void testThatInvalidLengthEscapedUnicode16SequenceThrowsException() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                     () -> Literals.replaceEscapedChars("\\u006"),
-                     Literals.ESCAPED_UNICODE_ERROR);
+        assertThrowsMatches(
+            () -> Literals.replaceEscapedChars("\\u006"),
+            IllegalArgumentException.class,
+            Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test
     public void testThatInvalidHexEscapedUnicode16SequenceThrowsException() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                     () -> Literals.replaceEscapedChars("\\u006G"),
-                     Literals.ESCAPED_UNICODE_ERROR);
+        assertThrowsMatches(
+            () -> Literals.replaceEscapedChars("\\u006G"),
+            IllegalArgumentException.class,
+            Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test
@@ -270,16 +272,18 @@ public class LiteralsTest {
 
     @Test
     public void testThatInvalidLengthEscapedUnicode32SequenceThrowsException() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                     () -> Literals.replaceEscapedChars("\\U0061"),
-                     Literals.ESCAPED_UNICODE_ERROR);
+        assertThrowsMatches(
+            () -> Literals.replaceEscapedChars("\\U0061"),
+            IllegalArgumentException.class,
+            Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test
     public void testThatInvalidHexEscapedUnicode32SequenceThrowsException() throws Exception {
-        assertThrows(IllegalArgumentException.class,
-                     () -> Literals.replaceEscapedChars("\\U0000006G"),
-                     Literals.ESCAPED_UNICODE_ERROR);
+        assertThrowsMatches(
+            () -> Literals.replaceEscapedChars("\\U0000006G"),
+            IllegalArgumentException.class,
+            Literals.ESCAPED_UNICODE_ERROR);
     }
 
     @Test

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -22,6 +22,7 @@
 package io.crate.sql.parser;
 
 import static io.crate.sql.SqlFormatter.formatSql;
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static io.crate.sql.tree.QueryUtil.selectList;
 import static io.crate.sql.tree.QueryUtil.table;
 import static java.lang.String.format;
@@ -31,7 +32,6 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Locale;
@@ -154,7 +154,7 @@ public class TestSqlParser {
     }
 
     @Test
-    public void testParameter() throws Exception {
+    public void testParameter() {
         assertExpression("?", new ParameterExpression(1));
         for (int i = 0; i < 1000; i++) {
             assertExpression(String.format(Locale.ENGLISH, "$%d", i), new ParameterExpression(i));
@@ -184,135 +184,154 @@ public class TestSqlParser {
 
     @Test
     public void testEmptyExpression() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createExpression(""),
-                     "line 1:1: mismatched input '<EOF>'");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression(""),
+            ParsingException.class,
+            "line 1:1: mismatched input '<EOF>'");
     }
 
     @Test
     public void testEmptyStatement() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement(""),
-                     "line 1:1: mismatched input '<EOF>'");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement(""),
+            ParsingException.class,
+            "line 1:1: mismatched input '<EOF>'");
     }
 
     @Test
     public void testExpressionWithTrailingJunk() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("1 + 1 x"),
-                     "line 1:7: extraneous input 'x' expecting");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression("1 + 1 x"),
+            ParsingException.class,
+            "line 1:7: extraneous input 'x' expecting");
     }
 
     @Test
     public void testTokenizeErrorStartOfLine() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("@select"),
-                     "line 1:1: extraneous input '@' expecting");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("@select"),
+            ParsingException.class,
+            "line 1:1: extraneous input '@' expecting");
     }
 
     @Test
     public void testTokenizeErrorMiddleOfLine() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select * from foo where @what"),
-                     "line 1:25: no viable alternative at input 'select * from foo where @'");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select * from foo where @what"),
+            ParsingException.class,
+            "line 1:25: no viable alternative at input 'select * from foo where @'");
     }
 
     @Test
     public void testTokenizeErrorIncompleteToken() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select * from 'oops"),
-                     "line 1:15: no viable alternative at input 'select * from ''");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select * from 'oops"),
+            ParsingException.class,
+            "line 1:15: no viable alternative at input 'select * from ''");
     }
 
     @Test
     public void testParseErrorStartOfLine() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select *\nfrom x\nfrom"),
-                     "line 3:1: extraneous input 'from' expecting");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select *\nfrom x\nfrom"),
+            ParsingException.class,
+            "line 3:1: extraneous input 'from' expecting");
     }
 
     @Test
     public void testParseErrorMiddleOfLine() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select *\nfrom x\nwhere from"),
-                     "line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select *\nfrom x\nwhere from"),
+            ParsingException.class,
+            "line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
     }
 
     @Test
     public void testParseErrorEndOfInput() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select * from"),
-                     "line 1:14: no viable alternative at input 'select * from'");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select * from"),
+            ParsingException.class,
+            "line 1:14: no viable alternative at input 'select * from'");
     }
 
     @Test
     public void testParseErrorEndOfInputWhitespace() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select * from  "),
-                     "line 1:16: no viable alternative at input 'select * from  '");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select * from  "),
+            ParsingException.class,
+            "line 1:16: no viable alternative at input 'select * from  '");
     }
 
     @Test
     public void testParseErrorBackquotes() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select * from `foo`"),
-                     "line 1:15: backquoted identifiers are not supported; use double quotes to quote identifiers");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select * from `foo`"),
+            ParsingException.class,
+            "line 1:15: backquoted identifiers are not supported; use double quotes to quote identifiers");
     }
 
     @Test
     public void testParseErrorBackquotesEndOfInput() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select * from foo `bar`"),
-                     "line 1:19: backquoted identifiers are not supported; use double quotes to quote identifiers");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select * from foo `bar`"),
+            ParsingException.class,
+            "line 1:19: backquoted identifiers are not supported; use double quotes to quote identifiers");
     }
 
     @Test
     public void testParseErrorDigitIdentifiers() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select 1x from dual"),
-                     "line 1:8: identifiers must not start with a digit; surround the identifier with double quotes");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select 1x from dual"),
+            ParsingException.class,
+            "line 1:8: identifiers must not start with a digit; surround the identifier with double quotes");
     }
 
     @Test
     public void testIdentifierWithColon() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select * from foo:bar"),
-                     "line 1:15: identifiers must not contain ':'");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select * from foo:bar"),
+            ParsingException.class,
+            "line 1:18: mismatched input ':' expecting {<EOF>, ';'}");
     }
 
     @Test
     public void testParseErrorDualOrderBy() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select fuu from dual order by fuu order by fuu"),
-                     "line 1:35: mismatched input 'order'");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select fuu from dual order by fuu order by fuu"),
+            ParsingException.class,
+            "line 1:35: mismatched input 'order'");
     }
 
     @Test
     public void testParseErrorReverseOrderByLimit() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select fuu from dual limit 10 order by fuu"),
-                     "line 1:31: mismatched input 'order' expecting {<EOF>, ';'}");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select fuu from dual limit 10 order by fuu"),
+            ParsingException.class,
+            "line 1:31: mismatched input 'order' expecting {<EOF>, ';'}");
     }
 
     @Test
     public void testParseErrorReverseOrderByLimitOffset() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select fuu from dual limit 10 offset 20 order by fuu"),
-                     "line 1:41: mismatched input 'order' expecting {<EOF>, ';'}");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select fuu from dual limit 10 offset 20 order by fuu"),
+            ParsingException.class,
+            "line 1:41: mismatched input 'order' expecting {<EOF>, ';'}");
     }
 
     @Test
     public void testParseErrorReverseOrderByOffset() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select fuu from dual offset 20 order by fuu"),
-                     "line 1:32: mismatched input 'order' expecting {<EOF>, ';'}");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select fuu from dual offset 20 order by fuu"),
+            ParsingException.class,
+            "line 1:32: mismatched input 'order' expecting {<EOF>, ';'}");
     }
 
     @Test
     public void testParseErrorReverseLimitOffset() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("select fuu from dual offset 20 order by fuu"),
-                     "line 1:32: mismatched input 'limit' expecting {<EOF>, ';'}");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("select fuu from dual offset 20 limit 10"),
+            ParsingException.class,
+            "line 1:32: mismatched input 'limit' expecting {<EOF>, ';'}");
     }
 
     @Test
@@ -393,9 +412,10 @@ public class TestSqlParser {
 
     @Test
     public void testTrimFunctionMissingFromWhenCharsToTrimIsPresentThrowsException() {
-        assertThrows(ParsingException.class,
-                     () -> assertInstanceOf("TRIM(' ' chars)", FunctionCall.class),
-                     "line 1:10: no viable alternative at input 'TRIM(' ' chars'");
+        assertThrowsMatches(
+            () -> assertInstanceOf("TRIM(' ' chars)", FunctionCall.class),
+            ParsingException.class,
+            "line 1:10: no viable alternative at input 'TRIM(' ' chars'");
     }
 
     private void assertInstanceOf(String expr, Class<? extends Node> cls) {
@@ -405,16 +425,18 @@ public class TestSqlParser {
 
     @Test
     public void testStackOverflowExpression() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createExpression(Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x)),
-                     "line 1:1: expression is too large (stack overflow while parsing)");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression(Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x)),
+            ParsingException.class,
+            "line 1:1: expression is too large (stack overflow while parsing)");
     }
 
     @Test
     public void testStackOverflowStatement() {
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createStatement("SELECT " + Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x)),
-                     "line 1:1: statement is too large (stack overflow while parsing)");
+        assertThrowsMatches(
+            () -> SqlParser.createStatement("SELECT " + Lists2.joinOn(" OR ", nCopies(4000, "x = y"), x -> x)),
+            ParsingException.class,
+            "line 1:1: statement is too large (stack overflow while parsing)");
     }
 
     @Test
@@ -432,16 +454,18 @@ public class TestSqlParser {
 
     @Test
     public void testFromStringLiteralCastDoesNotSupportArrayType() {
-        assertThrows(UnsupportedOperationException.class,
-                     () -> SqlParser.createExpression("array(boolean) '[1,2,0]'"),
-                     "type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression("array(boolean) '[1,2,0]'"),
+            UnsupportedOperationException.class,
+            "type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
     }
 
     @Test
     public void testFromStringLiteralCastDoesNotSupportObjectType() {
-        assertThrows(UnsupportedOperationException.class,
-                     () -> SqlParser.createExpression("object '{\"x\": 10}'"),
-                     "type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression("object '{\"x\": 10}'"),
+            UnsupportedOperationException.class,
+            "type 'string' cast notation only supports primitive types. Use '::' or cast() operator instead.");
     }
 
     private static void assertStatement(String query, Statement expected) {

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -22,6 +22,7 @@
 package io.crate.sql.parser;
 
 import static io.crate.sql.parser.TreeAssertions.assertFormattedSql;
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -31,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -236,16 +236,18 @@ public class TestStatementBuilder {
 
     @Test
     public void test_duplicates_in_window_definitions() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> printStatement("SELECT x FROM t WINDOW w AS (), w as ()"),
-                     "Window w is already defined");
+        assertThrowsMatches(
+            () -> printStatement("SELECT x FROM t WINDOW w AS (), w as ()"),
+            IllegalArgumentException.class,
+            "Window w is already defined");
     }
 
     @Test
     public void test_circular_references_in_window_definitions() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> printStatement("SELECT x FROM t WINDOW w AS (ww), ww as (w), www as ()"),
-                     "Window ww does not exist");
+        assertThrowsMatches(
+            () -> printStatement("SELECT x FROM t WINDOW w AS (ww), ww as (w), www as ()"),
+            IllegalArgumentException.class,
+            "Window ww does not exist");
     }
 
     @Test
@@ -264,9 +266,10 @@ public class TestStatementBuilder {
 
     @Test
     public void testNullNotAllowedAsArgToExtractField() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("select extract(null from x)"),
-                     "no viable alternative at input 'select extract(null'");
+    assertThrowsMatches(
+        () -> printStatement("select extract(null from x)"),
+        ParsingException.class,
+        "line 1:16: no viable alternative at input 'select extract(null'");
     }
 
     @Test
@@ -301,9 +304,10 @@ public class TestStatementBuilder {
 
     @Test
     public void test_decommission_node_id_is_missing() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("ALTER CLUSTER DECOMMISSION'"),
-                     "mismatched input");
+        assertThrowsMatches(
+            () -> printStatement("ALTER CLUSTER DECOMMISSION'"),
+            ParsingException.class,
+            "line 1:27: mismatched input ''' expecting {'(', '[', '[]', '{', '$', '?', ");
     }
 
     @Test
@@ -479,9 +483,10 @@ public class TestStatementBuilder {
 
     @Test
     public void testDeallocateWithoutParamThrowsParsingException() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("deallocate"),
-                     "line 1:11: mismatched input '<EOF>'");
+        assertThrowsMatches(
+            () -> printStatement("deallocate"),
+            ParsingException.class,
+            "line 1:11: mismatched input '<EOF>'");
     }
 
     @Test
@@ -525,9 +530,10 @@ public class TestStatementBuilder {
 
     @Test
     public void testSetSessionInvalidSetting() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("set session 'some_setting' TO 1, ON"),
-                     "no viable alternative");
+        assertThrowsMatches(
+            () -> printStatement("set session 'some_setting' TO 1, ON"),
+            ParsingException.class,
+            "line 1:13: no viable alternative at input 'set session 'some_setting''");
     }
 
     @Test
@@ -545,30 +551,34 @@ public class TestStatementBuilder {
 
     @Test
     public void testSetLicenseInputWithoutQuotesThrowsParsingException() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("set license LICENSE_KEY"),
-                     "no viable alternative at input");
+        assertThrowsMatches(
+            () -> printStatement("set license LICENSE_KEY"),
+            ParsingException.class,
+            "line 1:13: no viable alternative at input 'set license LICENSE_KEY'");
     }
 
     @Test
     public void testSetLicenseWithoutParamThrowsParsingException() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("set license"),
-                     "no viable alternative at input 'set license'");
+        assertThrowsMatches(
+            () -> printStatement("set license"),
+            ParsingException.class,
+            "line 1:12: no viable alternative at input 'set license'");
     }
 
     @Test
     public void testSetLicenseLikeAnExpressionThrowsParsingException() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("set license key='LICENSE_KEY'"),
-                     "no viable alternative at input");
+        assertThrowsMatches(
+            () -> printStatement("set license key='LICENSE_KEY'"),
+            ParsingException.class,
+            "line 1:13: no viable alternative at input 'set license key'");
     }
 
     @Test
     public void testSetLicenseMultipleInputThrowsParsingException() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("set license 'LICENSE_KEY' 'LICENSE_KEY2'"),
-                     "line 1:27: extraneous input ''LICENSE_KEY2'' expecting {<EOF>, ';'}");
+        assertThrowsMatches(
+            () -> printStatement("set license 'LICENSE_KEY' 'LICENSE_KEY2'"),
+            ParsingException.class,
+            "line 1:27: extraneous input ''LICENSE_KEY2'' expecting {<EOF>, ';'}");
     }
 
     @Test
@@ -678,9 +688,10 @@ public class TestStatementBuilder {
 
     @Test
     public void testCreateTableColumnTypeOrGeneratedExpressionAreDefined() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> printStatement("create table test (col1)"),
-                     "Column [col1]: data type needs to be provided or column should be defined as a generated expression");
+        assertThrowsMatches(
+            () -> printStatement("create table test (col1)"),
+            IllegalArgumentException.class,
+            "Column [col1]: data type needs to be provided or column should be defined as a generated expression");
     }
 
     @Test
@@ -691,17 +702,19 @@ public class TestStatementBuilder {
 
     @Test
     public void testCreateTableBothDefaultAndGeneratedExpressionsNotAllowed() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> printStatement("create table test (col1 int default random() as 1+1)"),
-                     "Column [col1]: the default and generated expressions are mutually exclusive");
+        assertThrowsMatches(
+            () -> printStatement("create table test (col1 int default random() as 1+1)"),
+            IllegalArgumentException.class,
+            "Column [col1]: the default and generated expressions are mutually exclusive");
     }
 
     @Test
     public void testCreateTableOptionsMultipleTimesNotAllowed() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement(
-                         "create table test (col1 int, col2 timestamp with time zone) partitioned by (col1) partitioned by (col2)"),
-                     "line 1:83: mismatched input 'partitioned' expecting {<EOF>, ';'}");
+        assertThrowsMatches(
+            () -> printStatement(
+                "create table test (col1 int, col2 timestamp with time zone) partitioned by (col1) partitioned by (col2)"),
+            ParsingException.class,
+            "line 1:83: mismatched input 'partitioned' expecting {<EOF>, ';'}");
     }
 
     @Test
@@ -906,12 +919,13 @@ public class TestStatementBuilder {
 
     @Test
     public void testCreateFunctionStmtBuilderWithIncorrectFunctionName() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> printStatement("create function foo.bar.a()" +
-                                         " returns object" +
-                                         " language sql as 'select 1'"),
-                     "[foo.bar.a] does not conform the " +
-                     "[[schema_name .] function_name] format");
+        assertThrowsMatches(
+            () -> printStatement("create function foo.bar.a() " +
+                             "returns object " +
+                             "language sql as 'select 1'"),
+            IllegalArgumentException.class,
+            "The function name is not correct! name [foo.bar.a] does not conform the [[schema_name .] " +
+                "function_name] format.");
     }
 
     @Test
@@ -1002,9 +1016,10 @@ public class TestStatementBuilder {
 
     @Test
     public void testThatEscapedStringLiteralContainingDoubleBackSlashAndSingleQuoteThrowsException() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> printStatement("select e'aa\\\\\'bb' as col1"),
-                     "Invalid Escaped String Literal");
+        assertThrowsMatches(
+            () -> printStatement("select e'aa\\\\\'bb' as col1"),
+            IllegalArgumentException.class,
+            "Invalid Escaped String Literal");
     }
 
     @Test
@@ -1098,16 +1113,18 @@ public class TestStatementBuilder {
 
     @Test
     public void testArrayConstructorSubSelectBuilderNoParenthesisThrowsParsingException() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("select array from f2"),
-                     "no viable alternative at input 'select array from'");
+    assertThrowsMatches(
+        () -> printStatement("select array from f2"),
+        ParsingException.class,
+        "line 1:14: no viable alternative at input 'select array from'");
     }
 
    @Test
     public void testArrayConstructorSubSelectBuilderNoSubQueryThrowsParsingException() {
-       assertThrows(ParsingException.class,
-                    () -> printStatement("select array() as array1 from f2"),
-                    "no viable alternative at input 'select array()'");
+       assertThrowsMatches(
+            () -> printStatement("select array() as array1 from f2"),
+            ParsingException.class,
+            "line 1:14: no viable alternative at input 'select array()'");
     }
 
     @Test
@@ -1358,9 +1375,10 @@ public class TestStatementBuilder {
         matchPredicate = (MatchPredicate) SqlParser.createExpression("match (a['1']['2']['4'], 'abc')");
         assertThat(matchPredicate.idents().get(0).columnIdent().toString(), is("\"a\"['1']['2']['4']"));
 
-        assertThrows(ParsingException.class,
-                     () -> SqlParser.createExpression("match ([1]['1']['2'], 'abc')"),
-                     "mismatched input '<EOF>' expecting 'SET'");
+        assertThrowsMatches(
+            () -> SqlParser.createExpression("match ([1]['1']['2'], 'abc')"),
+            ParsingException.class,
+            "line 1:8: mismatched input '[' expecting {'('");
     }
 
     @Test
@@ -1613,17 +1631,19 @@ public class TestStatementBuilder {
 
     @Test
     public void testAlterTableAddColumnTypeOrGeneratedExpressionAreDefined() {
-        assertThrows(IllegalArgumentException.class,
-                     () -> printStatement("alter table t add column col2"),
-                     "Column [\"col2\"]: data type needs to be provided or column should be defined as a generated expression");
+        assertThrowsMatches(
+            () -> printStatement("alter table t add column col2"),
+            IllegalArgumentException.class,
+            "Column [\"col2\"]: data type needs to be provided or column should be defined as a generated expression");
     }
 
 
     @Test
     public void testAddColumnWithDefaultExpressionIsNotSupported() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("mismatched input 'default'"),
-                     "mismatched input 'default'");
+        assertThrowsMatches(
+            () -> printStatement("mismatched input 'default'"),
+            ParsingException.class,
+            "line 1:1: mismatched input 'mismatched' expecting {'");
     }
 
 
@@ -1660,9 +1680,10 @@ public class TestStatementBuilder {
 
     @Test
     public void testAlterUserWithMissingProperties() {
-        assertThrows(ParsingException.class,
-                     () -> printStatement("alter user crate"),
-                     "mismatched input '<EOF>' expecting 'SET'");
+        assertThrowsMatches(
+            () -> printStatement("alter user crate"),
+            ParsingException.class,
+            "line 1:17: mismatched input '<EOF>' expecting 'SET'");
     }
 
     @Test

--- a/libs/sql-parser/src/test/java/io/crate/sql/testing/Asserts.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/testing/Asserts.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.testing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.function.Executable;
+
+public class Asserts {
+
+    private Asserts() {}
+
+    public static void assertThrowsMatches(Executable executable, Class<? extends Throwable> type, String subString) {
+        try {
+            executable.execute();
+            Assertions.fail("Expected exception to be thrown, but nothing was thrown.");
+        } catch (Throwable t) {
+            assertThat(t, instanceOf(type));
+            assertThat(t.getMessage(), startsWith(subString));
+        }
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/BitStringTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/BitStringTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.sql.tree;
 
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -37,6 +38,8 @@ import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
+
+import io.crate.sql.testing.Asserts;
 
 @RunWith(JUnitQuickcheck.class)
 public class BitStringTest {
@@ -69,7 +72,10 @@ public class BitStringTest {
 
     @Test
     public void test_bit_string_cannot_contain_values_other_than_zeros_or_ones() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> BitString.ofRawBits("0021💀"));
+        assertThrowsMatches(
+            () -> BitString.ofRawBits("0021💀"),
+            IllegalArgumentException.class,
+            "Bit string must only contain `0` or `1` values. Encountered: 2");
     }
 
     @Test

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedFollowingFrameBoundTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedFollowingFrameBoundTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.util.Comparator;
 import java.util.List;
 
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
 import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.core.Is.is;
@@ -63,9 +64,10 @@ public class UnboundedFollowingFrameBoundTest {
 
     @Test
     public void testUnboundeFollowingCannotBeTheStartOfTheFrame() {
-        assertThrows(IllegalStateException.class,
-                     () ->  UNBOUNDED_FOLLOWING.getStart(RANGE, 0, 3, 1, null, null, intComparator, partition),
-                     "UNBOUNDED FOLLOWING cannot be the start of a frame");
+        assertThrowsMatches(
+            () ->  UNBOUNDED_FOLLOWING.getStart(RANGE, 0, 3, 1, null, null, intComparator, partition),
+            IllegalStateException.class,
+            "UNBOUNDED FOLLOWING cannot be the start of a frame");
     }
 
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedPrecedingFrameBoundTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/UnboundedPrecedingFrameBoundTest.java
@@ -27,11 +27,11 @@ import org.junit.Test;
 import java.util.Comparator;
 import java.util.List;
 
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnboundedPrecedingFrameBoundTest {
 
@@ -62,8 +62,9 @@ public class UnboundedPrecedingFrameBoundTest {
 
     @Test
     public void testUnboundePrecedingCannotBeTheEndOfTheFrame() {
-        assertThrows(IllegalStateException.class,
-                     () -> UNBOUNDED_PRECEDING.getEnd(RANGE, 0, 3, 1, null, null, intComparator, partition),
-                     "UNBOUNDED PRECEDING cannot be the start of a frame");
+        assertThrowsMatches(
+            () -> UNBOUNDED_PRECEDING.getEnd(RANGE, 0, 3, 1, null, null, intComparator, partition),
+            IllegalStateException.class,
+            "UNBOUNDED PRECEDING cannot be the start of a frame");
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/WindowTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/WindowTest.java
@@ -26,11 +26,11 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static io.crate.sql.testing.Asserts.assertThrowsMatches;
 import static io.crate.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.crate.sql.tree.WindowFrame.Mode.RANGE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class WindowTest {
 
@@ -76,9 +76,10 @@ public class WindowTest {
         var current = new Window("w", List.of(), orderBy, Optional.empty());
         var provided = new Window(null, List.of(), List.of(), Optional.of(frame));
 
-        assertThrows(IllegalArgumentException.class,
-                     () -> current.merge(provided),
-                     "Cannot copy window w because it has a frame clause");
+        assertThrowsMatches(
+            () -> current.merge(provided),
+            IllegalArgumentException.class,
+            "Cannot copy window w because it has a frame clause");
     }
 
     @Test
@@ -86,17 +87,19 @@ public class WindowTest {
         Window current = new Window("w", List.of(), orderBy, Optional.empty());
         Window provided = new Window(null, List.of(), orderBy, Optional.empty());
 
-        assertThrows(IllegalArgumentException.class,
-                     () -> current.merge(provided),
-                     "Cannot override ORDER BY clause of window w");
+        assertThrowsMatches(
+            () -> current.merge(provided),
+            IllegalArgumentException.class,
+            "Cannot override ORDER BY clause of window w");
     }
 
     @Test
     public void test_merge_current_window_cannot_specify_partition_by() {
         var current = new Window("w", partitionBy, List.of(), Optional.empty());
 
-        assertThrows(IllegalArgumentException.class,
-                     () -> current.merge(emptyWindow),
-                     "Cannot override PARTITION BY clause of window w");
+        assertThrowsMatches(
+            () -> current.merge(emptyWindow),
+            IllegalArgumentException.class,
+            "Cannot override PARTITION BY clause of window w");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, the tests were using `assertThrows` and they didn't
assert the exception message, instead the string provided was a
failure string for junit, in case the assertion fails. Replaced
all usages with our custom `assertThrowsMatches` which is copied
from the server package (which is not accessible in the parser
module).

Adjusted some expected messages to match the actual error thrown.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
