### PR TITLE
Add `pg_catalog.pg_tables` and `pg_catalog.pg_views` tables

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -119,6 +119,9 @@ Changes
 - Added ``SUBSTRING`` to non-reserved SQL keywords in order to support the
   generic function call syntax for improved PostgreSQL compatibility.
   Example: ``SUBSTRING('crate', 1, 3)``
+  
+- Added ``pg_catalog.pg_tables`` and ``pg_catalog.pg_views`` tables for improved 
+  PostgreSQL compatibility.
 
 Fixes
 =====

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -102,8 +102,10 @@ number of replicas.
     | pg_catalog         | pg_stats                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_subscription         | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_subscription_rel     | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_tables               | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_tablespace           | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_type                 | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_views                | BASE TABLE |             NULL | NULL               |
     | sys                | allocations             | BASE TABLE |             NULL | NULL               |
     | sys                | checks                  | BASE TABLE |             NULL | NULL               |
     | sys                | cluster                 | BASE TABLE |             NULL | NULL               |
@@ -124,7 +126,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 57 rows in set (... sec)
+    SELECT 59 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -175,8 +175,10 @@ following tables:
  - `pg_range`_
  - `pg_roles`_
  - `pg_settings <pgsql_pg_settings_>`__
+ - `pg_tables`_
  - `pg_tablespace`_
  - `pg_type`_
+ - `pg_views`_
 
 
 .. _postgres-pg_type:
@@ -540,35 +542,37 @@ CrateDB and we love to hear feedback.
 
 
 .. _GitHub: https://github.com/crate/crate
-.. _pg_am: https://www.postgresql.org/docs/10/catalog-pg-am.html
-.. _pg_description: https://www.postgresql.org/docs/10/catalog-pg-description.html
-.. _pg_enum: https://www.postgresql.org/docs/10/catalog-pg-enum.html
-.. _pg_range: https://www.postgresql.org/docs/10/catalog-pg-range.html
-.. _pg_roles: https://www.postgresql.org/docs/10/view-pg-roles.html
-.. _pg_tablespace: https://www.postgresql.org/docs/13/catalog-pg-tablespace.html
+.. _pg_am: https://www.postgresql.org/docs/14/catalog-pg-am.html
+.. _pg_description: https://www.postgresql.org/docs/14/catalog-pg-description.html
+.. _pg_enum: https://www.postgresql.org/docs/14/catalog-pg-enum.html
+.. _pg_range: https://www.postgresql.org/docs/14/catalog-pg-range.html
+.. _pg_roles: https://www.postgresql.org/docs/14/view-pg-roles.html
+.. _pg_tables: https://www.postgresql.org/docs/14/view-pg-tables.html
+.. _pg_tablespace: https://www.postgresql.org/docs/14/catalog-pg-tablespace.html
+.. _pg_views: https://www.postgresql.org/docs/14/view-pg-views.html
 .. _pgjdbc: https://github.com/pgjdbc/pgjdbc
-.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/10/static/catalog-pg-attrdef.html
-.. _pgsql_pg_attribute: https://www.postgresql.org/docs/10/static/catalog-pg-attribute.html
-.. _pgsql_pg_class: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
-.. _pgsql_pg_constraint: https://www.postgresql.org/docs/10/static/catalog-pg-constraint.html
-.. _pgsql_pg_database: https://www.postgresql.org/docs/10/static/catalog-pg-database.html
-.. _pgsql_pg_index: https://www.postgresql.org/docs/10/static/catalog-pg-index.html
-.. _pgsql_pg_indexes: https://www.postgresql.org/docs/current/view-pg-indexes.html
-.. _pgsql_pg_locks: https://www.postgresql.org/docs/current/view-pg-locks.html
-.. _pgsql_pg_namespace: https://www.postgresql.org/docs/10/static/catalog-pg-namespace.html
-.. _pgsql_pg_proc: https://www.postgresql.org/docs/10/static/catalog-pg-proc.html
-.. _pgsql_pg_publication: https://www.postgresql.org/docs/current/catalog-pg-publication.html
-.. _pgsql_pg_publication_tables: https://www.postgresql.org/docs/current/view-pg-publication-tables.html
-.. _pgsql_pg_subscription: https://www.postgresql.org/docs/current/catalog-pg-subscription.html
-.. _pgsql_pg_subscription_rel: https://www.postgresql.org/docs/current/catalog-pg-subscription-rel.html
-.. _pgsql_pg_settings: https://www.postgresql.org/docs/10/view-pg-settings.html
-.. _pgsql_pg_type: https://www.postgresql.org/docs/10/static/catalog-pg-type.html
-.. _PostgreSQL Arrays: https://www.postgresql.org/docs/current/static/arrays.html
-.. _PostgreSQL extended query: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-.. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/current/static/functions-textsearch.html
+.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/14/static/catalog-pg-attrdef.html
+.. _pgsql_pg_attribute: https://www.postgresql.org/docs/14/static/catalog-pg-attribute.html
+.. _pgsql_pg_class: https://www.postgresql.org/docs/14/static/catalog-pg-class.html
+.. _pgsql_pg_constraint: https://www.postgresql.org/docs/14/static/catalog-pg-constraint.html
+.. _pgsql_pg_database: https://www.postgresql.org/docs/14/static/catalog-pg-database.html
+.. _pgsql_pg_index: https://www.postgresql.org/docs/14/static/catalog-pg-index.html
+.. _pgsql_pg_indexes: https://www.postgresql.org/docs/14/view-pg-indexes.html
+.. _pgsql_pg_locks: https://www.postgresql.org/docs/14/view-pg-locks.html
+.. _pgsql_pg_namespace: https://www.postgresql.org/docs/14/static/catalog-pg-namespace.html
+.. _pgsql_pg_proc: https://www.postgresql.org/docs/14/static/catalog-pg-proc.html
+.. _pgsql_pg_publication: https://www.postgresql.org/docs/14/catalog-pg-publication.html
+.. _pgsql_pg_publication_tables: https://www.postgresql.org/docs/14/view-pg-publication-tables.html
+.. _pgsql_pg_subscription: https://www.postgresql.org/docs/14/catalog-pg-subscription.html
+.. _pgsql_pg_subscription_rel: https://www.postgresql.org/docs/14/catalog-pg-subscription-rel.html
+.. _pgsql_pg_settings: https://www.postgresql.org/docs/14/view-pg-settings.html
+.. _pgsql_pg_type: https://www.postgresql.org/docs/14/static/catalog-pg-type.html
+.. _PostgreSQL Arrays: https://www.postgresql.org/docs/14/static/arrays.html
+.. _PostgreSQL extended query: https://www.postgresql.org/docs/14/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
+.. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/14/static/functions-textsearch.html
 .. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/head/connect.html#connection-failover
 .. _PostgreSQL JDBC Query docs: https://jdbc.postgresql.org/documentation/head/query.html
-.. _PostgreSQL simple query: https://www.postgresql.org/docs/current/static/protocol-flow.html#id-1.10.5.7.4
-.. _PostgreSQL value expressions: https://www.postgresql.org/docs/current/static/sql-expressions.html
-.. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/current/static/protocol.html
-.. _PostgreSQL cancelling requests: https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.9
+.. _PostgreSQL simple query: https://www.postgresql.org/docs/14/static/protocol-flow.html#id-1.10.5.7.4
+.. _PostgreSQL value expressions: https://www.postgresql.org/docs/14/static/sql-expressions.html
+.. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/14/static/protocol.html
+.. _PostgreSQL cancelling requests: https://www.postgresql.org/docs/14/protocol-flow.html#id-1.10.5.7.9

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -90,6 +90,7 @@ public class InformationSchemaIterables implements ClusterStateListener {
 
     private final Schemas schemas;
     private final Iterable<RelationInfo> relations;
+    private final Iterable<TableInfo> tables;
     private final Iterable<ViewInfo> views;
     private final PartitionInfos partitionInfos;
     private final Iterable<ColumnContext> columns;
@@ -116,6 +117,7 @@ public class InformationSchemaIterables implements ClusterStateListener {
         this.nodeCtx = nodeCtx;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         views = () -> viewsStream(schemas).iterator();
+        tables = () -> tablesStream(schemas).iterator();
         relations = () -> concat(tablesStream(schemas), viewsStream(schemas)).iterator();
         primaryKeys = () -> sequentialStream(relations)
             .filter(this::isPrimaryKey)
@@ -270,6 +272,10 @@ public class InformationSchemaIterables implements ClusterStateListener {
 
     public Iterable<RelationInfo> relations() {
         return relations;
+    }
+
+    public Iterable<TableInfo> tables() {
+        return tables;
     }
 
     public Iterable<PgIndexTable.Entry> pgIndices() {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -77,7 +77,9 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgPublicationTable.IDENT.name(), PgPublicationTable.create()),
             Map.entry(PgPublicationTablesTable.IDENT.name(), PgPublicationTablesTable.create()),
             Map.entry(PgSubscriptionTable.IDENT.name(), PgSubscriptionTable.create()),
-            Map.entry(PgSubscriptionRelTable.IDENT.name(), PgSubscriptionRelTable.create())
+            Map.entry(PgSubscriptionRelTable.IDENT.name(), PgSubscriptionRelTable.create()),
+            Map.entry(PgTablesTable.IDENT.name(), PgTablesTable.create()),
+            Map.entry(PgViewsTable.IDENT.name(), PgViewsTable.create())
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -197,6 +197,19 @@ public class PgCatalogTableDefinitions {
             (user, p) -> p.owner().equals(user.name()),
             PgSubscriptionRelTable.create().expressions()
         ));
+
+        tableDefinitions.put(PgTablesTable.IDENT, new StaticTableDefinition<>(
+            informationSchemaIterables::tables,
+            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.ident().fqn()),
+            PgTablesTable.create().expressions()
+        ));
+
+        tableDefinitions.put(PgViewsTable.IDENT, new StaticTableDefinition<>(
+            informationSchemaIterables::views,
+            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.VIEW, t.ident().fqn()),
+            PgViewsTable.create().expressions()
+        ));
+
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgTablesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgTablesTable.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.metadata.table.TableInfo;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.BOOLEAN;
+
+public final class PgTablesTable {
+
+    public static final String NAME = "pg_tables";
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, NAME);
+
+    public static SystemTable<TableInfo> create() {
+        return SystemTable.<TableInfo>builder(IDENT)
+            .add("schemaname", STRING, r -> r.ident().schema())
+            .add("tablename", STRING, r -> r.ident().name())
+            .add("tableowner", STRING, r -> null)
+            .add("tablespace", STRING, r -> null)
+            .add("hasindexes", BOOLEAN, r -> false)
+            .add("hasrules", BOOLEAN, r -> false)
+            .add("hastriggers", BOOLEAN, r -> false)
+            .add("rowsecurity", BOOLEAN, r -> false)
+            .build();
+    }
+}

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgViewsTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgViewsTable.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.metadata.view.ViewInfo;
+
+
+import static io.crate.types.DataTypes.STRING;
+
+public final class PgViewsTable {
+
+    public static final String NAME = "pg_views";
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, NAME);
+
+    public static SystemTable<ViewInfo> create() {
+        return SystemTable.<ViewInfo>builder(IDENT)
+            .add("schemaname", STRING, r -> r.ident().schema())
+            .add("viewname", STRING, r -> r.ident().name())
+            .add("viewowner", STRING, ViewInfo::owner)
+            .add("definition", STRING, ViewInfo::definition)
+            .build();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -62,7 +62,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(53L, response.rowCount());
+        assertEquals(55L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| character_sets| information_schema| BASE TABLE| NULL\n" +
@@ -97,8 +97,10 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_stats| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_subscription| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_subscription_rel| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_tables| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_tablespace| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_type| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_views| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| allocations| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| checks| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| cluster| sys| BASE TABLE| NULL\n" +
@@ -199,13 +201,13 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(53L, response.rowCount());
+        assertEquals(55L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(54L, response.rowCount());
+        assertEquals(56L, response.rowCount());
     }
 
     @Test
@@ -537,7 +539,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(923, response.rowCount());
+        assertEquals(935, response.rowCount());
     }
 
     @Test
@@ -790,7 +792,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(56L, response.rows()[0][0]);
+        assertEquals(58L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -96,6 +96,24 @@ public class PgCatalogITest extends SQLIntegrationTestCase {
     }
 
     @Test
+    public void testPgTablesTable() {
+        execute("select * from pg_tables WHERE tablename = 't1'");
+        assertThat(printedTable(response.rows()), is("false| false| false| false| doc| t1| NULL| NULL\n"));
+
+        execute("select count(*) from pg_tables WHERE tablename = 'v1'");
+        assertThat(printedTable(response.rows()), is("0\n"));
+    }
+
+    @Test
+    public void testPgViewsTable() {
+        execute("select * from pg_views WHERE viewname = 'v1'");
+        assertThat(printedTable(response.rows()), is("SELECT \"id\"\nFROM \"doc\".\"t1\"\n| doc| v1| crate\n"));
+
+        execute("select count(*) from pg_views WHERE viewname = 't1'");
+        assertThat(printedTable(response.rows()), is("0\n"));
+    }
+
+    @Test
     public void testPgDescriptionTableIsEmpty() {
         execute("select * from pg_description");
         assertThat(printedTable(response.rows()), is(""));

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -449,7 +449,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     public void testAccessesToPgClassEntriesWithRespectToPrivileges() throws Exception {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         execute("select relname from pg_catalog.pg_class order by relname", null, testUserSession());
-        assertThat(response.rowCount(), is(43L));
+        assertThat(response.rowCount(), is(45L));
         assertThat(printedTable(response.rows()), is(
             """
                 character_sets
@@ -478,8 +478,10 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
                 pg_stats
                 pg_subscription
                 pg_subscription_rel
+                pg_tables
                 pg_tablespace
                 pg_type
+                pg_views
                 referential_constraints
                 referential_constraints_pkey
                 routines
@@ -585,7 +587,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     public void testAccessesToPgAttributeEntriesWithRespectToPrivileges() throws Exception {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession());
-        assertThat(response.rowCount(), is(478L));
+        assertThat(response.rowCount(), is(490L));
 
         //create a table with an attribute that a new user is not privileged to access
         executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -99,7 +99,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(53L, response.rowCount());
+        assertEquals(55L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add `pg_catalog.pg_tables` and `pg_catalog.pg_views` tables for improved compatibility with PostgreSQL.
The information in those tables is redundant whit what is already in place, however some pg-compatible tools rely on those tables (E.g. Dremio).

**pg_tables**  and **pg_views** references (among others) the information from `pg_class` table.

reference:
https://www.postgresql.org/docs/current/view-pg-tables.html
https://www.postgresql.org/docs/current/view-pg-views.html

---

closes https://github.com/crate/crate/issues/12574

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
