### PR TITLE
Add initial very limited support for correlated subqueries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,9 @@ Deprecations
 Changes
 =======
 
+- Added support for correlated scalar sub-queries within the select list of a
+  query. See :ref:`Scalar subquery <sql-scalar-subquery>`.
+
 - Improve performance of queries on ``sys.snapshots``.
 
 - Added a ``application_name`` session setting that can be used to identify

--- a/docs/sql/general/value-expressions.rst
+++ b/docs/sql/general/value-expressions.rst
@@ -279,12 +279,35 @@ If zero rows are returned, it will be treated as null value. In the case that
 more than one row (or more than one column) is returned, CrateDB will treat it
 as an error.
 
-Columns from relations from outside of the subquery cannot be accessed from
-within the subquery. If you try to do so, CrateDB will treat it as an error,
-stating that the column is unknown.
+
+Scalar subqueries can access columns of its immediate parent if addressed via a
+table alias. Such a subquery is known as correlated subquery.
+
+::
+
+    cr> SELECT (SELECT t.mountain) as m FROM sys.summits t ORDER BY 1 ASC LIMIT 2;
+    +--------------+
+    | m            |
+    +--------------+
+    | Acherkogel   |
+    | Ackerlspitze |
+    +--------------+
+    SELECT 2 rows in set (... sec)
+
+
 
 .. NOTE::
 
     Scalar subqueries are restricted to :ref:`SELECT <sql-select>`, :ref:`DELETE
     <sql_reference_delete>` and :ref:`UPDATE <ref-update>` statements and
     cannot be used in other statements.
+
+.. NOTE::
+
+    Correlated subqueries are executed via a "Correlated Join". A correlated
+    join executes the sub-query for each row in the input relation. If the
+    result set of the outer relation is large this can be slow.
+
+.. NOTE::
+
+    Correlated subqueries are currently limited to the select list of a query.

--- a/libs/dex/src/main/java/io/crate/data/BiArrayRow.java
+++ b/libs/dex/src/main/java/io/crate/data/BiArrayRow.java
@@ -29,6 +29,14 @@ public class BiArrayRow extends Row {
     private Object[] firstCells;
     private Object[] secondCells;
 
+    public BiArrayRow() {
+    }
+
+    public BiArrayRow(Object[] firstCells, Object[] secondCells) {
+        this.firstCells = firstCells;
+        this.secondCells = secondCells;
+    }
+
     public void firstCells(Object[] cells) {
         this.firstCells = cells;
     }

--- a/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
+++ b/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
@@ -30,6 +30,12 @@ public final class CapturingRowConsumer implements RowConsumer {
     private final CompletableFuture<?> completionFuture;
     private final boolean requiresScroll;
 
+    public CapturingRowConsumer(boolean requiresScroll) {
+        this.batchIterator = new CompletableFuture<>();
+        this.completionFuture = batchIterator;
+        this.requiresScroll = requiresScroll;
+    }
+
     public CapturingRowConsumer(boolean requiresScroll, CompletableFuture<?> completionFuture) {
         this.batchIterator = new CompletableFuture<>();
         this.completionFuture = completionFuture;

--- a/libs/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
+++ b/libs/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.FailingBatchIterator;

--- a/server/src/main/java/io/crate/analyze/relations/ParentRelations.java
+++ b/server/src/main/java/io/crate/analyze/relations/ParentRelations.java
@@ -51,11 +51,21 @@ public class ParentRelations {
     }
 
     public boolean containsRelation(RelationName qualifiedName) {
-        return relation(qualifiedName) != null;
+        return getAncestor(qualifiedName) != null;
     }
 
     @Nullable
-    public AnalyzedRelation relation(RelationName relationName) {
+    public AnalyzedRelation getParent(RelationName relationName) {
+        if (sourcesTree.isEmpty() || sourcesTree.size() < 2) {
+            return null;
+        }
+        // the last item is the _current_ relation, need one before that for the immediate parent
+        Map<RelationName, AnalyzedRelation> parent = sourcesTree.get(sourcesTree.size() - 2);
+        return parent.get(relationName);
+    }
+
+    @Nullable
+    public AnalyzedRelation getAncestor(RelationName relationName) {
         AnalyzedRelation relation = null;
         for (int i = sourcesTree.size() - 1; i >= 0; i--) {
             relation = sourcesTree.get(i).get(relationName);

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -638,7 +638,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         var relationContext = context.currentRelationContext();
 
         var withQuery = relationContext.parentSources()
-            .relation(RelationName.of(tableQualifiedName, null));
+            .getAncestor(RelationName.of(tableQualifiedName, null));
         if (withQuery != null) {
             relation = withQuery;
         } else {

--- a/server/src/main/java/io/crate/execution/dsl/projection/CorrelatedJoinProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/CorrelatedJoinProjection.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dsl.projection;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.SubQueryResults;
+
+public class CorrelatedJoinProjection extends Projection {
+
+    private final List<Symbol> outputs;
+    private final LogicalPlan subQueryPlan;
+    private final SelectSymbol correlatedSubQuery;
+    private final PlannerContext plannerContext;
+    private final ProjectionBuilder projectionBuilder;
+    private final SubQueryResults subQueryResults;
+    private final Row params;
+    private final List<Symbol> inputPlanOutputs;
+    private final DependencyCarrier executor;
+
+    public CorrelatedJoinProjection(DependencyCarrier executor,
+                                    LogicalPlan subQueryPlan,
+                                    SelectSymbol correlatedSubQuery,
+                                    PlannerContext plannerContext,
+                                    ProjectionBuilder projectionBuilder,
+                                    SubQueryResults subQueryResults,
+                                    Row params,
+                                    List<Symbol> inputPlanOutputs,
+                                    List<Symbol> outputs) {
+        this.executor = executor;
+        this.subQueryPlan = subQueryPlan;
+        this.correlatedSubQuery = correlatedSubQuery;
+        this.plannerContext = plannerContext;
+        this.projectionBuilder = projectionBuilder;
+        this.subQueryResults = subQueryResults;
+        this.params = params;
+        this.inputPlanOutputs = inputPlanOutputs;
+        this.outputs = outputs;
+    }
+
+    public LogicalPlan subQueryPlan() {
+        return subQueryPlan;
+    }
+
+    public SelectSymbol correlatedSubQuery() {
+        return correlatedSubQuery;
+    }
+
+    public PlannerContext plannerContext() {
+        return plannerContext;
+    }
+
+    public ProjectionBuilder projectionBuilder() {
+        return projectionBuilder;
+    }
+
+    public SubQueryResults subQueryResults() {
+        return subQueryResults;
+    }
+
+    public Row params() {
+        return params;
+    }
+
+    public List<Symbol> inputPlanOutputs() {
+        return inputPlanOutputs;
+    }
+
+    @Override
+    public ProjectionType projectionType() {
+        return ProjectionType.CORRELATED_JOIN;
+    }
+
+    @Override
+    public <C, R> R accept(ProjectionVisitor<C, R> visitor, C context) {
+        return visitor.visitCorrelatedJoin(this, context);
+    }
+
+    @Override
+    public List<? extends Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("Cannot stream correlated join projection");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return false;
+    }
+
+    public DependencyCarrier executor() {
+        return executor;
+    }
+}

--- a/server/src/main/java/io/crate/execution/dsl/projection/ProjectionType.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ProjectionType.java
@@ -44,11 +44,14 @@ public enum ProjectionType {
     EVAL(EvalProjection::new),
     PROJECT_SET(ProjectSetProjection::new),
     WINDOW_AGGREGATION(WindowAggProjection::new),
-    TOPN_DISTINCT(TopNDistinctProjection::new);
+    TOPN_DISTINCT(TopNDistinctProjection::new),
+    CORRELATED_JOIN(in -> {
+        throw new UnsupportedOperationException("Cannot stream correlated join projection");
+    });
 
-    private final Projection.ProjectionFactory factory;
+    private final Projection.ProjectionFactory<?> factory;
 
-    ProjectionType(Projection.ProjectionFactory factory) {
+    ProjectionType(Projection.ProjectionFactory<?> factory) {
         this.factory = factory;
     }
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/ProjectionVisitor.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ProjectionVisitor.java
@@ -101,4 +101,8 @@ public class ProjectionVisitor<C, R> {
     public R visitTopNDistinct(TopNDistinctProjection topNDistinctProjection, C context) {
         return visitProjection(topNDistinctProjection, context);
     }
+
+    public R visitCorrelatedJoin(CorrelatedJoinProjection correlatedJoin, C context) {
+        return visitProjection(correlatedJoin, context);
+    }
 }

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -342,6 +342,13 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
 
     @Override
     public Symbol visitSelectSymbol(SelectSymbol selectSymbol, SourceSymbols sourceSymbols) {
+        if (selectSymbol.isCorrelated()) {
+            InputColumn inputColumn = sourceSymbols.inputs.get(selectSymbol);
+            if (inputColumn == null) {
+                throw new IllegalArgumentException("Couldn't find " + selectSymbol + " in " + sourceSymbols);
+            }
+            return inputColumn;
+        }
         return selectSymbol;
     }
 }

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPoints.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPoints.java
@@ -22,6 +22,7 @@
 package io.crate.execution.dsl.projection.builder;
 
 import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.OuterColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.WindowFunction;
 
@@ -49,18 +50,25 @@ public class SplitPoints {
     private final List<Function> tableFunctions;
     private final List<Function> tableFunctionsBelowGroupBy;
     private final List<WindowFunction> windowFunctions;
+    private final List<OuterColumn> outerColumns;
 
 
     SplitPoints(List<Symbol> toCollect,
+                List<OuterColumn> outerColumns,
                 List<Function> aggregates,
                 List<Function> tableFunctions,
                 List<Function> tableFunctionsBelowGroupBy,
                 List<WindowFunction> windowFunctions) {
         this.toCollect = toCollect;
+        this.outerColumns = outerColumns;
         this.aggregates = aggregates;
         this.tableFunctions = tableFunctions;
         this.tableFunctionsBelowGroupBy = tableFunctionsBelowGroupBy;
         this.windowFunctions = windowFunctions;
+    }
+
+    public List<OuterColumn> outerColumns() {
+        return outerColumns;
     }
 
     public List<Symbol> toCollect() {

--- a/server/src/main/java/io/crate/execution/engine/CorrelatedJoinProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/CorrelatedJoinProjector.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+import org.elasticsearch.common.UUIDs;
+
+import io.crate.data.AsyncFlatMapBatchIterator;
+import io.crate.data.AsyncFlatMapper;
+import io.crate.data.BatchIterator;
+import io.crate.data.BatchIterators;
+import io.crate.data.BiArrayRow;
+import io.crate.data.CapturingRowConsumer;
+import io.crate.data.CloseableIterator;
+import io.crate.data.Projector;
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.execution.engine.pipeline.TopN;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.SubQueryResults;
+
+public final class CorrelatedJoinProjector implements Projector {
+
+    private final LogicalPlan subQueryPlan;
+    private final PlannerContext plannerContext;
+    private final ProjectionBuilder projectionBuilder;
+    private final DependencyCarrier executor;
+    private final SubQueryResults subQueryResults;
+    private final SelectSymbol correlatedSubQuery;
+    private final List<Symbol> inputPlanOutputs;
+    private final Row params;
+
+    public CorrelatedJoinProjector(LogicalPlan subQueryPlan,
+                                   SelectSymbol correlatedSubQuery,
+                                   PlannerContext plannerContext,
+                                   ProjectionBuilder projectionBuilder,
+                                   DependencyCarrier executor,
+                                   SubQueryResults subQueryResults,
+                                   Row params,
+                                   List<Symbol> inputPlanOutputs) {
+        this.subQueryPlan = subQueryPlan;
+        this.correlatedSubQuery = correlatedSubQuery;
+        this.plannerContext = plannerContext;
+        this.projectionBuilder = projectionBuilder;
+        this.executor = executor;
+        this.subQueryResults = subQueryResults;
+        this.params = params;
+        this.inputPlanOutputs = inputPlanOutputs;
+    }
+
+    @Override
+    public BatchIterator<Row> apply(BatchIterator<Row> it) {
+        var bindAndExecuteSubQuery = new BindAndExecuteSubQuery();
+        return new AsyncFlatMapBatchIterator<>(it, bindAndExecuteSubQuery);
+    }
+
+    private final class BindAndExecuteSubQuery implements AsyncFlatMapper<Row, Row> {
+
+        // See `CorrelatedJoin` operator. The output is the output of the left relation + the sub-query result
+        final BiArrayRow outputRow = new BiArrayRow();
+        final Function<Row, Row> materialize = subQueryRow -> {
+            outputRow.secondCells(subQueryRow.materialize());
+            return outputRow;
+        };
+        final Collector<Row, ?, List<Row>> toList = Collectors.mapping(materialize, Collectors.toList());
+
+        @Override
+        public CompletableFuture<? extends CloseableIterator<Row>> apply(Row inputRow, boolean isLastCall) {
+            try {
+                var newSubQueryResults = subQueryResults.merge(
+                    correlatedSubQuery,
+                    inputPlanOutputs,
+                    inputRow
+                );
+                var executionPlan = subQueryPlan.build(
+                    executor,
+                    PlannerContext.forSubPlan(plannerContext, 2),
+                    Set.of(),
+                    projectionBuilder,
+                    TopN.NO_LIMIT,
+                    TopN.NO_OFFSET,
+                    null,
+                    null,
+                    params,
+                    newSubQueryResults
+                );
+                var nodeOps = List.of(NodeOperationTreeGenerator.fromPlan(executionPlan, executor.localNodeId()));
+                var capturingRowConsumer = new CapturingRowConsumer(false);
+                executor.phasesTaskFactory()
+                    .create(UUIDs.dirtyUUID(), nodeOps)
+                    .execute(capturingRowConsumer, plannerContext.transactionContext());
+
+                // Scalar sub-query returns 1 row, the materialization here shouldn't be too bad
+                outputRow.firstCells(inputRow.materialize());
+                return capturingRowConsumer.capturedBatchIterator()
+                    .thenCompose(it -> BatchIterators.collect(it, toList))
+                    .thenApply(rows -> {
+                        if (rows.size() > 1) {
+                            throw new UnsupportedOperationException(
+                                "Subquery returned more than 1 row when it shouldn't.");
+                        }
+                        return CloseableIterator.fromIterator(rows.iterator());
+                    });
+            } catch (Throwable t) {
+                return CompletableFuture.failedFuture(t);
+            }
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -68,6 +68,7 @@ import io.crate.execution.dml.upsert.ShardUpsertAction;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
 import io.crate.execution.dsl.projection.AggregationProjection;
 import io.crate.execution.dsl.projection.ColumnIndexWriterProjection;
+import io.crate.execution.dsl.projection.CorrelatedJoinProjection;
 import io.crate.execution.dsl.projection.DeleteProjection;
 import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.FetchProjection;
@@ -86,6 +87,7 @@ import io.crate.execution.dsl.projection.TopNProjection;
 import io.crate.execution.dsl.projection.UpdateProjection;
 import io.crate.execution.dsl.projection.WindowAggProjection;
 import io.crate.execution.dsl.projection.WriterProjection;
+import io.crate.execution.engine.CorrelatedJoinProjector;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.AggregationPipe;
 import io.crate.execution.engine.aggregation.GroupingProjector;
@@ -705,6 +707,20 @@ public class ProjectionToProjectorVisitor
             indexVersionCreated,
             ThreadPools.numIdleThreads(searchThreadPool, numProcessors),
             searchThreadPool
+        );
+    }
+
+    @Override
+    public Projector visitCorrelatedJoin(CorrelatedJoinProjection correlatedJoin, Context context) {
+        return new CorrelatedJoinProjector(
+            correlatedJoin.subQueryPlan(),
+            correlatedJoin.correlatedSubQuery(),
+            correlatedJoin.plannerContext(),
+            correlatedJoin.projectionBuilder(),
+            correlatedJoin.executor(),
+            correlatedJoin.subQueryResults(),
+            correlatedJoin.params(),
+            correlatedJoin.inputPlanOutputs()
         );
     }
 

--- a/server/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
@@ -89,5 +89,9 @@ public class SymbolVisitor<C, R> {
     public R visitFetchStub(FetchStub fetchStub, C context) {
         return visitSymbol(fetchStub, context);
     }
+
+    public R visitOuterColumn(OuterColumn outerColumn, C context) {
+        return visitSymbol(outerColumn, context);
+    }
 }
 

--- a/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.symbol;
 
-import io.crate.analyze.OrderBy;
-import io.crate.analyze.WindowDefinition;
-import io.crate.metadata.ColumnIdent;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.WindowDefinition;
+import io.crate.metadata.ColumnIdent;
 
 public class SymbolVisitors {
 
@@ -223,6 +223,14 @@ public class SymbolVisitors {
                 return true;
             }
             return aliasSymbol.symbol().accept(this, predicate);
+        }
+
+        @Override
+        public Boolean visitOuterColumn(OuterColumn outerColumn, Predicate<? super Symbol> predicate) {
+            if (predicate.test(outerColumn)) {
+                return true;
+            }
+            return outerColumn.symbol().accept(this, predicate);
         }
 
         @Override

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -56,6 +56,15 @@ public class Symbols {
 
     public static final Predicate<Symbol> IS_COLUMN = s -> s instanceof ScopedSymbol || s instanceof Reference;
     public static final Predicate<Symbol> IS_GENERATED_COLUMN = input -> input instanceof GeneratedReference;
+    public static final Predicate<Symbol> IS_CORRELATED_SUBQUERY = Symbols::isCorrelatedSubQuery;
+
+    public static boolean isCorrelatedSubQuery(Symbol symbol) {
+        return symbol instanceof SelectSymbol selectSymbol && selectSymbol.isCorrelated();
+    }
+
+    public static boolean containsCorrelatedSubQuery(Symbol symbol) {
+        return SymbolVisitors.any(IS_CORRELATED_SUBQUERY, symbol);
+    }
 
     public static boolean isAggregate(Symbol s) {
         return s instanceof Function && ((Function) s).signature().getKind() == FunctionType.AGGREGATE;

--- a/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -119,7 +119,7 @@ public final class UpdatePlanner {
                 )
             );
         }
-        Map<LogicalPlan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(update);
+        Map<LogicalPlan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(update).uncorrelated();
         return MultiPhasePlan.createIfNeeded(plan, subQueries);
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -64,6 +64,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
@@ -143,7 +144,8 @@ public class Collect implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.common.collections.Lists2;
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.CorrelatedJoinProjection;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.execution.engine.pipeline.TopN;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.Merge;
+import io.crate.planner.PlannerContext;
+import io.crate.statistics.TableStats;
+
+/**
+ * Operator that takes two relations.
+ * One input relation providing rows, and a second relation that is a correlated subquery.
+ * For each row in the input relation it binds and executes the correlated subquery, joining the result.
+ *
+ * <pre>
+ * {@code
+ * SELECT (SELECT t.mountain) FROM sys.summits t
+ *        ^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^
+ *        SubQuery                 Input
+ *                                  output: [mountain]
+ *
+ *
+ *         CorrelatedJoin (output: [mountain, (SELECT t.mountain)]
+ *             /     \              ^^^^^^^^  ^^^^^^^^^^^^^^^^^^^
+ *         Input     SubQuery       │         └ SelectSymbol
+ *                                  └─ ScopedSymbol
+ * }
+ * </pre>
+ *
+ **/
+public class CorrelatedJoin implements LogicalPlan {
+
+    private final LogicalPlan inputPlan;
+    private final LogicalPlan subQueryPlan;
+
+    private final List<Symbol> outputs;
+    private final SelectSymbol selectSymbol;
+
+    public CorrelatedJoin(LogicalPlan inputPlan,
+                          SelectSymbol selectSymbol,
+                          LogicalPlan subQueryPlan) {
+        this.inputPlan = inputPlan;
+        this.subQueryPlan = subQueryPlan;
+        this.selectSymbol = selectSymbol;
+        this.outputs = Lists2.concat(inputPlan.outputs(), selectSymbol);
+    }
+
+    @Override
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
+                               ProjectionBuilder projectionBuilder,
+                               int limit,
+                               int offset,
+                               OrderBy order,
+                               Integer pageSizeHint,
+                               Row params,
+                               SubQueryResults subQueryResults) {
+        ExecutionPlan sourcePlan = Merge.ensureOnHandler(
+            inputPlan.build(
+                executor,
+                plannerContext,
+                planHints,
+                projectionBuilder,
+                TopN.NO_LIMIT,
+                TopN.NO_OFFSET,
+                null,
+                null,
+                params,
+                subQueryResults
+            ),
+            plannerContext
+        );
+        var projection = new CorrelatedJoinProjection(
+            executor,
+            subQueryPlan,
+            selectSymbol,
+            plannerContext,
+            projectionBuilder,
+            subQueryResults,
+            params,
+            inputPlan.outputs(),
+            outputs
+        );
+        sourcePlan.addProjection(projection);
+        return sourcePlan;
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public List<AbstractTableRelation<?>> baseTables() {
+        return inputPlan.baseTables();
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of(inputPlan);
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return this;
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+        return this;
+    }
+
+    @Override
+    public Map<LogicalPlan, SelectSymbol> dependencies() {
+        return inputPlan.dependencies();
+    }
+
+    @Override
+    public long numExpectedRows() {
+        return inputPlan.numExpectedRows();
+    }
+
+    @Override
+    public long estimatedRowSize() {
+        return inputPlan.estimatedRowSize();
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitCorrelatedJoin(this, context);
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return inputPlan.getRelationNames();
+    }
+
+    @Override
+    public void print(PrintContext printContext) {
+        printContext
+            .text(getClass().getSimpleName())
+            .text("[")
+            .text(Lists2.joinOn(", ", outputs(), Symbol::toString))
+            .text("]")
+            .nest(Lists2.map(sources(), x -> x::print))
+            .nest(p -> {
+                p.text("SubPlan");
+                p.nest(subQueryPlan::print);
+            });
+    }
+}

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -46,6 +46,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.distribution.DistributionInfo;
@@ -72,7 +73,8 @@ public class Count implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,

--- a/server/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/server/src/main/java/io/crate/planner/operators/Fetch.java
@@ -41,6 +41,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -108,7 +109,8 @@ public final class Fetch extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -120,6 +122,7 @@ public final class Fetch extends ForwardingLogicalPlan {
         plannerContext.newReaderAllocations();
         var executionPlan = Merge.ensureOnHandler(
             source.build(
+                executor,
                 plannerContext,
                 hints,
                 projectionBuilder,

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -30,6 +30,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
@@ -71,7 +72,8 @@ public final class Filter extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -81,7 +83,7 @@ public final class Filter extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan executionPlan = source.build(
-            plannerContext, planHints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+            executor, plannerContext, planHints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
         Symbol boundQuery = SubQueryAndParamBinder.convert(query, params, subQueryResults);
         FilterProjection filterProjection = ProjectionBuilder.filterProjection(source.outputs(), boundQuery);
         if (executionPlan.resultDescription().executesOnShard()) {

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -62,6 +62,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.node.dql.Collect;
@@ -93,7 +94,8 @@ public class Get implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limitHint,

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -47,6 +47,7 @@ import io.crate.metadata.FunctionType;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -64,7 +65,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -74,7 +76,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan executionPlan = source.build(
-            plannerContext, planHints, projectionBuilder, LogicalPlanner.NO_LIMIT, 0, null, null, params, subQueryResults);
+            executor, plannerContext, planHints, projectionBuilder, LogicalPlanner.NO_LIMIT, 0, null, null, params, subQueryResults);
 
         AggregationOutputValidator.validateOutputs(aggregates);
         var paramBinder = new SubQueryAndParamBinder(params, subQueryResults);

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -52,6 +52,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.ResultDescription;
@@ -104,7 +105,8 @@ public class HashJoin implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -114,9 +116,9 @@ public class HashJoin implements LogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan leftExecutionPlan = lhs.build(
-            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
         ExecutionPlan rightExecutionPlan = rhs.build(
-            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
 
         LogicalPlan leftLogicalPlan = lhs;
         LogicalPlan rightLogicalPlan = rhs;

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -42,6 +42,7 @@ import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -62,7 +63,8 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -72,6 +74,7 @@ public class Insert implements LogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan sourcePlan = source.build(
+            executor,
             plannerContext,
             EnumSet.of(PlanHint.PREFER_SOURCE_LOOKUP),
             projectionBuilder,

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -807,7 +807,8 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -42,6 +42,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -80,7 +81,8 @@ public class Limit extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limitHint,
@@ -107,7 +109,7 @@ public class Limit extends ForwardingLogicalPlan {
             0);
 
         ExecutionPlan executionPlan = source.build(
-            plannerContext, planHints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+            executor, plannerContext, planHints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
         List<DataType<?>> sourceTypes = Symbols.typeView(source.outputs());
         ResultDescription resultDescription = executionPlan.resultDescription();
         if (resultDescription.hasRemainingLimitOrOffset()

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -88,7 +88,8 @@ public interface LogicalPlan extends Plan {
      * {@code limit}, {@code offset}, {@code order} can be passed from one operator to another. Depending on the
      * operators implementation. Operator may choose to make use of this information, but can also ignore it.
      */
-    ExecutionPlan build(PlannerContext plannerContext,
+    ExecutionPlan build(DependencyCarrier dependencyCarrier,
+                        PlannerContext plannerContext,
                         Set<PlanHint> planHints,
                         ProjectionBuilder projectionBuilder,
                         int limit,

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
@@ -114,4 +114,8 @@ public class LogicalPlanVisitor<C, R> {
     public R visitFetch(Fetch fetch, C context) {
         return visitPlan(fetch, context);
     }
+
+    public R visitCorrelatedJoin(CorrelatedJoin apply, C context) {
+        return visitPlan(apply, context);
+    }
 }

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -21,6 +21,20 @@
 
 package io.crate.planner.operators;
 
+import static io.crate.planner.operators.Limit.limitAndOffset;
+import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -41,6 +55,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
@@ -49,19 +64,6 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.statistics.TableStats;
-
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static io.crate.planner.operators.Limit.limitAndOffset;
-import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
 public class NestedLoopJoin implements LogicalPlan {
 
@@ -160,7 +162,8 @@ public class NestedLoopJoin implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -182,9 +185,9 @@ public class NestedLoopJoin implements LogicalPlan {
             : null;
 
         ExecutionPlan left = lhs.build(
-            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
         ExecutionPlan right = rhs.build(
-            plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
 
         PositionalOrderBy orderByFromLeft = left.resultDescription().orderBy();
         boolean hasDocTables = baseTables.stream().anyMatch(r -> r instanceof DocTableRelation);

--- a/server/src/main/java/io/crate/planner/operators/Order.java
+++ b/server/src/main/java/io/crate/planner/operators/Order.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -118,7 +119,8 @@ public class Order extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -128,7 +130,7 @@ public class Order extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan plan = source.build(
-            plannerContext, planHints, projectionBuilder, limit, offset, orderBy, pageSizeHint, params, subQueryResults);
+            executor, plannerContext, planHints, projectionBuilder, limit, offset, orderBy, pageSizeHint, params, subQueryResults);
         if (plan.resultDescription().orderBy() != null) {
             // Collect applied ORDER BY eagerly to produce a optimized execution plan;
             if (source instanceof Collect) {

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -41,6 +41,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionType;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
@@ -105,7 +106,8 @@ public class ProjectSet extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -115,6 +117,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         ExecutionPlan sourcePlan = source.build(
+            executor,
             plannerContext,
             planHints,
             projectionBuilder,

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -31,6 +31,7 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
@@ -182,7 +183,8 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -191,7 +193,8 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
-        return source.build(plannerContext, hints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
+        return source.build(
+            executor, plannerContext, hints, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryResults);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -30,6 +30,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -44,7 +45,8 @@ public class RootRelationBoundary extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -54,6 +56,7 @@ public class RootRelationBoundary extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         return Merge.ensureOnHandler(source.build(
+            executor,
             plannerContext,
             hints,
             projectionBuilder,

--- a/server/src/main/java/io/crate/planner/operators/SubQueryResults.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryResults.java
@@ -21,19 +21,33 @@
 
 package io.crate.planner.operators;
 
-import io.crate.expression.symbol.SelectSymbol;
-
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import io.crate.data.Row;
+import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
+import io.crate.expression.symbol.OuterColumn;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
 
 public class SubQueryResults {
 
     public static final SubQueryResults EMPTY = new SubQueryResults(Collections.emptyMap());
 
     private final Map<SelectSymbol, Object> valuesBySubQuery;
+    private final Map<OuterColumn, Object> boundOuterColumns;
 
     public SubQueryResults(Map<SelectSymbol, Object> valuesBySubQuery) {
         this.valuesBySubQuery = valuesBySubQuery;
+        this.boundOuterColumns = Map.of();
+    }
+
+    public SubQueryResults(Map<SelectSymbol, Object> valuesBySubQuery,
+                           Map<OuterColumn, Object> boundOuterColumns) {
+        this.valuesBySubQuery = valuesBySubQuery;
+        this.boundOuterColumns = boundOuterColumns;
     }
 
     public Object getSafe(SelectSymbol key) {
@@ -42,5 +56,32 @@ public class SubQueryResults {
             throw new IllegalArgumentException("Couldn't resolve value for subQuery: " + key);
         }
         return value;
+    }
+
+    public Object get(OuterColumn key) {
+        Object value = boundOuterColumns.get(key);
+        if (value == null && !boundOuterColumns.containsKey(key)) {
+            throw new IllegalArgumentException("Couldn't resolve value for OuterColumn: " + key);
+        }
+        return value;
+    }
+
+    public SubQueryResults merge(SelectSymbol selectSymbol, List<Symbol> subQueryOutputs, Row row) {
+        HashMap<OuterColumn, Object> boundOuterColumns = new HashMap<>();
+        selectSymbol.relation().visitSymbols(symbol -> {
+            symbol.accept(new DefaultTraversalSymbolVisitor<Void, Void>() {
+
+                @Override
+                public Void visitOuterColumn(OuterColumn outerColumn, Void context) {
+                    int index = subQueryOutputs.indexOf(outerColumn.symbol());
+                    if (index < 0) {
+                        throw new IllegalStateException("OuterColumn must appear in input of CorrelatedJoin");
+                    }
+                    boundOuterColumns.put(outerColumn, row.get(index));
+                    return null;
+                }
+            }, null);
+        });
+        return new SubQueryResults(this.valuesBySubQuery, boundOuterColumns);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -37,6 +37,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.node.dql.Collect;
@@ -71,7 +72,8 @@ public final class TableFunction implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,

--- a/server/src/main/java/io/crate/planner/operators/TopNDistinct.java
+++ b/server/src/main/java/io/crate/planner/operators/TopNDistinct.java
@@ -46,6 +46,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -75,7 +76,8 @@ public final class TopNDistinct extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limitHint,
@@ -85,6 +87,7 @@ public final class TopNDistinct extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         var executionPlan = source.build(
+            executor,
             plannerContext,
             planHints,
             projectionBuilder,

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -50,6 +50,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -83,7 +84,8 @@ public class Union implements LogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> hints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -98,9 +100,9 @@ public class Union implements LogicalPlan {
             : null;
 
         ExecutionPlan left = lhs.build(
-            plannerContext, hints, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
+            executor, plannerContext, hints, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
         ExecutionPlan right = rhs.build(
-            plannerContext, hints, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
+            executor, plannerContext, hints, projectionBuilder, limit + offset, TopN.NO_OFFSET, null, childPageSizeHint, params, subQueryResults);
 
         addCastsForIncompatibleObjects(lhs, left);
         addCastsForIncompatibleObjects(rhs, right);

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -50,6 +50,7 @@ import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.WindowFunction;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -139,7 +140,8 @@ public class WindowAgg extends ForwardingLogicalPlan {
     }
 
     @Override
-    public ExecutionPlan build(PlannerContext plannerContext,
+    public ExecutionPlan build(DependencyCarrier executor,
+                               PlannerContext plannerContext,
                                Set<PlanHint> planHints,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -162,6 +164,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
         );
         projections.add(windowAggProjection);
         ExecutionPlan sourcePlan = source.build(
+            executor,
             plannerContext,
             planHints,
             projectionBuilder,

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -115,6 +115,7 @@ public final class CopyToPlan implements Plan {
             subQueryResults);
 
         ExecutionPlan executionPlan = planCopyToExecution(
+            executor,
             boundedCopyTo,
             plannerContext,
             tableStats,
@@ -136,7 +137,8 @@ public final class CopyToPlan implements Plan {
     }
 
     @VisibleForTesting
-    static ExecutionPlan planCopyToExecution(BoundCopyTo boundedCopyTo,
+    static ExecutionPlan planCopyToExecution(DependencyCarrier executor,
+                                             BoundCopyTo boundedCopyTo,
                                              PlannerContext context,
                                              TableStats tableStats,
                                              ProjectionBuilder projectionBuilder,
@@ -166,7 +168,8 @@ public final class CopyToPlan implements Plan {
             context.params()
         );
         LogicalPlan source = optimizeCollect(context, tableStats, collect);
-        ExecutionPlan executionPlan = source.build(context, Set.of(), projectionBuilder, 0, 0, null, null, params, SubQueryResults.EMPTY);
+        ExecutionPlan executionPlan = source.build(
+            executor, context, Set.of(), projectionBuilder, 0, 0, null, null, params, SubQueryResults.EMPTY);
         executionPlan.addProjection(projection);
 
         return Merge.ensureOnHandler(

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -80,7 +80,7 @@ public final class DeletePlanner {
                                   SubqueryPlanner subqueryPlanner,
                                   PlannerContext context) {
         Plan plan = planDelete(delete, context);
-        return MultiPhasePlan.createIfNeeded(plan, subqueryPlanner.planSubQueries(delete));
+        return MultiPhasePlan.createIfNeeded(plan, subqueryPlanner.planSubQueries(delete).uncorrelated());
     }
 
     private static Plan planDelete(AnalyzedDeleteStatement delete, PlannerContext context) {

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import io.crate.testing.TestingHelpers;
+
+public class CorrelatedSubqueryITest extends SQLIntegrationTestCase {
+
+    @Test
+    public void test_simple_correlated_subquery() {
+        execute("EXPLAIN SELECT 1, (SELECT t.mountain) FROM sys.summits t");
+
+        // This should use the correlated-join execution path;
+        // If we later optimize this query, ensure there is a test for CorrelatedJoin execution
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
+            "Eval[1, (SELECT mountain FROM (empty_row))]\n" +
+            "  └ CorrelatedJoin[1, mountain, (SELECT mountain FROM (empty_row))]\n" +
+            "    └ Rename[1, mountain] AS t\n" +
+            "      └ Collect[sys.summits | [1, mountain] | true]\n" +
+            "    └ SubPlan\n" +
+            "      └ Eval[mountain]\n" +
+            "        └ TableFunction[empty_row | [] | true]\n"
+        );
+        execute("SELECT 1, (SELECT t.mountain) FROM sys.summits t");
+        Comparator<Object[]> compareMountain = Comparator.comparing((Object[] row) -> (String) row[1]);
+        List<Object[]> mountains = Stream.of(response.rows())
+            .sorted(compareMountain)
+            .limit(5)
+            .toList();
+        assertThat(TestingHelpers.printRows(mountains)).isEqualTo(
+            "1| Acherkogel\n" +
+            "1| Ackerlspitze\n" +
+            "1| Adamello\n" +
+            "1| Admonter Reichenstein\n" +
+            "1| Aiguille Méridionale d'Arves\n"
+        );
+    }
+
+    @Test
+    public void test_simple_correlated_subquery_with_user_table_as_input() {
+        execute("create table tbl (x int)");
+        execute("insert into tbl (x) values (1), (2), (3)");
+        execute("refresh table tbl");
+        execute("SELECT (SELECT t.x) FROM tbl t order by 1 desc");
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
+            "3\n" +
+            "2\n" +
+            "1\n"
+        );
+    }
+
+    @Test
+    public void test_query_fails_if_correlated_subquery_returns_more_than_1_row() {
+        String stmt = "SELECT (SELECT t.mountain from sys.summits) FROM sys.summits t";
+        assertThatThrownBy(() -> execute(stmt))
+            .hasMessageContaining("Subquery returned more than 1 row when it shouldn't.");
+    }
+
+    @Test
+    public void test_simple_correlated_subquery_with_order_by() {
+        String statement = "SELECT 1, (SELECT t.mountain) FROM sys.summits t order by 2 asc limit 5";
+        execute("EXPLAIN " + statement);
+
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
+            "Eval[1, (SELECT mountain FROM (empty_row))]\n" +
+            "  └ Limit[5::bigint;0]\n" +
+            "    └ OrderBy[(SELECT mountain FROM (empty_row)) ASC]\n" +
+            "      └ CorrelatedJoin[1, mountain, (SELECT mountain FROM (empty_row))]\n" +
+            "        └ Rename[1, mountain] AS t\n" +
+            "          └ Collect[sys.summits | [1, mountain] | true]\n" +
+            "        └ SubPlan\n" +
+            "          └ Eval[mountain]\n" +
+            "            └ TableFunction[empty_row | [] | true]\n"
+        );
+        execute(statement);
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
+            "1| Acherkogel\n" +
+            "1| Ackerlspitze\n" +
+            "1| Adamello\n" +
+            "1| Admonter Reichenstein\n" +
+            "1| Aiguille Méridionale d'Arves\n"
+        );
+    }
+
+    @Test
+    public void test_correlated_subquery_can_use_outer_column_in_where_clause() {
+        String statement = """
+            SELECT
+                mountain,
+                (SELECT height FROM sys.summits WHERE summits.mountain = t.mountain limit 1)
+            FROM
+                sys.summits t
+            ORDER BY 1 ASC LIMIT 5
+            """;
+        execute(statement);
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
+            "Acherkogel| 3008\n" +
+            "Ackerlspitze| 2329\n" +
+            "Adamello| 3539\n" +
+            "Admonter Reichenstein| 2251\n" +
+            "Aiguille Méridionale d'Arves| 3514\n"
+        );
+    }
+
+    @Test
+    public void test_correlated_subquery_within_case_using_outer_column_in_where_clause() {
+        String stmt = """
+            SELECT
+                CASE WHEN t.typtype = 'd' THEN
+                    (
+                        SELECT
+                            CASE WHEN typname = E'date' THEN 91 ELSE 1111 END
+                        FROM
+                            pg_type
+                        WHERE
+                            oid = t.typbasetype
+                    )
+                ELSE
+                    NULL
+                END AS base_type
+            FROM
+                pg_catalog.pg_type t
+            """;
+        execute(stmt);
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo("");
+    }
+
+    @Test
+    public void test_correlated_subquery_used_in_virtual_table_with_union() {
+        String stmt = """
+            SELECT
+                (SELECT t1.mountain)
+            FROM
+                sys.summits t1
+            UNION ALL
+            SELECT
+                (SELECT t2.mountain)
+            FROM sys.summits t2
+            ORDER BY 1 DESC
+            LIMIT 4
+            """;
+        execute(stmt);
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
+            "Špik\n" +
+            "Špik\n" +
+            "Škrlatica\n" +
+            "Škrlatica\n"
+        );
+    }
+
+    @Test
+    public void test_multiple_correlated_subqueries_in_selectlist() {
+        String stmt = "SELECT (SELECT t.mountain), (SELECT t.height) FROM sys.summits t order by 2 desc limit 3";
+        execute(stmt);
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
+            "Mont Blanc| 4808\n" +
+            "Monte Rosa| 4634\n" +
+            "Dom| 4545\n"
+        );
+    }
+}

--- a/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner;
+
+import static io.crate.planner.operators.LogicalPlannerTest.printPlan;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_correlated_subquery_without_using_alias_can_use_outer_column_in_where_clause() {
+        SQLExecutor e = SQLExecutor.builder(clusterService).build();
+        // In PostgreSQL this is supported.
+        // We currently have a limitation in the FullQualifiedNameFieldProvider
+        // Test case ensures that if we remove the limitation from FullQualifiedNameFieldProvider
+        // the planner must be able to handle it
+        String statement = "SELECT (SELECT mountain) FROM sys.summits t ORDER BY 1 ASC LIMIT 5";
+        assertThatThrownBy(() -> e.plan(statement))
+            .hasMessage("Column mountain unknown");
+    }
+
+    @Test
+    public void test_correlated_subquery_within_scalar() {
+        SQLExecutor e = SQLExecutor.builder(clusterService).build();
+        String statement = "SELECT 'Mountain-' || (SELECT t.mountain) FROM sys.summits t";
+        LogicalPlan logicalPlan = e.logicalPlan(statement);
+        assertThat(printPlan(logicalPlan)).isEqualTo(
+            "Eval[concat('Mountain-', (SELECT mountain FROM (empty_row)))]\n" +
+            "  └ CorrelatedJoin[mountain, (SELECT mountain FROM (empty_row))]\n" +
+            "    └ Rename[mountain] AS t\n" +
+            "      └ Collect[sys.summits | [mountain] | true]\n" +
+            "    └ SubPlan\n" +
+            "      └ Eval[mountain]\n" +
+            "        └ TableFunction[empty_row | [] | true]"
+        );
+    }
+
+    @Test
+    public void test_correlated_subquery_cannot_be_used_in_group_by() {
+        SQLExecutor e = SQLExecutor.builder(clusterService).build();
+        String statement = "SELECT (SELECT t.mountain), count(*) FROM sys.summits t GROUP BY (SELECT t.mountain)";
+        assertThatThrownBy(() -> e.plan(statement))
+            .hasMessage("Cannot use correlated subquery in GROUP BY clause");
+    }
+
+    @Test
+    public void test_correlated_subquery_cannot_be_used_in_having() {
+        SQLExecutor e = SQLExecutor.builder(clusterService).build();
+        String stmt = "SELECT (SELECT t.mountain), count(*) FROM sys.summits t HAVING (SELECT t.mountain) = 'Acherkogel'";
+        assertThatThrownBy(() -> e.plan(stmt))
+            .hasMessage("Cannot use correlated subquery in HAVING clause");
+    }
+}

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Set;
@@ -37,6 +38,7 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.Symbol;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
@@ -81,6 +83,7 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
         );
         LogicalPlan operator = logicalPlanner.plan(analyzedRelation, plannerCtx);
         ExecutionPlan build = operator.build(
+            mock(DependencyCarrier.class),
             plannerCtx,
             Set.of(),
             projectionBuilder,

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Set;
@@ -40,6 +41,7 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.Literal;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
@@ -77,6 +79,7 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
             "    └ Collect[doc.users | [name] | true]"));
         PlannerContext ctx = e.getPlannerContext(clusterService.state());
         Merge merge = (Merge) plan.build(
+            mock(DependencyCarrier.class),
             ctx,
             Set.of(),
             new ProjectionBuilder(e.nodeCtx),

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -24,6 +24,7 @@ package io.crate.planner.optimizer.symbol;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +51,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.SubQueryResults;
@@ -99,6 +101,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
             10
         );
         var plan = (io.crate.planner.node.dql.Collect) collect.build(
+            mock(DependencyCarrier.class),
             plannerContext,
             Set.of(),
             new ProjectionBuilder(e.nodeCtx),

--- a/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
@@ -25,6 +25,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,6 +46,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Merge;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.operators.SubQueryResults;
@@ -91,6 +93,7 @@ public class CopyToPlannerTest extends CrateDummyClusterServiceUnitTest {
             SubQueryResults.EMPTY);
         //noinspection unchecked
         return (T) CopyToPlan.planCopyToExecution(
+            mock(DependencyCarrier.class),
             boundedCopyTo,
             e.getPlannerContext(clusterService.state()),
             new TableStats(),

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -158,6 +158,7 @@ import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.view.ViewInfoFactory;
 import io.crate.metadata.view.ViewsMetadata;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
@@ -866,6 +867,7 @@ public class SQLExecutor {
         Plan plan = planner.plan(analyzedStatement, plannerContext);
         if (plan instanceof LogicalPlan) {
             return (T) ((LogicalPlan) plan).build(
+                mock(DependencyCarrier.class),
                 plannerContext,
                 Set.of(),
                 new ProjectionBuilder(nodeCtx),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adds support for correlated scalar subqueries within the select list. See https://github.com/crate/crate/issues/12663

- Introduces a new `OuterColumn` symbol to wrap columns from an outer relation.
- Adds a `isCorrelated` property to `SelectSymbol` to distinguish correlated & non-correlated subqueries
- Adds a new `CorrelatedJoin` operator. It takes an input relation and a correlated subquery. For each row in the input row it executes the subquery, outputting a joined row. The execution happens via a new `CorrelatedJoinProjection` and `CorrelatedJoinProjector`.

(I kept some individual commits but they must be squashed when merging)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
