### PR TITLE
Remove not-null contrsaints from the information_schema.table_constra…

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -191,7 +191,8 @@ Fixes
   ``SELECT NULL, count(*) from unnest([1, 2]) GROUP BY NULL::integer``.
 
 - Fixed an issue that not-null constraints used to be shown in the
-  ``pg_constraint`` table which contradicts with PostgreSQL.
+  ``pg_constraint`` table and ``information_schema.table_constraints`` view
+  which contradicts with PostgreSQL.
 
 - Fixed an issue that caused ``IllegalArgumentException`` to be thrown when
   attempting to insert values into a partitioned table, using less columns than

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -516,9 +516,8 @@ type, name and which table they are defined in.
     +--------------------+------------+-...------------------+-------------+
     | information_schema | tables     | tables_pk            | PRIMARY KEY |
     | doc                | quotes     | quotes_pk            | PRIMARY KEY |
-    | doc                | tbl        | doc_tbl_col_not_null | CHECK       |
     +--------------------+------------+-...------------------+-------------+
-    SELECT 3 rows in set (... sec)
+    SELECT 2 rows in set (... sec)
 
 
 ``key_column_usage``

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -300,10 +300,6 @@ public class InformationSchemaIterables implements ClusterStateListener {
         return columns;
     }
 
-    public Iterable<ConstraintInfo> constraints() {
-        return constraints;
-    }
-
     public Iterable<ConstraintInfo> pgConstraints() {
         return pgConstraints;
     }

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -73,7 +73,7 @@ public class InformationSchemaTableDefinitions {
             InformationColumnsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationTableConstraintsTableInfo.IDENT, new StaticTableDefinition<>(
-            informationSchemaIterables::constraints,
+            informationSchemaIterables::pgConstraints,
             (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.relationName().fqn()),
             InformationTableConstraintsTableInfo.create().expressions()
         ));

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -391,14 +391,6 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
         assertThat(printedTable(response.rows()),
             is(
                 "columns_pk| PRIMARY KEY| columns| information_schema\n" +
-                "information_schema_columns_column_name_not_null| CHECK| columns| information_schema\n" +
-                "information_schema_columns_data_type_not_null| CHECK| columns| information_schema\n" +
-                "information_schema_columns_is_generated_not_null| CHECK| columns| information_schema\n" +
-                "information_schema_columns_is_nullable_not_null| CHECK| columns| information_schema\n" +
-                "information_schema_columns_ordinal_position_not_null| CHECK| columns| information_schema\n" +
-                "information_schema_columns_table_catalog_not_null| CHECK| columns| information_schema\n" +
-                "information_schema_columns_table_name_not_null| CHECK| columns| information_schema\n" +
-                "information_schema_columns_table_schema_not_null| CHECK| columns| information_schema\n" +
                 "key_column_usage_pk| PRIMARY KEY| key_column_usage| information_schema\n" +
                 "referential_constraints_pk| PRIMARY KEY| referential_constraints| information_schema\n" +
                 "schemata_pk| PRIMARY KEY| schemata| information_schema\n" +
@@ -434,19 +426,16 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
         execute("SELECT constraint_type, constraint_name, table_name FROM information_schema.table_constraints " +
                 "WHERE table_schema = ?",
             new Object[]{sqlExecutor.getCurrentSchema()});
-        assertEquals(4L, response.rowCount());
+        assertEquals(3L, response.rowCount());
         assertThat(response.rows()[0][0], is("PRIMARY KEY"));
         assertThat(response.rows()[0][1], is("test_pk"));
         assertThat(response.rows()[0][2], is("test"));
         assertThat(response.rows()[1][0], is("CHECK"));
-        assertThat(response.rows()[1][1], is(sqlExecutor.getCurrentSchema() + "_test_col3_not_null"));
+        assertThat(response.rows()[1][1], is("unnecessary_check"));
         assertThat(response.rows()[1][2], is("test"));
         assertThat(response.rows()[2][0], is("CHECK"));
-        assertThat(response.rows()[2][1], is("unnecessary_check"));
+        assertThat(response.rows()[2][1], is("chk_1"));
         assertThat(response.rows()[2][2], is("test"));
-        assertThat(response.rows()[3][0], is("CHECK"));
-        assertThat(response.rows()[3][1], is("chk_1"));
-        assertThat(response.rows()[3][2], is("test"));
     }
 
     @Test
@@ -467,11 +456,8 @@ public class InformationSchemaTest extends SQLIntegrationTestCase {
                 "ORDER BY table_name ASC",
             new Object[]{sqlExecutor.getCurrentSchema()});
 
-        assertEquals(3L, response.rowCount());
-        assertThat(response.rows()[1][0], is("test2"));
-        assertThat(response.rows()[1][1], is("test2_pk"));
-        assertThat(response.rows()[2][0], is("test2"));
-        assertThat(response.rows()[2][1], is(sqlExecutor.getCurrentSchema() + "_test2_Col2a_not_null"));
+        assertEquals(2L, response.rowCount());
+        assertThat(printedTable(response.rows()), is("test| test_pk\ntest2| test2_pk\n"));
     }
 
 


### PR DESCRIPTION
follow up to https://github.com/crate/crate/pull/12585/commits/2e8b9703c966a297cd72561bf4bb43fc8403fd18

https://www.db-fiddle.com/f/h6SSAXRC1RYSC5oCrrmQYx/14
regular not-null constraints are not shown in table_constraints in PostgreSQL 13 - the only NOT-NULLS which can be shown there are PK not-nulls  - it's tracked in https://github.com/crate/crate/issues/12683 and will be addressed separately
