### PR TITLE
Fix NPE in maybeRefreshReaders

### DIFF
--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
@@ -74,8 +74,10 @@ public class SharedShardContexts {
                 continue;
             }
             IndexService indexService = indicesService.indexService(indexMetadata.getIndex());
-            if (indexService == null && !IndexParts.isPartitioned(indexName)) {
-                refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexName)));
+            if (indexService == null) {
+                if (!IndexParts.isPartitioned(indexName)) {
+                    refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexName)));
+                }
                 continue;
             }
             for (var shardCursor : entry.getValue()) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to 3aaa741bab643fe5c23f07c203915ebb160d428a

Some tests got flaky, e.g. `io.crate.integrationtests.MetadataTrackerITest.test_deleted_partition_is_replicated`

    java.lang.NullPointerException: Cannot invoke "org.elasticsearch.index.IndexService.getShard(int)" because "indexService" is null
    	at __randomizedtesting.SeedInfo.seed([1FC73DD75B589FAC:FE441B7A365B5BE4]:0)
    	at io.crate.execution.jobs.SharedShardContexts.maybeRefreshReaders(SharedShardContexts.java:83)
    	at io.crate.execution.engine.fetch.FetchTask.start(FetchTask.java:229)
    	at io.crate.execution.jobs.RootTask.start(RootTask.java:198)
    	at io.crate.execution.jobs.RootTask.start(RootTask.java:184)
    	at io.crate.execution.engine.JobLauncher.setupTasks(JobLauncher.java:268)
    	at io.crate.execution.engine.JobLauncher.execute(JobLauncher.java:172)
    	at io.crate.planner.operators.LogicalPlanner.executeNodeOpTree(LogicalPlanner.java:536)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
