### PR TITLE
Remove enterprise licence header from checkstyle

### DIFF
--- a/devs/docs/basics.rst
+++ b/devs/docs/basics.rst
@@ -152,7 +152,7 @@ Checkstyle
 If you use IntelliJ, there is a Checkstyle plugin available which lets you check
 Checkstyle compliance from within the IDE.
 
-The Checkstyle plugin enforces rules defined in `<PROJECT_ROOT>/gradle/checkstyle/rules.xml`.
+The Checkstyle plugin enforces rules defined in `<PROJECT_ROOT>/gradle/checkstyle/checkstyle.xml`.
 It checks for things such as unused imports, inconsistent formatting, and potential
 bugs.
 

--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -41,7 +41,7 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <module name="RegexpHeader">
-        <property name="headerFile" value="${checkstyleDir}/${licenseHeaderFile}"/>
+        <property name="headerFile" value="${checkstyleDir}/header.txt"/>
     </module>
 
     <!-- Checks for whitespace                               -->
@@ -51,7 +51,7 @@
     </module>
 
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyleDir}/suppressions.xml" />
+        <property name="file" value="${checkstyleDir}/suppressions.xml"/>
     </module>
     <module name="SuppressWarningsFilter"/>
 

--- a/gradle/checkstyle/enterprise_header.txt
+++ b/gradle/checkstyle/enterprise_header.txt
@@ -1,2 +1,0 @@
-^/\*
-^ \* (This file is part of a module with proprietary Enterprise Features|Copyright)

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -121,10 +121,8 @@ checkstyle {
     def checkstyle_dir = "$rootDir/gradle/checkstyle/"
     configProperties = [
         'checkstyleDir' : checkstyle_dir,
-        // May be overwritten by other modules, e.g. enterprise
-        'licenseHeaderFile' : 'header.txt'
     ]
-    configFile = file(checkstyle_dir + "rules.xml")
+    configDirectory = file(checkstyle_dir)
     checkstyleTest.enabled = false
 }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Remove the enterprise licence header from checkstyle since there is no
  code using it.
- Use default filename for checkstyle rules (rules.xml->checkstyle.xml)
  (helps when using the IntelliJ checkstyle plugin).

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
