### PR TITLE
Support decoding bit text without B' prefix & encode without

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -222,6 +222,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue in the serialization logic of the ``bit`` type. This could
+  cause issues with PostgreSQL clients using the text serialization mode.
+
 - Fixed an issue that caused ``col IS NULL`` to match empty arrays.
 
 - Fixed an issue that caused ``col IS NULL`` expressions to match rows where

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -222,7 +222,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-- Fixed an issue in the serialization logic of the ``bit`` type. This could
+- Fixed an issue that caused queries reading values of type ``BIT`` to fail if
+  the query contains a ``WHERE`` clause ``pk_col = ?`` condition.
+
+- Fixed an issue in the serialization logic of the ``BIT`` type. This could
   cause issues with PostgreSQL clients using the text serialization mode.
 
 - Fixed an issue that caused ``col IS NULL`` to match empty arrays.

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -251,7 +251,7 @@ public final class ExpressionFormatter {
 
         @Override
         public String visitBitString(BitString bitString, List<Expression> context) {
-            return bitString.asBitString();
+            return bitString.asPrefixedBitString();
         }
 
         @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/BitString.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/BitString.java
@@ -72,12 +72,34 @@ public class BitString extends Literal implements Comparable<BitString> {
         return length;
     }
 
-    public String asBitString() {
+    /**
+     * Return bits as string with B' prefix. Example:
+     *
+     * <pre>
+     *  B'1101'
+     * </pre>
+     */
+    public String asPrefixedBitString() {
         var sb = new StringBuilder("B'");
         for (int i = 0; i < length; i++) {
             sb.append(bitSet.get(i) ? '1' : '0');
         }
         sb.append("'");
+        return sb.toString();
+    }
+
+    /**
+     * Return bits as string without B' prefix. Example:
+     *
+     * <pre>
+     *  1101
+     * </pre>
+     */
+    public String asRawBitString() {
+        var sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append(bitSet.get(i) ? '1' : '0');
+        }
         return sb.toString();
     }
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/tree/BitStringTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/tree/BitStringTest.java
@@ -80,7 +80,7 @@ public class BitStringTest {
     public void test_can_render_bitstring_as_string() {
         String text = "00000110";
         BitString bit = BitString.ofRawBits(text);
-        assertThat(bit.asBitString(), is("B'00000110'"));
+        assertThat(bit.asPrefixedBitString(), is("B'00000110'"));
     }
 
     @Test
@@ -94,6 +94,6 @@ public class BitStringTest {
     @Property
     public void test_bitstring_compare_behaves_like_asBitString_compareTo(@From(BitStringGen.class) BitString a,
                                                                           @From(BitStringGen.class) BitString b) {
-        assertThat(a.compareTo(b), is(Integer.signum(a.asBitString().compareTo(b.asBitString()))));
+        assertThat(a.compareTo(b), is(Integer.signum(a.asPrefixedBitString().compareTo(b.asPrefixedBitString()))));
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
@@ -91,7 +91,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                             var partitionValue = partitionName.values().get(idx);
                             var source = response.getSource();
                             Maps.mergeInto(source, pColumn.name(), pColumn.path(), partitionValue);
-                            return ref.valueType().implicitCast(ValueExtractors.fromMap(source, columnIdent));
+                            return ref.valueType().sanitizeValue(ValueExtractors.fromMap(source, columnIdent));
                         });
                     }
                 }
@@ -100,7 +100,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                     if (response == null) {
                         return null;
                     }
-                    return ref.valueType().implicitCast(ValueExtractors.fromMap(response.getSource(), ref.column()));
+                    return ref.valueType().sanitizeValue(ValueExtractors.fromMap(response.getSource(), ref.column()));
                 });
         }
     }

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -22,6 +22,7 @@
 package io.crate.types;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Locale;
@@ -130,6 +131,9 @@ public final class BitStringType extends DataType<BitString> implements Streamer
 
     @Override
     public BitString sanitizeValue(Object value) {
+        if (value instanceof String str) {
+            return new BitString(BitSet.valueOf(str.getBytes(StandardCharsets.UTF_8)), length);
+        }
         return (BitString) value;
     }
 

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -211,7 +211,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
         } else if (value instanceof Regclass) {
             return ((Regclass) value).name();
         } else if (value instanceof BitString bitString) {
-            return bitString.asBitString();
+            return bitString.asPrefixedBitString();
         } else {
             return value.toString();
         }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ServerXContentExtension.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ServerXContentExtension.java
@@ -156,7 +156,7 @@ public class ServerXContentExtension implements XContentBuilderExtension {
         });
         writers.put(BitString.class, (b, v) -> {
             BitString bitString = (BitString) v;
-            b.value(bitString.asBitString());
+            b.value(bitString.asPrefixedBitString());
         });
         return writers;
     }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1976,12 +1976,12 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
             }
         }
         assertThat(results, Matchers.contains(
-            "B'0000'",
-            "B'0001'",
-            "B'0011'",
-            "B'0111'",
-            "B'1001'",
-            "B'1111'"
+            "0000",
+            "0001",
+            "0011",
+            "0111",
+            "1001",
+            "1111"
         ));
     }
 

--- a/server/src/test/java/io/crate/protocols/postgres/types/BitTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/BitTypeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.protocols.postgres.types;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import io.crate.sql.tree.BitString;
+
+public class BitTypeTest {
+
+    @Test
+    public void test_can_decode_text_without_B_prefix() {
+        assertThat(
+            BitType.INSTANCE.decodeUTF8Text("0010".getBytes(StandardCharsets.UTF_8)),
+            is(BitString.ofRawBits("0010"))
+        );
+    }
+
+    @Test
+    public void test_can_decode_text_with_B_prefix() {
+        assertThat(
+            BitType.INSTANCE.decodeUTF8Text("B'0010'".getBytes(StandardCharsets.UTF_8)),
+            is(BitString.ofRawBits("0010"))
+        );
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/12718
Adding a test-case for pyodbc with https://github.com/crate/crate-qa/pull/225

I also discovered a second issue related to primary key lookups. See the second commit.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
