### PR TITLE
Attempt to fix testTransientErrorsDuringRecoveryAreRetried

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -556,11 +556,13 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         @SuppressWarnings("sync-override")
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeVInt(recovered);
-            out.writeVInt(total);
-            out.writeVInt(totalOnStart);
-            if (out.getVersion().onOrAfter(Version.V_4_3_0)) {
-                out.writeVInt(totalLocal);
+            synchronized (this) {
+                out.writeVInt(recovered);
+                out.writeVInt(total);
+                out.writeVInt(totalOnStart);
+                if (out.getVersion().onOrAfter(Version.V_4_3_0)) {
+                    out.writeVInt(totalLocal);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Attempt to fix `testTransientErrorsDuringRecoveryAreRetried`
    
Previously, failed consistenly with:
```
./gradlew :server:test --tests "org.elasticsearch.indices.recovery.IndexRecoveryIT.testTransientErrorsDuringRecoveryAreRetried" -Dtests.seed=3114F0F908CF65BB -Dtests.nightly=true -Dtests.locale=en-CH -Dtests.timezone=Zulu
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
