### PR TITLE
pass concrete argument types when streaming signature as functionInfo

### DIFF
--- a/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -57,6 +57,8 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
 
+import static io.crate.expression.predicate.MatchPredicate.TEXT_MATCH;
+
 
 /**
  * The normalizer does several things:
@@ -174,7 +176,7 @@ public class EvaluatingNormalizer {
                         if (out.getVersion().onOrAfter(Version.V_4_2_4)) {
                             super.writeTo(out);
                         } else {
-                            io.crate.expression.predicate.MatchPredicate.TEXT_MATCH.writeAsFunctionInfo(out);
+                            TEXT_MATCH.writeAsFunctionInfo(out, TEXT_MATCH.getArgumentDataTypes());
                             if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
                                 Symbols.nullableToStream(filter, out);
                             }

--- a/server/src/main/java/io/crate/expression/symbol/Aggregation.java
+++ b/server/src/main/java/io/crate/expression/symbol/Aggregation.java
@@ -130,7 +130,7 @@ public class Aggregation implements Symbol {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getVersion().before(Version.V_5_0_0)) {
-            signature.writeAsFunctionInfo(out);
+            signature.writeAsFunctionInfo(out, Symbols.typeView(inputs));
         }
         DataTypes.toStream(valueType, out);
         if (out.getVersion().onOrAfter(Version.V_4_1_0)) {

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -187,7 +187,7 @@ public class Function implements Symbol, Cloneable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getVersion().before(Version.V_5_0_0)) {
-            signature.writeAsFunctionInfo(out);
+            signature.writeAsFunctionInfo(out, Symbols.typeView(arguments));
         }
         if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
             Symbols.nullableToStream(filter, out);

--- a/server/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/server/src/main/java/io/crate/metadata/functions/Signature.java
@@ -432,13 +432,15 @@ public final class Signature implements Writeable {
     /**
      * Write the given {@link Signature} to the stream in the format of the old FunctionInfo class for BWC compatibility
      * with nodes < 4.2.0
+     * @param argumentDataTypes is list of concrete types when getArgumentDataTypes() cannot be used as it's contains type variable constraints.
      */
-    public void writeAsFunctionInfo(StreamOutput out) throws IOException {
+    public void writeAsFunctionInfo(StreamOutput out, List<DataType<?>> argumentDataTypes) throws IOException {
+
         // old FunctionIdent
         name.writeTo(out);
-        var argumentTypes = getArgumentDataTypes();
-        out.writeVInt(argumentTypes.size());
-        for (DataType<?> argumentType : argumentTypes) {
+
+        out.writeVInt(argumentDataTypes.size());
+        for (DataType<?> argumentType : argumentDataTypes) {
             DataTypes.toStream(argumentType, out);
         }
         // FunctionIdent end

--- a/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
@@ -21,6 +21,20 @@
 
 package io.crate.execution.dsl.projection;
 
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
 import io.crate.analyze.WindowDefinition;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
@@ -32,19 +46,6 @@ import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.List;
-
-import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
 
 public class WindowAggProjectionSerialisationTest {
 
@@ -140,10 +141,10 @@ public class WindowAggProjectionSerialisationTest {
         return functions.getQualified(
             Signature.aggregate(
                 SumAggregation.NAME,
-                DataTypes.FLOAT.getTypeSignature(),
-                DataTypes.FLOAT.getTypeSignature()),
-            List.of(DataTypes.FLOAT),
-            DataTypes.FLOAT
+                DataTypes.LONG.getTypeSignature(),
+                DataTypes.LONG.getTypeSignature()),
+            List.of(DataTypes.LONG),
+            DataTypes.LONG
         );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/crate/crate-alerts/issues/292

<details>
<summary>
Stack trace
</summary>

```
java.lang.IllegalArgumentException: Cannot find data type: E
at io.crate.types.DataTypes.of(DataTypes.java:446)
at io.crate.types.TypeSignature.createType(TypeSignature.java:154)
at io.crate.common.collections.Lists2.map(Lists2.java:86)
at io.crate.metadata.functions.Signature.getArgumentDataTypes(Signature.java:364)
at io.crate.metadata.functions.Signature.writeAsFunctionInfo(Signature.java:439)
at io.crate.expression.symbol.Function.writeTo(Function.java:190)
at io.crate.expression.symbol.Symbols.toStream(Symbols.java:149)
at io.crate.execution.dsl.phases.RoutedCollectPhase.writeTo(RoutedCollectPhase.java:231)
at io.crate.execution.dsl.phases.ExecutionPhases.toStream(ExecutionPhases.java:55)
```

</details>

Additional logging on crate-qa revealed that failure happens on `EqOperator` as it has type variable signature and `Signature.writeAsFunctionInfo` uses `getArgumentDataTypes()` which tries to create a concrete type out of "E" which leads to `SQLParseException[Cannot find data type: E]`

I checked how it was done before in `Function` and `Aggregation`  - 
https://github.com/crate/crate/pull/12701/files#diff-1cb98d6027cd7b14a90c55893c1899feef4fb67ea05abfbae9dbff3c8cd974f7L110 - they provided concrete argument data types to create a functionInfo so I did the same