### PR TITLE
Add columns based on delta metadata

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -23,7 +23,6 @@ package io.crate.analyze;
 
 import static org.elasticsearch.index.mapper.TypeParsers.DOC_VALUES;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -301,7 +300,7 @@ public class AnalyzedColumnDefinition<T> {
 
     public String geoTree() {
         return this.geoTree;
-    };
+    }
 
     public GenericProperties<T> geoProperties() {
         return this.geoProperties;

--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -109,7 +109,7 @@ public class AnalyzedTableElements<T> {
         this.copyToMap = copyToMap;
     }
 
-    static Map<String, Object> toMapping(AnalyzedTableElements<Object> elements) {
+    public static Map<String, Object> toMapping(AnalyzedTableElements<Object> elements) {
         final Map<String, Object> mapping = new HashMap<>();
         final Map<String, Object> meta = new HashMap<>();
         final Map<String, Object> properties = new HashMap<>(elements.columns.size());
@@ -314,9 +314,9 @@ public class AnalyzedTableElements<T> {
         return builder.build();
     }
 
-    public static Map<String, Object> finalizeAndValidate(RelationName relationName,
-                                                          AnalyzedTableElements<Symbol> tableElementsWithExpressionSymbols,
-                                                          AnalyzedTableElements<Object> tableElementsEvaluated) {
+    public static void finalizeAndValidate(RelationName relationName,
+                                           AnalyzedTableElements<Symbol> tableElementsWithExpressionSymbols,
+                                           AnalyzedTableElements<Object> tableElementsEvaluated) {
         tableElementsEvaluated.expandColumnIdents();
         validateExpressions(tableElementsWithExpressionSymbols, tableElementsEvaluated);
         for (AnalyzedColumnDefinition<Object> column : tableElementsEvaluated.columns) {
@@ -325,7 +325,6 @@ public class AnalyzedTableElements<T> {
         }
         validateIndexDefinitions(relationName, tableElementsEvaluated);
         validatePrimaryKeys(relationName, tableElementsEvaluated);
-        return toMapping(tableElementsEvaluated);
     }
 
     private static void validateExpressions(AnalyzedTableElements<Symbol> tableElementsWithExpressionSymbols,
@@ -611,7 +610,7 @@ public class AnalyzedTableElements<T> {
     }
 
     @VisibleForTesting
-    Map<String, String> getCheckConstraints() {
+    public Map<String, String> getCheckConstraints() {
         return Map.copyOf(checkConstraints);
     }
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -425,23 +425,19 @@ public class AnalyzedTableElements<T> {
         formattedExpressionConsumer.accept(formattedExpression);
     }
 
-    public static <T> DataType realType(AnalyzedColumnDefinition<T> columnDefinition) {
-        DataType<?> type = columnDefinition.dataType() == null ? DataTypes.UNDEFINED : columnDefinition.dataType();
-        return ArrayType.NAME.equals(columnDefinition.collectionType())
-            ? new ArrayType<>(type)
-            : type;
-    }
-
     private static <T> void buildReference(RelationName relationName,
                                            AnalyzedColumnDefinition<T> columnDefinition,
                                            List<Reference> references) {
 
-
+        DataType<?> type = columnDefinition.dataType() == null ? DataTypes.UNDEFINED : columnDefinition.dataType();
+        DataType<?> realType = ArrayType.NAME.equals(columnDefinition.collectionType())
+            ? new ArrayType<>(type)
+            : type;
 
         SimpleReference simpleRef = new SimpleReference(
             new ReferenceIdent(relationName, columnDefinition.ident()),
             RowGranularity.DOC,
-            realType(columnDefinition),
+            realType,
             columnDefinition.position,
             null // not required in this context
         );

--- a/server/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/server/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -24,6 +24,7 @@ package io.crate.execution;
 import io.crate.execution.ddl.TransportSchemaUpdateAction;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
 import io.crate.execution.ddl.index.TransportSwapAndDropIndexNameAction;
+import io.crate.execution.ddl.tables.TransportAddColumnAction;
 import io.crate.execution.ddl.tables.TransportAlterTableAction;
 import io.crate.execution.ddl.tables.TransportCloseTable;
 import io.crate.execution.ddl.tables.TransportCreateTableAction;
@@ -66,6 +67,7 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportSwapRelationsAction.class).asEagerSingleton();
         bind(TransportAlterTableAction.class).asEagerSingleton();
         bind(TransportDropConstraintAction.class).asEagerSingleton();
+        bind(TransportAddColumnAction.class).asEagerSingleton();
         bind(TransportAnalyzeAction.class).asEagerSingleton();
         bind(TransportSetLicenseAction.class).asEagerSingleton();
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
 
     private final RelationName relationName;
-    private final boolean isPartitioned;
 
     // Used only with ADD COLUMN.
     // Not included into StreamableColumnInfo to avoid adding empty list in most cases.
@@ -61,7 +60,6 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
     public AddColumnRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
-        isPartitioned = in.readBoolean();
 
         int count = in.readVInt();
         for (int i = 0; i < count; i++) {
@@ -79,10 +77,8 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
      * Fields which cannot be resolved using Reference are initialized with default or null values.
      */
     public AddColumnRequest(RelationName relationName,
-                            boolean isPartitioned,
                             List<Reference> columnRefs) {
         this.relationName = relationName;
-        this.isPartitioned = isPartitioned;
         this.columns.addAll(columnRefs.stream().map(this::refToStreamableColumnInfo).collect(Collectors.toList()));
     }
 
@@ -119,11 +115,9 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
      * For ADD COLUMN.
      */
     public AddColumnRequest(RelationName relationName,
-                            boolean isPartitioned,
                             AnalyzedColumnDefinition colToAdd,
                             Map<String, String> checkConstraints) {
         this.relationName = relationName;
-        this.isPartitioned = isPartitioned;
         this.columns.add(new StreamableColumnInfo(colToAdd));
         this.checkConstraints.addAll(checkConstraints.entrySet()
             .stream()
@@ -133,10 +127,6 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
 
     public RelationName relationName() {
         return this.relationName;
-    }
-
-    public boolean isPartitioned() {
-        return isPartitioned;
     }
 
     public List<StreamableCheckConstraint> checkConstraints() {
@@ -151,7 +141,6 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
-        out.writeBoolean(isPartitioned);
 
         out.writeVInt(checkConstraints.size());
         for (int i = 0; i < checkConstraints.size(); i++) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
@@ -22,16 +22,13 @@
 package io.crate.execution.ddl.tables;
 
 import io.crate.analyze.AnalyzedColumnDefinition;
-import io.crate.analyze.AnalyzedTableElements;
-import io.crate.metadata.*;
-import io.crate.metadata.table.ColumnPolicies;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.RelationName;
 import io.crate.sql.tree.CheckColumnConstraint;
 import io.crate.sql.tree.ColumnPolicy;
-import io.crate.sql.tree.GenericProperties;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -45,8 +42,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static org.elasticsearch.index.mapper.TypeParsers.DOC_VALUES;
 
 public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
 
@@ -150,23 +145,23 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
                                        @Nonnull List<StreamableColumnInfo> children) implements Writeable {
 
         public StreamableColumnInfo(AnalyzedColumnDefinition<Object> colToAdd) {
-             this(
-                 colToAdd.name(),
-                 colToAdd.ident().fqn(),
-                 colToAdd.dataType(),
-                 colToAdd.position,
-                 colToAdd.hasPrimaryKeyConstraint(),
-                 colToAdd.hasNotNullConstraint(),
-                 !AnalyzedColumnDefinition.docValuesSpecifiedAndDisabled(colToAdd),
-                 colToAdd.indexConstraint(),
-                 ArrayType.NAME.equals(colToAdd.collectionType()),
-                 colToAdd.analyzer(),
-                 colToAdd.formattedGeneratedExpression(),
-                 colToAdd.objectType(),
-                 colToAdd.geoTree(),
-                 colToAdd.geoProperties() == null ? new HashMap<>(): colToAdd.geoProperties().properties(),
-                 colToAdd.copyToTargets() == null ? new ArrayList<>() : colToAdd.copyToTargets(),
-                 colToAdd.children().stream().map(child -> new StreamableColumnInfo(child)).collect(Collectors.toList())
+            this(
+                colToAdd.name(),
+                colToAdd.ident().fqn(),
+                colToAdd.dataType(),
+                colToAdd.position,
+                colToAdd.hasPrimaryKeyConstraint(),
+                colToAdd.hasNotNullConstraint(),
+                !AnalyzedColumnDefinition.docValuesSpecifiedAndDisabled(colToAdd),
+                colToAdd.indexConstraint(),
+                ArrayType.NAME.equals(colToAdd.collectionType()),
+                colToAdd.analyzer(),
+                colToAdd.formattedGeneratedExpression(),
+                colToAdd.objectType(),
+                colToAdd.geoTree(),
+                colToAdd.geoProperties() == null ? new HashMap<>() : colToAdd.geoProperties().properties(),
+                colToAdd.copyToTargets() == null ? new ArrayList<>() : colToAdd.copyToTargets(),
+                colToAdd.children().stream().map(child -> new StreamableColumnInfo(child)).collect(Collectors.toList())
             );
         }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
@@ -153,7 +153,7 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
              this(
                  colToAdd.name(),
                  colToAdd.ident().fqn(),
-                 AnalyzedTableElements.realType(colToAdd),
+                 colToAdd.dataType(),
                  colToAdd.position,
                  colToAdd.hasPrimaryKeyConstraint(),
                  colToAdd.hasNotNullConstraint(),
@@ -234,43 +234,6 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
             for (int i = 0; i < children.size(); i++) {
                 children.get(i).writeTo(out);
             }
-        }
-
-        /**
-         * Aligned with {@link AnalyzedColumnDefinition#toMapping(AnalyzedColumnDefinition)} )
-         */
-        public HashMap<String, Object> propertiesMap() {
-            HashMap<String, Object> properties = new HashMap<>();
-            AnalyzedColumnDefinition.addTypeOptions(properties, type, new GenericProperties(geoProperties), geoTree, analyzer);
-            properties.put("type", AnalyzedColumnDefinition.typeNameForESMapping(type, analyzer, indexType == IndexType.FULLTEXT));
-
-            properties.put("position", position);
-
-            if (indexType == IndexType.NONE) {
-                // we must use a boolean <p>false</p> and NO string "false", otherwise parser support for old indices will fail
-                properties.put("index", false);
-            }
-            if (copyToTargets.isEmpty() == false) {
-                properties.put("copy_to", copyToTargets);
-            }
-
-            if (isArrayType) {
-                HashMap<String, Object> outerMapping = new HashMap<>();
-                outerMapping.put("type", "array");
-                if (type().id() == ObjectType.ID) {
-                    properties.put("dynamic", ColumnPolicies.encodeMappingValue(columnPolicy));
-                }
-                outerMapping.put("inner", properties);
-                return outerMapping;
-            } else if (type().id() == ObjectType.ID) {
-                properties.put("dynamic", ColumnPolicies.encodeMappingValue(columnPolicy));
-            }
-
-            if (hasDocValues == false) {
-                properties.put(DOC_VALUES, "false");
-            }
-
-            return properties;
         }
     }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.sql.tree.CheckColumnConstraint;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Contains all supported for ADD COLUMN configurations such as constraints,
+ * doc values enabled flag, column type properties (bit length, text analyzer e.t.c).
+ */
+public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
+
+    private final RelationName relationName;
+    private final boolean isPartitioned;
+    private final Reference columnRef; // Contains isNullable and hasDocValues which reflects NOT-NULL and STORAGE WITH.
+    private final Map<String, Object> columnProperties = new LinkedHashMap<>();
+    private final boolean isPrimaryKey;
+
+    @Nullable
+    private final String generatedExpression;
+    private final List<StreamableCheckConstraint> checkConstraints = new ArrayList<>();
+
+    public AddColumnRequest(StreamInput in) throws IOException {
+        super(in);
+        relationName = new RelationName(in);
+        isPartitioned = in.readBoolean();
+        columnRef = Reference.fromStream(in);
+        columnProperties.putAll(in.readMap(StreamInput::readString, StreamInput::readGenericValue));
+        isPrimaryKey = in.readBoolean();
+        generatedExpression = in.readOptionalString();
+        int count = in.readVInt();
+        for (int i = 0; i < count; i++) {
+            checkConstraints.add(StreamableCheckConstraint.readFrom(in));
+        }
+    }
+
+    public AddColumnRequest(RelationName relationName,
+                            boolean isPartitioned,
+                            Reference column,
+                            @Nonnull Map<String, Object> columnTypeProperties,
+                            boolean isPrimaryKey,
+                            @Nullable String generatedExpression,
+                            @Nonnull Map<String, String> checkConstraints) {
+        this.relationName = relationName;
+        this.isPartitioned = isPartitioned;
+        this.columnRef = column;
+        this.columnProperties.putAll(columnTypeProperties);
+        this.isPrimaryKey = isPrimaryKey;
+        this.generatedExpression = generatedExpression;
+        this.checkConstraints.addAll(checkConstraints.entrySet()
+            .stream()
+            .map(nameExprEntry -> new StreamableCheckConstraint(nameExprEntry.getKey(), nameExprEntry.getValue()))
+            .collect(Collectors.toList()));
+    }
+
+    @Nonnull
+    public RelationName relationName() {
+        return this.relationName;
+    }
+
+    @Nonnull
+    public Reference columnRef() {
+        return this.columnRef;
+    }
+
+    public boolean isPrimaryKey() {
+        return this.isPrimaryKey;
+    }
+
+    public boolean isPartitioned() {
+        return isPartitioned;
+    }
+
+    @Nullable
+    public String generatedExpression() {
+        return this.generatedExpression;
+    }
+
+    @Nonnull
+    List<StreamableCheckConstraint> checkConstraints() {
+        return this.checkConstraints;
+    }
+
+    public Map<String, Object> columnProperties() {
+        return this.columnProperties;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        relationName.writeTo(out);
+        out.writeBoolean(isPartitioned);
+        Reference.toStream(columnRef, out);
+        out.writeMap(columnProperties, (o, v) -> o.writeString(v), (o, v) -> out.writeGenericValue(v));
+        out.writeBoolean(isPrimaryKey);
+        out.writeOptionalString(generatedExpression);
+        out.writeVInt(checkConstraints.size());
+        for (int i = 0; i < checkConstraints.size(); i++) {
+            checkConstraints.get(i).writeTo(out);
+        }
+    }
+
+    /**
+     * Streamable version of the {@link CheckColumnConstraint}.
+     * We don't need to stream columnName as it's already contained in the columnRef.
+     * We don't stream parsed expression, only raw string.
+     */
+    public record StreamableCheckConstraint(String name, String expression) implements Writeable {
+
+        public static StreamableCheckConstraint readFrom(StreamInput in) throws IOException {
+            var name = in.readString();
+            var expr = in.readString();
+            return new StreamableCheckConstraint(name, expr);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(name);
+            out.writeString(expression);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
@@ -79,36 +79,7 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
     public AddColumnRequest(RelationName relationName,
                             List<Reference> columnRefs) {
         this.relationName = relationName;
-        this.columns.addAll(columnRefs.stream().map(this::refToStreamableColumnInfo).collect(Collectors.toList()));
-    }
-
-    private StreamableColumnInfo refToStreamableColumnInfo(Reference reference) {
-        String geoTree = null;
-        Map<String, Object> geoProperties = new HashMap<>();
-        if (reference instanceof GeoReference geoRef) {
-            geoTree = geoRef.geoTree();
-            geoProperties.put("precision", geoRef.precision());
-            geoProperties.put("tree_levels", geoRef.treeLevels());
-            geoProperties.put("distance_error_pct", geoRef.distanceErrorPct());
-        }
-        return new StreamableColumnInfo(
-            reference.column().name(),
-            reference.column().fqn(),
-            reference.valueType(),
-            reference.position(),
-            false, // A primary key can be specified only on ADD COLUMN
-            true, // not-null can be specified only on ADD COLUMN
-            true, // Use default, can be specified only on ADD COLUMN
-            reference.indexType(),
-            reference.valueType().id() == ArrayType.ID,
-            null, // INDEX USING FULLTEXT can be specified only on ADD COLUMN
-            null, // generated expression can be specified only on ADD COLUMN
-            reference.columnPolicy(),
-            geoTree,
-            geoProperties,
-            List.of(), // copyToTargets is used when INDEX is specified, only for ADD COLUMN
-            List.of() // there is no tree-like Ref hierarchy in target.valueType().valueForInsert(row.get(i)), it's a single map
-        );
+        this.columns.addAll(columnRefs.stream().map(StreamableColumnInfo::of).collect(Collectors.toList()));
     }
 
     /**
@@ -261,6 +232,35 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
             for (int i = 0; i < children.size(); i++) {
                 children.get(i).writeTo(out);
             }
+        }
+
+        public static StreamableColumnInfo of(Reference reference) {
+            String geoTree = null;
+            Map<String, Object> geoProperties = new HashMap<>();
+            if (reference instanceof GeoReference geoRef) {
+                geoTree = geoRef.geoTree();
+                geoProperties.put("precision", geoRef.precision());
+                geoProperties.put("tree_levels", geoRef.treeLevels());
+                geoProperties.put("distance_error_pct", geoRef.distanceErrorPct());
+            }
+            return new StreamableColumnInfo(
+                reference.column().name(),
+                reference.column().fqn(),
+                reference.valueType(),
+                reference.position(),
+                false, // A primary key can be specified only on ADD COLUMN
+                true, // not-null can be specified only on ADD COLUMN
+                true, // Use default, can be specified only on ADD COLUMN
+                reference.indexType(),
+                reference.valueType().id() == ArrayType.ID,
+                null, // INDEX USING FULLTEXT can be specified only on ADD COLUMN
+                null, // generated expression can be specified only on ADD COLUMN
+                reference.columnPolicy(),
+                geoTree,
+                geoProperties,
+                List.of(), // copyToTargets is used when INDEX is specified, only for ADD COLUMN
+                List.of() // there is no tree-like Ref hierarchy in target.valueType().valueForInsert(row.get(i)), it's a single map
+            );
         }
     }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -140,18 +140,22 @@ public class AlterTableOperation {
     }
 
     public CompletableFuture<Long> executeAlterTableAddColumn(AddColumnRequest addColumnRequest) {
-        if (addColumnRequest.isPrimaryKey() || addColumnRequest.generatedExpression() != null) {
-            return getRowCount(addColumnRequest.relationName()).thenCompose(rowCount -> {
-                if (rowCount > 0) {
-                    String subject = addColumnRequest.isPrimaryKey() ? "primary key" : "generated";
-                    throw new UnsupportedOperationException("Cannot add a " + subject + " column to a table that isn't empty");
-                } else {
-                    return transportAddColumnAction.execute(addColumnRequest).thenApply(resp -> -1L);
-                }
-            });
-        } else {
-            return transportAddColumnAction.execute(addColumnRequest).thenApply(resp -> -1L);
+        if (addColumnRequest.columns().size() == 1) {
+            // Either ADD COLUMN or dynamic mapping update of a single column.
+            // In case of the latter PK and generated are false/null and we fall to regular request without extra rowCount check.
+            var colToAdd = addColumnRequest.columns().get(0);
+            if (colToAdd.isPrimaryKey() || colToAdd.genExpression() != null) {
+                return getRowCount(addColumnRequest.relationName()).thenCompose(rowCount -> {
+                    if (rowCount > 0) {
+                        String subject = colToAdd.isPrimaryKey() ? "primary key" : "generated";
+                        throw new UnsupportedOperationException("Cannot add a " + subject + " column to a table that isn't empty");
+                    } else {
+                        return transportAddColumnAction.execute(addColumnRequest).thenApply(resp -> -1L);
+                    }
+                });
+            }
         }
+        return transportAddColumnAction.execute(addColumnRequest).thenApply(resp -> -1L);
     }
 
     private CompletableFuture<Long> getRowCount(RelationName ident) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -24,6 +24,7 @@ package io.crate.execution.ddl.tables;
 import io.crate.analyze.AnalyzedTableElements;
 import io.crate.common.collections.Maps;
 import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.execution.ddl.TransportSchemaUpdateAction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.cluster.DDLClusterStateHelpers;
@@ -129,12 +130,9 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
 
             Map<String, Object> indexMapping = indexMetadata.mapping().sourceAsMap();
             mergeDeltaIntoExistingMapping(indexMapping, request);
+            TransportSchemaUpdateAction.populateColumnPositions(indexMapping);
 
             MapperService mapperService = indicesService.createIndexMapperService(indexMetadata);
-
-            // Add current mapping and initialize DocumentMapper, so that mapperService.documentMapper()
-            // is not null. It's needed to trigger ColumnPositionResolver and publish cluster state with non-negative calculated column positions
-            mapperService.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
 
             mapperService.merge(indexMapping, MapperService.MergeReason.MAPPING_UPDATE);
             DocumentMapper mapper = mapperService.documentMapper();

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -143,7 +143,7 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
             HashMap<String, Object> properties = new HashMap<>();
             AnalyzedColumnDefinition.addTypeOptions(properties,
                                                     columnInfo.type(),
-                                                    new GenericProperties(columnInfo.geoProperties()),
+                                                    new GenericProperties<>(columnInfo.geoProperties()),
                                                     columnInfo.geoTree(),
                                                     columnInfo.analyzer()
             );
@@ -266,7 +266,7 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
         // _meta fields
         if (convertedRequest.primaryKeys.isEmpty() == false) {
             Maps.mergeInto(existingMapping, "_meta", List.of("primary_keys"), convertedRequest.primaryKeys,
-                (map, key, value) -> ((ArrayList) map.computeIfAbsent(key, k -> new ArrayList<>())).addAll(convertedRequest.primaryKeys)
+                (map, key, value) -> ((ArrayList<String>) map.computeIfAbsent(key, k -> new ArrayList<String>())).addAll(convertedRequest.primaryKeys)
             );
         }
         if (convertedRequest.notNullColumns.isEmpty() == false) {
@@ -274,7 +274,7 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
                 (map, key, value) -> {
                     if ("not_null".equals(key)) {
                         // we are merging on the end pf the path, i.e adding to the list
-                        ((ArrayList) map.computeIfAbsent(key, k -> new ArrayList<>())).addAll(convertedRequest.notNullColumns);
+                        ((ArrayList<String>) map.computeIfAbsent(key, k -> new ArrayList<String>())).addAll(convertedRequest.notNullColumns);
                     } else {
                         // When adding not-null for the first time,
                         // Maps.mergeInto stops mid-path and transforms value (list) into chain of maps (to complement the remaining path) and adds value to the end.
@@ -287,12 +287,12 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
         }
         if (convertedRequest.generatedColumns.isEmpty() == false) {
             Maps.mergeInto(existingMapping, "_meta", List.of("generated_columns"), convertedRequest.generatedColumns,
-                (map, key, value) -> ((LinkedHashMap) map.computeIfAbsent(key, k -> new LinkedHashMap<>())).putAll(convertedRequest.generatedColumns)
+                (map, key, value) -> ((LinkedHashMap<String, String>) map.computeIfAbsent(key, k -> new LinkedHashMap<String, String>())).putAll(convertedRequest.generatedColumns)
             );
         }
         for (var check: request.checkConstraints()) {
             Maps.mergeInto(existingMapping, "_meta", List.of("check_constraints"), check,
-                (map, key, value) -> ((LinkedHashMap) map.computeIfAbsent(key, k -> new LinkedHashMap<>())).put(check.name(), check.expression())
+                (map, key, value) -> ((LinkedHashMap<String, String>) map.computeIfAbsent(key, k -> new LinkedHashMap<String, String>())).put(check.name(), check.expression())
             );
         }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.analyze.AnalyzedTableElements;
+import io.crate.common.collections.Maps;
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.cluster.DDLClusterStateHelpers;
+import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.metadata.doc.DocTableInfoFactory;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.crate.metadata.cluster.AlterTableClusterStateExecutor.resolveIndices;
+
+@Singleton
+public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColumnRequest, AcknowledgedResponse> {
+
+    private static final String ACTION_NAME = "internal:crate:sql/table/add_column";
+    private final NodeContext nodeContext;
+    private final IndicesService indicesService;
+
+    @Inject
+    public TransportAddColumnAction(TransportService transportService,
+                                    ClusterService clusterService,
+                                    IndicesService indicesService,
+                                    ThreadPool threadPool,
+                                    NodeContext nodeContext) {
+        super(ACTION_NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            AddColumnRequest::new,
+            AcknowledgedResponse::new,
+            AcknowledgedResponse::new,
+            "add-column");
+        this.nodeContext = nodeContext;
+        this.indicesService = indicesService;
+    }
+
+    @Override
+    public ClusterStateTaskExecutor<AddColumnRequest> clusterStateTaskExecutor(AddColumnRequest request) {
+        return new DDLClusterStateTaskExecutor<>() {
+            @Override
+            protected ClusterState execute(ClusterState currentState, AddColumnRequest request) throws Exception {
+                Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+                if (request.isPartitioned()) {
+                    String templateName = PartitionName.templateName(request.relationName().schema(), request.relationName().name());
+                    IndexTemplateMetadata indexTemplateMetadata = currentState.metadata().templates().get(templateName);
+
+                    Map<String, Object> existingTemplateMeta = new HashMap<>();
+                    mergeDeltaIntoExistingMapping(existingTemplateMeta, request);
+
+                    IndexTemplateMetadata newIndexTemplateMetadata = DDLClusterStateHelpers.updateTemplate(
+                        indexTemplateMetadata,
+                        existingTemplateMeta,
+                        Collections.emptyMap(),
+                        Settings.EMPTY,
+                        IndexScopedSettings.DEFAULT_SCOPED_SETTINGS // Not used if new settings are empty
+                    );
+                    metadataBuilder.put(newIndexTemplateMetadata);
+                }
+
+                currentState = updateMapping(currentState, request, metadataBuilder);
+                // ensure the new table can still be parsed into a DocTableInfo to avoid breaking the table.
+                new DocTableInfoFactory(nodeContext).create(request.relationName(), currentState);
+                return currentState;
+            }
+        };
+    }
+
+    /**
+     * Structure of the metadata is aligned with {@link AnalyzedTableElements#toMapping(AnalyzedTableElements)}
+     */
+    private ClusterState updateMapping(ClusterState currentState,
+                                       AddColumnRequest request,
+                                       Metadata.Builder metadataBuilder) throws IOException {
+        Index[] concreteIndices = resolveIndices(currentState, request.relationName().indexNameOrAlias());
+
+        for (Index index : concreteIndices) {
+            final IndexMetadata indexMetadata = currentState.metadata().getIndexSafe(index);
+
+            Map<String, Object> indexMapping = indexMetadata.mapping().sourceAsMap();
+            mergeDeltaIntoExistingMapping(indexMapping, request);
+
+            MapperService mapperService = indicesService.createIndexMapperService(indexMetadata);
+            mapperService.merge(indexMapping, MapperService.MergeReason.MAPPING_UPDATE);
+            DocumentMapper mapper = mapperService.documentMapper();
+
+            IndexMetadata.Builder imBuilder = IndexMetadata.builder(indexMetadata);
+            imBuilder.putMapping(new MappingMetadata(mapper.mappingSource())).mappingVersion(1 + imBuilder.mappingVersion());
+            metadataBuilder.put(imBuilder); // implicitly increments metadata version.
+        }
+
+        return ClusterState.builder(currentState).metadata(metadataBuilder).build();
+    }
+
+    private static void mergeDeltaIntoExistingMapping(Map<String, Object> existingMapping, AddColumnRequest request) {
+        // _meta fields
+        if (request.isPrimaryKey()) {
+            Maps.mergeInto(existingMapping, "_meta", List.of("primary_keys"), request.columnRef().column().fqn(),
+                (map, key, value) -> ((ArrayList) map.computeIfAbsent(key, k -> new ArrayList<>())).add(value)
+            );
+        }
+        if (request.columnRef().isNullable() == false) {
+            Maps.mergeInto(existingMapping, "_meta", List.of("constraints", "not_null"), request.columnRef().column().fqn(),
+                (map, key, value) -> ((ArrayList) map.computeIfAbsent(key, k -> new ArrayList<>())).add(value)
+            );
+        }
+        if (request.generatedExpression() != null) {
+            Maps.mergeInto(existingMapping, "_meta", List.of("generated_columns"), Map.entry(request.columnRef().column().fqn(), request.generatedExpression()),
+                (map, key, value) -> {
+                    Map.Entry<String, String> nameAndExpression = (Map.Entry) value;
+                    ((LinkedHashMap) map.computeIfAbsent(key, k -> new LinkedHashMap<>())).put(nameAndExpression.getKey(), nameAndExpression.getValue());
+                }
+            );
+        }
+        for (AddColumnRequest.StreamableCheckConstraint checkConstraint: request.checkConstraints()) {
+            Maps.mergeInto(existingMapping, "_meta", List.of("check_constraints"), checkConstraint,
+                (map, key, value) -> {
+                    AddColumnRequest.StreamableCheckConstraint constraint = (AddColumnRequest.StreamableCheckConstraint) value;
+                    ((LinkedHashMap) map.computeIfAbsent(key, k -> new LinkedHashMap<>())).put(constraint.name(), constraint.expression());
+                }
+            );
+        }
+
+        // properties field (columnstore, index flags and column type specific properties)
+        Maps.mergeInto(existingMapping, "properties", List.of(), request.columnProperties(),
+            (map, key, value) -> {
+                LinkedHashMap<String, Object> colProps = (LinkedHashMap) value;
+
+                ((LinkedHashMap) map.computeIfAbsent(key, k -> new LinkedHashMap<>())).put(request.columnRef().column().fqn(), colProps);
+            }
+        );
+    }
+
+    @Override
+    public ClusterBlockException checkBlock(AddColumnRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -125,13 +125,13 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
          */
         private HashMap<String, Object> collectColumnInfo(AddColumnRequest.StreamableColumnInfo columnInfo) {
             if (columnInfo.isPrimaryKey()) {
-                primaryKeys.add(columnInfo.name());
+                primaryKeys.add(columnInfo.fqn());
             }
             if (columnInfo.isNullable()) {
-                notNullColumns.add(columnInfo.name());
+                notNullColumns.add(columnInfo.fqn());
             }
             if (columnInfo.genExpression() != null) {
-                generatedColumns.put(columnInfo.name(), columnInfo.genExpression());
+                generatedColumns.put(columnInfo.fqn(), columnInfo.genExpression());
             }
             HashMap<String, Object> propertiesMap = columnInfo.propertiesMap();
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -131,6 +131,11 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
             mergeDeltaIntoExistingMapping(indexMapping, request);
 
             MapperService mapperService = indicesService.createIndexMapperService(indexMetadata);
+
+            // Add current mapping and initialize DocumentMapper, so that mapperService.documentMapper()
+            // is not null. It's needed to trigger ColumnPositionResolver and publish cluster state with non-negative calculated column positions
+            mapperService.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
+
             mapperService.merge(indexMapping, MapperService.MergeReason.MAPPING_UPDATE);
             DocumentMapper mapper = mapperService.documentMapper();
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -208,9 +208,10 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
                 Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
                 ConvertedRequest requestConverter = new ConvertedRequest(request);
 
-                if (request.isPartitioned()) {
-                    String templateName = PartitionName.templateName(request.relationName().schema(), request.relationName().name());
-                    IndexTemplateMetadata indexTemplateMetadata = currentState.metadata().templates().get(templateName);
+                String templateName = PartitionName.templateName(request.relationName().schema(), request.relationName().name());
+                IndexTemplateMetadata indexTemplateMetadata = currentState.metadata().templates().get(templateName);
+
+                if (indexTemplateMetadata != null) {
 
                     Map<String, Object> existingTemplateMeta = new HashMap<>();
 

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -80,7 +80,7 @@ import io.crate.metadata.doc.DocTableInfoFactory;
 
 public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<AlterTableRequest> {
 
-    public static final IndicesOptions FIND_OPEN_AND_CLOSED_INDICES_IGNORE_UNAVAILABLE_AND_NON_EXISTING = IndicesOptions.fromOptions(
+    private static final IndicesOptions FIND_OPEN_AND_CLOSED_INDICES_IGNORE_UNAVAILABLE_AND_NON_EXISTING = IndicesOptions.fromOptions(
         true, true, true, true);
 
     private final MetadataMappingService metadataMappingService;

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -80,7 +80,7 @@ import io.crate.metadata.doc.DocTableInfoFactory;
 
 public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<AlterTableRequest> {
 
-    private static final IndicesOptions FIND_OPEN_AND_CLOSED_INDICES_IGNORE_UNAVAILABLE_AND_NON_EXISTING = IndicesOptions.fromOptions(
+    public static final IndicesOptions FIND_OPEN_AND_CLOSED_INDICES_IGNORE_UNAVAILABLE_AND_NON_EXISTING = IndicesOptions.fromOptions(
         true, true, true, true);
 
     private final MetadataMappingService metadataMappingService;
@@ -108,6 +108,9 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
     }
 
     @Override
+    /**
+     * From 6.0 this should be simplified and used only for updating table settings, we have a dedicated action for adding columns.
+     */
     protected ClusterState execute(ClusterState currentState, AlterTableRequest request) throws Exception {
         if (request.isPartitioned()) {
             if (request.partitionIndexName() != null) {
@@ -191,6 +194,9 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
 
     @SuppressWarnings("unchecked")
     @VisibleForTesting
+    /**
+     * Used for BWC with versions < 5.1.0
+     */
     static String addExistingMeta(AlterTableRequest request, Map<String, Object> currentMeta) throws IOException {
         // The putMappingExtractor doesn't contain logic to merge _meta
         // and we need to preserve existing information.

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
@@ -32,9 +32,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import io.crate.execution.ddl.tables.AddColumnRequest;
-import io.crate.types.ArrayType;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 
@@ -52,13 +49,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.GeneratedReference;
-import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
@@ -104,7 +104,6 @@ public class AlterTableAddColumnPlan implements Plan {
             AnalyzedColumnDefinition colToAdd = tableElementsEvaluated.columns().get(0);
 
             var addColumnRequest = new AddColumnRequest(alterTable.tableInfo().ident(),
-                alterTable.tableInfo().isPartitioned(),
                 colToAdd,
                 tableElementsEvaluated.getCheckConstraints()
             );

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
@@ -38,6 +38,10 @@ import io.crate.planner.operators.SubQueryResults;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.Map;
+
+import static io.crate.analyze.AnalyzedTableElements.toMapping;
+
 public class AlterTableDropCheckConstraintPlan implements Plan {
 
     private final AnalyzedAlterTableDropCheckConstraint dropCheckConstraint;
@@ -84,15 +88,17 @@ public class AlterTableDropCheckConstraintPlan implements Plan {
             .stream()
             .filter(c -> !dropCheckConstraint.name().equals(c.name()))
             .forEach(c -> tableElementsBound.addCheckConstraint(tableInfo.ident(), c));
+        AnalyzedTableElements.finalizeAndValidate(
+            tableInfo.ident(),
+            new AnalyzedTableElements<>(),
+            tableElementsBound
+        );
+        Map<String, Object> mapping = toMapping(tableElementsBound);
         return new BoundAddColumn(
             tableInfo,
             tableElementsBound,
             Settings.builder().build(),
-            AnalyzedTableElements.finalizeAndValidate(
-                tableInfo.ident(),
-                new AnalyzedTableElements<>(),
-                tableElementsBound
-            ),
+            mapping,
             false,
             false
         );

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
@@ -159,6 +159,12 @@ public class CreateTablePlan implements Plan {
             tableElements
         );
 
+        // finalizeAndValidate used to compute mapping which implicitly validated storage settings.
+        // Since toMapping call is removed from finalizeAndValidate we are triggering this check explicitly
+        for (AnalyzedColumnDefinition<Object> column : tableElements.columns()) {
+            AnalyzedColumnDefinition.docValuesSpecifiedAndDisabled(column);
+        }
+
         // update table settings
         Settings tableSettings = AnalyzedTableElements.validateAndBuildSettings(
             tableElements, fulltextAnalyzerResolver);

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -1014,4 +1014,6 @@ public class DDLIntegrationTest extends IntegTestCase {
                 )""".stripIndent()
         ));
     }
+
+
 }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -909,8 +909,8 @@ public class DDLIntegrationTest extends IntegTestCase {
                                  "{\"dynamic\":\"strict\"," +
                                  "\"_meta\":{" +
                                  "\"generated_columns\":{" +
-                                 "\"added\":\"date_trunc('day', ts)\"," +
-                                 "\"day\":\"date_trunc('day', ts)\"}}," +
+                                 "\"day\":\"date_trunc('day', ts)\"," +
+                                 "\"added\":\"date_trunc('day', ts)\"}}," +
                                  "\"properties\":{" +
                                  "\"added\":{\"type\":\"date\",\"position\":3,\"format\":\"epoch_millis||strict_date_optional_time\"}," +
                                  "\"day\":{\"type\":\"date\",\"position\":2,\"format\":\"epoch_millis||strict_date_optional_time\"}," +
@@ -959,6 +959,59 @@ public class DDLIntegrationTest extends IntegTestCase {
                    )
                 )
                 """.stripIndent()
+        ));
+    }
+
+    @Test
+    public void test_add_column_all_supported_configs_applied_to_altered_table() throws Exception {
+        // add at least one of each constraints (not null, PK, check, generated) to the initial table
+        // to make sure that merge logic doesn't override existing mapping
+        execute("CREATE TABLE tbl (id int primary key constraint id_check check (id>0), gen_col int generated always as 123 not null)");
+
+        execute("ALTER TABLE tbl ADD COLUMN col1 text " +
+            "generated always as 'test' " +
+            "not null " +
+            "constraint test_check check (col1!='d') " +
+            "INDEX USING FULLTEXT WITH (analyzer = 'simple')");
+
+        execute("show create table tbl");
+        assertThat((String) response.rows()[0][0], startsWith(
+            """
+                CREATE TABLE IF NOT EXISTS "doc"."tbl" (
+                   "id" INTEGER NOT NULL,
+                   "gen_col" INTEGER GENERATED ALWAYS AS 123 NOT NULL,
+                   "col1" TEXT GENERATED ALWAYS AS 'test' NOT NULL INDEX USING FULLTEXT WITH (
+                      analyzer = 'simple'
+                   ),
+                   PRIMARY KEY ("id"),
+                   CONSTRAINT id_check CHECK("id" > 0),
+                   CONSTRAINT test_check CHECK("col1" <> 'd')
+                )""".stripIndent()
+        ));
+
+        // test other options, which couldn't be tested in the first scenario:
+        // Primary key can be used here as we don't have not null
+        // and doc values flag can be disabled on not fulltext columns (otherwise it's ignored)
+        execute("ALTER TABLE tbl ADD COLUMN col2 varchar(100) " +
+            "primary key " +
+            "storage with (columnstore=false)"
+        );
+        execute("show create table tbl");
+        assertThat((String) response.rows()[0][0], startsWith(
+            """
+                CREATE TABLE IF NOT EXISTS "doc"."tbl" (
+                   "id" INTEGER NOT NULL,
+                   "gen_col" INTEGER GENERATED ALWAYS AS 123 NOT NULL,
+                   "col1" TEXT GENERATED ALWAYS AS 'test' NOT NULL INDEX USING FULLTEXT WITH (
+                      analyzer = 'simple'
+                   ),
+                   "col2" VARCHAR(100) NOT NULL STORAGE WITH (
+                      columnstore = false
+                   ),
+                   PRIMARY KEY ("id", "col2"),
+                   CONSTRAINT id_check CHECK("id" > 0),
+                   CONSTRAINT test_check CHECK("col1" <> 'd')
+                )""".stripIndent()
         ));
     }
 }


### PR DESCRIPTION
Added new Request and Action to perform ADD COLUMN based only on diff and don't copy existing mapping data such as primary keys, checks, not-null constraints, existing columns. 

Column details (bit/varhar length, analyzer and so on, columnstore flag) comes in properties field

_copy-existing-mapping_ code hasn't removed yet as we need it for BWC. Changes in Plan are mostly re-organazing code - we still need validation, so I introduced new `validate` method and grouped checks there  - `validate` is used in both pre/post 5.1.0 plans.