### PR TITLE
fix gradle dependency typo

### DIFF
--- a/plugins/es-repository-s3/build.gradle
+++ b/plugins/es-repository-s3/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     implementation "commons-logging:commons-logging:${versions.commonslogging}"
     implementation "commons-codec:commons-codec:${versions.commonscodec}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jacksond_atabind}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     implementation "javax.xml.bind:jaxb-api:${versions.jaxb_api}"
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix gradle dependency typo

Follows: https://github.com/crate/crate/commit/d8b05ac849a40249de148b5622ce6bda203d76c5
 
## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
