### PR TITLE
Replace deprecated Tuple in XContentHelper.convertToMap

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -153,7 +153,7 @@ public class DocTableInfoFactory {
         } catch (Exception e) {
             try {
                 LOGGER.error(
-                    "Could not build DocIndexMetadata from: {}", indexMetadata.mapping().getSourceAsMap());
+                    "Could not build DocIndexMetadata from: {}", indexMetadata.mapping().sourceAsMap());
             } catch (Exception ignored) {
             }
             throw e;

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -66,7 +66,7 @@ public class MetadataIndexUpgrader implements UnaryOperator<IndexMetadata> {
         if (mappingMetadata == null) { // blobs have no mappingMetadata
             return null;
         }
-        Map<String, Object> oldMapping = mappingMetadata.getSourceAsMap();
+        Map<String, Object> oldMapping = mappingMetadata.sourceAsMap();
         LinkedHashMap<String, Object> newMapping = new LinkedHashMap<>(oldMapping.size());
         for (Map.Entry<String, Object> entry : oldMapping.entrySet()) {
             String fieldName = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -354,7 +354,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * The template source definition.
      */
     public PutIndexTemplateRequest source(BytesReference source, XContentType xContentType) {
-        return source(XContentHelper.convertToMap(source, true, xContentType).v2());
+        return source(XContentHelper.convertToMap(source, true, xContentType).map());
     }
 
     public Set<Alias> aliases() {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -438,7 +438,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
                 builder.startObject("mappings");
                 for (ObjectObjectCursor<String, CompressedXContent> cursor1 : templateMetadata.mappings()) {
-                    Map<String, Object> mapping = XContentHelper.convertToMap(new BytesArray(cursor1.value.uncompressed()), false).v2();
+                    Map<String, Object> mapping = XContentHelper.convertToMap(new BytesArray(cursor1.value.uncompressed()), false).map();
                     if (mapping.size() == 1 && mapping.containsKey(cursor1.key)) {
                         // the type name is the root value, reduce it
                         mapping = (Map<String, Object>) mapping.get(cursor1.key);
@@ -468,7 +468,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
                 MappingMetadata mmd = indexMetadata.mapping();
                 if (mmd != null) {
                     Map<String, Object> mapping = XContentHelper
-                            .convertToMap(new BytesArray(mmd.source().uncompressed()), false).v2();
+                            .convertToMap(new BytesArray(mmd.source().uncompressed()), false).map();
                     if (mapping.size() == 1 && mapping.containsKey(mmd.type())) {
                         // the type name is the root value, reduce it
                         mapping = (Map<String, Object>) mapping.get(mmd.type());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
@@ -303,7 +303,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
                 if (binary) {
                     builder.field("filter", aliasMetadata.filter.compressed());
                 } else {
-                    builder.field("filter", XContentHelper.convertToMap(new BytesArray(aliasMetadata.filter().uncompressed()), true).v2());
+                    builder.field("filter", XContentHelper.convertToMap(new BytesArray(aliasMetadata.filter().uncompressed()), true).map());
                 }
             }
             if (aliasMetadata.indexRouting() != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1134,7 +1134,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 if (binary) {
                     builder.value(mmd.source().compressed());
                 } else {
-                    builder.map(XContentHelper.convertToMap(new BytesArray(mmd.source().uncompressed()), true).v2());
+                    builder.map(XContentHelper.convertToMap(new BytesArray(mmd.source().uncompressed()), true).map());
                 }
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -344,7 +344,7 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
                 builder.startObject("mappings");
                 for (ObjectObjectCursor<String, CompressedXContent> cursor : indexTemplateMetadata.mappings()) {
                     byte[] mappingSource = cursor.value.uncompressed();
-                    Map<String, Object> mapping = XContentHelper.convertToMap(new BytesArray(mappingSource), true).v2();
+                    Map<String, Object> mapping = XContentHelper.convertToMap(new BytesArray(mappingSource), true).map();
                     if (mapping.size() == 1 && mapping.containsKey(cursor.key)) {
                         // the type name is the root value, reduce it
                         mapping = (Map<String, Object>) mapping.get(cursor.key);
@@ -357,7 +357,7 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
                 builder.startArray("mappings");
                 for (ObjectObjectCursor<String, CompressedXContent> cursor : indexTemplateMetadata.mappings()) {
                     byte[] data = cursor.value.uncompressed();
-                    builder.map(XContentHelper.convertToMap(new BytesArray(data), true).v2());
+                    builder.map(XContentHelper.convertToMap(new BytesArray(data), true).map());
                 }
                 builder.endArray();
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -51,7 +51,7 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
 
     public MappingMetadata(CompressedXContent mapping) throws IOException {
         this.source = mapping;
-        Map<String, Object> mappingMap = XContentHelper.convertToMap(mapping.compressedReference(), true).v2();
+        Map<String, Object> mappingMap = XContentHelper.convertToMap(mapping.compressedReference(), true).map();
         if (mappingMap.size() != 1) {
             throw new IllegalStateException("Can't derive type from mapping, no root type: " + mapping.string());
         }
@@ -86,7 +86,7 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
      */
     @SuppressWarnings("unchecked")
     public Map<String, Object> sourceAsMap() throws ElasticsearchParseException {
-        Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true).v2();
+        Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true).map();
         if (mapping.size() == 1 && mapping.containsKey(type())) {
             // the type name is the root value, reduce it
             mapping = (Map<String, Object>) mapping.get(type());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -94,13 +94,6 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
         return mapping;
     }
 
-    /**
-     * Converts the serialized compressed form of the mappings into a parsed map.
-     */
-    public Map<String, Object> getSourceAsMap() throws ElasticsearchParseException {
-        return sourceAsMap();
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(type());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -412,7 +412,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         if (fieldPredicate == MapperPlugin.NOOP_FIELD_PREDICATE) {
             return mappingMetadata;
         }
-        Map<String, Object> sourceAsMap = XContentHelper.convertToMap(mappingMetadata.source().compressedReference(), true).v2();
+        Map<String, Object> sourceAsMap = XContentHelper.convertToMap(mappingMetadata.source().compressedReference(), true).map();
         Map<String, Object> mapping;
         if (sourceAsMap.size() == 1 && sourceAsMap.containsKey(mappingMetadata.type())) {
             mapping = (Map<String, Object>) sourceAsMap.get(mappingMetadata.type());

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ParsedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ParsedXContent.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.common.xcontent;
+
+import java.util.Map;
+
+public record ParsedXContent(XContentType type, Map<String, Object> map) {
+}

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -19,16 +19,6 @@
 
 package org.elasticsearch.common.xcontent;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
-import io.crate.common.collections.Tuple;
-import org.elasticsearch.common.compress.Compressor;
-import org.elasticsearch.common.compress.CompressorFactory;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
-
-import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +28,16 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.Compressor;
+import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
 
 @SuppressWarnings("unchecked")
 public class XContentHelper {
@@ -86,8 +86,7 @@ public class XContentHelper {
      *             instead with the proper {@link XContentType}
      */
     @Deprecated
-    public static Tuple<XContentType, Map<String, Object>> convertToMap(BytesReference bytes, boolean ordered)
-            throws ElasticsearchParseException {
+    public static ParsedXContent convertToMap(BytesReference bytes, boolean ordered) throws ElasticsearchParseException {
         return convertToMap(bytes, ordered, null);
     }
 
@@ -120,13 +119,13 @@ public class XContentHelper {
     /**
      * Converts the given bytes into a map that is optionally ordered.
      */
-    public static Tuple<XContentType, Map<String, Object>> convertToMap(BytesReference bytes, boolean ordered, @Nullable XContentType xContentType)
+    public static ParsedXContent convertToMap(BytesReference bytes, boolean ordered, @Nullable XContentType xContentType)
         throws ElasticsearchParseException {
         try {
             final XContentType contentType;
             try (InputStream input = getUncompressedInputStream(bytes)) {
                 contentType = xContentType != null ? xContentType : XContentFactory.xContentType(input);
-                return new Tuple<>(Objects.requireNonNull(contentType), convertToMap(XContentFactory.xContent(contentType), input, ordered));
+                return new ParsedXContent(Objects.requireNonNull(contentType), convertToMap(XContentFactory.xContent(contentType), input, ordered));
             }
         } catch (IOException e) {
             throw new ElasticsearchParseException("Failed to parse content to map", e);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -75,7 +75,7 @@ public class DocumentMapperParser {
     public DocumentMapper parse(CompressedXContent source) throws MapperParsingException {
         Map<String, Object> mapping = null;
         if (source != null) {
-            Map<String, Object> root = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
+            Map<String, Object> root = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).map();
             mapping = extractMapping(root);
         }
         if (mapping == null) {

--- a/server/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/GeneratedColumnsTest.java
@@ -80,7 +80,7 @@ public class GeneratedColumnsTest extends CrateDummyClusterServiceUnitTest {
             1,
             1,
             1,
-            XContentHelper.convertToMap(bytes, false, XContentType.JSON).v2(),
+            XContentHelper.convertToMap(bytes, false, XContentType.JSON).map(),
             bytes::utf8ToString
         ));
         Map.Entry<? extends Reference, Input<?>> generatedColumn = generatedColumns.generatedToInject().iterator().next();

--- a/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
+++ b/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
@@ -54,7 +54,7 @@ public class DocRefResolverTest extends ESTestCase {
                                                   1L,
                                                   1L,
                                                   1L,
-                                                  XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).v2(),
+                                                  XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).map(),
                                                   SOURCE::utf8ToString);
 
     @Test
@@ -78,7 +78,7 @@ public class DocRefResolverTest extends ESTestCase {
 
         assertThat(collectExpressions.get(0).value(), is("abc"));
         assertThat(collectExpressions.get(1).value(), is(1L));
-        assertThat(collectExpressions.get(2).value(), is(XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).v2()));
+        assertThat(collectExpressions.get(2).value(), is(XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).map()));
         assertThat(collectExpressions.get(3).value(), is(SOURCE.utf8ToString()));
         assertThat(collectExpressions.get(4).value(), is(2));
         assertThat(collectExpressions.get(5).value(), is(1L));

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -49,6 +49,7 @@ import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResp
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.ParsedXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -56,7 +57,6 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import io.crate.Constants;
-import io.crate.common.collections.Tuple;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnPolicy;
@@ -390,10 +390,10 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
         IndexTemplateMetadata template = response.getIndexTemplates().get(0);
         CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(mappingStr, is(notNullValue()));
-        Tuple<XContentType, Map<String, Object>> typeAndMap =
+        ParsedXContent typeAndMap =
             XContentHelper.convertToMap(mappingStr.compressedReference(), false, XContentType.JSON);
         @SuppressWarnings("unchecked")
-        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.v2().get(Constants.DEFAULT_MAPPING_TYPE);
+        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.map().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(decodeMappingValue(mapping.get("dynamic")), is(ColumnPolicy.STRICT));
 
         execute("insert into numbers (num, odd, prime) values (?, ?, ?)",
@@ -429,9 +429,9 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
         IndexTemplateMetadata template = response.getIndexTemplates().get(0);
         CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(mappingStr, is(notNullValue()));
-        Tuple<XContentType, Map<String, Object>> typeAndMap = XContentHelper.convertToMap(mappingStr.compressedReference(), false);
+        ParsedXContent typeAndMap = XContentHelper.convertToMap(mappingStr.compressedReference(), false);
         @SuppressWarnings("unchecked")
-        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.v2().get(Constants.DEFAULT_MAPPING_TYPE);
+        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.map().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(decodeMappingValue(mapping.get("dynamic")), is(ColumnPolicy.STRICT));
 
         execute("insert into numbers (num, odd, prime) values (?, ?, ?)",
@@ -466,9 +466,9 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
         IndexTemplateMetadata template = templateResponse.getIndexTemplates().get(0);
         CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(mappingStr, is(notNullValue()));
-        Tuple<XContentType, Map<String, Object>> typeAndMap = XContentHelper.convertToMap(mappingStr.compressedReference(), false);
+        ParsedXContent typeAndMap = XContentHelper.convertToMap(mappingStr.compressedReference(), false);
         @SuppressWarnings("unchecked")
-        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.v2().get(Constants.DEFAULT_MAPPING_TYPE);
+        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.map().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(mapping.get("dynamic")), is("true"));
 
         execute("insert into numbers (num, odd, prime) values (?, ?, ?)",
@@ -591,10 +591,10 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
         IndexTemplateMetadata template = response.getIndexTemplates().get(0);
         CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(mappingStr, is(notNullValue()));
-        Tuple<XContentType, Map<String, Object>> typeAndMap =
+        ParsedXContent typeAndMap =
             XContentHelper.convertToMap(mappingStr.compressedReference(), false, XContentType.JSON);
         @SuppressWarnings("unchecked")
-        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.v2().get(Constants.DEFAULT_MAPPING_TYPE);
+        Map<String, Object> mapping = (Map<String, Object>) typeAndMap.map().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(decodeMappingValue(mapping.get("dynamic")), is(ColumnPolicy.DYNAMIC));
 
         execute("insert into dynamic_table (id, score, new_col) values (?, ?, ?)",

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -77,11 +77,11 @@ public class ColumnPolicyIntegrationTest extends SQLIntegrationTestCase {
     }
 
     private Map<String, Object> getSourceMap(String index) throws IOException {
-        return getMappingMetadata(getFqn(index)).getSourceAsMap();
+        return getMappingMetadata(getFqn(index)).sourceAsMap();
     }
 
     private Map<String, Object> getSourceMap(String schema, String index) throws IOException {
-        return getMappingMetadata(getFqn(schema, index)).getSourceAsMap();
+        return getMappingMetadata(getFqn(schema, index)).sourceAsMap();
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1640,7 +1640,7 @@ public class PartitionedTableIntegrationTest extends SQLIntegrationTestCase {
                 new RelationName(sqlExecutor.getCurrentSchema(), "dynamic_table"),
                 Collections.singletonList("10.0")).asIndexName())
             .mapping();
-        Map<String, Object> metaMap = (Map) partitionMetadata.getSourceAsMap().get("_meta");
+        Map<String, Object> metaMap = (Map) partitionMetadata.sourceAsMap().get("_meta");
         assertThat(String.valueOf(metaMap.get("partitioned_by")), Matchers.is("[[score, double]]"));
         execute("alter table dynamic_table set (column_policy= 'dynamic')");
         waitNoPendingTasksOnAll();
@@ -1649,7 +1649,7 @@ public class PartitionedTableIntegrationTest extends SQLIntegrationTestCase {
                 new RelationName(sqlExecutor.getCurrentSchema(), "dynamic_table"),
                 Collections.singletonList("10.0")).asIndexName())
             .mapping();
-        metaMap = (Map) partitionMetadata.getSourceAsMap().get("_meta");
+        metaMap = (Map) partitionMetadata.sourceAsMap().get("_meta");
         assertThat(String.valueOf(metaMap.get("partitioned_by")), Matchers.is("[[score, double]]"));
     }
 

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -109,7 +109,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
 
     private IndexMetadata getIndexMetadata(String indexName,
                                            XContentBuilder builder) throws IOException {
-        Map<String, Object> mappingSource = XContentHelper.convertToMap(BytesReference.bytes(builder), true, XContentType.JSON).v2();
+        Map<String, Object> mappingSource = XContentHelper.convertToMap(BytesReference.bytes(builder), true, XContentType.JSON).map();
         mappingSource = sortProperties(mappingSource);
 
         Settings.Builder settingsBuilder = Settings.builder()

--- a/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
@@ -51,7 +51,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
         MappingMetadata mappingMetadata = new MappingMetadata(createDynamicStringMappingTemplate());
         MappingMetadata newMappingMetadata = metadataIndexUpgrader.createUpdatedIndexMetadata(mappingMetadata, "dummy");
 
-        Object dynamicTemplates = newMappingMetadata.getSourceAsMap().get("dynamic_templates");
+        Object dynamicTemplates = newMappingMetadata.sourceAsMap().get("dynamic_templates");
         assertThat(dynamicTemplates, nullValue());
 
         // Check that the new metadata still has the root "default" element

--- a/server/src/testFixtures/java/org/elasticsearch/test/XContentTestUtils.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/XContentTestUtils.java
@@ -55,7 +55,7 @@ public final class XContentTestUtils {
         builder.startObject();
         part.toXContent(builder, EMPTY_PARAMS);
         builder.endObject();
-        return XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+        return XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).map();
     }
 
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
