### PR TITLE
Add support for `catalog` in FQNs of tables/columns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,6 +59,12 @@ Deprecations
 Changes
 =======
 
+- Added support for ``catalog`` in fully qualified table and column names,
+  i.e.::
+
+    SELECT * FROM crate.doc.t1;
+    SELECT crate.doc.t1.a, crate.doc.t1.b FROM crate.doc.t1;
+
 - Added support of ``GROUP BY`` on ``ARRAY`` typed columns.
 
 

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -48,9 +48,14 @@ identifier. An identifier is an unquoted or double quoted string.
 
 - quoted: ``"columnName"``
 
-It's also possible to include the name of a table or alias in order to
-unambiguously identify a column of a specific relation if a statement contains
-multiple alias or table definitions::
+It's also possible to include the name of a table with or without schema and
+catalog name, or an alias in order to unambiguously identify a column of a
+specific relation if a statement contains multiple aliases or table definitions::
+
+    crate.myschema.mytable.columnname
+    myschema.mytable.columname
+
+or::
 
     tab0.columnname
 
@@ -58,6 +63,10 @@ multiple alias or table definitions::
 
     :ref:`sql_lexical`
 
+.. NOTE::
+
+    As CrateDB doesn't support multiple catalogs, only multiple schemas, the
+    only valid catalog name is ``crate``.
 
 .. _sql-parameter-reference:
 

--- a/server/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -21,6 +21,13 @@
 
 package io.crate.analyze.relations;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.RelationUnknown;
@@ -29,12 +36,6 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
 
 /**
  * Resolves QualifiedNames to Fields considering multiple AnalyzedRelations.
@@ -71,6 +72,11 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Symbol> {
             case 3:
                 columnSchema = parts.get(0);
                 columnTableName = parts.get(1);
+                break;
+            case 4:
+                RelationName.ensureIsCrateCatalog(parts.get(0));
+                columnSchema = parts.get(1);
+                columnTableName = parts.get(2);
                 break;
             default:
                 throw new IllegalArgumentException("Column reference \"%s\" has too many parts. " +

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -146,10 +146,10 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testResolveTableInfoForValidFQN() throws IOException {
-        RelationName tableIdent = new RelationName("schema", "t");
+        RelationName tableIdent = RelationName.of(QualifiedName.of("crate", "schema", "t"), null);
         SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(tableIdent, "doc", "schema").build();
 
-        QualifiedName fqn = QualifiedName.of("schema", "t");
+        QualifiedName fqn = QualifiedName.of("crate", "schema", "t");
         SessionContext sessionContext = sqlExecutor.getSessionContext();
         TableInfo tableInfo = sqlExecutor.schemas()
             .resolveTableInfo(fqn, Operation.READ, sessionContext.sessionUser(), sessionContext.searchPath());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Add the ability to prefix FQNs of tables and columns with a catalog name
on top of the schema, i.e.
```
SELECT * FROM crate.doc.t1;
SELECT crate.doc.t1.a, crate.doc.t1.b FROM crate.doc.t1;
```

Closes: #12658

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
