### PR TITLE
Add `pg_catalog.pg_get_partkeydef` function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -148,6 +148,11 @@ Changes
   :ref:`pg_get_expr <scalar-pg_get_expr>` scalar function for improved
   PostgreSQL compatibility.
 
+- Added the :ref:`pg_get_partkeydef <scalar-pg_get_partkeydef>` scalar 
+  function for improved compatibility with PostgreSQL. Partitioning in CrateDB
+  is different from PostgreSQL, therefore this function always returns ``NULL``.
+
+
 Fixes
 =====
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3506,6 +3506,29 @@ Example::
     +------+
     SELECT 1 row in set (... sec)
 
+.. _scalar-pg_get_partkeydef:
+
+``pg_get_partkeydef()``
+-----------------------
+
+The function ``pg_get_partkeydef`` is implemented to improve compatibility with
+clients that use the PostgreSQL wire protocol. Partitioning in CrateDB is
+different from PostgreSQL, therefore this function always returns ``null``.
+
+Synopsis::
+
+   pg_get_partkeydef(relation_oid int)
+
+Example::
+
+    cr> select pg_get_partkeydef(1) AS col;
+    +------+
+    |  col |
+    +------+
+    | NULL |
+    +------+
+    SELECT 1 row in set (... sec)
+
 .. _scalar-pg_get_serial_sequence:
 
 ``pg_get_serial_sequence()``

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -83,6 +83,7 @@ import io.crate.expression.scalar.systeminformation.ObjDescriptionFunction;
 import io.crate.expression.scalar.systeminformation.PgFunctionIsVisibleFunction;
 import io.crate.expression.scalar.systeminformation.PgGetExpr;
 import io.crate.expression.scalar.systeminformation.PgGetFunctionResultFunction;
+import io.crate.expression.scalar.systeminformation.PgGetPartkeydefFunction;
 import io.crate.expression.scalar.systeminformation.PgGetSerialSequenceFunction;
 import io.crate.expression.scalar.systeminformation.PgTypeofFunction;
 import io.crate.expression.scalar.systeminformation.VersionFunction;
@@ -201,6 +202,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         CurrentSchemaFunction.register(this);
         CurrentSchemasFunction.register(this);
         PgGetExpr.register(this);
+        PgGetPartkeydefFunction.register(this);
         CurrentSettingFunction.register(this, getProvider(SessionSettingRegistry.class));
 
         PgBackendPidFunction.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.systeminformation;
+
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.types.DataTypes;
+import io.crate.expression.scalar.UnaryScalar;
+
+public class PgGetPartkeydefFunction {
+
+    public static final String NAME = "pg_get_partkeydef";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                FQN,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
+            (signature, boundSignature) ->
+            new UnaryScalar<>(
+                signature,
+                boundSignature,
+                DataTypes.INTEGER,
+                oid -> null
+            )
+        );
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgGetPartkeydefFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgGetPartkeydefFunctionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.postgres;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class PgGetPartkeydefFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_pg_get_partkeydef() throws Exception {
+        assertEvaluate("pg_get_partkeydef(1)", null);
+    }
+
+    @Test
+    public void test_pg_get_partkeydef_null_input() throws Exception {
+        assertEvaluate("pg_get_partkeydef(null)", null);
+    }
+
+    @Test
+    public void test_pg_get_partkeydef_with_FQN_fuction_name() throws Exception {
+        assertNormalize("pg_catalog.pg_get_partkeydef(1)", isLiteral(null));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Added the :ref:`pg_get_partkeydef <scalar-pg_get_partkeydef>` scalar function for improved compatibility with PostgreSQL. Partitioning in CrateDB is  different from PostgreSQL, therefore this function always returns ``NULL``.

Used by e.g. DBeaver

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
