### PR TITLE
Documentation: Add use case examples for the new `object_keys` function

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2593,6 +2593,32 @@ An alias for :ref:`scalar-array_upper`.
     SELECT 1 row in set (... sec)
 
 
+.. NOTE::
+
+    For compatibility with PostgreSQL, :ref:`array_length <scalar-array_length>`
+    will return ``NULL`` on both empty arrays and ``NULL`` values.
+
+::
+
+    cr> select array_length([]::int[], 1) AS len;
+    +------+
+    | len  |
+    +------+
+    | NULL |
+    +------+
+    SELECT 1 row in set (... sec)
+
+::
+
+    cr> select array_length(null::int[], 1) AS len;
+    +------+
+    | len  |
+    +------+
+    | NULL |
+    +------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-array_lower:
 
 ``array_lower(anyarray, dimension)``

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3005,6 +3005,26 @@ Returns: ``array(text)``
     +-------------+
     SELECT 1 row in set (... sec)
 
+For empty objects, the ``object_keys`` function returns an empty list::
+
+    cr> select object_keys({}) AS object_keys;
+    +-------------+
+    | object_keys |
+    +-------------+
+    | []          |
+    +-------------+
+    SELECT 1 row in set (... sec)
+
+For ``NULL`` values, the ``object_keys`` function also returns ``NULL``::
+
+    cr> select object_keys(null) AS object_keys;
+    +-------------+
+    | object_keys |
+    +-------------+
+    | NULL        |
+    +-------------+
+    SELECT 1 row in set (... sec)
+
 
 .. _scalar-conditional-fn-exp:
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -825,6 +825,31 @@ Object property can also be addressed in the :ref:`where clause
     +------------+----------------------------------------------------------------------+
     SELECT 1 row in set (... sec)
 
+For displaying the object's keys, use the :ref:`scalar-object_keys` function::
+
+    cr> select name, object_keys(inhabitants) as inhabitant_keys from locations
+    ... where name = 'Betelgeuse';
+    +------------+-------------------------+
+    | name       | inhabitant_keys         |
+    +------------+-------------------------+
+    | Betelgeuse | ["name", "description"] |
+    +------------+-------------------------+
+    SELECT 1 row in set (... sec)
+
+By combining the :ref:`scalar-object_keys` function with the ``ANY`` operator,
+you can find all records where an object contains a specific object key::
+
+    cr> select name from locations
+    ... where 'interests' = ANY(object_keys(inhabitants));
+    +-------------------+
+    | name              |
+    +-------------------+
+    | Arkintoofle Minor |
+    | Bartledan         |
+    | Argabuthon        |
+    +-------------------+
+    SELECT 3 rows in set (... sec)
+
 For selecting records having values with empty or unassigned objects, like::
 
     cr> insert into locations (id, name, position, kind, inhabitants) values

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -740,6 +740,34 @@ an upper-bound::
     Both the ``from`` and ``to`` index values are inclusive.
     Using an index greater than the array size results in an empty array.
 
+For selecting records having values with empty or unassigned arrays, like::
+
+    cr> insert into locations (id, name, position, kind, landmarks) values
+    ... (99, 'Voidspace', 0, 'Milliways', []);
+    INSERT OK, 1 row affected (... sec)
+
+.. Hidden: refresh locations
+
+    cr> refresh table locations;
+    REFRESH OK, 1 row affected (... sec)
+
+a suitable expression to match both conditions, is::
+
+    cr> select count(*) from locations where
+    ... array_length(landmarks, 1) is null;
+    +----------+
+    | count(*) |
+    +----------+
+    |       14 |
+    +----------+
+    SELECT 1 row in set (... sec)
+
+.. Hidden: drop record again
+
+    cr> delete from locations where id=99;
+    DELETE OK, 1 row affected  (... sec)
+
+
 .. _sql_dql_objects:
 
 Objects

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -825,6 +825,33 @@ Object property can also be addressed in the :ref:`where clause
     +------------+----------------------------------------------------------------------+
     SELECT 1 row in set (... sec)
 
+For selecting records having values with empty or unassigned objects, like::
+
+    cr> insert into locations (id, name, position, kind, inhabitants) values
+    ... (99, 'Voidspace', 0, 'Milliways', {});
+    INSERT OK, 1 row affected (... sec)
+
+.. Hidden: refresh locations
+
+    cr> refresh table locations;
+    REFRESH OK, 1 row affected (... sec)
+
+a suitable expression to match both conditions, is::
+
+    cr> select count(*) from locations where
+    ... inhabitants is null or inhabitants = {};
+    +----------+
+    | count(*) |
+    +----------+
+    |       12 |
+    +----------+
+    SELECT 1 row in set (... sec)
+
+.. Hidden: drop record again
+
+    cr> delete from locations where id=99;
+    DELETE OK, 1 row affected  (... sec)
+
 
 .. _sql_dql_nested:
 


### PR DESCRIPTION
This adds two exercises for the new `object_keys` function.
- ad88d2d6: Add example how to match record columns for empty or unassigned objects. References:
  - #12714 
  - #9398
- 2183302de69: Outline general usage within the storyline-like `dql/selects.rst`. One example displays the output, the other one uses it as a filter expression, combined with the `ANY` operator.