### PR TITLE
Ensure response handlers force execution

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
@@ -919,7 +919,7 @@ public final class InternalTestCluster extends TestCluster {
                 node.close();
                 try {
                     if (node.awaitClose(10, TimeUnit.SECONDS) == false) {
-                        throw new IOException("Node didn't close within 10 seconds.");
+                        throw new AssertionError("Node didn't close within 10 seconds.");
                     }
                 } catch (InterruptedException e) {
                     throw new AssertionError("Interruption while waiting for the node to close", e);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We're seeing some test failures with

    Some shards are still open after the threadpool terminated. Something is leaking index readers or store references

This PR does two things in an attempt to (help) solve that:

- Ensure tests trigger a failure if a node can't be closed in time by
  throwing an AssertionError

- Force execution of response handlers. If a response is not processed
  it could keep a reference open.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
