### PR TITLE
Fix linkcheck failure

### DIFF
--- a/docs/appendices/release-notes/4.6.0.rst
+++ b/docs/appendices/release-notes/4.6.0.rst
@@ -31,8 +31,7 @@ Released on 2021-07-13.
 Deprecations
 ============
 
-- Deprecated the :ref:`node.max_local_storage_nodes
-  <node.max_local_storage_nodes>` setting.
+- Deprecated the ``node.max_local_storage_nodes`` setting.
 
 
 Changes


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We removed the `node.max_local_storage_nodes` setting with 5.0.0. The
reason the link kept working so far is because inter-sphinx is enabled
and the released documentation still contained the link.

With 5.0.0 having moved to stable this is no longer the case.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
