### PR TITLE
Support selecting _doc['child-col'] with primary key lookups

### DIFF
--- a/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -41,7 +41,10 @@ import io.crate.types.DataTypes;
 public class SemanticSortValidator {
 
     private static final InnerValidator INNER_VALIDATOR = new InnerValidator();
-    private static final Set<Integer> SUPPORTED_TYPES = Stream.concat(
+
+    // Instead of this we should probably have a property on DataType
+    // that indicates if ordering is supported and encapsulate the required functionality somehow
+    public static final Set<Integer> SUPPORTED_TYPES = Stream.concat(
         DataTypes.PRIMITIVE_TYPES.stream(),
         Stream.of(
             DataTypes.REGCLASS,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

No changes/fix because we don't document `_doc` in the systems-columns
documentation.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
