### PR TITLE
Use ClusterSettings to retrieve setting values instead of CrateSettings

### DIFF
--- a/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -21,20 +21,20 @@
 
 package io.crate.metadata.sys;
 
-import io.crate.metadata.settings.CrateSettings;
-import io.crate.metadata.table.SchemaInfo;
-import io.crate.metadata.table.TableInfo;
-import io.crate.metadata.view.ViewInfo;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Supplier;
+import io.crate.metadata.table.SchemaInfo;
+import io.crate.metadata.table.TableInfo;
+import io.crate.metadata.view.ViewInfo;
 
 @Singleton
 public class SysSchemaInfo implements SchemaInfo {
@@ -43,9 +43,9 @@ public class SysSchemaInfo implements SchemaInfo {
     private final Map<String, TableInfo> tableInfos;
 
     @Inject
-    public SysSchemaInfo(ClusterService clusterService, CrateSettings crateSettings) {
+    public SysSchemaInfo(ClusterService clusterService) {
         tableInfos = new HashMap<>();
-        tableInfos.put(SysClusterTableInfo.IDENT.name(), SysClusterTableInfo.of(clusterService, crateSettings));
+        tableInfos.put(SysClusterTableInfo.IDENT.name(), SysClusterTableInfo.of(clusterService));
         tableInfos.put(SysNodesTableInfo.IDENT.name(), SysNodesTableInfo.create());
         tableInfos.put(SysShardsTableInfo.IDENT.name(), SysShardsTableInfo.create());
         Supplier<DiscoveryNode> localNode = clusterService::localNode;

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.regex.Regex;
 
 import java.util.ArrayList;
@@ -117,6 +118,13 @@ public abstract class AbstractScopedSettings {
         keySettings = other.keySettings;
         settingUpgraders = Map.copyOf(other.settingUpgraders);
         settingUpdaters.addAll(other.settingUpdaters);
+    }
+
+    public synchronized Settings getLoggerSettings() {
+        if (lastSettingsApplied == Settings.EMPTY) {
+            return settings.filter(Loggers.LOG_LEVEL_SETTING::match);
+        }
+        return lastSettingsApplied.filter(Loggers.LOG_LEVEL_SETTING::match);
     }
 
     /**

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -72,7 +72,6 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.SystemTable;
 import io.crate.metadata.doc.DocSchemaInfoFactory;
 import io.crate.metadata.doc.DocTableInfoFactory;
-import io.crate.metadata.settings.CrateSettings;
 import io.crate.metadata.shard.ShardReferenceResolver;
 import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.metadata.sys.SysShardsTableInfo;
@@ -92,14 +91,13 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() {
         NodeContext nodeCtx = createNodeContext();
         indexShard = mockIndexShard();
-        CrateSettings crateSettings = new CrateSettings(clusterService, clusterService.getSettings());
         UserDefinedFunctionService udfService = new UserDefinedFunctionService(
             clusterService,
             new DocTableInfoFactory(nodeCtx),
             nodeCtx
         );
         schemas = new Schemas(
-            Map.of("sys", new SysSchemaInfo(this.clusterService, crateSettings)),
+            Map.of("sys", new SysSchemaInfo(this.clusterService)),
             clusterService,
             new DocSchemaInfoFactory(new DocTableInfoFactory(nodeCtx), (ident, state) -> null , nodeCtx, udfService)
         );

--- a/server/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
@@ -28,9 +28,6 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.GatewayService;
 import org.junit.Test;
@@ -105,28 +102,5 @@ public class CrateSettingsTest extends CrateDummyClusterServiceUnitTest {
             .build();
         CrateSettings.flattenSettings(builder, "stats", value);
         assertThat(builder.build(), is(expected));
-    }
-
-    @Test
-    public void testDefaultValuesAreSet() {
-        CrateSettings crateSettings = new CrateSettings(clusterService, clusterService.getSettings());
-        assertThat(
-            crateSettings.settings().get(JobsLogService.STATS_ENABLED_SETTING.getKey()),
-            is(JobsLogService.STATS_ENABLED_SETTING.getDefaultRaw(Settings.EMPTY)));
-    }
-
-
-    @Test
-    public void testSettingsChanged() {
-        CrateSettings crateSettings = new CrateSettings(clusterService, clusterService.getSettings());
-
-        ClusterState newState = ClusterState.builder(clusterService.state())
-            .metadata(Metadata.builder().transientSettings(
-                Settings.builder().put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true).build()))
-            .build();
-        crateSettings.clusterChanged(new ClusterChangedEvent("settings updated", newState, clusterService.state()));
-        assertThat(
-            crateSettings.settings().getAsBoolean(JobsLogService.STATS_ENABLED_SETTING.getKey(), false),
-            is(true));
     }
 }

--- a/server/src/test/java/io/crate/metadata/sys/SysClusterTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysClusterTableInfoTest.java
@@ -29,16 +29,13 @@ import org.junit.Test;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.expression.reference.StaticTableReferenceResolver;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.settings.CrateSettings;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class SysClusterTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_license_data_can_be_selected() {
-        var clusterTable = SysClusterTableInfo.of(
-            clusterService,
-            new CrateSettings(clusterService, clusterService.getSettings()));
+        var clusterTable = SysClusterTableInfo.of(clusterService);
 
         StaticTableReferenceResolver<Void> refResolver = new StaticTableReferenceResolver<>(clusterTable.expressions());
         NestableCollectExpression<Void, ?> expiryDate = refResolver.getImplementation(clusterTable.getReference(new ColumnIdent(

--- a/server/src/test/java/io/crate/metadata/sys/SystemTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SystemTableInfoTest.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.metadata.Reference;
-import io.crate.metadata.settings.CrateSettings;
 import io.crate.metadata.table.TableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingHelpers;
@@ -40,10 +39,7 @@ public class SystemTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() {
-        sysSchemaInfo = new SysSchemaInfo(
-            this.clusterService,
-            new CrateSettings(clusterService, clusterService.getSettings())
-        );
+        sysSchemaInfo = new SysSchemaInfo(this.clusterService);
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -150,7 +150,6 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
-import io.crate.metadata.settings.CrateSettings;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.metadata.sys.SysSchemaInfo;
@@ -261,8 +260,7 @@ public class SQLExecutor {
             DocTableInfoFactory tableInfoFactory = new DocTableInfoFactory(nodeCtx);
             udfService = new UserDefinedFunctionService(clusterService, tableInfoFactory, nodeCtx);
             Map<String, SchemaInfo> schemaInfoByName = new HashMap<>();
-            CrateSettings crateSettings = new CrateSettings(clusterService, clusterService.getSettings());
-            schemaInfoByName.put("sys", new SysSchemaInfo(clusterService, crateSettings));
+            schemaInfoByName.put("sys", new SysSchemaInfo(clusterService));
             schemaInfoByName.put("information_schema", new InformationSchemaInfo());
             schemaInfoByName.put(PgCatalogSchemaInfo.NAME, new PgCatalogSchemaInfo(udfService, tableStats));
             schemaInfoByName.put(

--- a/server/src/testFixtures/java/org/apache/lucene/tests/util/CrateLuceneTestCase.java
+++ b/server/src/testFixtures/java/org/apache/lucene/tests/util/CrateLuceneTestCase.java
@@ -81,7 +81,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -231,7 +230,6 @@ import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.rules.NoClassHooksShadowingRule;
 import com.carrotsearch.randomizedtesting.rules.NoInstanceHooksOverridesRule;
-import com.carrotsearch.randomizedtesting.rules.StaticFieldsInvariantRule;
 
 import junit.framework.AssertionFailedError;
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/RandomObjects.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/RandomObjects.java
@@ -24,7 +24,6 @@ import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo;
 import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo.Failure;
-import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import io.crate.common.collections.Tuple;
@@ -48,7 +47,6 @@ import java.util.Random;
 import static com.carrotsearch.randomizedtesting.generators.RandomNumbers.randomIntBetween;
 import static com.carrotsearch.randomizedtesting.generators.RandomStrings.randomAsciiLettersOfLength;
 import static com.carrotsearch.randomizedtesting.generators.RandomStrings.randomUnicodeOfLengthBetween;
-import static java.util.Collections.singleton;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_UUID_NA_VALUE;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`ClusterSettings` is used to apply new settings and it keeps a reference
to the last applied settings (merged with the previous/initial settings)

`CrateSettings` also kept track of the applied setting. There is no need for both.
This makes cluster setting updates a tiny bit cheaper because we no
longer merge settings an additional time.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
