### PR TITLE
tests: Handle `null` methodName in ReproduceInfoPrinter

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -77,8 +77,11 @@ public class ReproduceInfoPrinter extends RunListener {
         // append Gradle test runner test filter string
         b.append(" --tests \"");
         b.append(failure.getDescription().getClassName());
-        b.append(".");
-        b.append(failure.getDescription().getMethodName());
+        String methodName = failure.getDescription().getMethodName();
+        if (methodName != null) {
+            b.append(".");
+            b.append(methodName);
+        }
         b.append("\"");
         GradleMessageBuilder gradleMessageBuilder = new GradleMessageBuilder(b);
         gradleMessageBuilder.appendAllOpts(failure.getDescription());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If there are execution errors on a class level the `methodName` can be
null.

Got the following output:

    REPRODUCE WITH: ./gradlew :server:test --tests "io.crate.integrationtests.MetadataTrackerITest.null" -Dtests.seed=BC8172C1529AD02F -Dtests.locale=en-US -Dtests.timezone=Europe/Berlin

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
