### PR TITLE
Add `parse_uri()` / `parse_url()` function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -159,6 +159,14 @@ Changes
   first level properties, taking the second object's values for duplicate
   properties.
 
+- Added the :ref:`parse_uri(text) <scalar-parse_uri>` scalar function which 
+  parses a valid URI string into an ``object`` containing the URI components, 
+  making it easier to query them.
+
+- Added the :ref:`parse_url(text) <scalar-parse_url>` scalar function which
+  parses a valid URL string into an ``object`` containing the URL components, 
+  including parsed query parameters, making it easier to query them.
+
 Fixes
 =====
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -770,6 +770,148 @@ Example::
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-parse_uri:
+
+``parse_uri(text)``
+-----------------------------------
+
+Returns: ``object``
+
+Parses the given URI string and returns an object containing the various 
+components of the URI. The returned object has the following properties::
+
+    "uri" OBJECT AS (
+        "scheme" TEXT,
+        "userinfo" TEXT,
+        "hostname" TEXT,
+        "port" INT,
+        "path" TEXT,
+        "query" TEXT,
+        "fragment" TEXT
+    )
+
+.. csv-table::
+   :header: "URI Component", "Description"
+   :widths: 25, 75
+   :align: left
+
+   ``scheme`` , "The scheme of the URI (e.g. ``http``, ``crate``, etc.)"
+   ``userinfo`` , "The decoded user-information component of this URI."
+   ``hostname`` , "The hostname or IP address specified in the URI."
+   ``port`` , "The port number specified in the URI"
+   ``path`` , "The decoded path specified in the URI."
+   ``query`` , "The decoded query string specified in the URI"
+   ``fragment`` , "The query string specified in the URI"
+
+.. NOTE::
+
+    For URI properties not specified in the input string, ``null`` is returned.
+
+Synopsis::
+
+    parse_uri(text)
+
+Example::
+
+    cr> SELECT parse_uri('crate://my_user@cluster.crate.io:5432/doc?sslmode=verify-full') as uri;                                                                               
+    +------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | uri                                                                                                                                                        |
+    +------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | {"fragment": null, "hostname": "cluster.crate.io", "path": "/doc", "port": 5432, "query": "sslmode=verify-full", "scheme": "crate", "userinfo": "my_user"} |
+    +------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+If you just want to select a specific URI component, you can use the bracket 
+notation on the returned object::
+
+    cr> SELECT parse_uri('crate://my_user@cluster.crate.io:5432')['hostname'] as uri_hostname;                                                                                  
+    +------------------+
+    | uri_hostname     |
+    +------------------+
+    | cluster.crate.io |
+    +------------------+
+    SELECT 1 row in set (... sec)
+
+
+.. _scalar-parse_url:
+
+``parse_url(text)``
+-----------------------------------
+
+Returns: ``object``
+
+Parses the given URL string and returns an object containing the various 
+components of the URL. The returned object has the following properties::
+
+    "url" OBJECT AS (
+        "scheme" TEXT,
+        "userinfo" TEXT,
+        "hostname" TEXT,
+        "port" INT,
+        "path" TEXT,
+        "query" TEXT,
+        "parameters" OBJECT AS (
+            "key1" ARRAY(TEXT),
+            "key2" ARRAY(TEXT)   
+        ),
+        "fragment" TEXT
+    )
+
+.. csv-table::
+   :header: "URL Component", "Description"
+   :widths: 25, 75
+   :align: left
+
+   ``scheme`` , "The scheme of the URL (e.g. ``https``, ``crate``, etc.)"
+   ``userinfo`` , "The decoded user-information component of this URL."
+   ``hostname`` , "The hostname or IP address specified in the URL."
+   ``port`` , "The port number specified in the URL. If no port number is specified, the default port for the given scheme will be used."
+   ``path`` , "The decoded path specified in the URL."
+   ``query`` , "The decoded query string specified in the URL."
+   ``parameters`` , "For each query parameter included in the URL, the ``parameter`` property holds an object property that stores an array of decoded text values for that specific query parameter."
+   ``fragment`` , "The decoded fragment specified in the URL"
+
+.. NOTE::
+
+    For URL properties not specified in the input string, ``null`` is returned.
+
+Synopsis::
+
+    parse_url(text)
+
+Example::
+
+    cr> SELECT parse_url('https://my_user@cluster.crate.io:4200/doc?sslmode=verify-full') as url;                                                                               
+    +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | url                                                                                                                                                                                                    |
+    +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | {"fragment": null, "hostname": "cluster.crate.io", "parameters": {"sslmode": ["verify-full"]}, "path": "/doc", "port": 4200, "query": "sslmode=verify-full", "scheme": "https", "userinfo": "my_user"} |
+    +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+If you just want to select a specific URL component, you can use the bracket 
+notation on the returned object::
+
+    cr> SELECT parse_url('https://my_user@cluster.crate.io:5432')['hostname'] as url_hostname;                                                                                  
+    +------------------+
+    | url_hostname     |
+    +------------------+
+    | cluster.crate.io |
+    +------------------+
+    SELECT 1 row in set (... sec)
+
+Parameter values are always treated as ``text``. There is no conversion of 
+comma-separated parameter values into arrays::
+
+    cr> SELECT parse_url('http://crate.io?p1=1,2,3&p1=a&p2[]=1,2,3')['parameters'] as params;                                                                                                                        
+    +-------------------------------------------+
+    | params                                    |
+    +-------------------------------------------+
+    | {"p1": ["1,2,3", "a"], "p2[]": ["1,2,3"]} |
+    +-------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-date-time:
 
 Date and time functions

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -69,6 +69,8 @@ import io.crate.expression.scalar.string.EncodeDecodeFunction;
 import io.crate.expression.scalar.string.HashFunctions;
 import io.crate.expression.scalar.string.InitCapFunction;
 import io.crate.expression.scalar.string.LengthFunction;
+import io.crate.expression.scalar.string.ParseURIFunction;
+import io.crate.expression.scalar.string.ParseURLFunction;
 import io.crate.expression.scalar.string.QuoteIdentFunction;
 import io.crate.expression.scalar.string.ReplaceFunction;
 import io.crate.expression.scalar.string.StringCaseFunction;
@@ -226,5 +228,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
 
         HasSchemaPrivilegeFunction.register(this);
         HasDatabasePrivilegeFunction.register(this);
+        ParseURIFunction.register(this);
+        ParseURLFunction.register(this);
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import java.net.URISyntaxException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public final class ParseURIFunction extends Scalar<Object, String> {
+
+    private static final String NAME = "parse_uri";
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.UNTYPED_OBJECT.getTypeSignature()
+            ),
+            ParseURIFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    public ParseURIFunction(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    @SafeVarargs
+    public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>... args) {
+        String uri = args[0].value();
+        if (uri == null) {
+            return null;
+        }
+        return parseURI(uri);
+    }
+
+    private final Object parseURI(String uriText) {
+        final Map<String, Object> uriMap = new HashMap<>();
+
+        URI uri = null;
+
+        try {
+            uri = new URI(uriText);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                         "unable to parse uri %s",
+                                                         uriText));
+        }
+
+        uriMap.put("scheme", uri.getScheme());
+        uriMap.put("userinfo", uri.getUserInfo());
+        uriMap.put("hostname", uri.getHost());
+        uriMap.put("port", uri.getPort() == -1 ? null : uri.getPort());
+        uriMap.put("path", uri.getPath());
+        uriMap.put("query", uri.getQuery());
+        uriMap.put("fragment", uri.getFragment());
+
+        return uriMap;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import java.net.URL;
+import java.net.URLDecoder;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.elasticsearch.common.Strings;
+
+import java.nio.charset.StandardCharsets;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public final class ParseURLFunction extends Scalar<Object, String> {
+
+    private static final String NAME = "parse_url";
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.UNTYPED_OBJECT.getTypeSignature()
+            ),
+            ParseURLFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    public ParseURLFunction(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    @SafeVarargs
+    public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>... args) {
+        String url = args[0].value();
+        if (url == null) {
+            return null;
+        }
+        return parseURL(url);
+    }
+
+    private final Object parseURL(String urlText) {
+        final Map<String, Object> urlMap = new HashMap<>();
+
+        URL url = null;
+
+        try {
+            url = new URL(urlText);
+        } catch (MalformedURLException e1) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                            "unable to parse url %s",
+                                                             urlText));
+        }
+
+        urlMap.put("scheme", url.getProtocol());
+        urlMap.put("userinfo", decodeText(url.getUserInfo()));
+        urlMap.put("hostname", url.getHost());
+        urlMap.put("port", url.getPort() == -1 ? null : url.getPort());
+        urlMap.put("path", decodeText(url.getPath()));
+        urlMap.put("query", decodeText(url.getQuery()));
+        urlMap.put("parameters", parseQuery(url.getQuery()));
+        urlMap.put("fragment", decodeText(url.getRef()));
+
+        return urlMap;
+    }
+
+    private final Map<String,List<String>> parseQuery(String query) {
+        if (Strings.isNullOrEmpty(query)) {
+            return null;
+        }
+
+        Map<String,List<String>> queryMap = new HashMap<String,List<String>>();
+        String[] parameters = query.split("&(?!amp)");
+        for (String parameter : parameters) {
+            final int idx = parameter.indexOf("=");
+            final String key = idx > 0 ? decodeText(parameter.substring(0, idx)) : decodeText(parameter);
+            final String value = idx > 0 && parameter.length() > idx + 1 ? decodeText(parameter.substring(idx + 1)) : null;
+            queryMap.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+        return queryMap;
+    }
+
+    private final String decodeText(String text) {
+        return text != null ? URLDecoder.decode(text, StandardCharsets.UTF_8) : null;
+    }
+
+}

--- a/server/src/test/java/io/crate/expression/scalar/ParseURIFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ParseURIFunctionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import org.junit.Test;
+
+import io.crate.common.collections.MapBuilder;
+
+import java.util.Locale;
+import java.util.Map;
+
+public class ParseURIFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_input() {
+        assertEvaluateNull("parse_uri(null)");
+    }
+
+    @Test
+    public void test_parse_uri() {
+        String uri = "https://crate.io/index.html";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo", null)
+            .put("hostname", "crate.io")
+            .put("port", null)
+            .put("path", "/index.html")
+            .put("query", null)
+            .put("fragment", null)
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_uri('%s')", uri), value);
+    }
+
+    @Test
+    public void test_parse_uri_userinfo() {
+        String uri = "https://user:pwd@crate.io/";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo", "user:pwd")
+            .put("hostname", "crate.io")
+            .put("port", null)
+            .put("path", "/")
+            .put("query", null)
+            .put("fragment", null)
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_uri('%s')", uri), value);
+    }
+
+    @Test
+    public void test_parse_uri_query() {
+        String uri = "https://crate.io/?foo=bar&foo=bar2&foo2";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo", null)
+            .put("hostname", "crate.io")
+            .put("port", null)
+            .put("path", "/")
+            .put("query", "foo=bar&foo=bar2&foo2")
+            .put("fragment", null)
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_uri('%s')", uri), value);
+    }
+
+    @Test
+    public void test_parse_uri_complete_example() {
+        String uri = "https://user:pw%26@testing.crate.io:4200/data/index.html?foo=bar&foo=&foo2=https%3A%2F%2Fcrate.io%2F%3Ffoo%3Dbar%26foo%3Dbar2%26foo2#ref";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo", "user:pw&")
+            .put("hostname", "testing.crate.io")
+            .put("port", 4200)
+            .put("path", "/data/index.html")
+            .put("query", "foo=bar&foo=&foo2=https://crate.io/?foo=bar&foo=bar2&foo2")
+            .put("fragment", "ref")
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_uri('%s')", uri), value);
+    }
+
+}

--- a/server/src/test/java/io/crate/expression/scalar/ParseURLFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ParseURLFunctionTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import org.junit.Test;
+
+import io.crate.common.collections.MapBuilder;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class ParseURLFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_input() {
+        assertEvaluateNull("parse_url(null)");
+    }
+
+    @Test
+    public void test_parse_url() {
+        String uri = "https://crate.io:8080/index.html";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo", null)
+            .put("hostname", "crate.io")
+            .put("port", 8080)
+            .put("path", "/index.html")
+            .put("query", null)
+            .put("parameters", null)
+            .put("fragment", null)
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_url('%s')", uri), value);
+    }
+
+    @Test
+    public void test_parse_url_userinfo() {
+        String uri = "https://user:pwd@crate.io:443/";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo", "user:pwd")
+            .put("hostname", "crate.io")
+            .put("port", 443)
+            .put("path", "/")
+            .put("query", null)
+            .put("parameters", null)
+            .put("fragment", null)
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_url('%s')", uri), value);
+    }
+
+    @Test
+    public void test_parse_url_query() {
+        String uri = "https://crate.io/?foo=bar&foo=bar2&foo2=bar&foo2";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo",null)
+            .put("hostname", "crate.io")
+            .put("port", null)
+            .put("path", "/")
+            .put("query", "foo=bar&foo=bar2&foo2=bar&foo2")
+            .put("parameters", MapBuilder.<String,Object>newMapBuilder()
+                                .put("foo",List.of("bar","bar2"))
+                                .put("foo2",Stream.of("bar",null).toList())
+                                .map())
+            .put("fragment", null)
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_url('%s')", uri), value);
+    }
+
+    @Test
+    public void test_parse_url_unsafe_character() {
+        String uri = "https://crate.io/sub%20space/hello.gif";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo",null)
+            .put("hostname", "crate.io")
+            .put("port", null)
+            .put("path", "/sub space/hello.gif")
+            .put("query", null)
+            .put("parameters", null)
+            .put("fragment", null)
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_url('%s')", uri), value);
+    }
+
+    @Test
+    public void test_parse_url_complete_example() {
+        String uri = "https://user:pw%26@testing.crate.io:4200/sub+space/sub%20space2/index.html?foo=bar&foo=&foo2=https%3A%2F%2Fcrate.io%2F%3Ffoo%3Dbar%26foo%3Dbar2%26foo2#ref";
+        Map<String, Object> value = MapBuilder.<String, Object>newMapBuilder()
+            .put("scheme", "https")
+            .put("userinfo", "user:pw&")
+            .put("hostname", "testing.crate.io")
+            .put("port", 4200)
+            .put("path", "/sub space/sub space2/index.html")
+            .put("query","foo=bar&foo=&foo2=https://crate.io/?foo=bar&foo=bar2&foo2")
+            .put("parameters", MapBuilder.<String,Object>newMapBuilder()
+                                .put("foo",Stream.of("bar",null).toList())
+                                .put("foo2",List.of("https://crate.io/?foo=bar&foo=bar2&foo2"))
+                                .map())
+            .put("fragment", "ref")
+            .map();
+        assertEvaluate(String.format(Locale.ENGLISH,"parse_url('%s')", uri), value);
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adding a `parse_uri(<TEXT>)` and `parse_url(<TEXT>)` function, that could resolve #11941.

**References from other DBs**
- `parse_url()` from [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/parse_url.html)
- [url functions from ClickHouse](https://clickhouse.com/docs/en/sql-reference/functions/url-functions/)
- `parse_url()` from [Databricks](https://docs.databricks.com/sql/language-manual/functions/parse_url.html)

---

```sql
cr> SELECT parse_uri('https://testing.crate.io:4200/') as url;
+--------------------------------------------------------------------------------+
| url                                                                            |
+--------------------------------------------------------------------------------+
| {"hostname": "testing.crate.io", "path": "/", "port": 4200, "scheme": "https"} |
+--------------------------------------------------------------------------------+
SELECT 1 row in set (0.003 sec)
```

```sql
cr> SELECT parse_url('https://user:pw%26@testing.crate.io:4200/sub+space/sub%20space2/index.html?foo=bar&foo=&foo2=https%3A%2F%2Fcrate.io%2F%3Ffoo%3Dbar%26foo%3Dbar2%26foo2#ref') as url;              
+---------------------------------------------------------------------------+
|  url                                                                      |
+---------------------------------------------------------------------------+
| {                                                                         |
|   "fragment": "ref",                                                      |
|   "hostname": "testing.crate.io",                                         |
|   "parameters":                                                           |
|     {                                                                     |
|       "foo": ["bar", null],                                               |
|       "foo2": ["https://crate.io/?foo=bar&foo=bar2&foo2"],                |
|     },                                                                    |
|   "path": "/sub space/sub space2/index.html",                             |
|   "port": 4200,                                                           |
|   "query": "foo=bar&foo=&foo2=https://crate.io/?foo=bar&foo=bar2&foo2",   |
|   "scheme": "https",                                                      |
|   "userinfo": "user:pw&"                                                  |
| }                                                                         |
+---------------------------------------------------------------------------+
```

```sql
CREATE TABLE uri_table (
   url TEXT,
   url_object OBJECT GENERATED ALWAYS AS parse_uri("url")
);
```

This would be currently rather hard to implement in CrateDB with UDFs as the GraalVM setup doesn't include the URL API

cc: @robd003 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
