### PR TITLE
Fix cast to `regclass` to be aware of the current search_path

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -217,3 +217,7 @@ Fixes
 
 - Fixed an issue that caused clients using PostrgreSQL wire protocol's simple
   query to hang, when an error occurred during planning.
+
+- Fixed casts of ``TEXT`` to ``REGCLASS`` data types which were resulting in
+  wrong ``REGCLASS`` values as the  ``current_schema`` was not taken into
+  account.

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -3503,6 +3503,13 @@ schema to reference relations in the `pg_class`_ table.
 :ref:`type-text` or :ref:`integer <type-numeric>` type will result
 in the corresponding relation name or ``oid`` value, respectively.
 
+.. NOTE::
+
+    String values casted to the ``REGCLASS`` type must match a valid relation
+    name identifier, see also
+    :ref:`identifier naming restrictions <ddl-create-table-naming>`.
+    The given relation name won't be validated against existing relations.
+
 .. _type-oidvector:
 
 ``OIDVECTOR``

--- a/libs/shared/src/main/java/io/crate/common/StringUtils.java
+++ b/libs/shared/src/main/java/io/crate/common/StringUtils.java
@@ -100,4 +100,19 @@ public final class StringUtils {
             return s + String.valueOf(c).repeat(minimumLength - s.length());
         }
     }
+
+    public static String trim(String target, char charToTrim) {
+        int start = 0;
+        int len = target.length();
+
+        while (start < len && target.charAt(start) == charToTrim) {
+            start++;
+        }
+
+        while (start < len && target.charAt(len - 1) == charToTrim) {
+            len--;
+        }
+
+        return target.substring(start, len);
+    }
 }

--- a/server/src/main/java/io/crate/exceptions/InvalidRelationName.java
+++ b/server/src/main/java/io/crate/exceptions/InvalidRelationName.java
@@ -21,16 +21,16 @@
 
 package io.crate.exceptions;
 
-import io.crate.metadata.RelationName;
-
 import java.util.Collections;
 import java.util.Locale;
+
+import io.crate.metadata.RelationName;
 
 public class InvalidRelationName extends RuntimeException implements TableScopeException {
 
     private final RelationName ident;
 
-    InvalidRelationName(String indexName, Throwable e) {
+    public InvalidRelationName(String indexName, Throwable e) {
         super(String.format(Locale.ENGLISH, "Relation name \"%s\" is invalid.", indexName), e);
         ident = RelationName.fromIndexName(indexName);
     }

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -21,6 +21,9 @@
 
 package io.crate.expression.scalar.cast;
 
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
 import io.crate.data.Input;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarFunctionModule;
@@ -31,9 +34,6 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
-
-import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class ExplicitCastFunction extends Scalar<Object, Object> {
 
@@ -65,7 +65,7 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
     @Override
     public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         try {
-            return returnType.explicitCast(args[0].value());
+            return returnType.explicitCast(args[0].value(), txnCtx.sessionSettings());
         } catch (ConversionException e) {
             throw e;
         } catch (ClassCastException | IllegalArgumentException e) {
@@ -95,7 +95,7 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
         if (argument instanceof Input) {
             Object value = ((Input<?>) argument).value();
             try {
-                return Literal.ofUnchecked(returnType, returnType.explicitCast(value));
+                return Literal.ofUnchecked(returnType, returnType.explicitCast(value, txnCtx.sessionSettings()));
             } catch (ConversionException e) {
                 throw e;
             } catch (ClassCastException | IllegalArgumentException e) {

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -21,6 +21,9 @@
 
 package io.crate.expression.scalar.cast;
 
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
@@ -30,9 +33,6 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
-
-import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 public class TryCastFunction extends Scalar<Object, Object> {
 
@@ -64,7 +64,7 @@ public class TryCastFunction extends Scalar<Object, Object> {
     @Override
     public Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
         try {
-            return returnType.explicitCast(args[0].value());
+            return returnType.explicitCast(args[0].value(), txnCtx.sessionSettings());
         } catch (ClassCastException | IllegalArgumentException e) {
             return null;
         }
@@ -92,7 +92,7 @@ public class TryCastFunction extends Scalar<Object, Object> {
         if (argument instanceof Input) {
             Object value = ((Input<?>) argument).value();
             try {
-                return Literal.ofUnchecked(returnType, returnType.explicitCast(value));
+                return Literal.ofUnchecked(returnType, returnType.explicitCast(value, txnCtx.sessionSettings()));
             } catch (ClassCastException | IllegalArgumentException e) {
                 return Literal.NULL;
             }

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -21,6 +21,11 @@
 
 package io.crate.expression.scalar.string;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import io.crate.common.StringUtils;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Symbol;
@@ -31,10 +36,6 @@ import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.TrimMode;
 import io.crate.types.DataTypes;
 import io.crate.user.UserLookup;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.function.BiFunction;
 
 
 public final class TrimFunctions {
@@ -222,19 +223,7 @@ public final class TrimFunctions {
             if (target == null) {
                 return null;
             }
-
-            int start = 0;
-            int len = target.length();
-
-            while (start < len && target.charAt(start) == charToTrim) {
-                start++;
-            }
-
-            while (start < len && target.charAt(len - 1) == charToTrim) {
-                len--;
-            }
-
-            return target.substring(start, len);
+            return StringUtils.trim(target, charToTrim);
         }
     }
 

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -47,7 +47,7 @@ import io.crate.user.UserLookup;
  *
  *     Functions also MUST NOT have any internal state that influences the result of future calls.
  *     Functions are used as singletons.
- *     An exception is if {@link #compile(List)} returns a NEW instance.
+ *     An exception is if {@link #compile(List, String, UserLookup)} returns a NEW instance.
  * </p>
  *
  * To implement scalar functions, you may want to use one of the following abstractions:

--- a/server/src/main/java/io/crate/protocols/postgres/types/RegclassType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/RegclassType.java
@@ -23,6 +23,7 @@ package io.crate.protocols.postgres.types;
 
 import java.nio.charset.StandardCharsets;
 
+import io.crate.metadata.IndexParts;
 import io.crate.types.Regclass;
 import io.netty.buffer.ByteBuf;
 
@@ -79,7 +80,8 @@ public class RegclassType extends PGType<Regclass> {
             int oid = Integer.parseInt(oidStr);
             return new Regclass(oid, oidStr);
         } catch (NumberFormatException e) {
-            return Regclass.fromRelationName(oidStr);
+            var indexParts = new IndexParts(oidStr);
+            return Regclass.fromRelationName(indexParts.toRelationName());
         }
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/types/TimestampZType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/TimestampZType.java
@@ -21,14 +21,16 @@
 
 package io.crate.protocols.postgres.types;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import javax.annotation.Nonnull;
+
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.types.DataTypes;
-
-import javax.annotation.Nonnull;
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 final class TimestampZType extends BaseTimestampType {
 
@@ -94,7 +96,7 @@ final class TimestampZType extends BaseTimestampType {
         // Other PostgreSQL clients send the parameter as Bigint or Varchar
         String s = new String(bytes, StandardCharsets.UTF_8);
         try {
-            return DataTypes.TIMESTAMPZ.explicitCast(s);
+            return DataTypes.TIMESTAMPZ.explicitCast(s, CoordinatorTxnCtx.systemTransactionContext().sessionSettings());
         } catch (Exception e) {
             int endOfSeconds = s.indexOf(".");
             int idx = endOfSeconds;

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -46,6 +46,8 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import io.crate.Streamer;
 import io.crate.common.collections.Lists2;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.protocols.postgres.parser.PgArrayParser;
 import io.crate.protocols.postgres.parser.PgArrayParsingException;
 import io.crate.sql.tree.CollectionColumnType;
@@ -133,17 +135,17 @@ public class ArrayType<T> extends DataType<List<T>> {
 
     @Override
     public List<T> implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
-        return convert(value, innerType, innerType::implicitCast);
+        return convert(value, innerType, innerType::implicitCast, CoordinatorTxnCtx.systemTransactionContext().sessionSettings());
     }
 
     @Override
-    public List<T> explicitCast(Object value) throws IllegalArgumentException, ClassCastException {
-        return convert(value, innerType, innerType::explicitCast);
+    public List<T> explicitCast(Object value, SessionSettings sessionSettings) throws IllegalArgumentException, ClassCastException {
+        return convert(value, innerType, val -> innerType.explicitCast(val, sessionSettings), sessionSettings);
     }
 
     @Override
     public List<T> sanitizeValue(Object value) {
-        return convert(value, innerType, innerType::sanitizeValue);
+        return convert(value, innerType, innerType::sanitizeValue, CoordinatorTxnCtx.systemTransactionContext().sessionSettings());
     }
 
     public List<String> fromAnyArray(Object[] values) throws IllegalArgumentException {
@@ -198,7 +200,10 @@ public class ArrayType<T> extends DataType<List<T>> {
 
     @Nullable
     @SuppressWarnings("unchecked")
-    private static <T> List<T> convert(@Nullable Object value, DataType<T> innerType, Function<Object, T> convertInner) {
+    private static <T> List<T> convert(@Nullable Object value,
+                                       DataType<T> innerType,
+                                       Function<Object, T> convertInner,
+                                       SessionSettings sessionSettings) {
         if (value == null) {
             return null;
         }
@@ -214,7 +219,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                 byte[] utf8Bytes = string.getBytes(StandardCharsets.UTF_8);
                 if (innerType instanceof JsonType) {
                     try {
-                        return (List<T>) parseJsonList(utf8Bytes);
+                        return (List<T>) parseJsonList(utf8Bytes, sessionSettings);
                     } catch (IOException ioEx) {
                         throw new UncheckedIOException(ioEx);
                     }
@@ -227,13 +232,13 @@ public class ArrayType<T> extends DataType<List<T>> {
         }
     }
 
-    private static List<String> parseJsonList(byte[] utf8Bytes) throws IOException {
+    private static List<String> parseJsonList(byte[] utf8Bytes, SessionSettings sessionSettings) throws IOException {
         XContentParser parser = JsonXContent.JSON_XCONTENT.createParser(
             NamedXContentRegistry.EMPTY,
             DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
             utf8Bytes
         );
-        return Lists2.map(parser.list(), StringType.INSTANCE::explicitCast);
+        return Lists2.map(parser.list(), value -> StringType.INSTANCE.explicitCast(value, sessionSettings));
     }
 
     private static <T> ArrayList<T> convertObjectArray(Object[] values, Function<Object, T> convertInner) {

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.Streamer;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
@@ -133,7 +134,7 @@ public final class BitStringType extends DataType<BitString> implements Streamer
     }
 
     @Override
-    public BitString explicitCast(Object value) throws IllegalArgumentException, ClassCastException {
+    public BitString explicitCast(Object value, SessionSettings sessionSettings) throws IllegalArgumentException, ClassCastException {
         // explicit cast is allowed to trim or extend the bitstring
         if (value instanceof String str) {
             return BitString.ofRawBits(str, length);

--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
@@ -131,7 +132,7 @@ public class CharacterType extends StringType {
     }
 
     @Override
-    public String explicitCast(Object value) throws IllegalArgumentException, ClassCastException {
+    public String explicitCast(Object value, SessionSettings sessionSettings) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import io.crate.Streamer;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
@@ -120,9 +121,10 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      * a data type subclass.
      *
      * @param value The value to cast to the target {@link DataType}.
+     * @param sessionSettings
      * @return The value casted the target {@link DataType}.
      */
-    public T explicitCast(Object value) throws IllegalArgumentException, ClassCastException {
+    public T explicitCast(Object value, SessionSettings sessionSettings) throws IllegalArgumentException, ClassCastException {
         return implicitCast(value);
     }
 

--- a/server/src/main/java/io/crate/types/JsonType.java
+++ b/server/src/main/java/io/crate/types/JsonType.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
 import io.crate.Streamer;
+import io.crate.metadata.settings.SessionSettings;
 
 public final class JsonType extends DataType<String> implements Streamer<String> {
 
@@ -85,7 +86,7 @@ public final class JsonType extends DataType<String> implements Streamer<String>
 
     @Override
     @SuppressWarnings("unchecked")
-    public String explicitCast(Object value) throws IllegalArgumentException, ClassCastException {
+    public String explicitCast(Object value, SessionSettings sessionSettings) throws IllegalArgumentException, ClassCastException {
         if (value instanceof Map<?, ?> map) {
             try {
                 return Strings.toString(XContentFactory.jsonBuilder().map((Map<String, ?>) map));

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -48,6 +48,7 @@ import io.crate.Streamer;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.MapComparator;
 import io.crate.exceptions.ConversionException;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
@@ -141,8 +142,8 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     }
 
     @Override
-    public Map<String, Object> explicitCast(Object value) throws IllegalArgumentException, ClassCastException {
-        return convert(value, DataType::explicitCast);
+    public Map<String, Object> explicitCast(Object value, SessionSettings sessionSettings) throws IllegalArgumentException, ClassCastException {
+        return convert(value, (dataType, val) -> dataType.explicitCast(val, sessionSettings));
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/Regclass.java
+++ b/server/src/main/java/io/crate/types/Regclass.java
@@ -57,10 +57,10 @@ public final class Regclass implements Comparable<Regclass>, Writeable {
         );
     }
 
-    public static Regclass fromRelationName(String name) {
+    public static Regclass fromRelationName(RelationName relationName) {
         return new Regclass(
-            OidHash.relationOid(OidHash.Type.TABLE, new RelationName(null, name)),
-            name
+            OidHash.relationOid(OidHash.Type.TABLE, relationName),
+            relationName.fqn()
         );
     }
 

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -48,6 +48,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import io.crate.Streamer;
 import io.crate.common.unit.TimeValue;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
@@ -217,7 +218,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
-    public String explicitCast(Object value) throws IllegalArgumentException, ClassCastException {
+    public String explicitCast(Object value, SessionSettings sessionSettings) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
         }

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -21,30 +21,6 @@
 
 package io.crate.expression.scalar.cast;
 
-import io.crate.exceptions.ConversionException;
-import io.crate.expression.scalar.ScalarTestCase;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.format.Style;
-import io.crate.geo.GeoJSONUtils;
-import io.crate.metadata.functions.Signature;
-import io.crate.types.ArrayType;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
-import io.crate.types.RegclassType;
-import io.crate.types.RegclassType;
-
-import org.hamcrest.core.IsSame;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.testing.DataTypeTesting.getDataGenerator;
 import static io.crate.testing.DataTypeTesting.randomType;
@@ -57,6 +33,30 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.core.IsSame;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.crate.exceptions.ConversionException;
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.format.Style;
+import io.crate.geo.GeoJSONUtils;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
+import io.crate.types.RegclassType;
 
 // cast is just a wrapper around  DataType.value(val) which is why here are just a few tests
 public class CastFunctionTest extends ScalarTestCase {
@@ -310,6 +310,7 @@ public class CastFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_can_cast_bigint_to_regclass() {
-        assertEvaluate("10::bigint::regclass", RegclassType.INSTANCE.explicitCast(10L));
+        assertEvaluate("10::bigint::regclass",
+            RegclassType.INSTANCE.explicitCast(10L, CoordinatorTxnCtx.systemTransactionContext().sessionSettings()));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -21,24 +21,23 @@
 
 package io.crate.integrationtests;
 
-import io.crate.metadata.RelationName;
-import io.crate.metadata.pgcatalog.OidHash;
-import io.crate.testing.UseHashJoins;
-import io.crate.testing.UseRandomizedSchema;
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
-import java.util.Arrays;
-import java.util.List;
-
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
-import static org.hamcrest.Matchers.is;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseRandomizedSchema;
 
 public class PgCatalogITest extends SQLIntegrationTestCase {
 
@@ -327,5 +326,16 @@ public class PgCatalogITest extends SQLIntegrationTestCase {
             "[2, 3]| tbl_pk| p\n"
         ));
 
+    }
+
+    @UseRandomizedSchema(random = false)
+    @Test
+    public void test_pg_class_oid_equals_cast_of_string_to_regclass() {
+        execute("CREATE TABLE persons (x INT)");
+        execute("SELECT " +
+            " '\"persons\"'::regclass::integer oid_from_relname, " +
+            " oid " +
+            " FROM pg_class WHERE relname ='persons'");
+        assertThat(printedTable(response.rows()), is("1726373441| 1726373441\n"));
     }
 }

--- a/server/src/test/java/io/crate/types/BitStringTypeTest.java
+++ b/server/src/test/java/io/crate/types/BitStringTypeTest.java
@@ -30,11 +30,15 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
 import io.crate.testing.Asserts;
 import io.crate.testing.DataTypeTesting;
 
 public class BitStringTypeTest extends ESTestCase {
+
+    private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();
 
     @Test
     public void test_value_streaming_roundtrip() throws Exception {
@@ -61,14 +65,14 @@ public class BitStringTypeTest extends ESTestCase {
     @Test
     public void test_explicit_cast_can_trim_bitstring() throws Exception {
         BitStringType type = new BitStringType(3);
-        BitString result = type.explicitCast(BitString.ofRawBits("1111"));
+        BitString result = type.explicitCast(BitString.ofRawBits("1111"), SESSION_SETTINGS);
         assertThat(result, is(BitString.ofRawBits("111")));
     }
 
     @Test
     public void test_explicit_cast_can_extend_bitstring() throws Exception {
         BitStringType type = new BitStringType(4);
-        BitString result = type.explicitCast(BitString.ofRawBits("111"));
+        BitString result = type.explicitCast(BitString.ofRawBits("111"), SESSION_SETTINGS);
         assertThat(result, is(BitString.ofRawBits("1110")));
     }
 }

--- a/server/src/test/java/io/crate/types/CharacterTypeTest.java
+++ b/server/src/test/java/io/crate/types/CharacterTypeTest.java
@@ -26,7 +26,12 @@ import static org.hamcrest.Matchers.is;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.settings.SessionSettings;
+
 public class CharacterTypeTest extends ESTestCase {
+
+    private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();
 
     @Test
     public void test_value_for_insert_adds_blank_padding() {
@@ -45,9 +50,9 @@ public class CharacterTypeTest extends ESTestCase {
 
     @Test
     public void test_explicit_cast_truncates_overflow_chars() {
-        assertThat(CharacterType.of(1).explicitCast("foo"), is("f"));
-        assertThat(CharacterType.of(1).explicitCast(true), is("t"));
-        assertThat(CharacterType.of(1).explicitCast(12), is("1"));
-        assertThat(CharacterType.of(1).explicitCast(-12), is("-"));
+        assertThat(CharacterType.of(1).explicitCast("foo", SESSION_SETTINGS), is("f"));
+        assertThat(CharacterType.of(1).explicitCast(true, SESSION_SETTINGS), is("t"));
+        assertThat(CharacterType.of(1).explicitCast(12, SESSION_SETTINGS), is("1"));
+        assertThat(CharacterType.of(1).explicitCast(-12, SESSION_SETTINGS), is("-"));
     }
 }

--- a/server/src/test/java/io/crate/types/JsonTypeTest.java
+++ b/server/src/test/java/io/crate/types/JsonTypeTest.java
@@ -29,11 +29,14 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.settings.SessionSettings;
+
 public class JsonTypeTest {
 
     @Test
     public void test_can_cast_object_to_json_string() throws Exception {
-        String result = JsonType.INSTANCE.explicitCast(Map.of("x", 200));
+        String result = JsonType.INSTANCE.explicitCast(Map.of("x", 200), CoordinatorTxnCtx.systemTransactionContext().sessionSettings());
         assertThat(result, is("{\"x\":200}"));
     }
 }

--- a/server/src/test/java/io/crate/types/RegclassTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegclassTypeTest.java
@@ -21,11 +21,25 @@
 
 package io.crate.types;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
 import org.junit.Test;
 
+import io.crate.exceptions.InvalidRelationName;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.settings.SessionSettings;
 import io.crate.testing.Asserts;
 
 public class RegclassTypeTest {
+
+    private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();
+
+    private Regclass explicitCast(Object value) {
+        return RegclassType.INSTANCE.explicitCast(value, SESSION_SETTINGS);
+    }
 
     @Test
     public void test_cannot_cast_long_outside_int_range_to_regclass() {
@@ -33,6 +47,47 @@ public class RegclassTypeTest {
             () -> RegclassType.INSTANCE.implicitCast(Integer.MAX_VALUE + 42L),
             IllegalArgumentException.class,
             "2147483689 is outside of `int` range and cannot be cast to the regclass type"
+        );
+    }
+
+    @Test
+    public void test_cast_from_string_uses_current_schema() {
+        var sessionSettings = new SessionSettings("crate", SearchPath.createSearchPathFrom("my_schema"));
+        var regclass = RegclassType.INSTANCE.explicitCast("my_table", sessionSettings);
+
+        assertThat(regclass.toString(), is("2034491507"));
+    }
+
+    @Test
+    public void test_cast_from_quoted_string_identifier() {
+        var regclassQuotedIdentifier = explicitCast("\"my_table\"");
+        var regclass = explicitCast("my_table");
+
+        assertThat(regclassQuotedIdentifier, is(regclass));
+    }
+
+    @Test
+    public void test_cast_from_string_unquoted_ignores_capital_case() {
+        var regclassQuotedIdentifier = explicitCast("\"mytable\"");
+        var regclass = explicitCast("myTable");
+
+        assertThat(regclassQuotedIdentifier, is(regclass));
+    }
+
+    @Test
+    public void test_cast_from_string_quoted_does_not_ignore_capital_case() {
+        var regclassQuotedIdentifier = explicitCast("\"myTable\"");
+        var regclass = explicitCast("mytable");
+
+        assertThat(regclassQuotedIdentifier, not(is(regclass)));
+    }
+
+    @Test
+    public void test_cast_from_string_raise_exception_if_not_valid_relation_name() {
+        Asserts.assertThrowsMatches(
+            () -> explicitCast("\"\"myTable\"\""),
+            InvalidRelationName.class,
+            "Relation name \"\"\"myTable\"\"\" is invalid"
         );
     }
 }

--- a/server/src/test/java/io/crate/types/StringTypeTest.java
+++ b/server/src/test/java/io/crate/types/StringTypeTest.java
@@ -21,17 +21,22 @@
 
 package io.crate.types;
 
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.settings.SessionSettings;
 
 public class StringTypeTest extends ESTestCase {
+
+    private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();
 
     @Test
     public void test_implicit_cast_boolean_to_text() {
@@ -60,25 +65,25 @@ public class StringTypeTest extends ESTestCase {
 
     @Test
     public void test_explicit_cast_text_with_length_truncates_exceeding_length_chars() {
-        assertThat(StringType.of(1).explicitCast("abcde"), is("a"));
-        assertThat(StringType.of(2).explicitCast("a    "), is("a "));
+        assertThat(StringType.of(1).explicitCast("abcde", SESSION_SETTINGS), is("a"));
+        assertThat(StringType.of(2).explicitCast("a    ", SESSION_SETTINGS), is("a "));
     }
 
     @Test
     public void test_explicit_cast_text_with_length_on_literals_of_length_lte_length() {
-        assertThat(StringType.of(5).explicitCast("abc"), is("abc"));
-        assertThat(StringType.of(1).explicitCast("a"), is("a"));
+        assertThat(StringType.of(5).explicitCast("abc", SESSION_SETTINGS), is("abc"));
+        assertThat(StringType.of(1).explicitCast("a", SESSION_SETTINGS), is("a"));
     }
 
     @Test
     public void test_explicit_cast_text_without_length() {
-        assertThat(StringType.INSTANCE.explicitCast("abc"), is("abc"));
+        assertThat(StringType.INSTANCE.explicitCast("abc", SESSION_SETTINGS), is("abc"));
     }
 
     @Test
     public void test_explicit_cast_text_without_length_on_literals_of_length_lte_length() {
-        assertThat(StringType.INSTANCE.explicitCast("abc"), is("abc"));
-        assertThat(StringType.INSTANCE.explicitCast("a"), is("a"));
+        assertThat(StringType.INSTANCE.explicitCast("abc", SESSION_SETTINGS), is("abc"));
+        assertThat(StringType.INSTANCE.explicitCast("a", SESSION_SETTINGS), is("a"));
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -53,6 +53,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import io.crate.integrationtests.SQLIntegrationTestCase;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.types.DataTypes;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
@@ -329,7 +330,7 @@ public class ReplicaShardAllocatorIT extends SQLIntegrationTestCase {
             assertThat(rentetionLease.size(), is(activeRetentionLeaseIds.size()));
             for (var activeRetentionLease : rentetionLease) {
                 assertThat(
-                    DataTypes.LONG.explicitCast(activeRetentionLease.get("retaining_seq_no")),
+                    DataTypes.LONG.explicitCast(activeRetentionLease.get("retaining_seq_no"), CoordinatorTxnCtx.systemTransactionContext().sessionSettings()),
                     is(globalCheckPoint + 1L)
                 );
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

While casting to `regclass`, the used regclass type must be
constructed using the current defined `search_path` to create
the correct relation OID.

~The Scalar.compile() functionality is used to create new
cast function instances with the adjusted regclass type.~

Fixes #12586.
Closes https://github.com/crate/crate/issues/10735


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
