### PR TITLE
Fix issue with constraint on generated col

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -94,7 +94,15 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-- Fix an issue, causing ``IndexOutOfBoundsException`` to be thrown when using
+- Fixed an issue, preventing users from defining a constraint on a generated
+  column, when creating a table or when adding a generated column, i.e.::
+
+    CREATE TABLE test(
+        col1 INT,
+        col2 INT GENERATED ALWAYS AS col1*2 CHECK (col2 > 0)
+   )
+
+- Fixed an issue causing ``IndexOutOfBoundsException`` to be thrown when using
   ``LEFT``/``RIGHT`` or ``FULL`` ``OUTER JOIN`` and one of the tables (or
   sub-selects) joined has 0 rows.
 

--- a/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -37,6 +37,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
@@ -123,6 +124,13 @@ class AlterTableAddColumnAnalyzer {
                 analyzedTableElements.addCheckColumnConstraint(tableInfo.ident(), check);
                 analyzedTableElementsWithExpressions.addCheckColumnConstraint(tableInfo.ident(), check);
             });
+        if (addColumnDefinitionWithExpression.generatedExpression() != null) {
+            GeneratedColumnValidator.validate(
+                addColumnDefinitionWithExpression.generatedExpression(),
+                tableInfo.ident(),
+                analyzedTableElements.columnIdents().iterator().next().name(),
+                tableInfo.generatedColumns().stream().map(GeneratedReference::column).toList());
+        }
         return new AnalyzedAlterTableAddColumn(tableInfo, analyzedTableElements, analyzedTableElementsWithExpressions);
     }
 

--- a/server/src/main/java/io/crate/analyze/GeneratedColumnValidator.java
+++ b/server/src/main/java/io/crate/analyze/GeneratedColumnValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import java.util.List;
+
+import io.crate.exceptions.ColumnValidationException;
+import io.crate.expression.symbol.RefVisitor;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+
+final class GeneratedColumnValidator {
+
+    private GeneratedColumnValidator() {}
+
+    public static void validate(final Symbol symbol,
+                                RelationName relationName,
+                                String columnName,
+                                List<ColumnIdent> generatedCols) throws UnsupportedOperationException {
+        RefVisitor.visitRefs(symbol,
+                             ref -> {
+                                 if (generatedCols.stream()
+                                     .anyMatch(genCol -> genCol.equals(ref.column()))) {
+                                     throw new ColumnValidationException(columnName, relationName,
+                                        "a generated column cannot be based on a generated column");
+                                 }
+                             });
+    }
+}

--- a/server/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
+++ b/server/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
@@ -55,9 +54,6 @@ public class TableReferenceResolver implements FieldProvider<Reference> {
         ColumnIdent columnIdent = ColumnIdent.fromNameSafe(qualifiedName, path);
         for (var reference : tableReferences) {
             if (reference.column().equals(columnIdent)) {
-                if (reference instanceof GeneratedReference) {
-                    throw new IllegalArgumentException("A generated column cannot be based on a generated column");
-                }
                 references.add(reference);
                 return reference;
             }

--- a/server/src/main/java/io/crate/analyze/relations/ExcludedFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/ExcludedFieldProvider.java
@@ -35,12 +35,12 @@ import java.util.List;
  *  a) checks if a QualifiedName matches the excluded table
  *  b) resolves the column name to Literal specified in the VALUES part of INSERT INTO
  *
- * Otherwise it just calls the wrapped field provider.
+ * Otherwise, it just calls the wrapped field provider.
  */
 public class ExcludedFieldProvider implements FieldProvider<Symbol> {
 
-    private ValuesResolver valuesResolver;
-    private FieldProvider<?> fieldProvider;
+    private final ValuesResolver valuesResolver;
+    private final FieldProvider<?> fieldProvider;
 
     public ExcludedFieldProvider(FieldProvider<?> fieldProvider, ValuesResolver valuesResolver) {
         this.fieldProvider = fieldProvider;

--- a/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -38,7 +38,7 @@ import java.util.Locale;
  */
 public class NameFieldProvider implements FieldProvider<Symbol> {
 
-    private AnalyzedRelation relation;
+    private final AnalyzedRelation relation;
 
     public NameFieldProvider(AnalyzedRelation relation) {
         this.relation = relation;

--- a/server/src/main/java/io/crate/exceptions/ColumnValidationException.java
+++ b/server/src/main/java/io/crate/exceptions/ColumnValidationException.java
@@ -35,11 +35,6 @@ public class ColumnValidationException extends RuntimeException implements Table
         this.relationName = relationName;
     }
 
-    public ColumnValidationException(String column, RelationName relationName, Throwable e) {
-        super(String.format(Locale.ENGLISH, "Validation failed for %s: %s", column, e.getMessage()));
-        this.relationName = relationName;
-    }
-
     @Override
     public Iterable<RelationName> getTableIdents() {
         return Collections.singletonList(relationName);

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
@@ -59,6 +58,7 @@ import io.crate.common.Booleans;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.MapBuilder;
 import io.crate.common.collections.Maps;
+import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -667,9 +667,9 @@ public class DocIndexMetadata {
 
         for (var generatedReference : generatedColumnReferences) {
             Expression expression = SqlParser.createExpression(generatedReference.formattedGeneratedExpression());
+            tableReferenceResolver.references().clear();
             generatedReference.generatedExpression(exprAnalyzer.convert(expression, analysisCtx));
             generatedReference.referencedReferences(List.copyOf(tableReferenceResolver.references()));
-            tableReferenceResolver.references().clear();
         }
         return this;
     }

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -146,5 +146,19 @@ public class CreateTableIntegrationTest extends IntegTestCase {
 
     }
 
-
+    public void test_constraint_on_generated_column() {
+        execute(
+            """
+                CREATE TABLE test(
+                    col1 INT,
+                    col2 INT GENERATED ALWAYS AS col1*2 CONSTRAINT gt_zero CHECK (col2 > 0)
+                )
+                """);
+        assertThrowsMatches(
+            () -> execute("INSERT INTO test(col1) VALUES(0)"),
+            isSQLError(startsWith("Failed CONSTRAINT gt_zero CHECK (\"col2\" > 0) and values {col2=0, col1=0}"),
+                       INTERNAL_ERROR,
+                       BAD_REQUEST,
+                       4000));
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -163,5 +163,9 @@ public class CreateTableIntegrationTest extends IntegTestCase {
                        INTERNAL_ERROR,
                        BAD_REQUEST,
                        4000));
+
+        execute("INSERT INTO test(col1) VALUES(1),(2),(3)");
+        assertThat(printedTable(response.rows()))
+            .isEqualTo("");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -22,14 +22,14 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.hamcrest.Matchers.is;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThrows;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -73,18 +73,19 @@ public class CreateTableIntegrationTest extends IntegTestCase {
         client().admin().indices().putMapping(new PutMappingRequest("tbl").source(builder))
             .get(5, TimeUnit.SECONDS);
 
-        assertThat(
-            internalCluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"),
-            is(true)
-        );
-        assertThrows(Exception.class, () -> execute("select * from doc.tbl"));
+        assertThat(internalCluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"))
+            .isTrue();
+        assertThrowsMatches(
+            () -> execute("select * from doc.tbl"),
+            isSQLError(startsWith("Relation 'doc.tbl' unknown"),
+                       UNDEFINED_TABLE,
+                       NOT_FOUND,
+                       4041));
         execute("drop table doc.tbl");
         execute("select count(*) from information_schema.tables where table_name = 'tbl'");
-        assertThat(response.rows()[0][0], is(0L));
-        assertThat(
-            internalCluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"),
-            is(false)
-        );
+        assertThat(response.rows()[0][0]).isEqualTo(0L);
+        assertThat(internalCluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"))
+            .isFalse();
     }
 
     private void executeCreateTableThreaded(final String statement) throws Throwable {
@@ -105,7 +106,9 @@ public class CreateTableIntegrationTest extends IntegTestCase {
         }
 
         executorService.shutdown();
-        assertThat("executorservice did not shutdown within timeout", executorService.awaitTermination(10, TimeUnit.SECONDS), is(true));
+        assertThat(executorService.awaitTermination(10, TimeUnit.SECONDS))
+            .as("executorservice did not shutdown within timeout")
+            .isTrue();
 
         Throwable throwable = lastThrowable.get();
         if (throwable != null) {
@@ -122,7 +125,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
         execute("insert into test(t) values('2020-02-11 15:44:17')");
         refresh();
         execute("select date_format('%Y-%m-%d %H:%i:%s', calculated) from test");
-        assertThat(printedTable(response.rows()), is("2020-02-11 15:30:00\n"));
+        assertThat(printedTable(response.rows())).isEqualTo("2020-02-11 15:30:00\n");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, it was impossible to create a table with a constraint on a
generated column, or add a generated column with a constraint to an
existing table, i.e.:
```
CREATE TABLE test(
    col1 INT,
    col2 INT GENERATED ALWAYS AS col1*2 CHECK (col2 > 0)
)
```
or
```
CREATE TABLE test(col1 INT)

ALTER TABLE test ADD COLUMN col2 INT GENERATED ALWAYS AS col1*2 CHECK (col2 > 0)
```

Remove validation from `TableReferenceResolver` and implement validation
with a visitor.

Closes: #12852

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
