### PR TITLE
Add an application_name session setting

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -59,6 +59,9 @@ Deprecations
 Changes
 =======
 
+- Added a ``application_name`` session setting that can be used to identify
+  clients or applications which connect to a CrateDB node.
+
 - Added support for ``catalog`` in fully qualified table and column names,
   i.e.::
 

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -63,6 +63,17 @@ Supported session settings
      includes it in the ``search_path`` *before* the configured schemas, unless
      it is already explicitly in the schema configuration.
 
+.. _conf-session-application-name:
+
+**application_name**
+  | *Default:* ``null``
+  | *Modifiable:* ``yes``
+
+  An arbitrary application name that can be set to identify an application that
+  connects to a CrateDB node.
+
+  Some clients set this implicitly to their client name.
+
 .. _conf-session-enable-hashjoin:
 
 **enable_hashjoin**

--- a/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
@@ -41,6 +41,7 @@ public class CoordinatorSessionSettings extends SessionSettings {
     private final User authenticatedUser;
     private User sessionUser;
     private Set<Class<? extends Rule<?>>> excludedOptimizerRules;
+    private String applicationName;
 
     public CoordinatorSessionSettings(User authenticatedUser, String ... searchPath) {
         this(authenticatedUser, authenticatedUser, SearchPath.createSearchPathFrom(searchPath), true, Set.of(), true);
@@ -97,5 +98,14 @@ public class CoordinatorSessionSettings extends SessionSettings {
 
     public Set<Class<? extends Rule<?>>> excludedOptimizerRules() {
         return excludedOptimizerRules;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    @Override
+    public String applicationName() {
+        return this.applicationName;
     }
 }

--- a/server/src/main/java/io/crate/metadata/settings/SessionSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/SessionSettings.java
@@ -89,6 +89,11 @@ public class SessionSettings implements Writeable {
         return errorOnUnknownObjectKey;
     }
 
+    public String applicationName() {
+        // Only available on coordinator.
+        return null;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(userName);

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 
 public class PgCatalogITest extends SQLIntegrationTestCase {
@@ -142,12 +143,14 @@ public class PgCatalogITest extends SQLIntegrationTestCase {
     }
 
     @Test
+    @UseJdbc(0)
     @UseRandomizedSchema(random = false)
     @UseHashJoins(0)
     public void testPgSettingsTable() {
         execute("select name, setting, short_desc, min_val, max_val from pg_catalog.pg_settings");
         String printedTable = printedTable(response.rows());
         assertThat(printedTable.split("\\n"), Matchers.arrayContaining(
+            "application_name| NULL| Optional application name. Can be set by a client to identify the application which created the connection| NULL| NULL",
             "enable_hashjoin| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL",
             "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.| NULL| NULL",
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -36,6 +36,7 @@ import java.util.Locale;
 import org.junit.Test;
 
 import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 
 @UseRandomizedSchema(random = false)
@@ -397,10 +398,12 @@ public class ShowIntegrationTest extends SQLIntegrationTestCase {
     }
 
     @UseHashJoins(1)
+    @UseJdbc(1)
     @Test
     public void testShowAll() {
         execute("show all");
         assertThat(printedTable(response.rows()), is(
+            "application_name| PostgreSQL JDBC Driver| Optional application name. Can be set by a client to identify the application which created the connection\n" +
             "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.\n" +
             "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.\n" +
             "max_index_keys| 32| Shows the maximum number of index keys.\n" +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Depends on https://github.com/crate/crate/pull/12835

The PostgreSQL JDBC client sets this implicitly. So far this resulted in
a warning in the logs

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
