### PR TITLE
Fix flaky testShardNotAvailableExceptionWhenEngineClosedConcurrently

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3264,7 +3264,7 @@ public class InternalEngineTests extends EngineTestCase {
                                 break;
                             }
                             case "flush": {
-                                engine.flush(true, false);
+                                engine.flush(true, true);
                                 break;
                             }
                         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Failed with:

    java.lang.AssertionError: wait_if_ongoing must be true for a force flush: force=true wait_if_ongoing=false
    	at __randomizedtesting.SeedInfo.seed([58A5FC44A946A8B9]:0)
    	at org.elasticsearch.index.engine.InternalEngine.flush(InternalEngine.java:1774)
    	at org.elasticsearch.index.engine.InternalEngineTests$5.run(InternalEngineTests.java:3267)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
