### PR TITLE
Don't overwrite formattedGeneratedExpression with formattedDefaultExpression

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -192,7 +192,7 @@ public class AnalyzedColumnDefinition<T> {
             copyToTargets,
             isParentColumn,
             storageProperties == null ? null : storageProperties.map(mapper),
-            formattedDefaultExpression,
+            formattedGeneratedExpression,
             generatedExpression == null ? null : mapper.apply(generatedExpression),
             formattedDefaultExpression,
             defaultExpression == null ? null : mapper.apply(defaultExpression),


### PR DESCRIPTION
There is a typo, `formattedDefaultExpression` is passed twice to the ctor. I was concerned about the case where at least one of the  `formattedGeneratedExpression` and `formattedDefaultExpression` is not null.

However, they got their values in  `AnalyzedTableElements.finalizeAndValidate` and `map()` is called before that - so it doesn't cause any issues, as both are nulls initially. 

Just minor clean up