### PR TITLE
tests: Fix printed gradle reproduction line

### DIFF
--- a/devs/docs/tests.rst
+++ b/devs/docs/tests.rst
@@ -45,8 +45,6 @@ value for the remainder of your terminal session.
 
 Filter tests::
 
-    $ ./gradlew test -Dtest.single='YourTestClass'
-
     $ ./gradlew test --tests '*ClassName.testMethodName'
 
 Extra options::

--- a/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -36,6 +36,7 @@ import java.util.TimeZone;
 
 import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_ITERATIONS;
 import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_PREFIX;
+import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_TESTCLASS;
 import static com.carrotsearch.randomizedtesting.SysGlobals.SYSPROP_TESTMETHOD;
 
 /**
@@ -72,10 +73,13 @@ public class ReproduceInfoPrinter extends RunListener {
 
         final String gradlew = Constants.WINDOWS ? "gradlew" : "./gradlew";
         final StringBuilder b = new StringBuilder("REPRODUCE WITH: " + gradlew + " ");
-        String task = System.getProperty("tests.task");
-        // TODO: enforce (intellij still runs the runner?) or use default "test" but that won't work for integ
-        b.append(task);
-
+        b.append(System.getProperty("tests.task"));
+        // append Gradle test runner test filter string
+        b.append(" --tests \"");
+        b.append(failure.getDescription().getClassName());
+        b.append(".");
+        b.append(failure.getDescription().getMethodName());
+        b.append("\"");
         GradleMessageBuilder gradleMessageBuilder = new GradleMessageBuilder(b);
         gradleMessageBuilder.appendAllOpts(failure.getDescription());
 
@@ -97,11 +101,6 @@ public class ReproduceInfoPrinter extends RunListener {
         public ReproduceErrorMessageBuilder appendAllOpts(Description description) {
             super.appendAllOpts(description);
 
-            if (description.getMethodName() != null) {
-                //prints out the raw method description instead of methodName(description) which filters out the parameters
-                super.appendOpt(SYSPROP_TESTMETHOD(), "\"" + description.getMethodName() + "\"");
-            }
-
             return appendESProperties();
         }
 
@@ -119,9 +118,14 @@ public class ReproduceInfoPrinter extends RunListener {
             if (sysPropName.equals(SYSPROP_ITERATIONS())) { // we don't want the iters to be in there!
                 return this;
             }
+            if (sysPropName.equals(SYSPROP_TESTCLASS())) {
+                // don't print out the test class, we print it ourselves in appendAllOpts
+                // without filtering out the parameters (needed for REST tests)
+                return this;
+            }
             if (sysPropName.equals(SYSPROP_TESTMETHOD())) {
-                //don't print out the test method, we print it ourselves in appendAllOpts
-                //without filtering out the parameters (needed for REST tests)
+                // don't print out the test method, we print it ourselves in appendAllOpts
+                // without filtering out the parameters (needed for REST tests)
                 return this;
             }
             if (sysPropName.equals(SYSPROP_PREFIX())) {
@@ -134,7 +138,7 @@ public class ReproduceInfoPrinter extends RunListener {
             return this;
         }
 
-        public ReproduceErrorMessageBuilder appendESProperties() {
+        private ReproduceErrorMessageBuilder appendESProperties() {
             appendProperties("tests.es.logger.level");
             if (inVerifyPhase()) {
                 // these properties only make sense for integration tests


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`-Dtests.class/-Dtests.method` don't work to test a specific
class/method with gradle. Instead, `--tests="<class>.<method>"`
must be used.


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
