### PR TITLE
Allow group by on array type

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,7 +54,7 @@ None
 Changes
 =======
 
-None
+- Added support of ``GROUP BY`` on ``ARRAY`` typed columns.
 
 
 Fixes

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -1061,9 +1061,7 @@ This is useful if used in conjunction with :ref:`aggregation functions
    Grouping will be executed against the real table column when aliases that
    shadow the table columns are used.
 
-   Grouping on array columns doesn't work, but arrays can be unnested in a
-   :ref:`subquery <gloss-subquery>` using :ref:`unnest <unnest>`. It is then
-   possible to use ``GROUP BY`` on the subquery.
+   Grouping on array columns is supported. Arrays are compared per element.
 
 
 .. _sql_dql_having:

--- a/server/src/main/java/io/crate/exceptions/ArrayViaDocValuesUnsupportedException.java
+++ b/server/src/main/java/io/crate/exceptions/ArrayViaDocValuesUnsupportedException.java
@@ -29,13 +29,13 @@ import java.io.IOException;
 /**
  * This exception can be in the <p>anonymous</p> scope as it can only be thrown when executed with proper authorization.
  */
-public class GroupByOnArrayUnsupportedException extends ElasticsearchException implements UnscopedException {
+public class ArrayViaDocValuesUnsupportedException extends ElasticsearchException implements UnscopedException {
 
-    public GroupByOnArrayUnsupportedException(String columnName) {
-        super("Column \"" + columnName + "\" has a value that is an array. Group by doesn't work on Arrays");
+    public ArrayViaDocValuesUnsupportedException(String columnName) {
+        super("Column \"" + columnName + "\" has a value that is an array. Loading arrays via doc-values is not supported.");
     }
 
-    public GroupByOnArrayUnsupportedException(StreamInput in) throws IOException {
+    public ArrayViaDocValuesUnsupportedException(StreamInput in) throws IOException {
         super(in);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -31,8 +31,6 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
-import io.crate.types.ArrayType;
-import io.crate.types.DataType;
 import org.elasticsearch.Version;
 
 import java.util.List;
@@ -55,7 +53,6 @@ public class GroupingProjector implements Projector {
                              Version minNodeVersion,
                              Version indexVersionCreated) {
         assert keys.size() == keyInputs.size() : "number of key types must match with number of key inputs";
-        ensureAllTypesSupported(keys);
 
         AggregationFunction[] functions = new AggregationFunction[aggregations.length];
         Input[][] inputs = new Input[aggregations.length][];
@@ -96,15 +93,6 @@ public class GroupingProjector implements Projector {
                 typeView(keys),
                 indexVersionCreated
             );
-        }
-    }
-
-    private static void ensureAllTypesSupported(Iterable<? extends Symbol> keys) {
-        for (Symbol key : keys) {
-            DataType<?> type = key.valueType();
-            if (type instanceof ArrayType) {
-                throw new UnsupportedOperationException("Cannot GROUP BY type: " + type);
-            }
         }
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -65,7 +65,7 @@ import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.exceptions.Exceptions;
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.Projection;
@@ -321,7 +321,7 @@ final class GroupByOptimizedIterator {
                             aggregateValues(aggregations, ramAccounting, memoryManager, states);
                         }
                         if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
-                            throw new GroupByOnArrayUnsupportedException(keyColumnName);
+                            throw new ArrayViaDocValuesUnsupportedException(keyColumnName);
                         }
                     } else {
                         if (nullStates == null) {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/BitStringColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/BitStringColumnReference.java
@@ -29,7 +29,7 @@ import java.util.BitSet;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.sql.tree.BitString;
 
@@ -51,7 +51,7 @@ public class BitStringColumnReference extends LuceneCollectorExpression<BitStrin
             if (values.advanceExact(docId)) {
                 long ord = values.nextOrd();
                 if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
-                    throw new GroupByOnArrayUnsupportedException(columnName);
+                    throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
                 var bytesRef = values.lookupOrd(ord);
                 var buffer = ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length);

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.util.BytesRef;
@@ -51,7 +51,7 @@ public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
                         return values.nextValue().compareTo(TRUE_BYTESREF) == 0;
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/ByteColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/ByteColumnReference.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -48,7 +48,7 @@ public class ByteColumnReference extends LuceneCollectorExpression<Byte> {
                         return (byte) values.nextValue();
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
 
                 }
             } else {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/BytesRefColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/BytesRefColumnReference.java
@@ -29,7 +29,7 @@ import org.apache.lucene.index.DocValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 
 public class BytesRefColumnReference extends LuceneCollectorExpression<String> {
 
@@ -42,13 +42,13 @@ public class BytesRefColumnReference extends LuceneCollectorExpression<String> {
     }
 
     @Override
-    public String value() throws GroupByOnArrayUnsupportedException {
+    public String value() throws ArrayViaDocValuesUnsupportedException {
         try {
             if (values.advanceExact(docId)) {
                 if (values.docValueCount() == 1) {
                     return values.nextValue().utf8ToString();
                 } else {
-                    throw new GroupByOnArrayUnsupportedException(columnName);
+                    throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
@@ -30,7 +30,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 
 public class DoubleColumnReference extends LuceneCollectorExpression<Double> {
 
@@ -51,7 +51,7 @@ public class DoubleColumnReference extends LuceneCollectorExpression<Double> {
                         return values.nextValue();
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatColumnReference.java
@@ -29,7 +29,7 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.NumericUtils;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 
 public class FloatColumnReference extends LuceneCollectorExpression<Float> {
 
@@ -50,7 +50,7 @@ public class FloatColumnReference extends LuceneCollectorExpression<Float> {
                         return NumericUtils.sortableIntToFloat((int) values.nextValue());
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/GeoPointColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/GeoPointColumnReference.java
@@ -32,7 +32,7 @@ import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 
 public class GeoPointColumnReference extends LuceneCollectorExpression<Point> {
 
@@ -58,7 +58,7 @@ public class GeoPointColumnReference extends LuceneCollectorExpression<Point> {
                         );
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -48,7 +48,7 @@ public class IntegerColumnReference extends LuceneCollectorExpression<Integer> {
                         return (int) values.nextValue();
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
@@ -22,7 +22,7 @@
 package io.crate.expression.reference.doc.lucene;
 
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedSetDocValues;
@@ -48,7 +48,7 @@ public class IpColumnReference extends LuceneCollectorExpression<String> {
             if (values.advanceExact(docId)) {
                 long ord = values.nextOrd();
                 if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
-                    throw new GroupByOnArrayUnsupportedException(columnName);
+                    throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
                 BytesRef encoded = values.lookupOrd(ord);
                 return (String) DocValueFormat.IP.format(encoded);

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LongColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LongColumnReference.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -48,7 +48,7 @@ public class LongColumnReference extends LuceneCollectorExpression<Long> {
                         return values.nextValue();
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/ShortColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/ShortColumnReference.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -48,7 +48,7 @@ public class ShortColumnReference extends LuceneCollectorExpression<Short> {
                         return (short) values.nextValue();
 
                     default:
-                        throw new GroupByOnArrayUnsupportedException(columnName);
+                        throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
             } else {
                 return null;

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -20,6 +20,7 @@
 package org.elasticsearch;
 
 import io.crate.common.CheckedFunction;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.exceptions.SQLExceptions;
 
 import org.elasticsearch.action.admin.indices.alias.AliasesNotFoundException;
@@ -1028,8 +1029,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             161,
             Version.V_4_7_0),
         GROUP_BY_ON_ARRAY_UNSUPPORTED_EXCEPTION(
-            io.crate.exceptions.GroupByOnArrayUnsupportedException.class,
-            io.crate.exceptions.GroupByOnArrayUnsupportedException::new,
+            ArrayViaDocValuesUnsupportedException.class,
+            ArrayViaDocValuesUnsupportedException::new,
             162,
             Version.V_4_7_0),
         INVALID_ARGUMENT_EXCEPTION(

--- a/server/src/test/java/io/crate/expression/reference/doc/IpColumnReferenceTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/IpColumnReferenceTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.reference.doc;
 
-import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.IpColumnReference;
 import org.apache.lucene.document.Document;
@@ -126,8 +126,8 @@ public class IpColumnReferenceTest extends DocLevelExpressionsTest {
         ScoreDoc doc = topDocs.scoreDocs[0];
         columnReference.setNextDocId(doc.doc);
 
-        expectedException.expect(GroupByOnArrayUnsupportedException.class);
-        expectedException.expectMessage("Column \"ia\" has a value that is an array. Group by doesn't work on Arrays");
+        expectedException.expect(ArrayViaDocValuesUnsupportedException.class);
+        expectedException.expectMessage("Column \"ia\" has a value that is an array. Loading arrays via doc-values is not supported.");
 
         columnReference.value();
     }

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1417,4 +1417,24 @@ public class GroupByAggregateTest extends SQLIntegrationTestCase {
             is("10| 1\nfoo| 1\n")
         ));
     }
+
+    @Test
+    public void test_group_by_array_type() {
+        execute("create table tbl (arr array(int))");
+        execute("insert into tbl(arr) values ([1, 2, null]), ([2, 1]), ([1, 2]), ([1, 2])");
+        execute("insert into tbl(arr) values ([]::int[]), ([]::int[]), ([]::int[])");
+        execute("insert into tbl(arr) values ([null]), ([null]), ([null]), ([null])");
+        execute("insert into tbl(arr) values (null), (null), (null), (null), (null)");
+        refresh();
+        execute("select arr, count(*) cnt from tbl group by arr order by cnt, arr[1]");
+        assertThat(TestingHelpers.printedTable(response.rows()),
+            Is.is("[1, 2, null]| 1\n" +
+                "[2, 1]| 1\n" +
+                "[1, 2]| 2\n" +
+                "[]| 3\n" +
+                "[null]| 4\n" +
+                "NULL| 5\n"
+            )
+        );
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11796

Can be supported by lifting restrictions on array type, done in the first commit and passes tests.

However, there are other things to be considered, quote from https://github.com/crate/crate/pull/12582#issuecomment-1145716745:

1) > - probably won't work when using docvalues for optimized group iterators 
2) > -  should be discussed if we want to do that specially when having in mind that we may remove source storage in future. 

on 1 - we use source lookup for arrays - https://github.com/crate/crate/commit/e3d09834721cd2b74022d5b7185fca17aabb0b27, so group by array will not fall to doc values aggregation  - but it works with regular GroupingCollector, so nothing bad here, rather performance thing?

on 2 - In case we drop source - we will update LuceneReferenceResolver for arrays and will update ArrayMapper to use DocValues as a follow up?

3) Was not sure what to do with `GroupByOnArrayUnsupportedException` - I didn't remove it as it's used in all ColumnsRefs, for example:
https://github.com/crate/crate/blob/b8f5bfc1ae1d34b0426f2a01217fde663505225b/server/src/main/java/io/crate/expression/reference/doc/lucene/LongColumnReference.java#L51
and Optimised iterator https://github.com/crate/crate/blob/ffba331c0f012b8143ad233fe2b036938730b889/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java#L324
it seems to me that it's unreachable code(?) and if it's showed it indicates a bug ( for example https://github.com/crate/crate/issues/10045) - but I decided to keep the exception with slightly updated message to understand better a failing scenario if it happens.

