### PR TITLE
Fix resolveNodeId error handling in ShardDMLExecutor

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,6 +67,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed a race condition that could cause a ``INSERT INTO`` operation to get
+  stuck.
+
 - Fixed an issue that could cause queries with ``objectColumn = ?`` expressions
   to fail if the object contains inner arrays.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`resolveNodeId` in `ShardDMLExecutor` could raise an exception that
wasn't caught by `BatchIteratorBackpressureExecutor`. This could lead to
an operation getting stuck.

`testInsertToPartitionFromQuery` failed with:

    java.lang.AssertionError: All incoming requests on node [node_s1] should have finished. Expected 0 but got 2456
    Expected: <0L>
         but: was <2456L>
            at __randomizedtesting.SeedInfo.seed([10627E584D438717:877660B1673F5B1]:0)
            at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
            at org.junit.Assert.assertThat(Assert.java:964)
            at org.elasticsearch.test.InternalTestCluster.lambda$assertRequestsFinished$38(InternalTestCluster.java:2219)
            at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:741)
            at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:715)
            at org.elasticsearch.test.InternalTestCluster.assertRequestsFinished(InternalTestCluster.java:2216)
            at org.elasticsearch.test.InternalTestCluster.assertAfterTest(InternalTestCluster.java:2195)
            at org.elasticsearch.test.ESIntegTestCase.afterInternal(ESIntegTestCase.java:440)
            at org.elasticsearch.test.ESIntegTestCase.cleanUpCluster(ESIntegTestCase.java:1299)

and:

    Cause 5: com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=997, name=cratedb[node_s1][scheduler][T#10], state=RUNNABLE, group=TGRP-PartitionedTableIntegrationTest]
    Caused by: [bs..partitioned.my_table.04132/tZM4exSMQkqYr8f-BLh7MQ] org.elasticsearch.index.IndexNotFoundException: no such index
            at __randomizedtesting.SeedInfo.seed([10627E584D438717]:0)
            at app//org.elasticsearch.cluster.routing.RoutingTable.shardRoutingTable(RoutingTable.java:150)
            at app//io.crate.execution.engine.indexing.ShardDMLExecutor.resolveNodeId(ShardDMLExecutor.java:123)
            at app//io.crate.execution.engine.indexing.ShardDMLExecutor.lambda$apply$4(ShardDMLExecutor.java:160)
            at app//io.crate.execution.engine.indexing.BatchIteratorBackpressureExecutor.resumeConsumption(BatchIteratorBackpressureExecutor.java:214)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
