### PR TITLE
bp: Remove Redundant Loading of RepositoryData during Restore

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -525,7 +525,7 @@ should be crossed out as well.
 - [ ] 350288ddf83 Check dot-index rules after template application (#52087)
 - [ ] 28a8db730f4 In FieldTypeLookup, factor out flat object field logic. (#52091)
 - [ ] d8169e5fdcf Don't Upload Redundant Shard Files (#51729) (#52147)
-- [ ] 90eb6a020da Remove Redundant Loading of RepositoryData during Restore (#51977) (#52108)
+- [x] 90eb6a020da Remove Redundant Loading of RepositoryData during Restore (#51977) (#52108)
 - [x] b77ef1f61bc Cleanup some Dead Code in o.e.index.store (#52045) (#52084)
 - [x] 337d73a7c6f Rename MapperService#fullName to fieldType.
 - [s] 91e938ead81 Add Trace Logging of REST Requests (#51684) (#52015)

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
@@ -21,12 +21,14 @@ package org.elasticsearch.cluster.routing;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.Snapshot;
 
 import java.io.IOException;
@@ -142,7 +144,6 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
          */
         public static final String FORCED_ALLOCATION_ID = "_forced_allocation_";
 
-
         public static final ExistingStoreRecoverySource INSTANCE = new ExistingStoreRecoverySource(false);
         public static final ExistingStoreRecoverySource FORCE_STALE_PRIMARY_INSTANCE = new ExistingStoreRecoverySource(true);
 
@@ -215,14 +216,14 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
     public static class SnapshotRecoverySource extends RecoverySource {
         private final String restoreUUID;
         private final Snapshot snapshot;
-        private final String index;
+        private final IndexId index;
         private final Version version;
 
-        public SnapshotRecoverySource(String restoreUUID, Snapshot snapshot, Version version, String index) {
+        public SnapshotRecoverySource(String restoreUUID, Snapshot snapshot, Version version, IndexId indexId) {
             this.restoreUUID = restoreUUID;
             this.snapshot = Objects.requireNonNull(snapshot);
             this.version = Objects.requireNonNull(version);
-            this.index = Objects.requireNonNull(index);
+            this.index = Objects.requireNonNull(indexId);
         }
 
         SnapshotRecoverySource(StreamInput in) throws IOException {
@@ -233,7 +234,11 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             }
             snapshot = new Snapshot(in);
             version = Version.readVersion(in);
-            index = in.readString();
+            if (in.getVersion().onOrAfter(Version.V_5_1_0)) {
+                index = new IndexId(in);
+            } else {
+                index = new IndexId(in.readString(), IndexMetadata.INDEX_UUID_NA_VALUE);
+            }
         }
 
         public String restoreUUID() {
@@ -244,7 +249,13 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             return snapshot;
         }
 
-        public String index() {
+        /**
+         * Gets the {@link IndexId} of the recovery source. May contain {@link IndexMetadata#INDEX_UUID_NA_VALUE} as the index uuid if it
+         * was created by an older version master in a mixed version cluster.
+         *
+         * @return IndexId
+         */
+        public IndexId index() {
             return index;
         }
 
@@ -259,7 +270,11 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             }
             snapshot.writeTo(out);
             Version.writeVersion(version, out);
-            out.writeString(index);
+            if (out.getVersion().onOrAfter(Version.V_5_1_0)) {
+                index.writeTo(out);
+            } else {
+                out.writeString(index.getName());
+            }
         }
 
         @Override
@@ -272,7 +287,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             builder.field("repository", snapshot.getRepository())
                 .field("snapshot", snapshot.getSnapshotId().getName())
                 .field("version", version.toString())
-                .field("index", index)
+                .field("index", index.getName())
                 .field("restoreUUID", restoreUUID);
         }
 
@@ -290,11 +305,11 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
                 return false;
             }
 
-            @SuppressWarnings("unchecked") SnapshotRecoverySource that = (SnapshotRecoverySource) o;
+            SnapshotRecoverySource that = (SnapshotRecoverySource) o;
             return restoreUUID.equals(that.restoreUUID)
-                && snapshot.equals(that.snapshot)
-                && index.equals(that.index)
-                && version.equals(that.version);
+                   && snapshot.equals(that.snapshot)
+                   && index.equals(that.index)
+                   && version.equals(that.version);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -271,7 +271,8 @@ public class RestoreService implements ClusterStateApplier {
                                             for (Map.Entry<String, String> indexEntry : indices.entrySet()) {
                                                 String index = indexEntry.getValue();
                                                 boolean partial = checkPartial(index);
-                                                SnapshotRecoverySource recoverySource = new SnapshotRecoverySource(restoreUUID, snapshot, snapshotInfo.version(), index);
+                                                SnapshotRecoverySource recoverySource = new SnapshotRecoverySource(restoreUUID, snapshot,
+                                                    snapshotInfo.version(), repositoryData.resolveIndexId(index));
                                                 IndexMetadata snapshotIndexMetadata = metadata.index(index);
                                                 if (snapshotIndexMetadata == null) {
                                                     throw new IndexNotFoundException(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -171,7 +171,7 @@ public class ShardRoutingTests extends ESTestCase {
                                                         otherRouting.relocatingNodeId(), otherRouting.primary(), otherRouting.state(),
                                                         new RecoverySource.SnapshotRecoverySource(UUIDs.randomBase64UUID(),
                                                         new Snapshot("test",
-                                                        new SnapshotId("s1", UUIDs.randomBase64UUID())), Version.CURRENT, new IndexId("test", UUIDs.randomBase64UUID(random())).getId()),
+                                                        new SnapshotId("s1", UUIDs.randomBase64UUID())), Version.CURRENT, new IndexId("test", UUIDs.randomBase64UUID(random()))),
                                                         otherRouting.unassignedInfo(), otherRouting.allocationId(), otherRouting.getExpectedShardSize());
                     }
                     break;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -74,6 +74,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryA
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.VersionUtils;
@@ -381,7 +382,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
                                                               new SnapshotRecoverySource(
                                                                   UUIDs.randomBase64UUID(),
                                                                   new Snapshot("rep1", new SnapshotId("snp1", UUIDs.randomBase64UUID())),
-                                                                  Version.CURRENT, "test")).build())
+                                                                  Version.CURRENT, new IndexId("test", UUIDs.randomBase64UUID(random())))).build())
             .nodes(DiscoveryNodes.builder().add(newNode).add(oldNode1).add(oldNode2)).build();
         AllocationDeciders allocationDeciders = new AllocationDeciders(Arrays.asList(
             new ReplicaAfterPrimaryActiveAllocationDecider(),
@@ -495,14 +496,15 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(decision.getExplanation(), is("cannot relocate primary shard from a node with version [" +
                                                  newNode.node().getVersion() + "] to a node with older version [" + oldNode.node().getVersion() + "]"));
 
+        final IndexId indexId = new IndexId("test", UUIDs.randomBase64UUID(random()));
         final SnapshotRecoverySource newVersionSnapshot = new SnapshotRecoverySource(
             UUIDs.randomBase64UUID(),
             new Snapshot("rep1", new SnapshotId("snp1", UUIDs.randomBase64UUID())),
-            newNode.node().getVersion(), "test");
+            newNode.node().getVersion(), indexId);
         final SnapshotRecoverySource oldVersionSnapshot = new SnapshotRecoverySource(
             UUIDs.randomBase64UUID(),
             new Snapshot("rep1", new SnapshotId("snp1", UUIDs.randomBase64UUID())),
-            oldNode.node().getVersion(), "test");
+            oldNode.node().getVersion(), indexId);
 
         decision = allocationDecider.canAllocate(ShardRoutingHelper.newWithRestoreSource(primaryShard, newVersionSnapshot),
                                                  oldNode, routingAllocation);

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3467,7 +3467,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 UUIDs.randomBase64UUID(),
                 snapshot,
                 Version.CURRENT,
-                "test")
+                new IndexId("test", UUIDs.randomBase64UUID(random())))
         );
         target = reinitShard(target, routing);
         Store sourceStore = source.store();

--- a/server/src/testFixtures/java/org/elasticsearch/cluster/routing/TestShardRouting.java
+++ b/server/src/testFixtures/java/org/elasticsearch/cluster/routing/TestShardRouting.java
@@ -24,10 +24,12 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.apache.lucene.tests.util.CrateLuceneTestCase.random;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 
 /**
@@ -154,6 +156,6 @@ public class TestShardRouting {
                 UUIDs.randomBase64UUID(),
                 new Snapshot("repo", new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())),
                 Version.CURRENT,
-                "some_index"));
+                new IndexId("some_index", UUIDs.randomBase64UUID(random()))));
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -934,11 +934,10 @@ public abstract class IndexShardTestCase extends ESTestCase {
                                             final Repository repository) {
         final Version version = Version.CURRENT;
         final ShardId shardId = shard.shardId();
-        final String index = shardId.getIndexName();
         final IndexId indexId = new IndexId(shardId.getIndex().getName(), shardId.getIndex().getUUID());
         final DiscoveryNode node = getFakeDiscoNode(shard.routingEntry().currentNodeId());
         final RecoverySource.SnapshotRecoverySource recoverySource =
-            new RecoverySource.SnapshotRecoverySource(UUIDs.randomBase64UUID(), snapshot, version, index);
+            new RecoverySource.SnapshotRecoverySource(UUIDs.randomBase64UUID(), snapshot, version, indexId);
         final ShardRouting shardRouting = newShardRouting(shardId, node.getId(), true, ShardRoutingState.INITIALIZING, recoverySource);
         shard.markAsRecovering("from snapshot", new RecoveryState(shardRouting, node, null));
         final PlainActionFuture<Void> future = PlainActionFuture.newFuture();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We can just put the `IndexId` instead of just the index name into the recovery soruce and
save one load of `RepositoryData` on each shard restore that way.

https://github.com/elastic/elasticsearch/commit/90eb6a020dac8955c1cd99ee8f3c75d1f58bd9e4

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
