### PR TITLE
Fix refresh after idle for queries with fetch operation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -164,6 +164,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that prevented rows inserted after the last refresh from
+  showing up in the result if a shard had been idle for more than 30 seconds.
+  This affected tables without an explicit ``refresh_interval`` setting.
+
 - Fixed an issue that caused NPE to be thrown, instead of a user-friendly error
   message when ``NULL`` is passed as shardId for the
   ``ALTER TABLE XXX REROUTE XXX`` statements (MOVE, ALLOCATE, PROMOTE, CANCEL).

--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -156,7 +156,7 @@ public class CollectTask implements Task {
     }
 
     @Override
-    public void start() {
+    public CompletableFuture<Void> start() {
         if (started.compareAndSet(false, true)) {
             try {
                 var futureIt = collectOperation.createIterator(
@@ -176,6 +176,7 @@ public class CollectTask implements Task {
                 batchIterator.completeExceptionally(t);
             }
         }
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/AbstractTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/AbstractTask.java
@@ -51,18 +51,20 @@ public abstract class AbstractTask implements Task {
         };
     }
 
-    protected void innerStart() {
+    protected CompletableFuture<Void> innerStart() {
+        return null;
     }
 
     @Override
-    public final void start() {
+    public final CompletableFuture<Void> start() {
         if (!firstClose.get()) {
             try {
-                innerStart();
+                return innerStart();
             } catch (Throwable t) {
                 kill(t);
             }
         }
+        return null;
     }
 
     protected void innerClose() {

--- a/server/src/main/java/io/crate/execution/jobs/CountTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/CountTask.java
@@ -61,12 +61,12 @@ public class CountTask extends AbstractTask {
     }
 
     @Override
-    public synchronized void innerStart() {
+    public synchronized CompletableFuture<Void> innerStart() {
         try {
             countFuture = countOperation.count(txnCtx, indexShardMap, countPhase.where());
         } catch (Throwable t) {
             consumer.accept(null, t);
-            return;
+            return null;
         }
         countFuture.whenComplete((rowCount, failure) -> {
             Throwable killed = killReason;  // 1 volatile read
@@ -79,6 +79,7 @@ public class CountTask extends AbstractTask {
                 kill(failure);
             }
         });
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
@@ -72,13 +72,14 @@ public class DistResultRXTask implements Task, DownstreamRXTask {
     }
 
     @Override
-    public void start() {
+    public CompletableFuture<Void> start() {
         // E.g. If the upstreamPhase is a collectPhase for a partitioned table without any partitions
         // there won't be any executionNodes for that collectPhase
         // -> no upstreams -> just finish
         if (numBuckets == 0) {
             pageBucketReceiver.consumeRows();
         }
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
@@ -21,6 +21,16 @@
 
 package io.crate.execution.jobs;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.elasticsearch.index.shard.ShardId;
+
 import io.crate.breaker.BlockBasedRamAccounting;
 import io.crate.breaker.RamAccounting;
 import io.crate.data.BatchIterator;
@@ -38,14 +48,6 @@ import io.crate.memory.MemoryManager;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.PKAndVersion;
-import org.elasticsearch.index.shard.ShardId;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Function;
 
 public final class PKLookupTask extends AbstractTask {
 
@@ -101,7 +103,7 @@ public final class PKLookupTask extends AbstractTask {
     }
 
     @Override
-    protected void innerStart() {
+    protected CompletableFuture<Void> innerStart() {
         BatchIterator<Row> rowBatchIterator = pkLookupOperation.lookup(
             jobId,
             txnCtx,
@@ -115,6 +117,7 @@ public final class PKLookupTask extends AbstractTask {
         );
         consumer.accept(rowBatchIterator, null);
         close();
+        return null;
     }
 
     private Row resultToRow(Doc getResult) {

--- a/server/src/main/java/io/crate/execution/jobs/Task.java
+++ b/server/src/main/java/io/crate/execution/jobs/Task.java
@@ -21,12 +21,24 @@
 
 package io.crate.execution.jobs;
 
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
 import io.crate.concurrent.CompletionListenable;
 import io.crate.data.Killable;
 
 public interface Task extends CompletionListenable<Void>, Killable {
 
-    void start();
+    /**
+     * Start a task.
+     * @return future that is completed once the start action completed its preparation phase.
+     *         This does *NOT* indicate that the task finished. Use {@link #completionFuture()} for that.
+     *         If null the start method is synchronous and users can assume the task is initiated once
+     *         the method returns.
+     */
+    @Nullable
+    CompletableFuture<Void> start();
 
     String name();
 

--- a/server/src/main/java/io/crate/metadata/Routing.java
+++ b/server/src/main/java/io/crate/metadata/Routing.java
@@ -21,20 +21,21 @@
 
 package io.crate.metadata;
 
-import com.carrotsearch.hppc.IntArrayList;
-import com.carrotsearch.hppc.IntIndexedContainer;
-import com.carrotsearch.hppc.cursors.IntCursor;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntIndexedContainer;
+import com.carrotsearch.hppc.cursors.IntCursor;
 
 public class Routing implements Writeable {
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -3235,6 +3236,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 });
             }
         }
+    }
+
+    /**
+     * Wait for an idle shard to refresh. Completes immediately if the shard wasn't idle or if there are no pending refresh locations.
+     */
+    public CompletableFuture<Boolean> awaitShardSearchActive() {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        awaitShardSearchActive(b -> result.complete(b));
+        return result;
     }
 
     /**

--- a/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.crate.testing.Asserts.assertThrowsMatches;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitTest {

--- a/server/src/test/java/io/crate/execution/jobs/AbstractTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/AbstractTaskTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.greaterThan;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nonnull;
@@ -112,8 +113,9 @@ public class AbstractTaskTest extends ESTestCase {
         }
 
         @Override
-        protected void innerStart() {
+        protected CompletableFuture<Void> innerStart() {
             numStart.incrementAndGet();
+            return null;
         }
 
         public List<Integer> stats() {

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
@@ -65,7 +65,6 @@ import org.junit.Before;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.LogicalReplicationSettings;
-import io.crate.replication.logical.MetadataTracker;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.engine;
 import io.crate.common.io.IOUtils;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -46,7 +46,6 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The FetchTask eagerly acquired the index searcher without calling
`awaitShardSearchActive`.

This makes `Task.start` optionally asynchronous. This seemed to have the
least impact - otherwise `createContext` and possibly
`getOrCreateContext` would need to return a Future and that would've had
a much bigger impact.

Fixes https://github.com/crate/crate/issues/12102

The following reproduction shows that this only affected queries with
fetch:

```
crash <<EOF
  DROP TABLE IF EXISTS source_table;
  DROP TABLE IF EXISTS sink_table;
  CREATE TABLE source_table (txt TEXT, db DOUBLE);
  CREATE TABLE sink_table (txt TEXT, db DOUBLE);
EOF

sleep 45s

crash <<EOF
  INSERT INTO source_table (txt,db) SELECT 'Hello World', 10 FROM generate_series(0,1,1);
EOF

sleep 5s

crash <<EOF
  INSERT INTO sink_table SELECT txt, db FROM source_table;
EOF

sleep 5s

crash <<EOF
  SELECT * FROM source_table LIMIT 100;
EOF

crash <<EOF
  SELECT * FROM sink_table limit 100;
  SELECT db FROM sink_table order by db limit 100;
  SELECT DISTINCT txt FROM sink_table;
EOF
```



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
