### PR TITLE
Fix `MapComparator` util

### DIFF
--- a/server/src/main/java/io/crate/common/collections/MapComparator.java
+++ b/server/src/main/java/io/crate/common/collections/MapComparator.java
@@ -28,12 +28,12 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 
-public class MapComparator implements Comparator<Map> {
+@SuppressWarnings({"rawtypes", "unchecked"})
+public final class MapComparator implements Comparator<Map> {
 
     private static final MapComparator INSTANCE = new MapComparator();
 
-    private MapComparator() {
-    }
+    private MapComparator() {}
 
     public static MapComparator getInstance() {
         return INSTANCE;
@@ -60,18 +60,22 @@ public class MapComparator implements Comparator<Map> {
                 if (otherValue == null) {
                     return -1;
                 }
+                DataType leftType = DataTypes.guessType(thisValue);
+                int cmp;
                 if (!thisValue.getClass().equals(otherValue.getClass())) {
-                    DataType leftType = DataTypes.guessType(thisValue);
-                    int cmp = leftType.compare(
+                    cmp = leftType.compare(
                         thisValue,
                         leftType.implicitCast(otherValue)
                     );
-                    if (cmp == 0) {
-                        continue;
-                    }
-                    return cmp;
+                } else if (leftType == DataTypes.UNTYPED_OBJECT) {
+                    cmp = compareMaps((Map) thisValue, (Map) otherValue);
+                } else {
+                    cmp = leftType.compare(thisValue, otherValue);
                 }
-                return 1;
+                if (cmp == 0) {
+                    continue;
+                }
+                return cmp;
             }
         }
         return 0;

--- a/server/src/test/java/io/crate/common/collections/MapComparatorTest.java
+++ b/server/src/test/java/io/crate/common/collections/MapComparatorTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.common.collections;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -73,9 +74,9 @@ public class MapComparatorTest extends ESTestCase {
         assertThat(MapComparator.compareMaps(map1, map2), is(0));
         assertThat(MapComparator.compareMaps(map2, map1), is(0));
 
-        map2.put("str2", 5);
+        map1.put("str2", 5);
         assertThat(MapComparator.compareMaps(map1, map2), is(1));
-        assertThat(MapComparator.compareMaps(map2, map1), is(1));
+        assertThat(MapComparator.compareMaps(map2, map1), is(-1));
     }
 
     public void testCompareMapsWithValuesOfDifferentClass() {
@@ -95,6 +96,27 @@ public class MapComparatorTest extends ESTestCase {
         map1.put("str2", 5.0);
         assertThat(MapComparator.compareMaps(map1, map2), is(1));
         assertThat(MapComparator.compareMaps(map2, map1), is(-1));
+    }
+
+    public void testCompareMapsWithValuesOfDifferentClassNested() {
+        Map<String, Object> map1 = new HashMap<>() {{
+                put("str1", 1);
+                put("str2", Map.of("str3", Short.valueOf("1234")));
+            }};
+        Map<String, Object> map2 = new HashMap<>() {{
+                put("str1", 1);
+                put("str2", Map.of("str3", Short.valueOf("1234")));
+            }};
+        assertThat(MapComparator.compareMaps(map1, map2), is(0));
+        assertThat(MapComparator.compareMaps(map2, map1), is(0));
+
+        map1.put("str2", Map.of("str3", Long.valueOf("1234")));
+        assertThat(MapComparator.compareMaps(map1, map2), is(0));
+        assertThat(MapComparator.compareMaps(map2, map1), is(0));
+
+        map1.put("str2", Map.of("str3", 123.45));
+        assertThat(MapComparator.compareMaps(map1, map2), is(-1));
+        assertThat(MapComparator.compareMaps(map2, map1), greaterThan(1));
     }
 
     public void testCompareMapsWithStringAndBytesRef() {

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -65,7 +65,7 @@ public class DataTypesTest extends ESTestCase {
         assertThat(objectType.compare(emptyMap, testMap), is(-1));
 
         // then values
-        assertThat(objectType.compare(testMap, testCompareMap), is(1));
+        assertThat(objectType.compare(testMap, testCompareMap), is(-1));
         assertThat(objectType.compare(testCompareMap, testMap), is(1));
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix comparison for nested maps (objects), i.e.:
```
m1: {a={b={123}} // 123 Short
m2: {a={b={123}} // 123 Long
```
`compareMaps(m1, m2)` must return `0` (true)

Found via: 
```
./gradlew :server:test --tests "io.crate.integrationtests.TransportSQLActionTest.test_types_with_storage_can_be_inserted_and_queried" -Dtests.seed=CBA296E46FC0EC -Dtests.locale=en-AE -Dtests.timezone=Asia/Muscat
```
Inserted value = `{x={x=9145}}` where `9145` is `Short`
Response value = `x={x=9145}}` where `9145` is `Long`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
