### PR TITLE
add support of the CharacterType to the HyperLogLogDistinctAggregation

### DIFF
--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -61,6 +61,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.module.ExtraFunctionsModule;
 import io.crate.types.BooleanType;
 import io.crate.types.ByteType;
+import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -229,6 +230,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                     }
                 );
             case StringType.ID:
+            case CharacterType.ID:
                 var precision = optionalParams.size() == 1 ? (Integer) optionalParams.get(0).value() : HyperLogLogPlusPlus.DEFAULT_PRECISION;
                 return new HllAggregator(reference.column().fqn(), dataType, precision) {
                     @Override
@@ -488,6 +490,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                 case StringType.ID:
                 case BooleanType.ID:
                 case IpType.ID:
+                case CharacterType.ID:
                     if (allOn4_1) {
                         return Bytes64.INSTANCE;
                     } else {


### PR DESCRIPTION
`./gradlew :extensions:functions:test --tests "io.crate.operation.aggregation.HyperLogLogDistinctAggregationTest.test_random_type_random_values" -Dtests.seed=E06CBF9E6BA7D315 -Dtests.nightly=true -Dtests.locale=en-TO -Dtests.timezone=Africa/Windhoek`

used to fail as we use switch to assign appropriate hash function per type

since `Character` type extends `String` type HLL logic for Character is same with `String`

