### PR TITLE
Documentation: Fix broken links

### DIFF
--- a/docs/config/environment.rst
+++ b/docs/config/environment.rst
@@ -119,7 +119,7 @@ General
       Make sure there is enough disk space available for heap dumps.
 
 
-.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-unix-macos-windows
-.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/install.html#linux
-.. _CrateDB on Docker: https://crate.io/docs/crate/tutorials/en/latest/install.html#docker
+.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/basic/
+.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#linux
+.. _CrateDB on Docker: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#docker
 .. _environment variables: https://en.wikipedia.org/wiki/Environment_variable

--- a/docs/config/logging.rst
+++ b/docs/config/logging.rst
@@ -166,8 +166,8 @@ garbage collection logging.
   If you have installed `a CrateDB Linux package`_, the default directory is
   ``/var/log/crate`` instead.
 
-.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-unix-macos-windows
-.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/install.html#linux
+.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/basic/
+.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#linux
 
 .. _conf-logging-gc-log-size:
 


### PR DESCRIPTION
This patch just fixes a few links to the `crate-tutorials` documentation. The change was originating from https://github.com/crate/crate-tutorials/pull/81.