### PR TITLE
Documentation: Add examples how to match empty or unassigned arrays

### DIFF
--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -740,6 +740,34 @@ an upper-bound::
     Both the ``from`` and ``to`` index values are inclusive.
     Using an index greater than the array size results in an empty array.
 
+For selecting records having values with empty or unassigned arrays, like::
+
+    cr> insert into locations (id, name, position, kind, landmarks) values
+    ... (99, 'Voidspace', 0, 'Milliways', []);
+    INSERT OK, 1 row affected (... sec)
+
+.. Hidden: refresh locations
+
+    cr> refresh table locations;
+    REFRESH OK, 1 row affected (... sec)
+
+a suitable expression to match both conditions, is::
+
+    cr> select count(*) from locations where
+    ... landmarks is null or landmarks = [];
+    +----------+
+    | count(*) |
+    +----------+
+    |       14 |
+    +----------+
+    SELECT 1 row in set (... sec)
+
+.. Hidden: drop record again
+
+    cr> delete from locations where id=99;
+    DELETE OK, 1 row affected  (... sec)
+
+
 .. _sql_dql_objects:
 
 Objects


### PR DESCRIPTION
Hi again,

my previous attempt #12688 was misguided and also did not fit properly into the story the doctests were telling. This is another attempt to improve the documentation with respect to the inquiry/use case at #9398, which fits a bit better.

> I have an ARRAY column with some data.
> Some records contain an empty array `[]`, some records contain `NULL`.
> I want to find both.

The patch takes different suggestions from the previous review into account. Its gist is a bit like #12702. Let me know what you think about it.

With kind regards,
Andreas.
