### PR TITLE
Try to fix flaky testInsertFromClosedTableNotAllowed

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -455,6 +455,7 @@ public class SysShardsTest extends SQLIntegrationTestCase {
         execute("create table doc.tbl (x int)");
         execute("insert into doc.tbl values(1)");
         execute("alter table doc.tbl close");
+        waitNoPendingTasksOnAll(); // ensure close is processed
         assertThrowsMatches(() -> execute("insert into doc.tbl values(2)"),
                      OperationOnInaccessibleRelationException.class,
                      "The relation \"doc.tbl\" doesn't support or allow INSERT operations, as it is currently closed.");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The alter table close might not be fully processed, leading to a:

    Expected: an instance of io.crate.exceptions.OperationOnInaccessibleRelationException
         but: <org.elasticsearch.cluster.block.ClusterBlockException: blocked by: [FORBIDDEN/4/Table or partition preparing to close. Reopen the table to allow writes again or retry closing the table to fully close it.];> is a org.elasticsearch.cluster.block.ClusterBlockException

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
