### PR TITLE
Documentation: Improve rendering of 5.0.0 release notes

### DIFF
--- a/docs/appendices/release-notes/5.0.0.rst
+++ b/docs/appendices/release-notes/5.0.0.rst
@@ -70,17 +70,17 @@ Breaking Changes
   name as column name unless the function returns more than one column. Some
   examples:
 
-    ``cr> SELECT * FROM generate_series(1, 2);``
+  1. ``cr> SELECT * FROM generate_series(1, 2);``
 
-  This used to return a column named ``col1`` and now returns a column named
-  ``generate_series``
+     This used to return a column named ``col1`` and now returns a column named
+     ``generate_series``.
 
-    ``cr> SELECT * FROM generate_series(1, 2) as numbers;``
+  2. ``cr> SELECT * FROM generate_series(1, 2) as numbers;``
 
-  This used to return a column named ``col1`` and now returns a column named
-  ``numbers``
+     This used to return a column named ``col1`` and now returns a column named
+     ``numbers``.
 
-  To ease migration we added a new setting
+  To ease migration, we added a new setting
   (:ref:`legacy.table_function_column_naming
   <legacy.table_function_column_naming>`.) to opt-out of this new behavior.
 


### PR DESCRIPTION
Hi there,

@proddata just reported a minor rendering flaw on the 5.0.0 release notes documentation at https://crate.io/docs/crate/reference/en/5.0/appendices/release-notes/5.0.0.html.

### Problem
It looks like the font size of [literal blocks](https://docutils.sourceforge.io/docs/user/rst/quickref.html#literal-blocks) are too large here.

> ![image](https://user-images.githubusercontent.com/453543/180983282-14912fa2-c47a-4c8f-ba01-2f7fb272452f.png)

### Investigation
@msbt quickly discovered that there is no literal block formatting, but, due to inappropriate indentation, a [block quote](https://docutils.sourceforge.io/docs/user/rst/quickref.html#block-quotes) element will be used. The display style of that element is apparently responsible for the font size adjustments, in turn looking a bit off here.

> ![image](https://user-images.githubusercontent.com/453543/180983716-eb2ae3e4-d65b-4401-ad3d-f8f25a671e76.png)

### Improvement
This patch adjusts the formatting a bit to improve the rendering.

> ![image](https://user-images.githubusercontent.com/453543/180983924-ed085378-e7f9-49b6-96fe-58c9c880aaf3.png)

With kind regards,
Andreas.
