### PR TITLE
Fix unused setup warning in ESIntegTestCase

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -263,16 +263,15 @@ public abstract class ESIntegTestCase extends ESTestCase {
             case SUITE:
                 assert SUITE_SEED != null : "Suite seed was not initialized";
                 currentCluster = buildAndPutCluster(currentClusterScope, SUITE_SEED);
+                RandomizedContext.current().runWithPrivateRandomness(SUITE_SEED, setup);
                 break;
             case TEST:
                 currentCluster = buildAndPutCluster(currentClusterScope, randomLong());
+                setup.call();
                 break;
             default:
                 fail("Unknown Scope: [" + currentClusterScope + "]");
         }
-        cluster().beforeTest(random());
-        cluster().wipe(excludeTemplates());
-        randomIndexTemplate();
     }
 
     private void printTestMessage(String message) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/crate/crate/commit/9e80e3223a397b6803538f7b95e43bfc692283bd
added the `Callable<Void> setup` block but missed the changes from https://github.com/elastic/elasticsearch/commit/ac2e09b25abc2319e86ea74492edb54458690019


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
