### PR TITLE
Fix PostgreSQL wire protocol simple query on error

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -193,3 +193,6 @@ Fixes
 
 - Fixed an issue that caused failure of ``ALTER TABLE`` statements when updating
   dynamic or non-dynamic table settings on closed tables.
+
+- Fixed an issue that caused clients using PostrgreSQL wire protocol's simple
+  query to hang, when an error occurred during planning.

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -793,6 +793,7 @@ public class PostgresWireProtocol {
             }
             return session.sync();
         } catch (Throwable t) {
+            channel.discardDelayedWrites();
             Messages.sendErrorResponse(channel, accessControl, t);
             result.completeExceptionally(t);
             return result;

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -610,10 +610,22 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testHandleMultipleSimpleQueries() {
-        submitQueriesThroughSimpleQueryMode("select 'first'; select 'second';", null);
+    public void testHandleSimpleQueryFailing() {
+        CompletableFuture<?> completableFuture = new CompletableFuture<>();
+        submitQueriesThroughSimpleQueryMode("SELECT 'fail'",
+                                            new RuntimeException("fail"),
+                                            completableFuture);
+        // the completableFuture is not completed but the channel is flushed
+        readErrorResponse(channel);
         readReadyForQueryMessage(channel);
-        assertThat(channel.outboundMessages().size() , is(0));
+        assertThat(channel.outboundMessages().size(), is(0));
+    }
+
+    @Test
+    public void testHandleMultipleSimpleQueries() {
+        submitQueriesThroughSimpleQueryMode("select 'first'; select 'second';");
+        readReadyForQueryMessage(channel);
+        assertThat(channel.outboundMessages().size(), is(0));
     }
 
     @Test
@@ -683,7 +695,8 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         assertThat(capturedKillJobRequest.innerRequest().toKill(), is(List.of(targetJobID)));
 
         assertThat(channel.isOpen(), is(false));
-        Asserts.assertThrowsMatches( // implicitly verifies that cancelling did not affect the internal map hence the original session
+        Asserts.assertThrowsMatches(
+            // implicitly verifies that cancelling did not affect the internal map hence the original session
             () -> pgSessions.add(keyData, targetSession),
             AssertionError.class,
             "The given KeyData already has an associated active Session"
@@ -693,9 +706,21 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         verify(targetSession, times(0)).close();
     }
 
-    private void submitQueriesThroughSimpleQueryMode(String statements, @Nullable Throwable failure) {
+    private void submitQueriesThroughSimpleQueryMode(String statements) {
+        submitQueriesThroughSimpleQueryMode(statements, null, null);
+    }
+
+    private void submitQueriesThroughSimpleQueryMode(String statements, Throwable failure) {
+        submitQueriesThroughSimpleQueryMode(statements, failure, null);
+    }
+
+    private void submitQueriesThroughSimpleQueryMode(String statements,
+                                                     @Nullable Throwable failure,
+                                                     @Nullable CompletableFuture future) {
         SQLOperations sqlOperations = Mockito.mock(SQLOperations.class);
         Session session = mock(Session.class);
+        when(session.execute(any(String.class), any(int.class), any(RowCountReceiver.class))).
+            thenReturn(future);
         SessionContext sessionContext = new SessionContext(User.CRATE_USER);
         when(session.sessionContext()).thenReturn(sessionContext);
         when(sqlOperations.createSession(any(String.class), any(User.class))).thenReturn(session);
@@ -716,10 +741,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
 
         if (failure != null) {
-            when(session.sync()).thenAnswer(invocationOnMock -> {
-                Messages.sendErrorResponse(channel, AccessControl.DISABLED, failure);
-                return CompletableFuture.failedFuture(failure);
-            });
+            when(session.sync()).thenThrow(failure);
         } else {
             when(session.sync()).thenReturn(CompletableFuture.completedFuture(null));
         }
@@ -789,7 +811,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         int secretKey = response.readInt();
         response.release();
         return new KeyData(pid, secretKey);
-    };
+    }
 
     private static void readReadyForQueryMessage(EmbeddedChannel channel) {
         ByteBuf response = channel.readOutbound();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For SimpleQuery execution, when the `session.execute()` returns
a `CompletableFuture`, then a `DelayableWriteChannel` is used which
normally it would be flushed when the future bound to the
`ChannelFuture` completes. When an error occurs though, during
`session.sync()`, we call the `Messages#sendErrorResponse()` and in turn
the `Messages#sendReadyForQuery`, using the `DelayableWriteChannel`
which is not bound to any future, and those messages remain bufferred
forever, and the client hangs.

Call `channel.discardDelayedWrites()` to force the flushing of the
buffer.

See also: https://github.com/crate/crate/pull/12044
Relates to: https://github.com/crate/crate/issues/12646 (`psql` hangs for the insert statement failure)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
