### PR TITLE
reuse content builder on COPY FROM CSV

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -153,7 +153,7 @@ public class JsonReaderBenchmark {
             List.of("id", "name"),
             CopyFromParserProperties.DEFAULT,
             JSON,
-            Settings.EMPTY);
+            Settings.EMPTY, false);
 
         while (batchIterator.moveNext()) {
             blackhole.consume(batchIterator.currentElement().get(0));

--- a/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
+++ b/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
@@ -252,7 +252,7 @@ public class S3FileReadingCollectorTest extends ESTestCase {
             List.of("id", "name", "details"),
             CopyFromParserProperties.DEFAULT,
             FileUriCollectPhase.InputFormat.JSON,
-            Settings.EMPTY);
+            Settings.EMPTY, true);
     }
 
     private static class WriteBufferAnswer implements Answer<Integer> {

--- a/server/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.collect.files;
 
 import io.crate.analyze.CopyFromParserProperties;
+import io.crate.execution.engine.collect.files.FileReadingIterator.ReusableJsonBuilder;
 import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.operation.collect.files.CSVLineParser;
 
@@ -51,9 +52,10 @@ public class LineParser {
 
     public void readFirstLine(URI currentUri,
                               FileUriCollectPhase.InputFormat inputFormat,
-                              BufferedReader currentReader) throws IOException {
+                              BufferedReader currentReader,
+                              ReusableJsonBuilder reusableJsonBuilder) throws IOException {
         if (isInputCsv(inputFormat, currentUri)) {
-            csvLineParser = new CSVLineParser(parserProperties, targetColumns);
+            csvLineParser = new CSVLineParser(parserProperties, targetColumns, reusableJsonBuilder);
             if (parserProperties.fileHeader()) {
                 csvLineParser.parseHeader(currentReader.readLine());
             }

--- a/server/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/LineProcessor.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.collect.files;
 
 import io.crate.analyze.CopyFromParserProperties;
+import io.crate.execution.engine.collect.files.FileReadingIterator.ReusableJsonBuilder;
 import io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat;
 import io.crate.expression.reference.file.LineContext;
 
@@ -50,8 +51,8 @@ public final class LineProcessor {
         lineContext.currentUri(currentUri);
     }
 
-    void readFirstLine(URI currentUri, InputFormat inputFormat, BufferedReader currentReader) throws IOException {
-        lineParser.readFirstLine(currentUri, inputFormat, currentReader);
+    void readFirstLine(URI currentUri, InputFormat inputFormat, BufferedReader currentReader, ReusableJsonBuilder reusableJsonBuilder) throws IOException {
+        lineParser.readFirstLine(currentUri, inputFormat, currentReader, reusableJsonBuilder);
     }
 
     public void process(String line) throws IOException {

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -90,7 +90,8 @@ public class FileCollectSource implements CollectSource {
             fileUriCollectPhase.targetColumns(),
             fileUriCollectPhase.parserProperties(),
             fileUriCollectPhase.inputFormat(),
-            fileUriCollectPhase.withClauseOptions()
+            fileUriCollectPhase.withClauseOptions(),
+            true
         ));
     }
 

--- a/server/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
+++ b/server/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
@@ -137,7 +137,6 @@ public class CSVLineParser {
     private void reset() throws IOException {
         reusableJsonBuilder.out().reset();
         reusableJsonBuilder.rowItems().clear();
-        reusableJsonBuilder.jsonBuilder().startObject();
     }
 
     /**
@@ -147,6 +146,7 @@ public class CSVLineParser {
      */
     private byte[] getByteArray() throws IOException {
         int notNullCounter = 0;
+        reusableJsonBuilder.jsonBuilder().startObject();
         for (int i = 0; i < columnNamesArray.length; i++) {
             var key = columnNamesArray[i];
             if (key != null) {

--- a/server/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
+++ b/server/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
@@ -146,8 +146,10 @@ public class CSVLineParser {
      */
     private byte[] getByteArray() throws IOException {
         int notNullCounter = 0;
+        // Even if there are not items in the row, we need to start/emd object to create an empty json {}
+        // Verified by parse_givenEmptyRow_thenParsesToEmptyJson
         reusableJsonBuilder.jsonBuilder().startObject();
-        for (int i = 0; i < columnNamesArray.length; i++) {
+        for (int i = 0; i < columnNamesArray.length && notNullCounter < reusableJsonBuilder.rowItems().size(); i++) {
             var key = columnNamesArray[i];
             if (key != null) {
                 reusableJsonBuilder.jsonBuilder().field(key, reusableJsonBuilder.rowItems().get(notNullCounter));

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -249,7 +249,7 @@ public class FileReadingCollectorTest extends ESTestCase {
             List.of("a", "b"),
             CopyFromParserProperties.DEFAULT,
             FileUriCollectPhase.InputFormat.JSON,
-            Settings.EMPTY);
+            Settings.EMPTY, true);
     }
 
     private static class WriteBufferAnswer implements Answer<Integer> {

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -205,7 +205,8 @@ public class FileReadingIteratorTest extends ESTestCase {
                 List.of("name", "id", "age"),
                 CopyFromParserProperties.DEFAULT,
                 JSON,
-                Settings.EMPTY
+                Settings.EMPTY,
+                true
             ) {
 
                 @Override
@@ -254,6 +255,7 @@ public class FileReadingIteratorTest extends ESTestCase {
             List.of("name", "id", "age"),
             CopyFromParserProperties.DEFAULT,
             format,
-            Settings.EMPTY);
+            Settings.EMPTY,
+            true);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -229,7 +229,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         List<Object[]> expectedResult = Arrays.asList(
             new Object[]{CSV_AS_MAP_FIRST_LINE},
-            new Object[]{CSV_AS_MAP_SECOND_LINE});
+            new Object[]{CSV_AS_MAP_SECOND_LINE.trim()}); // here we start with the new reader, so will be root and no trailing space.
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -65,7 +65,9 @@ public class FileReadingIteratorTest extends ESTestCase {
     private static final String JSON_AS_MAP_FIRST_LINE = "{\"name\": \"Arthur\", \"id\": 4, \"details\": {\"age\": 38}}";
     private static final String JSON_AS_MAP_SECOND_LINE = "{\"id\": 5, \"name\": \"Trillian\", \"details\": {\"age\": 33}}";
     private static final String CSV_AS_MAP_FIRST_LINE = "{\"name\":\"Arthur\",\"id\":\"4\",\"age\":\"38\"}";
-    private static final String CSV_AS_MAP_SECOND_LINE = "{\"name\":\"Trillian\",\"id\":\"5\",\"age\":\"33\"}";
+    private static final String CSV_AS_MAP_SECOND_LINE = " {\"name\":\"Trillian\",\"id\":\"5\",\"age\":\"33\"}";
+    // Extra space because we reuse JsonGenerator and on second time it thinks it's not root and adds space.
+    // See https://github.com/elastic/elasticsearch/blob/master/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java#L90
     private static final TransactionContext TXN_CTX = CoordinatorTxnCtx.systemTransactionContext();
 
     private InputFactory inputFactory;

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -61,7 +61,9 @@ public class LineProcessorTest {
         Reader reader = new StringReader("some/string");
         bufferedReader = new BufferedReader(reader);
 
-        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader, null); // ReusableJsonBuilder is used only for converting csv line to json
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        FileReadingIterator.ReusableJsonBuilder reusableJsonBuilder = new FileReadingIterator.ReusableJsonBuilder(new XContentBuilder(JsonXContent.JSON_XCONTENT, out), out, new ArrayList());
+        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader, reusableJsonBuilder); // Extension is .csv, so CSVLineParser will be used, we need to pass not null object
 
         assertThat(bufferedReader.readLine(), is(nullValue()));
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -28,13 +28,17 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,7 +61,7 @@ public class LineProcessorTest {
         Reader reader = new StringReader("some/string");
         bufferedReader = new BufferedReader(reader);
 
-        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader);
+        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader, null); // ReusableJsonBuilder is used only for converting csv line to json
 
         assertThat(bufferedReader.readLine(), is(nullValue()));
     }
@@ -67,8 +71,11 @@ public class LineProcessorTest {
         uri = new URI("file.any");
         Reader reader = new StringReader("some/string");
         bufferedReader = new BufferedReader(reader);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        FileReadingIterator.ReusableJsonBuilder reusableJsonBuilder = new FileReadingIterator.ReusableJsonBuilder(new XContentBuilder(JsonXContent.JSON_XCONTENT, out), out, new ArrayList());
 
-        subjectUnderTest.readFirstLine(uri, CSV, bufferedReader);
+
+        subjectUnderTest.readFirstLine(uri, CSV, bufferedReader, reusableJsonBuilder);
 
         assertThat(bufferedReader.readLine(), is(nullValue()));
     }
@@ -79,7 +86,7 @@ public class LineProcessorTest {
         Reader reader = new StringReader("some/string");
         bufferedReader = new BufferedReader(reader);
 
-        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader);
+        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader, null); // ReusableJsonBuilder is used only for converting csv line to json
 
         assertThat(bufferedReader.readLine(), is("some/string"));
     }
@@ -90,7 +97,7 @@ public class LineProcessorTest {
         Reader reader = new StringReader("some/string");
         bufferedReader = new BufferedReader(reader);
 
-        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader);
+        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader, null); // ReusableJsonBuilder is used only for converting csv line to json
 
         assertThat(bufferedReader.readLine(), is("some/string"));
     }


### PR DESCRIPTION
Reusing `XContentBuilder` is a valid scenario - there is a [test](https://github.com/elastic/elasticsearch/blob/master/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java#L74-L91) for it in ES repo. 