### PR TITLE
Support ORDER BY + LIMIT 0 in SortingTopNProjector

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -164,6 +164,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused queries with ``ORDER BY`` clause and ``LIMIT 0`` to
+  fail.
+
 - Fixed an issue that prevented rows inserted after the last refresh from
   showing up in the result if a shard had been idle for more than 30 seconds.
   This affected tables without an explicit ``refresh_interval`` setting.

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingTopNProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingTopNProjectorTest.java
@@ -24,7 +24,9 @@ package io.crate.execution.engine.sort;
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.breaker.RowAccounting;
 import io.crate.breaker.RowCellsAccountingWithEstimators;
+import io.crate.data.BatchIterator;
 import io.crate.data.Bucket;
+import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
@@ -157,11 +159,11 @@ public class SortingTopNProjectorTest extends ESTestCase {
     }
 
     @Test
-    public void testInvalidZeroLimit() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid LIMIT: value must be > 0; got: 0");
-
-        getProjector(2, 0, 0);
+    public void test_zero_limit() throws Exception {
+        Projector projector = getProjector(2, 0, 0);
+        BatchIterator<Row> it = projector.apply(TestingBatchIterators.range(1, 6));
+        assertThat(it.moveNext(), is(false));
+        assertThat(it.allLoaded(), is(true));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2047,4 +2047,12 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
         assertThat(printedTable(response.rows()), Matchers.is("\"\"\n"));
     }
 
+    @Test
+    public void test_select_with_order_by_can_have_limit_zero() {
+        execute("select 1 order by 1 limit 0");
+        assertThat(response.rowCount(), is(0L));
+
+        execute("select 1 order by 1 offset 10 limit 0");
+        assertThat(response.rowCount(), is(0L));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/12621

As an alternative this could've been optimized in the planner to create some sort of no-op plan, but I think it's less error prone to support it in the projector. Query optimizations should be optional and not required for correct semantics.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
