### PR TITLE
Fix flaky `testFailsToStartIfDowngraded` test

### DIFF
--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -18,13 +18,11 @@
  */
 package org.elasticsearch.env;
 
-import io.crate.common.collections.Tuple;
-import org.elasticsearch.Version;
-import org.elasticsearch.gateway.MetadataStateFormat;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.EqualsHashCodeTestUtils;
-import org.elasticsearch.test.VersionUtils;
-import org.junit.Test;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,11 +30,14 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
+import org.elasticsearch.Version;
+import org.elasticsearch.gateway.MetadataStateFormat;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.VersionUtils;
+import org.junit.Test;
+
+import io.crate.common.collections.Tuple;
 
 public class NodeMetadataTests extends ESTestCase {
     private Version randomVersion() {
@@ -117,7 +118,7 @@ public class NodeMetadataTests extends ESTestCase {
     }
 
     public static Version tooNewVersion() {
-        return Version.fromId(between(Version.CURRENT.internalId + 1, 99999999));
+        return Version.fromId(between(Version.CURRENT.internalId + 10000, 99999999));
     }
 
     public static Version tooOldVersion() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Since CrateDB 4.4.0, commit https://github.com/crate/crate/commit/f939b02fe79, downgrading a CrateDB node to a previous hotfix version is supported.
Thus the used `tooNewVersion` method used inside the tests must reflect that.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
