### PR TITLE
Handle arrays within objects in EqOperator

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,5 +67,8 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could cause queries with ``objectColumn = ?`` expressions
+  to fail if the object contains inner arrays.
+
 - Fixed a ``NullPointerException`` when using a ``IS NULL`` expression on an
   object column that just had a child column added.

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -204,7 +204,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                 if (cmpVal == 0) {
                     return IsNullPredicate.refExistsQuery(arrayRef, context);
                 } else if (cmpVal == 1) {
-                    return NumTermsPerDocQuery.forArray(arrayRef, valueCountIsMatch);
+                    return NumTermsPerDocQuery.forRef(arrayRef, valueCountIsMatch);
                 } else {
                     return genericFunctionFilter(parent, context);
                 }
@@ -234,7 +234,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
         query.setMinimumNumberShouldMatch(1);
         return query
             .add(
-                NumTermsPerDocQuery.forArray(arrayRef, valueCountIsMatch),
+                NumTermsPerDocQuery.forRef(arrayRef, valueCountIsMatch),
                 BooleanClause.Occur.SHOULD
             )
             .add(genericFunctionFilter(parent, context), BooleanClause.Occur.SHOULD)
@@ -247,7 +247,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                                                  IntPredicate valueCountIsMatch) {
         return new BooleanQuery.Builder()
             .add(
-                NumTermsPerDocQuery.forArray(arrayRef, valueCountIsMatch),
+                NumTermsPerDocQuery.forRef(arrayRef, valueCountIsMatch),
                 BooleanClause.Occur.MUST
             )
             .add(genericFunctionFilter(parent, context), BooleanClause.Occur.FILTER)

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.locationtech.spatial4j.shape.Point;
 
 import io.crate.Streamer;
 import io.crate.common.collections.Lists2;
@@ -227,6 +228,11 @@ public class ArrayType<T> extends DataType<List<T>> {
                     throw new IllegalArgumentException("Cannot parse `" + value + "` as array", e);
                 }
             }
+        } else if (value instanceof Point point && DataTypes.isNumericPrimitive(innerType)) {
+            // As per docs: [<lon_value>, <lat_value>]
+            return (List<T>) List.of(
+                innerType.sanitizeValue(point.getLon()),
+                innerType.sanitizeValue(point.getLat()));
         } else {
             return convertObjectArray((Object[]) value, convertInner);
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The EqOperator tried to create a `termQuery` (via `fromPrimitive`) for
arrays within objects instead of using the array logic.

Detected this via the new
`test_types_with_storage_can_be_inserted_and_queried` test with seed
`AA9715AB421D53E7`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
