### PR TITLE
Fix an issue with `RecordingSortedMergeIterator`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -75,6 +75,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fix an issue, causing ``IndexOutOfBoundsException`` to be thrown when using
+  ``LEFT``/``RIGHT`` or ``FULL`` ``OUTER JOIN`` and one of the tables (or
+  sub-selects) joined has 0 rows.
+
 - Updated the bundled JDK from 18.0.1+10 to 18.0.2+9.
 
 - Fixed a race condition that could cause a ``INSERT INTO`` operation to get

--- a/server/src/main/java/io/crate/execution/engine/distribution/merge/RecordingSortedMergeIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/merge/RecordingSortedMergeIterator.java
@@ -29,6 +29,7 @@ import io.crate.common.collections.PeekingIterator;
 import org.elasticsearch.common.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -119,6 +120,9 @@ final class RecordingSortedMergeIterator<TKey, TRow> implements SortedMergeItera
     }
 
     public Iterable<TRow> repeat() {
+        if (storedIterables.isEmpty()) {
+            return Collections.emptyList();
+        }
         return () -> new ReplayingIterator<>(sortRecording.buffer, Iterables.transform(storedIterables, Iterable::iterator));
     }
 

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
@@ -29,6 +29,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
@@ -136,6 +137,22 @@ public class SortedPagingIteratorTest extends ESTestCase {
         List<Object> replayedRows = new ArrayList<>();
         consumeSingleColumnRows(pagingIterator.repeat().iterator(), replayedRows);
         assertThat(rows, is(replayedRows));
+    }
+
+    @Test
+    public void testReplayOnEmptyIterators() {
+        SortedPagingIterator<Void, Row> pagingIterator = new SortedPagingIterator<>(ORDERING, true);
+        pagingIterator.merge(numberedBuckets(List.of(new ArrayBucket(new Object[][]{}))));
+        List<Object> rows = new ArrayList<>();
+        consumeSingleColumnRows(pagingIterator, rows);
+
+        pagingIterator.merge(numberedBuckets(List.of(new ArrayBucket(new Object[][]{}))));
+        pagingIterator.finish();
+        consumeSingleColumnRows(pagingIterator, rows);
+        Assertions.assertThat(rows).isEmpty();
+        List<Object> replayedRows = new ArrayList<>();
+        consumeSingleColumnRows(pagingIterator.repeat().iterator(), replayedRows);
+        Assertions.assertThat(replayedRows).isEmpty();
     }
 
     private Iterable<? extends KeyIterable<Void, Row>> numberedBuckets(List<Bucket> buckets) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, when attempting to `repeat()` a `ReplayingIterator` was instantiated,
even if `storedIterables` was empty, leading to an IndexOutOfBoundsException in
`computeNext()` when calling `iters.get(iterIdx)` on an empty List.

Users could experience this when outer joining (left/right or full) tables (or
sub-selects) in a multi-node cluster when one of those tables (or sub-selects)
returned 0 rows.

When `storedIterables` is empty don't create a `ReplayingIterator` but return an
empty Iterable instead.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
