### PR TITLE
Add a `Exposed` Property for settings as replacement for the CrateSettings list

### DIFF
--- a/server/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/server/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -48,6 +48,7 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Setting.Property;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -74,15 +75,16 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
         DataAvailability.PRIMARIES.name(),
         DataAvailability::of,
         DataTypes.STRING,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Property.Dynamic,
+        Property.NodeScope,
+        Property.Exposed
     );
 
     public static final Setting<Boolean> GRACEFUL_STOP_FORCE_SETTING = Setting.boolSetting(
-        "cluster.graceful_stop.force", false, Setting.Property.Dynamic, Setting.Property.NodeScope);
+        "cluster.graceful_stop.force", false, Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     public static final Setting<TimeValue> GRACEFUL_STOP_TIMEOUT_SETTING = Setting.positiveTimeSetting(
-        "cluster.graceful_stop.timeout", new TimeValue(7_200_000), Setting.Property.Dynamic, Setting.Property.NodeScope);
+        "cluster.graceful_stop.timeout", new TimeValue(7_200_000), Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     private final ClusterService clusterService;
     private final JobsLogs jobsLogs;

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -82,11 +83,11 @@ import io.crate.types.DataTypes;
 public class JobsLogService extends AbstractLifecycleComponent implements Provider<JobsLogs> {
 
     public static final Setting<Boolean> STATS_ENABLED_SETTING = Setting.boolSetting(
-        "stats.enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        "stats.enabled", true, Property.NodeScope, Property.Dynamic, Property.Exposed);
     public static final Setting<Integer> STATS_JOBS_LOG_SIZE_SETTING = Setting.intSetting(
-        "stats.jobs_log_size", 10_000, 0, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        "stats.jobs_log_size", 10_000, 0, Property.NodeScope, Property.Dynamic, Property.Exposed);
     public static final Setting<TimeValue> STATS_JOBS_LOG_EXPIRATION_SETTING = Setting.timeSetting(
-        "stats.jobs_log_expiration", TimeValue.timeValueSeconds(0L), Setting.Property.NodeScope, Setting.Property.Dynamic);
+        "stats.jobs_log_expiration", TimeValue.timeValueSeconds(0L), Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     private static final FilterValidator FILTER_VALIDATOR = new FilterValidator();
 
@@ -97,8 +98,9 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
         Function.identity(),
         FILTER_VALIDATOR,
         DataTypes.STRING,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Property.NodeScope,
+        Property.Dynamic,
+        Property.Exposed
     );
 
     // Explicit generic is required for eclipse JDT, otherwise it won't compile
@@ -108,15 +110,16 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
         Function.identity(),
         FILTER_VALIDATOR,
         DataTypes.STRING,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Property.NodeScope,
+        Property.Dynamic,
+        Property.Exposed
     );
 
     public static final Setting<Integer> STATS_OPERATIONS_LOG_SIZE_SETTING = Setting.intSetting(
-        "stats.operations_log_size", 10_000, 0, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        "stats.operations_log_size", 10_000, 0, Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     public static final Setting<TimeValue> STATS_OPERATIONS_LOG_EXPIRATION_SETTING = Setting.timeSetting(
-        "stats.operations_log_expiration", TimeValue.timeValueSeconds(0L), Setting.Property.NodeScope, Setting.Property.Dynamic);
+        "stats.operations_log_expiration", TimeValue.timeValueSeconds(0L), Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     private static final JobContextLogSizeEstimator JOB_CONTEXT_LOG_ESTIMATOR = new JobContextLogSizeEstimator();
     private static final OperationContextLogSizeEstimator OPERATION_CONTEXT_LOG_SIZE_ESTIMATOR = new OperationContextLogSizeEstimator();

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -51,6 +51,7 @@ import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -76,8 +77,9 @@ public class ShardingUpsertExecutor
     public static final Setting<TimeValue> BULK_REQUEST_TIMEOUT_SETTING = Setting.positiveTimeSetting(
         "bulk.request_timeout",
         new TimeValue(1, TimeUnit.MINUTES),
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Property.NodeScope,
+        Property.Dynamic,
+        Property.Exposed
     );
 
     private static final Logger LOGGER = LogManager.getLogger(ShardingUpsertExecutor.class);

--- a/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
+++ b/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
@@ -44,10 +44,14 @@ public class NodeLimits {
     private final Map<String, ConcurrencyLimit> limitsPerNode = new ConcurrentHashMap<>();
     private final ClusterSettings clusterSettings;
 
-    public static final Setting<Integer> INITIAL_CONCURRENCY = Setting.intSetting("overload_protection.dml.initial_concurrency", 5, Property.NodeScope, Property.Dynamic);
-    public static final Setting<Integer> MIN_CONCURRENCY = Setting.intSetting("overload_protection.dml.min_concurrency", 1, Property.NodeScope, Property.Dynamic);
-    public static final Setting<Integer> MAX_CONCURRENCY = Setting.intSetting("overload_protection.dml.max_concurrency", 2000, Property.NodeScope, Property.Dynamic);
-    public static final Setting<Integer> QUEUE_SIZE = Setting.intSetting("overload_protection.dml.queue_size", 200, Property.NodeScope, Property.Dynamic);
+    public static final Setting<Integer> INITIAL_CONCURRENCY =
+        Setting.intSetting("overload_protection.dml.initial_concurrency", 5, Property.NodeScope, Property.Dynamic, Property.Exposed);
+    public static final Setting<Integer> MIN_CONCURRENCY =
+        Setting.intSetting("overload_protection.dml.min_concurrency", 1, Property.NodeScope, Property.Dynamic, Property.Exposed);
+    public static final Setting<Integer> MAX_CONCURRENCY =
+        Setting.intSetting("overload_protection.dml.max_concurrency", 2000, Property.NodeScope, Property.Dynamic, Property.Exposed);
+    public static final Setting<Integer> QUEUE_SIZE =
+        Setting.intSetting("overload_protection.dml.queue_size", 200, Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     private static final double SMOOTHING = 0.2;
     private static final int LONG_WINDOW = 600;

--- a/server/src/main/java/io/crate/memory/MemoryManagerFactory.java
+++ b/server/src/main/java/io/crate/memory/MemoryManagerFactory.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 
 import java.util.Set;
 import java.util.function.Function;
@@ -73,8 +74,9 @@ public final class MemoryManagerFactory implements Function<RamAccounting, Memor
                 "Invalid argument `" + input + "` for `memory.allocation.type`, valid values are: " + TYPES);
         },
         DataTypes.STRING,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Property.NodeScope,
+        Property.Dynamic,
+        Property.Exposed
     );
 
     private volatile MemoryType currentMemoryType = MemoryType.ON_HEAP;

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocatio
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.IndexSettings;
@@ -43,7 +44,9 @@ public class LogicalReplicationSettings {
 
     public static final Setting<Integer> REPLICATION_CHANGE_BATCH_SIZE = Setting.intSetting(
         "replication.logical.ops_batch_size", 50000, 16,
-        Setting.Property.Dynamic, Setting.Property.NodeScope
+        Property.Dynamic,
+        Property.NodeScope,
+        Property.Exposed
     );
 
     public static final Setting<TimeValue> REPLICATION_READ_POLL_DURATION = Setting.timeSetting(
@@ -51,8 +54,9 @@ public class LogicalReplicationSettings {
         TimeValue.timeValueMillis(50),
         TimeValue.timeValueMillis(1),
         TimeValue.timeValueSeconds(1),
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
+        Property.Dynamic,
+        Property.NodeScope,
+        Property.Exposed
     );
 
     public static final Setting<ByteSizeValue> REPLICATION_RECOVERY_CHUNK_SIZE =
@@ -60,8 +64,9 @@ public class LogicalReplicationSettings {
             new ByteSizeValue(1, ByteSizeUnit.MB),
             new ByteSizeValue(1, ByteSizeUnit.KB),
             new ByteSizeValue(1, ByteSizeUnit.GB),
-            Setting.Property.Dynamic,
-            Setting.Property.NodeScope
+            Property.Dynamic,
+            Property.NodeScope,
+            Property.Exposed
         );
 
     /**
@@ -70,7 +75,9 @@ public class LogicalReplicationSettings {
     public static final Setting<Integer> REPLICATION_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS =
         Setting.intSetting("replication.logical.recovery.max_concurrent_file_chunks",
             2, 1, 5,
-            Setting.Property.Dynamic, Setting.Property.NodeScope
+            Property.Dynamic,
+            Property.NodeScope,
+            Property.Exposed
         );
 
     /**

--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -51,7 +52,7 @@ public class TableStatsService implements Runnable {
     private static final Logger LOGGER = LogManager.getLogger(TableStatsService.class);
 
     public static final Setting<TimeValue> STATS_SERVICE_REFRESH_INTERVAL_SETTING = Setting.timeSetting(
-        "stats.service.interval", TimeValue.timeValueHours(24), Setting.Property.NodeScope, Setting.Property.Dynamic);
+        "stats.service.interval", TimeValue.timeValueHours(24), Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     static final String STMT = "ANALYZE";
     private static final Statement PARSED_STMT = SqlParser.createStatement(STMT);

--- a/server/src/main/java/io/crate/udc/service/UDCService.java
+++ b/server/src/main/java/io/crate/udc/service/UDCService.java
@@ -32,6 +32,8 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Setting.Property;
+
 import io.crate.common.unit.TimeValue;
 
 import java.util.Timer;
@@ -43,20 +45,23 @@ public class UDCService extends AbstractLifecycleComponent {
     private static final Logger LOGGER = LogManager.getLogger(UDCService.class);
 
     public static final Setting<Boolean> UDC_ENABLED_SETTING = Setting.boolSetting(
-        "udc.enabled", true, Setting.Property.NodeScope);
+        "udc.enabled", true, Property.NodeScope, Property.Exposed);
 
     // Explicit generic is required for eclipse JDT, otherwise it won't compile
     public static final Setting<String> UDC_URL_SETTING = new Setting<String>(
         "udc.url", "https://udc.crate.io/",
-        Function.identity(), DataTypes.STRING, Setting.Property.NodeScope);
+        Function.identity(), DataTypes.STRING, Property.NodeScope, Property.Exposed);
 
     public static final Setting<TimeValue> UDC_INITIAL_DELAY_SETTING = Setting.positiveTimeSetting(
         "udc.initial_delay", new TimeValue(10, TimeUnit.MINUTES),
-        Setting.Property.NodeScope);
+        Property.NodeScope,
+        Property.Exposed);
 
     public static final Setting<TimeValue> UDC_INTERVAL_SETTING = Setting.positiveTimeSetting(
         "udc.interval", new TimeValue(24, TimeUnit.HOURS),
-        Setting.Property.NodeScope);
+        Property.NodeScope,
+        Property.Exposed
+    );
 
     private final Timer timer;
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -57,6 +57,7 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -103,9 +104,12 @@ public abstract class TransportReplicationAction<
     /**
      * The timeout for retrying replication requests.
      */
-    public static final Setting<TimeValue> REPLICATION_RETRY_TIMEOUT =
-        Setting.timeSetting("indices.replication.retry_timeout", TimeValue.timeValueSeconds(60), Setting.Property.Dynamic,
-            Setting.Property.NodeScope);
+    public static final Setting<TimeValue> REPLICATION_RETRY_TIMEOUT = Setting.timeSetting(
+        "indices.replication.retry_timeout",
+        TimeValue.timeValueSeconds(60),
+        Property.Dynamic,
+        Property.NodeScope,
+        Property.Exposed);
 
     /**
      * The maximum bound for the first retry backoff for failed replication operations. The backoff bound

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -82,7 +82,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
 
     public static final Setting<TimeValue> INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING =
         Setting.timeSetting("cluster.info.update.interval", TimeValue.timeValueSeconds(30), TimeValue.timeValueSeconds(10),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
     public static final Setting<TimeValue> INTERNAL_CLUSTER_INFO_TIMEOUT_SETTING =
         Setting.positiveTimeSetting("cluster.info.update.timeout", TimeValue.timeValueSeconds(15),
             Property.Dynamic, Property.NodeScope);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -19,21 +19,23 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import io.crate.common.unit.TimeValue;
-import io.crate.types.DataTypes;
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.RatioValue;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.RatioValue;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.types.DataTypes;
 
 /**
  * A container to keep settings for disk thresholds up to date with cluster setting changes.
@@ -41,25 +43,25 @@ import java.util.Map;
 public class DiskThresholdSettings {
     public static final Setting<Boolean> CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING =
         Setting.boolSetting("cluster.routing.allocation.disk.threshold_enabled", true,
-            Setting.Property.Dynamic, Setting.Property.NodeScope);
+            Setting.Property.Dynamic, Setting.Property.NodeScope, Property.Exposed);
     public static final Setting<String> CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING =
         new Setting<>("cluster.routing.allocation.disk.watermark.low", "85%",
             (s) -> validWatermarkSetting(s, "cluster.routing.allocation.disk.watermark.low"),
             new LowDiskWatermarkValidator(),
             DataTypes.STRING,
-            Setting.Property.Dynamic, Setting.Property.NodeScope);
+            Setting.Property.Dynamic, Setting.Property.NodeScope, Property.Exposed);
     public static final Setting<String> CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING =
         new Setting<>("cluster.routing.allocation.disk.watermark.high", "90%",
             (s) -> validWatermarkSetting(s, "cluster.routing.allocation.disk.watermark.high"),
             new HighDiskWatermarkValidator(),
             DataTypes.STRING,
-            Setting.Property.Dynamic, Setting.Property.NodeScope);
+            Setting.Property.Dynamic, Setting.Property.NodeScope, Property.Exposed);
     public static final Setting<String> CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING =
         new Setting<>("cluster.routing.allocation.disk.watermark.flood_stage", "95%",
             (s) -> validWatermarkSetting(s, "cluster.routing.allocation.disk.watermark.flood_stage"),
             new FloodStageValidator(),
             DataTypes.STRING,
-            Setting.Property.Dynamic, Setting.Property.NodeScope);
+            Setting.Property.Dynamic, Setting.Property.NodeScope, Property.Exposed);
     public static final Setting<Boolean> CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING =
         Setting.boolSetting("cluster.routing.allocation.disk.include_relocations", true,
             Setting.Property.Dynamic, Setting.Property.NodeScope);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -83,12 +83,12 @@ public class BalancedShardsAllocator implements ShardsAllocator {
     private static final Logger LOGGER = LogManager.getLogger(BalancedShardsAllocator.class);
 
     public static final Setting<Float> INDEX_BALANCE_FACTOR_SETTING =
-        Setting.floatSetting("cluster.routing.allocation.balance.index", 0.55f, 0.0f, Property.Dynamic, Property.NodeScope);
+        Setting.floatSetting("cluster.routing.allocation.balance.index", 0.55f, 0.0f, Property.Dynamic, Property.NodeScope, Property.Exposed);
     public static final Setting<Float> SHARD_BALANCE_FACTOR_SETTING =
-        Setting.floatSetting("cluster.routing.allocation.balance.shard", 0.45f, 0.0f, Property.Dynamic, Property.NodeScope);
+        Setting.floatSetting("cluster.routing.allocation.balance.shard", 0.45f, 0.0f, Property.Dynamic, Property.NodeScope, Property.Exposed);
     public static final Setting<Float> THRESHOLD_SETTING =
         Setting.floatSetting("cluster.routing.allocation.balance.threshold", 1.0f, 0.0f,
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     private volatile WeightFunction weightFunction;
     private volatile float threshold;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
@@ -58,7 +58,7 @@ public class ClusterRebalanceAllocationDecider extends AllocationDecider {
     private static final String CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE = "cluster.routing.allocation.allow_rebalance";
     public static final Setting<ClusterRebalanceType> CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING =
         new Setting<>(CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE, ClusterRebalanceType.INDICES_ALL_ACTIVE.toString(),
-            ClusterRebalanceType::parseString, DataTypes.STRING, Property.Dynamic, Property.NodeScope);
+            ClusterRebalanceType::parseString, DataTypes.STRING, Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     /**
      * An enum representation for the configured re-balance type.

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -48,7 +48,7 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
 
     public static final Setting<Integer> CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE_SETTING =
         Setting.intSetting("cluster.routing.allocation.cluster_concurrent_rebalance", 2, -1,
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
     private volatile int clusterConcurrentRebalance;
 
     public ConcurrentRebalanceAllocationDecider(Settings settings, ClusterSettings clusterSettings) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -67,7 +67,7 @@ public class EnableAllocationDecider extends AllocationDecider {
 
     public static final Setting<Allocation> CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING =
         new Setting<>("cluster.routing.allocation.enable", Allocation.ALL.toString(), Allocation::parse,
-            DataTypes.STRING, Property.Dynamic, Property.NodeScope);
+            DataTypes.STRING, Property.Dynamic, Property.NodeScope, Property.Exposed);
     public static final Setting<Allocation> INDEX_ROUTING_ALLOCATION_ENABLE_SETTING =
         new Setting<>("index.routing.allocation.enable", Allocation.ALL.toString(), Allocation::parse,
             DataTypes.STRING, Property.Dynamic, Property.IndexScope, Property.ReplicatedIndexScope);
@@ -77,7 +77,7 @@ public class EnableAllocationDecider extends AllocationDecider {
         Rebalance.ALL.toString(),
         Rebalance::parse,
         DataTypes.STRING,
-        Property.Dynamic, Property.NodeScope
+        Property.Dynamic, Property.NodeScope, Property.Exposed
     );
 
     public static final Setting<Rebalance> INDEX_ROUTING_REBALANCE_ENABLE_SETTING = new Setting<>(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
@@ -82,7 +82,8 @@ public class ShardsLimitAllocationDecider extends AllocationDecider {
             -1,
             -1,
             Property.Dynamic,
-            Property.NodeScope
+            Property.NodeScope,
+            Property.Exposed
         );
 
     public ShardsLimitAllocationDecider(Settings settings, ClusterSettings clusterSettings) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -68,11 +68,11 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             Integer.toString(DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES),
             (s) -> Setting.parseInt(s, 0, "cluster.routing.allocation.node_concurrent_recoveries"),
             DataTypes.INTEGER,
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
     public static final Setting<Integer> CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING =
         Setting.intSetting("cluster.routing.allocation.node_initial_primaries_recoveries",
             DEFAULT_CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES, 0,
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
     public static final Setting<Integer> CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING =
         new Setting<>("cluster.routing.allocation.node_concurrent_incoming_recoveries",
             CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING::getRaw,

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -142,7 +142,12 @@ public class Setting<T> implements ToXContentObject {
         /**
          * Indicates a setting that contains sensitive information. Such a setting will be masked when shown to the users.
          */
-        Masked
+        Masked,
+
+        /**
+         * Exposes the setting via sys.cluster.settings
+         */
+        Exposed
     }
 
     private final Key key;
@@ -1850,5 +1855,9 @@ public class Setting<T> implements ToXContentObject {
 
     public List<String> path() {
         return path;
+    }
+
+    public boolean isExposed() {
+        return properties.contains(Property.Exposed);
     }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -52,9 +52,9 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
     private static final Logger LOGGER = LogManager.getLogger(GatewayService.class);
 
     public static final Setting<Integer> EXPECTED_NODES_SETTING =
-        Setting.intSetting("gateway.expected_nodes", -1, -1, Property.NodeScope, Property.Deprecated);
+        Setting.intSetting("gateway.expected_nodes", -1, -1, Property.NodeScope, Property.Deprecated, Property.Exposed);
     public static final Setting<Integer> EXPECTED_DATA_NODES_SETTING =
-        Setting.intSetting("gateway.expected_data_nodes", -1, -1, Property.NodeScope);
+        Setting.intSetting("gateway.expected_data_nodes", -1, -1, Property.NodeScope, Property.Exposed);
     public static final Setting<Integer> EXPECTED_MASTER_NODES_SETTING =
         Setting.intSetting("gateway.expected_master_nodes", -1, -1, Property.NodeScope, Property.Deprecated);
 
@@ -71,12 +71,13 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
                 return TimeValue.timeValueMillis(0);
             },
             TimeValue.ZERO,
-            Property.NodeScope
+            Property.NodeScope,
+            Property.Exposed
         );
     public static final Setting<Integer> RECOVER_AFTER_NODES_SETTING =
-        Setting.intSetting("gateway.recover_after_nodes", -1, -1, Property.NodeScope, Property.Deprecated);
+        Setting.intSetting("gateway.recover_after_nodes", -1, -1, Property.NodeScope, Property.Deprecated, Property.Exposed);
     public static final Setting<Integer> RECOVER_AFTER_DATA_NODES_SETTING =
-        Setting.intSetting("gateway.recover_after_data_nodes", -1, -1, Property.NodeScope);
+        Setting.intSetting("gateway.recover_after_data_nodes", -1, -1, Property.NodeScope, Property.Exposed);
     public static final Setting<Integer> RECOVER_AFTER_MASTER_NODES_SETTING =
         Setting.intSetting("gateway.recover_after_master_nodes", 0, 0, Property.NodeScope, Property.Deprecated);
 

--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 
 /**
@@ -41,7 +42,7 @@ import org.elasticsearch.common.settings.Settings;
  */
 public class ShardLimitValidator {
     public static final Setting<Integer> SETTING_CLUSTER_MAX_SHARDS_PER_NODE =
-        Setting.intSetting("cluster.max_shards_per_node", 1000, 1, Setting.Property.Dynamic, Setting.Property.NodeScope);
+        Setting.intSetting("cluster.max_shards_per_node", 1000, 1, Property.Dynamic, Property.NodeScope, Property.Exposed);
     protected final AtomicInteger shardLimitPerNode = new AtomicInteger();
 
     public ShardLimitValidator(final Settings settings, ClusterService clusterService) {

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -60,10 +60,10 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     private final ConcurrentMap<String, CircuitBreaker> breakers = new ConcurrentHashMap<>();
 
     public static final Setting<ByteSizeValue> TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING =
-        Setting.memorySizeSetting("indices.breaker.total.limit", "95%", Property.Dynamic, Property.NodeScope);
+        Setting.memorySizeSetting("indices.breaker.total.limit", "95%", Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     public static final Setting<ByteSizeValue> REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING =
-        Setting.memorySizeSetting("indices.breaker.request.limit", "60%", Property.Dynamic, Property.NodeScope);
+        Setting.memorySizeSetting("indices.breaker.request.limit", "60%", Property.Dynamic, Property.NodeScope, Property.Exposed);
     public static final Setting<CircuitBreaker.Type> REQUEST_CIRCUIT_BREAKER_TYPE_SETTING =
         new Setting<>("indices.breaker.request.type", "memory", CircuitBreaker.Type::parseValue, DataTypes.STRING, Property.NodeScope);
 
@@ -81,15 +81,15 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     public static final String QUERY = "query";
 
     public static final Setting<ByteSizeValue> QUERY_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
-        "indices.breaker.query.limit", "60%", Setting.Property.Dynamic, Setting.Property.NodeScope);
+        "indices.breaker.query.limit", "60%", Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     public static final String JOBS_LOG = "jobs_log";
     public static final Setting<ByteSizeValue> JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
-        "stats.breaker.log.jobs.limit", "5%", Setting.Property.Dynamic, Setting.Property.NodeScope);
+        "stats.breaker.log.jobs.limit", "5%", Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     public static final String OPERATIONS_LOG = "operations_log";
     public static final Setting<ByteSizeValue> OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
-        "stats.breaker.log.operations.limit", "5%", Setting.Property.Dynamic, Setting.Property.NodeScope);
+        "stats.breaker.log.operations.limit", "5%", Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     public static final String BREAKING_EXCEPTION_MESSAGE =
         "[query] Data too large, data for [%s] would be larger than limit of [%d/%s]";

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -37,7 +37,7 @@ public class RecoverySettings {
 
     public static final Setting<ByteSizeValue> INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING =
         Setting.byteSizeSetting("indices.recovery.max_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     /**
      * Controls the maximum number of file chunk requests that can be sent concurrently from the source node to the target node.
@@ -57,17 +57,17 @@ public class RecoverySettings {
      */
     public static final Setting<TimeValue> INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING =
         Setting.positiveTimeSetting("indices.recovery.retry_delay_state_sync", TimeValue.timeValueMillis(500),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     /** how long to wait before retrying after network related issues */
     public static final Setting<TimeValue> INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING =
         Setting.positiveTimeSetting("indices.recovery.retry_delay_network", TimeValue.timeValueSeconds(5),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     /** timeout value to use for requests made as part of the recovery process */
     public static final Setting<TimeValue> INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING =
         Setting.positiveTimeSetting("indices.recovery.internal_action_timeout", TimeValue.timeValueMinutes(15),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     /** timeout value to use for the retrying of requests made as part of the recovery process */
     public static final Setting<TimeValue> INDICES_RECOVERY_INTERNAL_ACTION_RETRY_TIMEOUT_SETTING =
@@ -84,7 +84,8 @@ public class RecoverySettings {
             (s) -> TimeValue.timeValueMillis(INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT_SETTING.get(s).millis() * 2),
             TimeValue.timeValueSeconds(0),
             Property.Dynamic,
-            Property.NodeScope
+            Property.NodeScope,
+            Property.Exposed
         );
 
     /**
@@ -94,7 +95,7 @@ public class RecoverySettings {
     public static final Setting<TimeValue> INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING =
         Setting.timeSetting("indices.recovery.recovery_activity_timeout",
             INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT_SETTING::get, TimeValue.timeValueSeconds(0),
-            Property.Dynamic, Property.NodeScope);
+            Property.Dynamic, Property.NodeScope, Property.Exposed);
 
     // choose 512KB-16B to ensure that the resulting byte[] is not a humongous allocation in G1.
     public static final ByteSizeValue DEFAULT_CHUNK_SIZE = new ByteSizeValue(512 * 1024 - 16, ByteSizeUnit.BYTES);

--- a/server/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node.ddl;
 
 import static io.crate.planner.node.ddl.ResetSettingsPlan.buildSettingsFrom;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -80,12 +81,11 @@ public class ResetSettingsPlanTest extends ESTestCase {
 
     @Test
     public void testResetNonRuntimeSetting() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
-
         Set<Symbol> settings = Set.of(Literal.of("gateway"));
 
-        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+        assertThatThrownBy(() -> buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("cannot be set/reset at runtime");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It kinda belongs to the setting definition

We could eventually flip this and instead mark internal ones.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
