### PR TITLE
Update Jackson library to 2.12.7

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -10,7 +10,7 @@ aws=1.11.1021
 jaxb_api=2.2.2
 jopt_simple=5.0.2
 
-jackson=2.11.2
+jackson=2.12.7
 jackson_jaxrs=1.9.13
 jackson_xc=1.9.13
 jacksonasl=1.9.13


### PR DESCRIPTION
Use the most recent patch release of the [2.12 series] of the [Jackson] library. It is the latest patch from the previous stable branch. Thank you, @WalBeh.

References: GHSA-57j2-w4cx-62h2, GHSA-xmc8-26q4-qjhx

[2.12 series]: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12
[Jackson]: https://github.com/FasterXML/jackson
