### PR TITLE
Optimize `arr = []` queries

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -26,31 +26,13 @@ import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.function.IntPredicate;
-import java.util.function.IntUnaryOperator;
 
-import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreScorer;
-import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryVisitor;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.TwoPhaseIterator;
-import org.apache.lucene.search.Weight;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.fielddata.FieldData;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
 import io.crate.data.Input;
 import io.crate.expression.operator.EqOperator;
@@ -64,27 +46,15 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
-import io.crate.types.BooleanType;
-import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.DoubleType;
-import io.crate.types.FloatType;
-import io.crate.types.GeoPointType;
-import io.crate.types.IntegerType;
-import io.crate.types.IpType;
-import io.crate.types.LongType;
 import io.crate.types.ObjectType;
-import io.crate.types.ShortType;
-import io.crate.types.StringType;
-import io.crate.types.TimestampType;
 
 public class ArrayUpperFunction extends Scalar<Integer, Object> {
 
@@ -233,7 +203,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                 if (cmpVal == 0) {
                     return IsNullPredicate.refExistsQuery(arrayRef, context);
                 } else if (cmpVal == 1) {
-                    return numTermsPerDocQuery(arrayRef, valueCountIsMatch);
+                    return NumTermsPerDocQuery.forArray(arrayRef, valueCountIsMatch);
                 } else {
                     return genericFunctionFilter(parent, context);
                 }
@@ -261,19 +231,11 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                                                  IntPredicate valueCountIsMatch) {
         return new BooleanQuery.Builder()
             .add(
-                numTermsPerDocQuery(arrayRef, valueCountIsMatch),
+                NumTermsPerDocQuery.forArray(arrayRef, valueCountIsMatch),
                 BooleanClause.Occur.MUST
             )
             .add(genericFunctionFilter(parent, context), BooleanClause.Occur.FILTER)
             .build();
-    }
-
-    private static NumTermsPerDocQuery numTermsPerDocQuery(Reference arrayRef, IntPredicate valueCountIsMatch) {
-        return new NumTermsPerDocQuery(
-            arrayRef.column().fqn(),
-            leafReaderContext -> getNumTermsPerDocFunction(leafReaderContext.reader(), arrayRef),
-            valueCountIsMatch
-        );
     }
 
     private static IntPredicate predicateForFunction(String cmpFuncName, int cmpValue) {
@@ -295,175 +257,6 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
 
             default:
                 throw new IllegalArgumentException("Unknown comparison function: " + cmpFuncName);
-        }
-    }
-
-    private static IntUnaryOperator getNumTermsPerDocFunction(LeafReader reader, Reference ref) {
-        DataType<?> elementType = ArrayType.unnest(ref.valueType());
-        switch (elementType.id()) {
-            case BooleanType.ID:
-            case ByteType.ID:
-            case ShortType.ID:
-            case IntegerType.ID:
-            case LongType.ID:
-            case TimestampType.ID_WITH_TZ:
-            case TimestampType.ID_WITHOUT_TZ:
-            case FloatType.ID:
-            case DoubleType.ID:
-            case GeoPointType.ID:
-                return numValuesPerDocForSortedNumeric(reader, ref.column());
-
-            case StringType.ID:
-                return numValuesPerDocForString(reader, ref.column());
-
-            case IpType.ID:
-                return numValuesPerDocForIP(reader, ref.column());
-
-            default:
-                throw new UnsupportedOperationException("NYI: " + elementType);
-        }
-    }
-
-    private static IntUnaryOperator numValuesPerDocForIP(LeafReader reader, ColumnIdent column) {
-        SortedSetDocValues docValues;
-        try {
-            docValues = reader.getSortedSetDocValues(column.fqn());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return doc -> {
-            try {
-                if (docValues.advanceExact(doc)) {
-                    int c = 1;
-                    while (docValues.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
-                        c++;
-                    }
-                    return c;
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return 0;
-        };
-    }
-
-    private static IntUnaryOperator numValuesPerDocForString(LeafReader reader, ColumnIdent column) {
-        SortedBinaryDocValues docValues;
-        try {
-            docValues = FieldData.toString(DocValues.getSortedSet(reader, column.fqn()));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return doc -> {
-            try {
-                return docValues.advanceExact(doc) ? docValues.docValueCount() : 0;
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
-    }
-
-    private static IntUnaryOperator numValuesPerDocForSortedNumeric(LeafReader reader, ColumnIdent column) {
-        final SortedNumericDocValues sortedNumeric;
-        try {
-            sortedNumeric = DocValues.getSortedNumeric(reader, column.fqn());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return doc -> {
-            try {
-                return sortedNumeric.advanceExact(doc) ? sortedNumeric.docValueCount() : 0;
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
-    }
-
-    static class NumTermsPerDocQuery extends Query {
-
-        private final String column;
-        private final java.util.function.Function<LeafReaderContext, IntUnaryOperator> numTermsPerDocFactory;
-        private final IntPredicate matches;
-
-        NumTermsPerDocQuery(String column,
-                            java.util.function.Function<LeafReaderContext, IntUnaryOperator> numTermsPerDocFactory,
-                            IntPredicate matches) {
-            this.column = column;
-            this.numTermsPerDocFactory = numTermsPerDocFactory;
-            this.matches = matches;
-        }
-
-        @Override
-        public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-            return new ConstantScoreWeight(this, boost) {
-                @Override
-                public boolean isCacheable(LeafReaderContext ctx) {
-                    return false;
-                }
-
-                @Override
-                public Scorer scorer(LeafReaderContext context) {
-                    return new ConstantScoreScorer(
-                        this,
-                        0f,
-                        scoreMode,
-                        new NumTermsPerDocTwoPhaseIterator(context.reader(), numTermsPerDocFactory.apply(context), matches));
-                }
-            };
-        }
-
-        @Override
-        public void visit(QueryVisitor visitor) {
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            NumTermsPerDocQuery that = (NumTermsPerDocQuery) o;
-
-            if (!numTermsPerDocFactory.equals(that.numTermsPerDocFactory)) return false;
-            return matches.equals(that.matches);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = numTermsPerDocFactory.hashCode();
-            result = 31 * result + matches.hashCode();
-            return result;
-        }
-
-        @Override
-        public String toString(String field) {
-            return "NumTermsPerDoc: " + column;
-        }
-    }
-
-    private static class NumTermsPerDocTwoPhaseIterator extends TwoPhaseIterator {
-
-        private final IntUnaryOperator numTermsOfDoc;
-        private final IntPredicate matches;
-
-        NumTermsPerDocTwoPhaseIterator(LeafReader reader,
-                                       IntUnaryOperator numTermsOfDoc,
-                                       IntPredicate matches) {
-            super(DocIdSetIterator.all(reader.maxDoc()));
-            this.numTermsOfDoc = numTermsOfDoc;
-            this.matches = matches;
-        }
-
-        @Override
-        public boolean matches() {
-            int doc = approximation.docID();
-            return matches.test(numTermsOfDoc.applyAsInt(doc));
-        }
-
-        @Override
-        public float matchCost() {
-            // This is an arbitrary number;
-            // It's less than what is used in GenericFunctionQuery to indicate that this check should be cheaper
-            return 2;
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.io.IOException;
+import java.util.function.IntPredicate;
+import java.util.function.IntUnaryOperator;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.types.ArrayType;
+import io.crate.types.BooleanType;
+import io.crate.types.ByteType;
+import io.crate.types.DataType;
+import io.crate.types.DoubleType;
+import io.crate.types.FloatType;
+import io.crate.types.GeoPointType;
+import io.crate.types.IntegerType;
+import io.crate.types.IpType;
+import io.crate.types.LongType;
+import io.crate.types.ShortType;
+import io.crate.types.StringType;
+import io.crate.types.TimestampType;
+
+public class NumTermsPerDocQuery extends Query {
+
+    private final String column;
+    private final java.util.function.Function<LeafReaderContext, IntUnaryOperator> numTermsPerDocFactory;
+    private final IntPredicate matches;
+
+    public static NumTermsPerDocQuery forArray(Reference arrayRef, IntPredicate valueCountIsMatch) {
+        return new NumTermsPerDocQuery(
+            arrayRef.column().fqn(),
+            leafReaderContext -> getNumTermsPerDocFunction(leafReaderContext.reader(), arrayRef),
+            valueCountIsMatch
+        );
+    }
+
+    private static IntUnaryOperator getNumTermsPerDocFunction(LeafReader reader, Reference ref) {
+        DataType<?> elementType = ArrayType.unnest(ref.valueType());
+        switch (elementType.id()) {
+            case BooleanType.ID:
+            case ByteType.ID:
+            case ShortType.ID:
+            case IntegerType.ID:
+            case LongType.ID:
+            case TimestampType.ID_WITH_TZ:
+            case TimestampType.ID_WITHOUT_TZ:
+            case FloatType.ID:
+            case DoubleType.ID:
+            case GeoPointType.ID:
+                return numValuesPerDocForSortedNumeric(reader, ref.column());
+
+            case StringType.ID:
+                return numValuesPerDocForString(reader, ref.column());
+
+            case IpType.ID:
+                return numValuesPerDocForIP(reader, ref.column());
+
+            default:
+                throw new UnsupportedOperationException("NYI: " + elementType);
+        }
+    }
+
+    private static IntUnaryOperator numValuesPerDocForIP(LeafReader reader, ColumnIdent column) {
+        SortedSetDocValues docValues;
+        try {
+            docValues = reader.getSortedSetDocValues(column.fqn());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return doc -> {
+            try {
+                if (docValues.advanceExact(doc)) {
+                    int c = 1;
+                    while (docValues.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
+                        c++;
+                    }
+                    return c;
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return 0;
+        };
+    }
+
+    private static IntUnaryOperator numValuesPerDocForString(LeafReader reader, ColumnIdent column) {
+        SortedBinaryDocValues docValues;
+        try {
+            docValues = FieldData.toString(DocValues.getSortedSet(reader, column.fqn()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return doc -> {
+            try {
+                return docValues.advanceExact(doc) ? docValues.docValueCount() : 0;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    private static IntUnaryOperator numValuesPerDocForSortedNumeric(LeafReader reader, ColumnIdent column) {
+        final SortedNumericDocValues sortedNumeric;
+        try {
+            sortedNumeric = DocValues.getSortedNumeric(reader, column.fqn());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return doc -> {
+            try {
+                return sortedNumeric.advanceExact(doc) ? sortedNumeric.docValueCount() : 0;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    NumTermsPerDocQuery(String column,
+                        java.util.function.Function<LeafReaderContext, IntUnaryOperator> numTermsPerDocFactory,
+                        IntPredicate matches) {
+        this.column = column;
+        this.numTermsPerDocFactory = numTermsPerDocFactory;
+        this.matches = matches;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false;
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) {
+                return new ConstantScoreScorer(
+                    this,
+                    0f,
+                    scoreMode,
+                    new NumTermsPerDocTwoPhaseIterator(context.reader(), numTermsPerDocFactory.apply(context), matches));
+            }
+        };
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        NumTermsPerDocQuery that = (NumTermsPerDocQuery) o;
+
+        if (!numTermsPerDocFactory.equals(that.numTermsPerDocFactory)) return false;
+        return matches.equals(that.matches);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = numTermsPerDocFactory.hashCode();
+        result = 31 * result + matches.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString(String field) {
+        return "NumTermsPerDoc: " + column;
+    }
+
+    static class NumTermsPerDocTwoPhaseIterator extends TwoPhaseIterator {
+
+        private final IntUnaryOperator numTermsOfDoc;
+        private final IntPredicate matches;
+
+        NumTermsPerDocTwoPhaseIterator(LeafReader reader,
+                                       IntUnaryOperator numTermsOfDoc,
+                                       IntPredicate matches) {
+            super(DocIdSetIterator.all(reader.maxDoc()));
+            this.numTermsOfDoc = numTermsOfDoc;
+            this.matches = matches;
+        }
+
+        @Override
+        public boolean matches() {
+            int doc = approximation.docID();
+            return matches.test(numTermsOfDoc.applyAsInt(doc));
+        }
+
+        @Override
+        public float matchCost() {
+            // This is an arbitrary number;
+            // It's less than what is used in GenericFunctionQuery to indicate that this check should be cheaper
+            return 2;
+        }
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -362,10 +362,11 @@ public class LuceneQueryBuilderIntegrationTest extends SQLIntegrationTestCase {
     @Test
     public void testArrayElementComparisons() {
         execute("create table t1 (a array(long)) clustered into 1 shards with (number_of_replicas = 0)");
-        execute("insert into t1(a) values ([1, 2, 3])");
-        execute("insert into t1(a) values ([3, 4, 5, 1])");
-        execute("insert into t1(a) values ([6, 7, 8])");
+        execute("insert into t1 (a) values ([1, 2, 3]), ([3, 4, 5, 1]), ([6, 7,8]), ([])");
         execute("refresh table t1");
+
+        execute("select * from t1 where a = []");
+        assertThat(printedTable(response.rows()), is("[]\n"));
 
         execute("select * from t1 where a[1] = 1");
         assertThat(printedTable(response.rows()), is("[1, 2, 3]\n"));

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -634,4 +634,10 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query.toString(), is("(text_no_index IS NULL)"));
         assertThat(query, instanceOf(GenericFunctionQuery.class));
     }
+
+    @Test
+    public void test_arr_eq_empty_array_literal_is_optimized() {
+        Query query = convert("y_array = []");
+        assertThat(query.toString(), is("+NumTermsPerDoc: y_array +(y_array = [])"));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We can use the doc-value count as approximation before running the
generic function filter.

This helps a lot for tables where there are few empty arrays:

    Q: select count(*) from t_arrays_biased_5_elements where xs = []
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |     1183.464 ±  941.087 |    519.783 |   1125.056 |   1426.058 |   6537.926 |
    |   V2    |      166.165 ±  656.880 |     26.856 |     36.494 |     46.460 |   7236.325 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               - 150.75%                           - 187.43%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 150.75%
    The test has statistical significance

And adds a slight cost to tables where the majority of the arrays is
empty:

    Q: select count(*) from t_arrays_biased_empty where xs = []
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      429.168 ±  400.471 |     84.141 |    246.755 |    831.188 |   2981.456 |
    |   V2    |      457.291 ±  407.171 |     85.589 |    403.508 |    833.148 |   3217.098 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               +   6.34%                           +  48.21%
    There is a 51.34% probability that the observed difference is not random, and the best estimate of that difference is 6.34%
    The test has no statistical significance

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
