### PR TITLE
Run tests on windows only nightly instead of on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Gradle Java
@@ -25,7 +25,7 @@ jobs:
         env:
           CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
         with:
-          arguments: :server:test -Dtests.crate.run-windows-incompatible=${{ matrix.os == 'ubuntu-latest' }}
+          arguments: :server:test -Dtests.crate.run-windows-incompatible=true
 
 
   forbiddenApis:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,28 @@
+---
+name: Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  test:
+    name: Test CrateDB SQL on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Gradle Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Run tests on ${{ matrix.os }}
+        uses: eskatos/gradle-command-action@v1
+        env:
+          CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
+        with:
+          arguments: :server:test -Dtests.crate.run-windows-incompatible=false

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ queue_rules:
     conditions:
       - check-success=ci/jenkins/pr_tests
       - check-success~=^Test CrateDB SQL on ubuntu
-      - check-success~=^Test CrateDB SQL on windows
       - check-success=docs/readthedocs.org:crate
       - check-success~=^checkstyle
       - check-success~=^Vale
@@ -17,7 +16,6 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - status-success=ci/jenkins/pr_tests
       - status-success~=^Test CrateDB SQL on ubuntu
-      - status-success~=^Test CrateDB SQL on windows
       - status-success=docs/readthedocs.org:crate
       - status-success~=^checkstyle
       - status-success~=^Vale


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Windows runners are slow, taking 40-50 minutes compared to ~10 minutes
(Jenkins) or ~20 minutes (GHA linux)

Most of our code is platform independent. It should be good enough to
detect windows specific issues with a nightly run instead of on a PR.

Running it on Jenkins windows-runners would be an option, but we'd
probably need more slaves given our PR load. I think that's currently
not justified.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
