### PR TITLE
Use configured timeout on dynamic mapping updates

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/SchemaUpdateClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/SchemaUpdateClient.java
@@ -60,7 +60,9 @@ public class SchemaUpdateClient {
 
     public void blockingUpdateOnMaster(Index index, Mapping mappingUpdate) {
         TimeValue timeout = this.dynamicMappingUpdateTimeout;
-        var response = FutureUtils.get(schemaUpdateAction.execute(new SchemaUpdateRequest(index, mappingUpdate.toString())));
+        SchemaUpdateRequest request = new SchemaUpdateRequest(index, mappingUpdate.toString());
+        request.masterNodeTimeout(timeout);
+        var response = FutureUtils.get(schemaUpdateAction.execute(request), timeout);
         if (!response.isAcknowledged()) {
             throw new ElasticsearchTimeoutException("Failed to acknowledge mapping update within [" + timeout + "]");
         }

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
@@ -259,7 +259,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         internalCluster.startNodes(3,
                                    Settings.builder()
                                        .put(SchemaUpdateClient.INDICES_MAPPING_DYNAMIC_TIMEOUT_SETTING.getKey(),
-                                            "1ms")
+                                            "500ms")
                                        .build()
         );
         ensureStableCluster(3);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Should speed up `testMappingNewFieldsTimeoutDoesntAffectCheckpoints`
No release notes entry because the setting is undocumented.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
