### PR TITLE
Fix gradle deprecation warnings (prepare for v8.0)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -299,7 +299,7 @@ task downloadAdminUI {
 processResources.dependsOn(downloadPlugins)
 
 task(runDebug, dependsOn: 'classes', type: JavaExec) {
-    main = 'io.crate.bootstrap.CrateDB'
+    mainClass = 'io.crate.bootstrap.CrateDB'
     debug = true
     enableAssertions = true
     classpath = sourceSets.main.runtimeClasspath
@@ -308,7 +308,7 @@ task(runDebug, dependsOn: 'classes', type: JavaExec) {
 }
 
 task(run, dependsOn: 'classes', type: JavaExec) {
-    main = 'io.crate.bootstrap.CrateDB'
+    mainClass = 'io.crate.bootstrap.CrateDB'
     debug = false
     enableAssertions = true
     classpath = sourceSets.main.runtimeClasspath
@@ -318,7 +318,7 @@ task(run, dependsOn: 'classes', type: JavaExec) {
 
 task createCrateNodeScripts(type: CreateStartScripts) {
     outputDir = file('build/bin')
-    mainClassName = 'org.elasticsearch.cluster.coordination.NodeToolCli'
+    mainClass = 'org.elasticsearch.cluster.coordination.NodeToolCli'
     applicationName = 'crate-node'
     classpath = sourceSets.main.runtimeClasspath + files('lib/crate-app.jar')
 

--- a/build.gradle
+++ b/build.gradle
@@ -197,12 +197,12 @@ task jacocoReport(type: JacocoReport) {
 
     reports {
         xml {
-            enabled true
+            required = true
             destination file(project.buildDir.path + '/reports/jacoco/test/jacocoTestReport.xml')
         }
-        csv.enabled false
+        csv.required = false
         html {
-            enabled true
+            required = true
             destination file(project.buildDir.path + '/reports/jacoco/jacocoHtml')
         }
     }

--- a/libs/pgwire/build.gradle
+++ b/libs/pgwire/build.gradle
@@ -60,7 +60,7 @@ task generateGrammarSource(dependsOn: antlrOutputDir, type: JavaExec) {
 
     def grammars = fileTree(antlr.source).include('**/*.g4')
 
-    main = 'org.antlr.v4.Tool'
+    mainClass = 'org.antlr.v4.Tool'
     classpath = configurations.antlr4
     args = [
         "-o", "${antlr.output}",

--- a/libs/sql-parser/build.gradle
+++ b/libs/sql-parser/build.gradle
@@ -41,7 +41,7 @@ task generateGrammarSource(dependsOn: antlrOutputDir, type: JavaExec) {
 
     def grammars = fileTree(antlr.source).include('**/*.g4')
 
-    main = 'org.antlr.v4.Tool'
+    mainClass = 'org.antlr.v4.Tool'
     classpath = configurations.antlr4
     args = ["-o", "${antlr.output}", "-visitor", "-package", antlr.package, grammars.files].flatten()
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -148,7 +148,7 @@ dependencies {
 task getVersion(dependsOn: 'classes', type: JavaExec) {
     def stdout = new ByteArrayOutputStream()
     classpath = sourceSets.main.runtimeClasspath
-    main = 'org.elasticsearch.Version'
+    mainClass = 'org.elasticsearch.Version'
     standardOutput = stdout
 
     doLast {
@@ -190,7 +190,7 @@ task generateGrammarSource(dependsOn: antlrOutputDir, type: JavaExec) {
 
     def grammars = fileTree(antlr.source).include('**/*.g4')
 
-    main = 'org.antlr.v4.Tool'
+    mainClass = 'org.antlr.v4.Tool'
     classpath = configurations.antlr4
     args = [
         "-o", "${antlr.output}",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix gradle deprecation warnings (prepare for v8.0)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
