### PR TITLE
Add empty `pg_catalog.pg_shdescription` table

### DIFF
--- a/.github/styles/Vocab/CrateDB/accept.txt
+++ b/.github/styles/Vocab/CrateDB/accept.txt
@@ -85,6 +85,7 @@ schemaless
 sharded
 sharding
 Sharding
+shdescription
 simplefs
 sql
 SQL

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -157,6 +157,8 @@ Changes
   function for improved compatibility with PostgreSQL. Partitioning in CrateDB
   is different from PostgreSQL, therefore this function always returns ``NULL``.
 
+- Added an empty ``pg_catalog.pg_shdescription`` table for improved PostgreSQL
+  compatibility.
 
 Fixes
 =====

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -99,6 +99,7 @@ number of replicas.
     | pg_catalog         | pg_range                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_roles                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_settings             | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_shdescription        | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_stats                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_subscription         | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_subscription_rel     | BASE TABLE |             NULL | NULL               |
@@ -126,7 +127,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 59 rows in set (... sec)
+    SELECT 60 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -170,11 +170,13 @@ following tables:
  - `pg_proc <pgsql_pg_proc_>`__
  - `pg_publication <pgsql_pg_publication_>`__
  - `pg_publication_tables <pgsql_pg_publication_tables_>`__
- - `pg_subscription <pgsql_pg_subscription_>`__
- - `pg_subscription_rel <pgsql_pg_subscription_rel_>`__
  - `pg_range`_
  - `pg_roles`_
  - `pg_settings <pgsql_pg_settings_>`__
+ - `pg_shdescription`_
+ - `pg_stats`_
+ - `pg_subscription <pgsql_pg_subscription_>`__
+ - `pg_subscription_rel <pgsql_pg_subscription_rel_>`__
  - `pg_tables`_
  - `pg_tablespace`_
  - `pg_type`_
@@ -550,6 +552,8 @@ CrateDB and we love to hear feedback.
 .. _pg_tables: https://www.postgresql.org/docs/14/view-pg-tables.html
 .. _pg_tablespace: https://www.postgresql.org/docs/14/catalog-pg-tablespace.html
 .. _pg_views: https://www.postgresql.org/docs/14/view-pg-views.html
+.. _pg_shdescription: https://www.postgresql.org/docs/14/catalog-pg-shdescription.html
+.. _pg_stats: https://www.postgresql.org/docs/14/view-pg-stats.html
 .. _pgjdbc: https://github.com/pgjdbc/pgjdbc
 .. _pgsql_pg_attrdef: https://www.postgresql.org/docs/14/static/catalog-pg-attrdef.html
 .. _pgsql_pg_attribute: https://www.postgresql.org/docs/14/static/catalog-pg-attribute.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -76,6 +76,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgLocksTable.IDENT.name(), PgLocksTable.create()),
             Map.entry(PgPublicationTable.IDENT.name(), PgPublicationTable.create()),
             Map.entry(PgPublicationTablesTable.IDENT.name(), PgPublicationTablesTable.create()),
+            Map.entry(PgShdescriptionTable.IDENT.name(), PgShdescriptionTable.create()),
             Map.entry(PgSubscriptionTable.IDENT.name(), PgSubscriptionTable.create()),
             Map.entry(PgSubscriptionRelTable.IDENT.name(), PgSubscriptionRelTable.create()),
             Map.entry(PgTablesTable.IDENT.name(), PgTablesTable.create()),

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -210,6 +210,12 @@ public class PgCatalogTableDefinitions {
             PgViewsTable.create().expressions()
         ));
 
+        tableDefinitions.put(PgShdescriptionTable.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgShdescriptionTable.create().expressions(),
+            false)
+        );
+
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgShdescriptionTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgShdescriptionTable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+
+public final class PgShdescriptionTable {
+
+    public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_shdescription");
+
+    public static SystemTable<Void> create() {
+        return SystemTable.<Void>builder(IDENT)
+            .add("objoid", INTEGER, c -> null)
+            .add("classoid", INTEGER, c -> null)
+            .add("description", STRING , c -> null)
+            .build();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -64,7 +64,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(55L, response.rowCount());
+        assertEquals(56L, response.rowCount());
 
         assertThat(printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| character_sets| information_schema| BASE TABLE| NULL\n" +
@@ -96,6 +96,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_range| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_roles| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_settings| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_shdescription| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_stats| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_subscription| pg_catalog| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| pg_catalog| pg_subscription_rel| pg_catalog| BASE TABLE| NULL\n" +
@@ -203,13 +204,13 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(55L, response.rowCount());
+        assertEquals(56L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(56L, response.rowCount());
+        assertEquals(57L, response.rowCount());
     }
 
     @Test
@@ -541,7 +542,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(942, response.rowCount());
+        assertEquals(945, response.rowCount());
     }
 
     @Test
@@ -855,7 +856,7 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(58L, response.rows()[0][0]);
+        assertEquals(59L, response.rows()[0][0]);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -135,6 +135,13 @@ public class PgCatalogITest extends SQLIntegrationTestCase {
     }
 
     @Test
+    public void testPgShdescriptionTableIsEmpty() {
+        execute("select * from pg_shdescription");
+        assertThat(printedTable(response.rows()), is(""));
+        assertThat(response.cols(), arrayContaining("classoid", "description", "objoid"));
+    }
+
+    @Test
     @UseRandomizedSchema(random = false)
     @UseHashJoins(0)
     public void testPgSettingsTable() {

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -449,7 +449,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     public void testAccessesToPgClassEntriesWithRespectToPrivileges() throws Exception {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         execute("select relname from pg_catalog.pg_class order by relname", null, testUserSession());
-        assertThat(response.rowCount(), is(45L));
+        assertThat(response.rowCount(), is(46L));
         assertThat(printedTable(response.rows()), is(
             """
                 character_sets
@@ -475,6 +475,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
                 pg_range
                 pg_roles
                 pg_settings
+                pg_shdescription
                 pg_stats
                 pg_subscription
                 pg_subscription_rel
@@ -587,7 +588,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     public void testAccessesToPgAttributeEntriesWithRespectToPrivileges() throws Exception {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession());
-        assertThat(response.rowCount(), is(497L));
+        assertThat(response.rowCount(), is(500L));
 
         //create a table with an attribute that a new user is not privileged to access
         executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -99,7 +99,7 @@ public class TableSettingsTest extends SQLIntegrationTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(55L, response.rowCount());
+        assertEquals(56L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Add empty `pg_catalog.pg_shdescription` table for improved compatibility with PostgreSQL.
Similiar to `pg_catalog.pg_description`

https://www.postgresql.org/docs/current/catalog-pg-shdescription.html

---

PostgreSQL 14:
```
postgres=# SELECT * FROM pg_shdescription
postgres-# ;
 objoid | classoid |                description                 
--------+----------+--------------------------------------------
      1 |     1262 | default template for new databases
  14020 |     1262 | unmodifiable empty database
  14021 |     1262 | default administrative connection database
(3 rows)
```

Might become relevant when implementing a `COMMENT` functionality in CrateDB.
https://www.postgresql.org/docs/current/sql-comment.html

---

e.g. used by Datagrip
```sql
select N.oid::bigint as id,
       datname as name,
       D.description,
       datistemplate as is_template,
       datallowconn as allow_connections,
       pg_catalog.pg_get_userbyid(N.datdba) as "owner"
from pg_catalog.pg_database N
  left join pg_catalog.pg_shdescription D on N.oid = D.objoid
order by case when datname = pg_catalog.current_database() then -1::bigint else N.oid::bigint end
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
