### PR TITLE
Support using a subscript expression on an alias within ORDER BY

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -85,6 +85,10 @@ Deprecations
 Changes
 =======
 
+- Added support for using subscript expressions on top of aliases within the
+  ``ORDER BY`` clause. An example: ``SELECT percentile(x, [0.90, 0.95]) AS
+  percentiles FROM tbl ORDER BY percentiles[1]``.
+
 - Added support for array element access on top of a subscript on an object
   array. An example: ``object_array['subelement'][1]``
 

--- a/server/src/main/java/io/crate/analyze/relations/SelectListFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/SelectListFieldProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.crate.analyze.relations.select.SelectAnalysis;
+import io.crate.exceptions.AmbiguousColumnAliasException;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.table.Operation;
+import io.crate.sql.tree.QualifiedName;
+
+public class SelectListFieldProvider implements FieldProvider<Symbol> {
+
+    private final SelectAnalysis selectAnalysis;
+    private final FieldProvider<? extends Symbol> fallback;
+
+    public SelectListFieldProvider(SelectAnalysis selectAnalysis, FieldProvider<? extends Symbol> fallback) {
+        this.selectAnalysis = selectAnalysis;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public Symbol resolveField(QualifiedName qualifiedName,
+                               List<String> path,
+                               Operation operation,
+                               boolean errorOnUnknownObjectKey) {
+        List<String> parts = qualifiedName.getParts();
+        if (parts.size() == 1 && (path == null || path.isEmpty())) {
+            String part = parts.get(0);
+            Symbol result = getOneOrAmbiguous(selectAnalysis.outputMultiMap(), part);
+            if (result != null) {
+                return result;
+            }
+        }
+        return fallback.resolveField(qualifiedName, path, operation, errorOnUnknownObjectKey);
+    }
+
+    @Nullable
+    public static Symbol getOneOrAmbiguous(Map<String, Set<Symbol>> selectList, String key) throws AmbiguousColumnAliasException {
+        Collection<Symbol> symbols = selectList.get(key);
+        if (symbols == null) {
+            return null;
+        }
+        if (symbols.size() > 1) {
+            throw new AmbiguousColumnAliasException(key, symbols);
+        }
+        return symbols.iterator().next();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1244,7 +1244,7 @@ public class JoinIntegrationTest extends SQLIntegrationTestCase {
         execute("EXPLAIN " + stmt);
         assertThat(printedTable(response.rows()), is(
             "Eval[id, table_name, schema_name, partition_ident, state, id AS node_id, name AS node_name]\n" +
-            "  └ OrderBy[id AS node_id ASC id ASC]\n" +
+            "  └ OrderBy[id ASC id ASC]\n" +
             "    └ HashJoin[(node['id'] = id)]\n" +
             "      ├ Collect[sys.shards | [id, table_name, schema_name, partition_ident, state, node['id']] | true]\n" +
             "      └ Rename[id, name] AS nodes\n" +

--- a/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -89,7 +89,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
             instanceOf(EvalProjection.class),
             isTopN(3, 0)
         ));
-        assertThat(projections.get(0).outputs(), isSQL("INPUT(1), INPUT(1)"));
+        assertThat(projections.get(0).outputs(), isSQL("INPUT(0)"));
         assertThat(projections.get(4).outputs(), isSQL("INPUT(0)"));
     }
 

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -479,7 +479,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "Eval[name AS usr]\n" +
                 "  └ Limit[10::bigint;0]\n" +
                 "    └ NestedLoopJoin[CROSS]\n" +
-                "      ├ OrderBy[name AS usr ASC]\n" +
+                "      ├ OrderBy[name ASC]\n" +
                 "      │  └ Collect[doc.users | [name] | true]\n" +
                 "      └ Collect[doc.t1 | [] | true]"));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/7644

Some unit tests required updates because the symbol now gets normalized
and normalization drops the alias.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
