### PR TITLE
Switch CrateDBs `pg_node_tree` representation from `OBJECT(ARRAY)` to `TEXT` in `pg_index` and `pg_class `

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,6 +67,10 @@ Breaking Changes
   aliased and is returning a base data type, the table function name is used
   as the column name.
 
+- Fields of type ``pg_node_tree`` in PostgreSQL in the ``pg_class`` and
+  ``pg_index`` tables now return ``TEXT`` instead of ``ARRAY(OBJECT)`` for
+  improved compatibility with PostgreSQL.
+
 Deprecations
 ============
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
@@ -75,8 +75,7 @@ public class PgClassTable {
             .startObjectArray("relacl", x -> null)
             .endObjectArray()
             .add("reloptions", STRING_ARRAY, x -> null)
-            .startObjectArray("relpartbound", x -> null)
-            .endObjectArray()
+            .add("relpartbound", STRING, x -> null)
             .build();
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
@@ -32,6 +32,7 @@ import static io.crate.types.DataTypes.INTEGER_ARRAY;
 import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.SHORT_ARRAY;
 import static io.crate.types.DataTypes.REGCLASS;
+import static io.crate.types.DataTypes.STRING;
 
 public class PgIndexTable {
 
@@ -56,10 +57,8 @@ public class PgIndexTable {
             .add("indcollation", INTEGER_ARRAY, x -> null)
             .add("indclass", INTEGER_ARRAY, x -> null)
             .add("indoption", SHORT_ARRAY, x -> null)
-            .startObjectArray("indexprs", x -> null)
-            .endObjectArray()
-            .startObjectArray("indpred", x -> null)
-            .endObjectArray()
+            .add("indexprs", STRING, x -> null)
+            .add("indpred", STRING, x -> null)
             .build();
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -64,6 +64,12 @@ public class PgCatalogITest extends SQLIntegrationTestCase {
     }
 
     @Test
+    public void test_pg_class_table_with_pg_get_expr() {
+        execute("select pg_get_expr(relpartbound,0) from pg_catalog.pg_class limit 1");
+        assertThat(printedTable(response.rows()), is("NULL\n"));
+    }
+
+    @Test
     public void testPgNamespaceTable() {
         execute("select * from pg_catalog.pg_namespace order by nspname");
         assertThat(printedTable(response.rows()), is(
@@ -88,6 +94,12 @@ public class PgCatalogITest extends SQLIntegrationTestCase {
     public void testPgIndexTable() {
         execute("select count(*) from pg_catalog.pg_index");
         assertThat(printedTable(response.rows()), is("23\n"));
+    }
+
+    @Test
+    public void test_pg_index_table_with_pg_get_expr() {
+        execute("select pg_get_expr(indexprs,0), pg_get_expr(indpred,0) from pg_catalog.pg_index limit 1");
+        assertThat(printedTable(response.rows()), is("NULL| NULL\n"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

**Switch CrateDBs `pg_node_tree` representation from `OBJECT(ARRAY)` to `TEXT`**
> pg_node_tree - An internal data type to represent nodeToString output

- `indexprs` and `indpred` in `pg_index` table
- `relpartbound`  in `pg_class` table


Better reflects PostgreSQL behaviour of the `pg_node_tree` internal type. Otherwise functions like `pg_get_expr(text, int)` (pg: `pg_get_expr(pg_node_tree, oid)`)  won't work in CrateDB. Another option, might have been to switch the `pg_get_expr` function, however as noted above `pg_node_tree` is represented by `nodeToString` output.

--

Although this change might be considered breaking, the affects should be minimal.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
