### PR TITLE
Prevent `IS NULL` from matching rows without NULL values

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -165,6 +165,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused ``col IS NULL`` expressions to match rows where
+  ``col`` is not ``null`` if ``col`` had ``INDEX OFF`` and ``STORAGE WITH
+  (columnstore = false)`` set.
+
 - Fixed an issue that caused queries with ``ORDER BY`` clause and ``LIMIT 0`` to
   fail.
 

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -624,4 +624,11 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("content is null");
         assertThat(query.toString(), is("+*:* -FieldExistsQuery [field=content]"));
     }
+
+    @Test
+    public void test_is_null_without_index_and_docvalues() {
+        Query query = convert("text_no_index is null");
+        assertThat(query.toString(), is("(text_no_index IS NULL)"));
+        assertThat(query, instanceOf(GenericFunctionQuery.class));
+    }
 }

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -52,6 +52,7 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
             " name string," +
             " tags string index using fulltext not null," +
             " content string index using fulltext," +
+            " text_no_index text index off storage with (columnstore = false)," +
             " x integer not null," +
             " f float," +
             " d double," +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We created a NOT term query on `_field_names`, but if the index option
is NONE, `_field_names` terms are not created.

Also closes https://github.com/crate/crate/issues/8524

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
