### PR TITLE
bp: Fix constructors of NoOpResult

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -74,7 +74,7 @@ should be crossed out as well.
 - [ ] 20d2313d4b6 Ensure ReplicationOperation notify listener once (#68256)
 - [ ] b8102b2e0f3 [DOCS] Fix response typo in transport message listener (#68125) (#68169)
 - [ ] e9b798bdb15 [7.10] Make FilterAllocationDecider totally ignore tier-based allocation settings (#67019) (#67034)
-- [ ] 5000ec87caa Fix constructors of NoOpResult (#66269)
+- [x] 5000ec87caa Fix constructors of NoOpResult (#66269)
 - [ ] 7e1fc6dc674 Adjust Cleanup Order of Internal State in SnapshotsService (#66225) (#66244)
 - [ ] 8cbb9612d0f [7.10] Create AllocationDeciders in the main method of the ILM step (#65037) (8ac30f9a) (#66070)
 - [ ] 16fae5d66d3 Also reroute after shard snapshot size fetch failure (#66008)

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -473,11 +473,11 @@ public abstract class Engine implements Closeable {
     public static class NoOpResult extends Result {
 
         NoOpResult(long term, long seqNo) {
-            super(Operation.TYPE.NO_OP, term, 0, seqNo);
+            super(Operation.TYPE.NO_OP, 0, term, seqNo);
         }
 
         NoOpResult(long term, long seqNo, Exception failure) {
-            super(Operation.TYPE.NO_OP, failure, term, 0, seqNo);
+            super(Operation.TYPE.NO_OP, failure, 0, term, seqNo);
         }
 
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Spotted this missing backport while looking into a (unrelated) flaky test
The term/version argument was swapped

https://github.com/elastic/elasticsearch/commit/5000ec87caa54517d169918c6615d96ec35894d5

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
