### PR TITLE
docs: Fix PostgresSQL link for cancelling requests

### DIFF
--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -581,4 +581,4 @@ CrateDB and we love to hear feedback.
 .. _PostgreSQL simple query: https://www.postgresql.org/docs/14/static/protocol-flow.html#id-1.10.5.7.4
 .. _PostgreSQL value expressions: https://www.postgresql.org/docs/14/static/sql-expressions.html
 .. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/14/static/protocol.html
-.. _PostgreSQL cancelling requests: https://www.postgresql.org/docs/14/protocol-flow.html#id-1.10.5.7.9
+.. _PostgreSQL cancelling requests: https://www.postgresql.org/docs/14/protocol-flow.html#id-1.10.5.7.10


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

docs: Fix PostgresSQL link for cancelling requests
(paragraph numbering must have been changed)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
