### PR TITLE
parser: Fix grammar warning

### DIFF
--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -134,7 +134,7 @@ query
 queryNoWith
     : queryTerm
       (ORDER BY sortItem (',' sortItem)*)?
-      (limitClause? offsetClause? | offsetClause? limitClause?)?
+      (limitClause? offsetClause? | offsetClause? limitClause?)
     ;
 
 limitClause


### PR DESCRIPTION
Fix grammar to remove warning mentioning rule that leads to empty
statement.
```
> Task :libs:sql-parser:generateGrammarSource
warning(154): /home/matriv/crate/crate/libs/sql-parser/src/main/antlr/SqlBase.g4:134:0: rule queryNoWith contains an optional block with at least one alternative that can match an empty string
```

Follows: 75378b32577829512843e20128b828864f545343

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
