### PR TITLE
Wait for pending logical replication operations on test teardown

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -613,4 +613,9 @@ public final class MetadataTracker implements Closeable {
     public void close() {
         stop();
     }
+
+    @VisibleForTesting
+    public boolean isActive() {
+        return isActive;
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Right after deleting the subscription the teardown logic asserts
sequence numbers. This is done *before* the cluster is closed, so the logical
replication service is still running and might asynchronously keep inserting /
restoring until the deletion of the subscription is fully processed.

That means primary and replica sequence numbers can still diverge which trips
the assertions in the test teardown.

This should fix one potential cause of MetadataTrackerITest test
failures.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
