### PR TITLE
Fix flaky test_types_with_storage_can_be_inserted_and_queried

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2014,11 +2014,19 @@ public class TransportSQLActionTest extends SQLIntegrationTestCase {
             execute("refresh table tbl");
 
             var resp1 = execute("select _doc['x'], x, _raw FROM tbl where x = ?", new Object[] { val1 });
-            assertThat(
-                "inserted value must match selected value for type " + type,
-                ((DataType) type).compare(resp1.rows()[0][1], val1),
-                is(0)
-            );
+            Object x = resp1.rows()[0][1];
+            boolean hasPrecisionChange = false;
+            if (val1 instanceof Map<?, ?> map) {
+                Object x1 = map.get("x");
+                hasPrecisionChange = x1 instanceof Map<?, ?> innerMap && innerMap.containsKey("coordinates");
+            }
+            if (!hasPrecisionChange) {
+                assertThat(
+                    "inserted value must match selected value for type " + type + ": val=" + val1 + " response=" + x,
+                    ((DataType) type).compare(x, val1),
+                    is(0)
+                );
+            }
 
             var resp2 = execute("select _doc['x'], x, _raw FROM tbl where id = ?", new Object[] { 1 });
             assertThat(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If the object type randomly uses a shape as inner type the value
comparison from selected & inserted value fails due to floating point
inaccuracies.
This skips the comparison

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
