### PR TITLE
Dump active tasks and threads on timeout in LR tests

### DIFF
--- a/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/SQLIntegrationTestCase.java
@@ -419,12 +419,6 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
         return response;
     }
 
-    private void dumpActiveTasks() {
-        for (var tasksService : internalCluster().getInstances(TasksService.class)) {
-            tasksService.logActiveTasksToError();
-        }
-    }
-
     /**
      * Execute an SQL Statement on a random node of the cluster
      *
@@ -439,7 +433,7 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
             return response;
         } catch (ElasticsearchTimeoutException e) {
             LOGGER.error("Timeout on SQL statement: {} {}", stmt, e);
-            dumpActiveTasks();
+            internalCluster().dumpActiveTasks();
             throw e;
         }
     }
@@ -459,7 +453,7 @@ public abstract class SQLIntegrationTestCase extends ESIntegTestCase {
             return response;
         } catch (ElasticsearchTimeoutException e) {
             LOGGER.error("Timeout on SQL statement: {} {}", stmt, e);
-            dumpActiveTasks();
+            internalCluster().dumpActiveTasks();
             throw e;
         }
     }

--- a/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/InternalTestCluster.java
@@ -152,6 +152,7 @@ import io.crate.action.sql.SQLOperations;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.execution.ddl.SchemaUpdateClient;
+import io.crate.execution.jobs.TasksService;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.testing.SQLTransportExecutor;
 
@@ -2270,5 +2271,11 @@ public final class InternalTestCluster extends TestCluster {
                 }
             }
         );
+    }
+
+    public void dumpActiveTasks() {
+        for (var tasksService : getInstances(TasksService.class)) {
+            tasksService.logActiveTasksToError();
+        }
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/threadpool/TestThreadPool.java
+++ b/server/src/testFixtures/java/org/elasticsearch/threadpool/TestThreadPool.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.threadpool;
 
+import java.util.Map;
+
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 
@@ -30,5 +32,17 @@ public class TestThreadPool extends ThreadPool {
 
     public TestThreadPool(String name, Settings settings) {
         super(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), name).put(settings).build());
+    }
+
+    public static void dumpThreads() {
+        Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
+        for (var entry : allStackTraces.entrySet()) {
+            Thread thread = entry.getKey();
+            StackTraceElement[] stackTraces = entry.getValue();
+            System.err.println("Thread: " + thread.getName());
+            for (var stackTrace : stackTraces) {
+                System.err.println("    " + stackTrace.toString());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`test_deleted_and_recreated_partition_is_also_deleted_and_restored_on_subscriber`
is flaky and times out sometimes at a `SELECT id, p FROM t1 ORDER BY id`

This should give us some more clues on what could be causing the timeout.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
