### PR TITLE
tests: Revert removal of suppress warnings

### DIFF
--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -219,6 +219,7 @@ public class CastFunctionTest extends ScalarTestCase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void test_cast_wkt_point_string_array_to_geo_shape_array() {
         Symbol funcSymbol = sqlExpressions.asSymbol("['POINT(2 3)']::array(geo_shape)");
         assertThat(funcSymbol.valueType(), is(new ArrayType<>(GEO_SHAPE)));

--- a/server/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
@@ -84,7 +84,7 @@ public class BulkInsertOnClientNodeTest extends SQLIntegrationTestCase {
             execute("insert into test (id, value) values (?, ?)",
                 new Object[][]{
                     new Object[]{1, 1},                                 // use id 1 to ensure shard 0
-                    new Object[] {3, Map.of("foo", 127)}
+                    new Object[] {3, Map.of("foo", 127)}         // use id 3 to ensure shard 1
                 })).boxed().collect(Collectors.toList());
         assertThat(rowCounts.size(), is(2));
         assertThat(rowCounts, Matchers.anyOf(

--- a/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -103,14 +103,14 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
     private static void performInputSanityChecks(Object[]... inputs) {
         List<Integer> inputSizes = Arrays.stream(inputs)
             .map(Array::getLength)
-            .distinct()
-            .collect(Collectors.toList());
+            .distinct().toList();
 
         if (inputSizes.size() != 1) {
             throw new IllegalArgumentException("Inputs need to be of equal size");
         }
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     protected <T> void assertEvaluate(String functionExpression,
                                       Matcher<T> expectedValue,
                                       List<ColumnIdent> rowsColumnDescription,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Revert accidental removal of suppress warnings.
Follows: 4d15525b3560a4754d725069dad1c43813ffbdd5

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
