### PR TITLE
fix NPE on streaming GeneratedReference

### DIFF
--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -63,7 +63,11 @@ public class GeneratedReference implements Reference {
             ref = new SimpleReference(in);
         }
         formattedGeneratedExpression = in.readString();
-        generatedExpression = Symbols.fromStream(in);
+        if (in.getVersion().onOrAfter(Version.V_5_1_0)) {
+            generatedExpression = Symbols.nullableFromStream(in);
+        } else {
+            generatedExpression = Symbols.fromStream(in);
+        }
         int size = in.readVInt();
         referencedReferences = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
@@ -94,7 +98,12 @@ public class GeneratedReference implements Reference {
             }
         }
         out.writeString(formattedGeneratedExpression);
-        Symbols.toStream(generatedExpression, out);
+        if (out.getVersion().onOrAfter(Version.V_5_1_0)) {
+            Symbols.nullableToStream(generatedExpression, out);
+        } else {
+            Symbols.toStream(generatedExpression, out);
+        }
+
         out.writeVInt(referencedReferences.size());
         for (Reference reference : referencedReferences) {
             Reference.toStream(reference, out);

--- a/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
@@ -77,4 +77,21 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(generatedReferenceInfo2, is(generatedReferenceInfo));
     }
+
+    @Test
+    public void test_streaming_generated_reference_with_null_expression_symbol() throws Exception {
+        ReferenceIdent referenceIdent = new ReferenceIdent(t1Info.ident(), "generated_column");
+        String formattedGeneratedExpression = "concat(a, 'bar')";
+        SimpleReference simpleRef = new SimpleReference(referenceIdent, RowGranularity.DOC, StringType.INSTANCE, 1, null);
+        GeneratedReference generatedReference = new GeneratedReference(simpleRef, formattedGeneratedExpression, null);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        Reference.toStream(generatedReference, out);
+
+        StreamInput in = out.bytes().streamInput();
+        GeneratedReference generatedReference2 = Reference.fromStream(in);
+
+        assertThat(generatedReference2, is(generatedReference));
+
+    }
 }


### PR DESCRIPTION
Spot this while working on delta based add column - on the first iteration I used `Reference` which could be a `GeneratedReference` and since ctor arg is `Nullable` (and in this case Symbol was redundant to send, raw String is enough) I passed `null` and faced NPE.

Not sure about 4.8 - we don't pass expression Symbol to ctor in this branch but looks like it can be null anyway if not assigned via setter - also worth backporting? I think so as we have null check on expression getter but it's a valid scenario to send only raw string and then receiving side can resolve Symbol from a raw string when needed.