### PR TITLE
`pg_get_expr` should also accept `pretty` arg

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -144,6 +144,9 @@ Changes
   ``regexp_matches``, and ``generate_series`` to be the respective table
   function names.
 
+- Added support for an optional boolean argument ``pretty`` at the 
+  :ref:`pg_get_expr <scalar-pg_get_expr>` scalar function for improved
+  PostgreSQL compatibility.
 
 Fixes
 =====

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3494,7 +3494,7 @@ clients that use the PostgreSQL wire protocol. The function always returns
 
 Synopsis::
 
-   pg_get_expr(expr text, relation_oid int)
+   pg_get_expr(expr text, relation_oid int [, pretty boolean])
 
 Example::
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -46,6 +46,16 @@ public class PgGetExpr extends Scalar<String, Object> {
             ),
             PgGetExpr::new
         );
+        module.register(
+            Signature.scalar(
+                FQN,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.BOOLEAN.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature()
+            ),
+            PgGetExpr::new
+        );
     }
 
     private final Signature signature;

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgGetExprFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgGetExprFunctionTest.java
@@ -29,12 +29,17 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 public class PgGetExprFunctionTest extends ScalarTestCase {
 
     @Test
-    public void testPgGetExpr() throws Exception {
+    public void test_pg_get_expr() throws Exception {
         assertEvaluate("pg_get_expr('whatever', 1)", null);
     }
 
     @Test
-    public void testPgGetExprWithFQNFunctionName() throws Exception {
+    public void test_pg_get_expr_pretty() throws Exception {
+        assertEvaluate("pg_get_expr('whatever', 1, false)", null);
+    }
+
+    @Test
+    public void test_pg_get_expr_with_fqn_function_name() throws Exception {
         assertNormalize("pg_catalog.pg_get_expr('whatever', 1)", isLiteral(null));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
`pg_get_expr` now also accepts `pretty` arg.

`pg_get_expr(pg_node_tree, relation_oid, pretty_bool)`
https://www.postgresql.org/docs/current/catalog-pg-class.html

used by e.g. DBeaver

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
