### PR TITLE
Add a note that changing `codec` only applies to newly written segments

### DIFF
--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -32,6 +32,10 @@ In order to set a parameter to its default value use ``reset``::
     cr> alter table my_table reset (number_of_replicas);
     ALTER OK, -1 rows affected (... sec)
 
+.. NOTE::
+    Changing compression using the ``codec`` parameter only takes effect for
+    newly written segments. To enforce a rewrite of already existing segments,
+    run :ref:`sql-optimize` with the parameter ``max_num_segments = 1``.
 
 .. _alter-shard-number:
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes #12629 by mentioning the need to run `OPTIMIZE` when changing `codec`, potentially with `max_num_segments = 1` if the table was already optimized.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
