### PR TITLE
allow group by null ordinal, casted to a specific type

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -140,3 +140,7 @@ Fixes
 - Fixed an issue that caused queries operating on expressions with no defined
   type to fail. Examples are queries with ``GROUP BY`` on an ignored object
   column or ``UNION`` on ``NULL`` literals.
+
+- Fixed an issue that caused ``GROUP BY`` and ``ORDER BY`` statements with
+  ``NULL`` ordinal casted to a specific type, throw an error. Example:
+  ``SELECT NULL, count(*) from unnest([1, 2]) GROUP BY NULL::integer``.

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -542,6 +542,11 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     }
 
     private static Symbol getByPosition(List<Symbol> outputSymbols, Literal<?> ordinal, String clause) {
+        if (ordinal.valueType().equals(DataTypes.UNDEFINED)) {
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "Cannot use %s in %s clause", ordinal, clause));
+        }
         Integer ord;
         try {
             ord = DataTypes.INTEGER.sanitizeValue(ordinal.value());
@@ -551,9 +556,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 "Cannot use %s in %s clause", ordinal, clause));
         }
         if (ord == null) {
-            throw new IllegalArgumentException(String.format(
-                Locale.ENGLISH,
-                "Cannot use %s in %s clause", ordinal, clause));
+            // It's NULL ordinal explicitly casted to some type, we allow it in GROUP BY or ORDER BY clauses to align with PG.
+            return ordinal;
         }
         return ordinalOutputReference(outputSymbols, ord, clause);
     }

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -344,6 +344,12 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_group_by_null_ordinal_with_explicit_cast_works() {
+        QueriedSelectRelation relation = analyze("select max(id) from users u group by NULL::int");
+        assertThat(relation.groupBy(), isSQL("NULL"));
+    }
+
+    @Test
     public void testGroupByHaving() throws Exception {
         QueriedSelectRelation relation = analyze("select sum(floats) from users group by name having name like 'Slartibart%'");
         assertThat(relation.having(), isFunction(LikeOperators.OP_LIKE));

--- a/server/src/test/java/io/crate/analyze/relations/OrderByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/OrderByAnalyzerTest.java
@@ -22,11 +22,14 @@
 package io.crate.analyze.relations;
 
 import io.crate.analyze.OrderBy;
+import io.crate.analyze.QueriedSelectRelation;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.SortItem;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 import io.crate.testing.SymbolMatchers;
 import org.junit.Test;
 
@@ -34,12 +37,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static io.crate.testing.TestingHelpers.isSQL;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
 
-public class OrderByAnalyzerTest {
+public class OrderByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void analyzeEmptySortItemsReturnsNull() {
@@ -78,4 +81,11 @@ public class OrderByAnalyzerTest {
         assertThat(nullsFirst[1], is(false));
     }
 
+    @Test
+    public void test_order_by_null_ordinal_with_explicit_cast() {
+        var e = SQLExecutor.builder(clusterService)
+            .build();
+        QueriedSelectRelation relation = e.analyze("select * from unnest([1, 2]) order by null::integer");
+        assertThat(relation.orderBy(), isSQL("NULL"));
+    }
 }


### PR DESCRIPTION
In PG grouping by null ordinal, casted to a type is allowed. https://www.db-fiddle.com/f/e1CSuBiuieepcKCuG4RsZb/3.

Spot while working on union 2 nulls, https://github.com/crate/crate/pull/12582#issuecomment-1145657014.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
