### PR TITLE
`buildSrc` cleanup and use assertj

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,4 +10,5 @@ dependencies {
     implementation 'org.apache.commons:commons-compress:1.20'
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.27.0"
+    testImplementation "org.assertj:assertj-core:3.23.1"
 }

--- a/buildSrc/src/main/java/io/crate/gradle/OS.java
+++ b/buildSrc/src/main/java/io/crate/gradle/OS.java
@@ -26,6 +26,7 @@ public enum OS {
     MAC,
     LINUX;
 
+    @SuppressWarnings("unused")
     public static OS current() {
         String os = System.getProperty("os.name", "");
         if (os.startsWith("Windows")) {

--- a/buildSrc/src/main/java/io/crate/gradle/plugins/jdk/Jdk.java
+++ b/buildSrc/src/main/java/io/crate/gradle/plugins/jdk/Jdk.java
@@ -21,16 +21,16 @@
 
 package io.crate.gradle.plugins.jdk;
 
+import java.io.File;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+
 import org.gradle.api.Buildable;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.TaskDependency;
-
-import java.io.File;
-import java.util.Iterator;
-import java.util.List;
-import java.util.regex.Pattern;
 
 public class Jdk implements Buildable, Iterable<File> {
 
@@ -38,7 +38,7 @@ public class Jdk implements Buildable, Iterable<File> {
     private static final List<String> ALLOWED_OS = List.of("linux", "windows", "mac");
     private static final List<String> ALLOWED_ARCH = List.of("x64", "aarch64");
     private static final Pattern VERSION_PATTERN = Pattern.compile(
-        "(\\d+)(\\.\\d+\\.\\d+)?\\+(\\d+(?:\\.\\d+)?)(@([a-f0-9]{32}))?");
+        "(\\d+)(\\.\\d+\\.\\d+)?\\+(\\d+(?:\\.\\d+)?)(@([a-f\\d]{32}))?");
 
     private final String name;
     private final Configuration configuration;
@@ -59,10 +59,6 @@ public class Jdk implements Buildable, Iterable<File> {
         this.version = objectFactory.property(String.class);
         this.arch = objectFactory.property(String.class);
         this.os = objectFactory.property(String.class);
-    }
-
-    public String name() {
-        return name;
     }
 
     public String vendor() {
@@ -95,10 +91,6 @@ public class Jdk implements Buildable, Iterable<File> {
         build = versionMatcher.group(3);
         hash = versionMatcher.group(5);
         this.version.set(version);
-    }
-
-    public String platform() {
-        return arch() + "_" + os();
     }
 
     public String arch() {
@@ -149,20 +141,18 @@ public class Jdk implements Buildable, Iterable<File> {
         return configuration.getSingleFile().toString();
     }
 
-    public Configuration configuration() {
-        return configuration;
-    }
-
     @Override
     public String toString() {
         return path();
     }
 
+    @SuppressWarnings("NullableProblems")
     @Override
     public TaskDependency getBuildDependencies() {
         return configuration.getBuildDependencies();
     }
 
+    @SuppressWarnings("unused")
     public Object getBinJavaPath() {
         return new Object() {
             @Override
@@ -176,7 +166,6 @@ public class Jdk implements Buildable, Iterable<File> {
         return new File(path() + ("mac".equals(os()) ? "/Contents/Home" : ""));
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     void finalizeValues() {
         if (!version.isPresent()) {
             throw new IllegalArgumentException("version is not specified for jdk [" + name + "]");

--- a/buildSrc/src/main/java/io/crate/gradle/plugins/jdk/transform/UnzipTransform.java
+++ b/buildSrc/src/main/java/io/crate/gradle/plugins/jdk/transform/UnzipTransform.java
@@ -35,6 +35,8 @@ import java.util.zip.ZipInputStream;
 
 public abstract class UnzipTransform implements UnpackTransform {
 
+    private static final int BUFFER_SIZE = 4096;
+
     public void unpack(File zipFile, File targetDir) throws IOException {
         Logging.getLogger(UnzipTransform.class)
             .info("Unpacking " + zipFile.getName() + " using " + UnzipTransform.class.getSimpleName() + ".");
@@ -49,14 +51,14 @@ public abstract class UnzipTransform implements UnpackTransform {
                 File outFile = new File(targetDir, child);
                 outFile.getParentFile().mkdirs();
                 try (FileOutputStream outputStream = new FileOutputStream(outFile)) {
-                    copy(inputStream, outputStream, 4096);
+                    copy(inputStream, outputStream);
                 }
             }
         }
     }
 
-    private static void copy(InputStream in, OutputStream out, int bufferSize) throws IOException {
-        byte[] buf = new byte[bufferSize];
+    private static void copy(InputStream in, OutputStream out) throws IOException {
+        byte[] buf = new byte[BUFFER_SIZE];
         int len;
         while ((len = in.read(buf)) >= 0) {
             out.write(buf, 0, len);

--- a/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
+++ b/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
@@ -22,6 +22,8 @@
 package io.crate.gradle.plugins.jdk;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+
+import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.Test;
@@ -39,9 +41,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Note: the downloading of the JDK bundles are not covered by the test,
@@ -85,10 +85,14 @@ public class JdkDownloadPluginFunctionalTest {
                                          String version) {
         runBuild(task, result -> {
             Matcher matcher = JDK_HOME_LOG.matcher(result.getOutput());
-            assertThat("could not find jdk home in: " + result.getOutput(), matcher.find(), is(true));
+            Assertions.assertThat(matcher.find())
+                .as("could not find jdk home in: " + result.getOutput())
+                .isTrue();
             String jdkHome = matcher.group(1);
             Path javaPath = Paths.get(jdkHome, javaBin);
-            assertThat(javaPath.toString(), Files.exists(javaPath), is(true));
+            Assertions.assertThat(Files.exists(javaPath))
+                .as(javaPath.toString())
+                .isTrue();
         }, os, arch, vendor, version);
     }
 

--- a/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkTest.java
+++ b/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkTest.java
@@ -20,18 +20,15 @@
  */
 package io.crate.gradle.plugins.jdk;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class JdkTest {
-
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     private static Project rootProject;
 
@@ -42,112 +39,116 @@ public class JdkTest {
 
     @Test
     public void testMissingArch() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "architecture is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            null,
-            "11.0.2+33",
-            "linux",
-            null
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     null,
+                     "11.0.2+33",
+                     "linux",
+                     null
+           ))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("architecture is not specified for jdk [testjdk]");
     }
 
     @Test
     public void testUnknownArch() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "unknown architecture [x86] for jdk [testjdk], must be one of [x64, aarch64]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "11.0.2+33",
-            "windows",
-            "x86"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "11.0.2+33",
+                     "windows",
+                     "x86"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("unknown architecture [x86] for jdk [testjdk], must be one of [x64, aarch64]");
+
     }
 
     @Test
     public void testMissingVendor() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "vendor is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            null,
-            "11.0.2+33",
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     null,
+                     "11.0.2+33",
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("vendor is not specified for jdk [testjdk]");
     }
 
     @Test
     public void testUnknownVendor() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "unknown vendor [unknown] for jdk [testjdk], must be one of [adoptopenjdk, adoptium]");
-        createJdk(createProject(),
-            "testjdk",
-            "unknown",
-            "11.0.2+33",
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "unknown",
+                     "11.0.2+33",
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("unknown vendor [unknown] for jdk [testjdk], must be one of [adoptopenjdk, adoptium]");
     }
 
     @Test
     public void testMissingVersion() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("version is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            null,
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     null,
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("version is not specified for jdk [testjdk]");
+
     }
 
     @Test
     public void testBadVersionFormat() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("malformed version [badversion] for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "badversion",
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "badversion",
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("malformed version [badversion] for jdk [testjdk]");
     }
 
     @Test
     public void testMissingOS() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("OS is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "11.0.2+33",
-            null,
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "11.0.2+33",
+                     null,
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("OS is not specified for jdk [testjdk]");
     }
 
     @Test
     public void testUnknownOS() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "unknown OS [unknown] for jdk [testjdk], " +
-            "must be one of [linux, windows, mac]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "11.0.2+33",
-            "unknown",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "11.0.2+33",
+                     "unknown",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("unknown OS [unknown] for jdk [testjdk], must be one of [linux, windows, mac]");
     }
 
     private void createJdk(Project project,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

-  Use assertj for assertions in `buildSrc`
- Code cleanups in `buildSrc`
    - Remove unused methods
    - Replace deprecated attributes
    - Use constant for buffer size
    - Suppress warnings

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
