### PR TITLE
Allow cast from bigint to regclass

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,6 +81,9 @@ Deprecations
 Changes
 =======
 
+- Added support for casts from ``bigint`` to ``regclass`` for improved
+  compatibility with PostgreSQL clients.
+
 - Added support for ``FETCH [FIRST | NEXT] <noRows> [ROW | ROWS] ONLY`` clause
   as and alternative to the ``LIMIT`` clause.
 

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -199,8 +199,14 @@ public final class DataTypes {
             Stream.of(RegprocType.ID, RegclassType.ID)
         ).collect(Collectors.toUnmodifiableSet())),
         entry(REGPROC.id(), Set.of(STRING.id(), INTEGER.id())),
-        entry(REGCLASS.id(), Set.of(STRING.id(), INTEGER.id())),
-        entry(LONG.id(), NUMBER_CONVERSIONS),
+        entry(REGCLASS.id(), Set.of(STRING.id(), INTEGER.id(), LONG.id())),
+        entry(
+            LONG.id(),
+            Stream.concat(
+                NUMBER_CONVERSIONS.stream(),
+                Stream.of(RegprocType.ID, RegclassType.ID)
+            ).collect(Collectors.toUnmodifiableSet())
+        ),
         entry(NUMERIC.id(), NUMBER_CONVERSIONS),
         entry(FLOAT.id(), NUMBER_CONVERSIONS),
         entry(DOUBLE.id(), NUMBER_CONVERSIONS),

--- a/server/src/main/java/io/crate/types/RegclassType.java
+++ b/server/src/main/java/io/crate/types/RegclassType.java
@@ -87,8 +87,15 @@ public final class RegclassType extends DataType<Regclass> implements Streamer<R
         if (value instanceof Regclass) {
             return (Regclass) value;
         }
-        if (value instanceof Integer) {
-            return new Regclass((int) value, value.toString());
+        if (value instanceof Integer num) {
+            return new Regclass(num.intValue(), value.toString());
+        }
+        if (value instanceof Long num) {
+            if (num > Integer.MAX_VALUE || num < Integer.MIN_VALUE) {
+                throw new IllegalArgumentException(
+                    value + " is outside of `int` range and cannot be cast to the regclass type");
+            }
+            return new Regclass(num.intValue(), value.toString());
         }
         if (value instanceof String) {
             return Regclass.fromRelationName(value.toString());

--- a/server/src/main/java/io/crate/types/RegprocType.java
+++ b/server/src/main/java/io/crate/types/RegprocType.java
@@ -56,8 +56,14 @@ public class RegprocType extends DataType<Regproc> implements Streamer<Regproc> 
     public Regproc implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof Integer) {
-            return Regproc.of((int) value, value.toString());
+        } else if (value instanceof Integer num) {
+            return Regproc.of(num, value.toString());
+        } else if (value instanceof Long num) {
+            if (num > Integer.MAX_VALUE || num < Integer.MIN_VALUE) {
+                throw new IllegalArgumentException(
+                    value + " is outside of `int` range and cannot be cast to the regproc type");
+            }
+            return Regproc.of(num.intValue(), value.toString());
         } else if (value instanceof String) {
             return Regproc.of((String) value);
         } else if (value instanceof Regproc) {

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -32,6 +32,8 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
+import io.crate.types.RegclassType;
+import io.crate.types.RegclassType;
 
 import org.hamcrest.core.IsSame;
 import org.junit.AfterClass;
@@ -304,5 +306,10 @@ public class CastFunctionTest extends ScalarTestCase {
     @Test
     public void test_implicit_cast_is_compiled() throws Exception {
         assertCompile("_cast(a, 'double precision')", (s) -> not(IsSame.sameInstance(s)) );
+    }
+
+    @Test
+    public void test_can_cast_bigint_to_regclass() {
+        assertEvaluate("10::bigint::regclass", RegclassType.INSTANCE.explicitCast(10L));
     }
 }

--- a/server/src/test/java/io/crate/types/RegclassTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegclassTypeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import org.junit.Test;
+
+import io.crate.testing.Asserts;
+
+public class RegclassTypeTest {
+
+    @Test
+    public void test_cannot_cast_long_outside_int_range_to_regclass() {
+        Asserts.assertThrowsMatches(
+            () -> RegclassType.INSTANCE.implicitCast(Integer.MAX_VALUE + 42L),
+            IllegalArgumentException.class,
+            "2147483689 is outside of `int` range and cannot be cast to the regclass type"
+        );
+    }
+}

--- a/server/src/test/java/io/crate/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegprocTypeTest.java
@@ -33,6 +33,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.testing.Asserts;
 
 public class RegprocTypeTest extends ESTestCase {
 
@@ -101,5 +102,14 @@ public class RegprocTypeTest extends ESTestCase {
 
         var in = out.bytes().streamInput();
         assertThat(DataTypes.fromStream(in), is(REGPROC));
+    }
+
+    @Test
+    public void test_cannot_cast_long_outside_int_range_to_regproc() {
+        Asserts.assertThrowsMatches(
+            () -> RegprocType.INSTANCE.implicitCast(Integer.MAX_VALUE + 2038L),
+            IllegalArgumentException.class,
+            "2147485685 is outside of `int` range and cannot be cast to the regproc type"
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Casts from int to regclass are already supported. We can allow casts
from bigint to regclass as well - as long as the values fall into int
range.

Closes https://github.com/crate/crate/issues/12648

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
