### PR TITLE
Add `SUBSTRING(s,i[,j])` as alternative to `SUBSTRING(s FROM i [FOR j])`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -116,6 +116,9 @@ Changes
 
 - Updated Admin UI to 1.22.0, including an update with the new logo and colors.
 
+- Added ``SUBSTRING(s,i[,j])`` as alternative to ``SUBSTRING(s FROM i [FOR j])``
+  for improved compatibility with PostgreSQL.
+
 Fixes
 =====
 

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -311,7 +311,8 @@ explicitFunction
     | SESSION_USER                                                                   #sessionUser
     | LEFT '(' strOrColName=expr ',' len=expr ')'                                    #left
     | RIGHT '(' strOrColName=expr ',' len=expr ')'                                   #right
-    | SUBSTRING '(' expr FROM expr (FOR expr)? ')'                                   #substring
+    | SUBSTRING '(' expr ( (FROM expr (FOR expr)?)
+                         | (','  expr (',' expr)?) ) ')'                             #substring
     | TRIM '(' ((trimMode=(LEADING | TRAILING | BOTH))?
                 (charsToTrim=expr)? FROM)? target=expr ')'                           #trim
     | EXTRACT '(' stringLiteralOrIdentifier FROM expr ')'                            #extract


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Added ``SUBSTRING(s,i[,j])`` as alternative to ``SUBSTRING(s FROM i [FOR j])``
for improved compatibility with PostgreSQL.

Example Metabase:

```sql
SELECT
    "demo"."world_cities"."city" AS "city",
    SUBSTRING("demo"."world_cities"."city_ascii", 1, 1234) AS "substring1115"
FROM "demo"."world_cities"
LIMIT 100
```

--

⚠️ _This seems to be not fully documented in the PostgreSQL docs, but there are quite some references, that it is supported by PostgreSQL and apparently Metabase is using it._

https://www.postgresql.org/docs/14/functions-string.html

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
