### PR TITLE
Remove dead updateMapping code from AlterTableClusterStateExecutor

### DIFF
--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -111,8 +111,9 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
     protected ClusterState execute(ClusterState currentState, AlterTableRequest request) throws Exception {
         if (request.isPartitioned()) {
             if (request.partitionIndexName() != null) {
+                assert request.mappingDelta() == null
+                    : "Cannot add column to a single partition. Template and index mappings must stay in sync";
                 Index[] concreteIndices = resolveIndices(currentState, request.partitionIndexName());
-                currentState = updateMapping(currentState, request, concreteIndices);
                 currentState = updateSettings(currentState, request.settings(), concreteIndices);
             } else {
                 // template gets all changes unfiltered


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Clarifies a contract. See `AlterTableOperation.addColumnToTable`, the
`partitionIndexName` is never set and we must never set it.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
