### PR TITLE
Stop logical replication shard tracking in beforeIndexShardDeleted

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/ShardReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/ShardReplicationService.java
@@ -121,7 +121,7 @@ public class ShardReplicationService implements Closeable, IndexEventListener {
     }
 
     @Override
-    public void afterIndexShardDeleted(ShardId shardId, Settings indexSettings) {
+    public void beforeIndexShardDeleted(ShardId shardId, Settings indexSettings) {
         closeTracker(shardId);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits - just some minor improvements.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
