### PR TITLE
Reduce overhead of TimestampType.explicit/implicitCast on non-number strings

### DIFF
--- a/benchmarks/src/main/java/io/crate/common/StringUtilsBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/common/StringUtilsBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.common;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@Fork(value = 2)
+@Measurement(iterations = 3)
+public class StringUtilsBenchmark {
+
+    @Benchmark
+    public Long measure_Long_parseLong_valid() {
+        try {
+            return Long.parseLong("1658149133924");
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    @Benchmark
+    public Long measure_Long_parseLong_invalid() {
+        try {
+            return Long.parseLong("2022-07-18");
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    @Benchmark
+    public Long measure_StringUtils_tryParseLong_valid() {
+        long[] out = StringUtils.PARSE_LONG_BUFFER.get();
+        if (StringUtils.tryParseLong("1658149133924", out)) {
+            return out[0];
+        }
+        return null;
+    }
+
+    @Benchmark
+    public Long measure_StringUtils_tryParseLong_invalid() {
+        long[] out = StringUtils.PARSE_LONG_BUFFER.get();
+        if (StringUtils.tryParseLong("2022-07-18", out)) {
+            return out[0];
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`Long.parseLong` has quite some overhead on inputs that don't parse
successfully due to filling in the stacktrace of the
NumberFormatException that's raised.

This adds a `tryParseLong` variant that is cheaper when parsing fails.

    Benchmark                                                      Mode  Cnt  Score    Error  Units
    StringUtilsBenchmark.measure_Long_parseLong_invalid            avgt    6  1.618 ±  0.034  us/op
    StringUtilsBenchmark.measure_Long_parseLong_valid              avgt    6  0.023 ±  0.001  us/op
    StringUtilsBenchmark.measure_StringUtils_tryParseLong_invalid  avgt    6  0.012 ±  0.001  us/op
    StringUtilsBenchmark.measure_StringUtils_tryParseLong_valid    avgt    6  0.026 ±  0.001  us/op

I noticed that this has quite a big impact on COPY FROM imports where
CSV data contains timestamps


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
