### PR TITLE
Gradle cleanup & mockito upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,7 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-import java.nio.file.Paths
-import org.apache.tools.ant.filters.ReplaceTokens;
+import org.apache.tools.ant.filters.ReplaceTokens
 
 apply plugin: 'distribution'
 apply from: "$rootDir/gradle/javaModule.gradle"
@@ -69,7 +68,7 @@ dependencies {
     impl "org.graalvm.sdk:graal-sdk:${versions.graalvm}"
     impl "org.graalvm.truffle:truffle-api:${versions.graalvm}"
 
-    impl('org.apache.xbean:xbean-finder:4.5') {
+    impl("org.apache.xbean:xbean-finder:${versions.xbeanfinder}") {
         exclude group: 'org.apache.xbean', module: 'xbean-asm-util'
     }
     impl "com.google.code.findbugs:jsr305:${versions.jsr305}"

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,9 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-import org.gradle.api.JavaVersion
-import io.crate.gradle.TestLogger;
+import com.github.jk1.license.filter.LicenseBundleNormalizer
+import com.github.jk1.license.render.InventoryMarkdownReportRenderer
+import io.crate.gradle.TestLogger
 
 buildscript {
     repositories {
@@ -177,8 +178,8 @@ allprojects {
     }
 }
 
-final testLogger = new TestLogger();
-project.gradle.addListener(testLogger);
+final testLogger = new TestLogger()
+project.gradle.addListener(testLogger)
 
 
 task jacocoReport(type: JacocoReport) {
@@ -278,8 +279,6 @@ idea {
     }
 }
 
-import com.github.jk1.license.render.InventoryMarkdownReportRenderer;
-import com.github.jk1.license.filter.LicenseBundleNormalizer;
 task generateLicenseNotes() {
     // Generate report about the licenses of the dependencies.
     // This task is an improved variant of the vanilla "generateLicenseReport".

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation 'org.apache.commons:commons-compress:1.20'
-    testImplementation "junit:junit:4.12"
+    testImplementation "junit:junit:4.13.2"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.27.0"
 }

--- a/extensions/lang-js/build.gradle
+++ b/extensions/lang-js/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     testImplementation(testFixtures(project(':server')))
     testImplementation(testFixtures(project(':libs:dex')))
-    testImplementation 'org.skyscreamer:jsonassert:1.3.0'
+    testImplementation "org.skyscreamer:jsonassert:${versions.jsonassert}"
     testImplementation "junit:junit:${versions.junit}"
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
         because 'allows JUnit 3 and JUnit 4 tests to run'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -64,16 +64,16 @@ allprojects {
             force "io.netty:netty-handler:${versions.netty4}"
             force "io.netty:netty-resolver:${versions.netty4}"
             force "io.netty:netty-transport:${versions.netty4}"
-            force 'net.sf.jopt-simple:jopt-simple:5.0.2'
+            force "net.sf.jopt-simple:jopt-simple:${versions.jopt_simple}"
 
             // ensure to check following dependencies and their versions against those of HDFS plugin libs
             // https://crate.io/docs/reference/en/latest/sql/snapshot_restore.html
-            force "org.codehaus.jackson:jackson-core-asl:${versions.jacksonasl}"
-            force "org.codehaus.jackson:jackson-mapper-asl:${versions.jacksonasl}"
+            force "org.codehaus.jackson:jackson-core-asl:${versions.jackson_asl}"
+            force "org.codehaus.jackson:jackson-mapper-asl:${versions.jackson_asl}"
             force "org.codehaus.jackson:jackson-jaxrs:${versions.jackson_jaxrs}"
             force "org.codehaus.jackson:jackson-xc:${versions.jackson_xc}"
             force "com.google.code.findbugs:jsr305:${versions.jsr305}"
-            force "commons-lang:commons-lang:2.6"
+            force "commons-lang:commons-lang:${versions.commonslang}"
             force "org.apache.logging.log4j:log4j-api:${versions.log4j2}"
             force "org.apache.logging.log4j:log4j-core:${versions.log4j2}"
         }

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,19 +1,28 @@
 # crate and components deps
 antlr=4.9.3
 jodatime=2.10.1
+bouncycastle=1.68
+caffeine=3.0.5
 commonscli=1.3.1
 commonsmath=3.6.1
+commonslang=2.6
 commonslang3=3.5
 netty4=4.1.77.Final
 jsr305=3.0.1
 aws=1.11.1021
+hdrhistogram=2.1.9
 jaxb_api=2.2.2
 jopt_simple=5.0.2
+jsonassert=1.5.1
+tdigest=3.2
+xbeanfinder=4.5
 
 jackson=2.11.2
+jackson_annotations=2.6.0
+jackson_asl=1.9.13
+jackson_databind=2.6.7.1
 jackson_jaxrs=1.9.13
 jackson_xc=1.9.13
-jacksonasl=1.9.13
 
 crate_admin_ui = 1.22.1
 jdbc=42.3.5

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -49,7 +49,7 @@ httpcore=4.4.15
 commonslogging=1.1.3
 commonscodec=1.10
 hamcrest=2.1
-mockito=3.4.0
+mockito=4.6.1
 carrotsearch_hppc:0.8.2
 quickcheck=1.0
 

--- a/plugins/es-repository-s3/build.gradle
+++ b/plugins/es-repository-s3/build.gradle
@@ -11,9 +11,9 @@ dependencies {
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     implementation "commons-logging:commons-logging:${versions.commonslogging}"
     implementation "commons-codec:commons-codec:${versions.commonscodec}"
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.6.0'
-    implementation 'javax.xml.bind:jaxb-api:2.2.2'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jacksond_atabind}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
+    implementation "javax.xml.bind:jaxb-api:${versions.jaxb_api}"
 
     testImplementation(testFixtures(project(':server')))
     testImplementation "junit:junit:${versions.junit}"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -95,11 +95,11 @@ dependencies {
 
     implementation "net.java.dev.jna:jna:${versions.jna}"
 
-    implementation "com.tdunning:t-digest:3.2"
-    implementation "org.hdrhistogram:HdrHistogram:2.1.9"
+    implementation "com.tdunning:t-digest:${versions.tdigest}"
+    implementation "org.hdrhistogram:HdrHistogram:${versions.hdrhistogram}"
     implementation "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
 
-    implementation ("com.github.ben-manes.caffeine:caffeine:3.0.5") {
+    implementation ("com.github.ben-manes.caffeine:caffeine:${versions.caffeine}") {
         exclude group: 'org.checkerframework', module: 'checker-qual'
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
@@ -120,7 +120,7 @@ dependencies {
     testRuntimeOnly "org.apache.lucene:lucene-codecs:${versions.lucene}"
     testImplementation "com.pholser:junit-quickcheck-core:${versions.quickcheck}"
     testImplementation "com.pholser:junit-quickcheck-generators:${versions.quickcheck}"
-    testImplementation 'org.skyscreamer:jsonassert:1.3.0'
+    testImplementation "org.skyscreamer:jsonassert:${versions.jsonassert}"
     testImplementation "junit:junit:${versions.junit}"
     testFixturesApi "org.junit.jupiter:junit-jupiter:${versions.junit5}"
     testRuntimeOnly ("org.junit.vintage:junit-vintage-engine") {
@@ -128,7 +128,7 @@ dependencies {
     }
 
     // Required to use SelfSignedCertificate from netty
-    testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:1.68"
+    testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
 
     testFixturesApi(testFixtures(project(':libs:dex')))
     testFixturesApi "org.apache.lucene:lucene-test-framework:${versions.lucene}"

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutorTests.java
@@ -19,6 +19,19 @@
 
 package org.elasticsearch.cluster.coordination;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -27,19 +40,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.test.ESTestCase;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class NodeRemovalClusterStateTaskExecutorTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
@@ -18,6 +18,18 @@
  */
 package org.elasticsearch.gateway;
 
+import static org.elasticsearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexGraveyard;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -28,18 +40,6 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.Map;
-
-import static org.elasticsearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class DanglingIndicesStateTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -18,6 +18,28 @@
  */
 package org.elasticsearch.gateway;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThan;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,28 +73,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import io.crate.common.collections.Tuple;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.lessThan;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 

--- a/server/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
@@ -20,6 +20,10 @@ package org.elasticsearch.index.shard;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,11 +50,6 @@ import org.elasticsearch.index.translog.TestTranslog;
 import org.elasticsearch.index.translog.Translog;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 
 public class PrimaryReplicaSyncerTests extends IndexShardTestCase {
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -66,11 +65,11 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
@@ -554,7 +553,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         doAnswer(invocation -> {
             ((ActionListener<Releasable>)invocation.getArguments()[0]).onResponse(() -> {});
             return null;
-        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), anyObject());
+        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), any());
 
         final IndexMetadata.Builder indexMetadata = IndexMetadata.builder("test").settings(Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0,5))
@@ -743,7 +742,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             freed.set(false);
             ((ActionListener<Releasable>)invocation.getArguments()[0]).onResponse(() -> freed.set(true));
             return null;
-        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), anyObject());
+        }).when(shard).acquirePrimaryOperationPermit(any(), anyString(), any());
 
         Thread cancelingThread = new Thread(() -> cancellableThreads.cancel("test"));
         cancelingThread.start();
@@ -824,7 +823,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                     startingSeqNo,
                     threadPool.absoluteTimeInMillis(),
                     ReplicationTracker.PEER_RECOVERY_RETENTION_LEASE_SOURCE));
-            };
+            }
 
         };
         cancelRecovery.set(() -> handler.cancel("test"));

--- a/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -19,7 +19,34 @@
 
 package org.elasticsearch.repositories.blobstore;
 
-import io.crate.common.unit.TimeValue;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
 import org.apache.lucene.util.SameThreadExecutorService;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
@@ -49,33 +76,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.NoSuchFileException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import io.crate.common.unit.TimeValue;
 
 public final class BlobStoreTestUtil {
 
@@ -233,7 +234,7 @@ public final class BlobStoreTestUtil {
                     (e) -> {}
                 )
             );
-        };
+        }
         maxShardCountsSeen.forEach(((indexId, count) -> assertThat("Found unreferenced shard paths for index [" + indexId + "]",
                                                                    count, lessThanOrEqualTo(maxShardCountsExpected.get(indexId)))));
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Add and use properties file for all dependencies
- Upgrade version for mockito, This is a prerequisite to avoid version conflicts of `net.bytebuddy:byte-buddy` when we add dependency to `assertj`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
