### PR TITLE
Deprecate the azure discovery plugin

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,7 +74,8 @@ Breaking Changes
 Deprecations
 ============
 
-None
+- Deprecated the azure discovery functionality. It only works for classic VM and
+  Microsoft deprecated classic VM support on Azure.
 
 
 Changes

--- a/plugins/azure-discovery/src/main/java/io/crate/azure/plugin/AzureDiscoveryPlugin.java
+++ b/plugins/azure-discovery/src/main/java/io/crate/azure/plugin/AzureDiscoveryPlugin.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -65,6 +66,7 @@ public class AzureDiscoveryPlugin extends Plugin implements DiscoveryPlugin {
     private AzureComputeServiceImpl azureComputeService;
 
     protected final Logger logger = LogManager.getLogger(AzureDiscoveryPlugin.class);
+    private final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
 
     public AzureDiscoveryPlugin(Settings settings) {
         this.settings = settings;
@@ -117,6 +119,8 @@ public class AzureDiscoveryPlugin extends Plugin implements DiscoveryPlugin {
             AzureConfiguration.AZURE,
             () -> {
                 if (AzureConfiguration.isDiscoveryReady(settings, logger)) {
+                    deprecationLogger.deprecated(
+                        "The azure discovery functionality is deprecated and will be removed in the future.");
                     return new AzureSeedHostsProvider(settings,
                                                       azureComputeService(),
                                                       transportService,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Because of https://docs.microsoft.com/en-us/azure/virtual-machines/classic-vm-deprecation

It is unclear how much use the plugin had given that a lot of
deployments now happen on Kubernetes

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
