### PR TITLE
Support character type in array_length queries

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
@@ -48,6 +48,7 @@ import io.crate.metadata.Reference;
 import io.crate.types.ArrayType;
 import io.crate.types.BooleanType;
 import io.crate.types.ByteType;
+import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
@@ -89,6 +90,7 @@ public class NumTermsPerDocQuery extends Query {
                 return numValuesPerDocForSortedNumeric(reader, ref.column());
 
             case StringType.ID:
+            case CharacterType.ID:
                 return numValuesPerDocForString(reader, ref.column());
 
             case IpType.ID:

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
@@ -276,7 +276,7 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             if (type.storageSupport() == null) {
                 continue;
             }
-            Supplier dataGenerator = DataTypeTesting.getDataGenerator(type);
+            Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
             Object val1 = dataGenerator.get();
             Object val2 = dataGenerator.get();
             Object[] arr = {val1, val2};
@@ -294,9 +294,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
                 Version.CURRENT,
                 "create table \"t_"+ type.getName() + "\" (xs array(\"" + type.getName() + "\"))"
             ).indexValues("xs", values).build()) {
-                System.out.println(type);
-                List<Object> result = tester.runQuery("xs", "array_length(xs, 1) >= 2");
-                assertThat(result.size(), is(1));
+                List<Object> result = tester.runQuery("xs", "array_length(xs, 1) > 1");
+                assertThat("array_length(xs, 1) > 1 must match for " + type, result.size(), is(1));
                 ArrayType arrayType = new ArrayType<>(type);
                 // Object compareValueTo does type-guessing which might result in
                 // double/float conversions which are not fully accurate, so we skip that here

--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -143,7 +143,14 @@ public class DataTypeTesting {
                 return () -> {
                     // Can't use immutable Collections.singletonMap; insert-analyzer mutates the map
                     Map<String, Object> geoShape = new HashMap<>(2);
-                    geoShape.put("coordinates", Arrays.asList(10.2d, 32.2d));
+
+                    geoShape.put(
+                        "coordinates",
+                        Arrays.asList(
+                            BiasedNumbers.randomDoubleBetween(random, -180, 180),
+                            BiasedNumbers.randomDoubleBetween(random, -90, 90)
+                        )
+                    );
                     geoShape.put("type", "Point");
                     return (T) geoShape;
                 };


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/12672
Spotted this while working on https://github.com/crate/crate/pull/12696

We had a test for `array_length` that goes through all types,
but unfortunately it used `array_length(..) >= 2` as query which doesn't
trigger the `NumTermsPerDocQuery` path but instead uses the
`GenericFunctionQuery`.

Changing the query to `> 1` makes it test the specialized code path.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
