### PR TITLE
Make interval of date_trunc case insensitive

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,8 @@ Deprecations
 Changes
 =======
 
+- Changed the ``interval`` parameter of ``date_trunc`` to be case insensitive.
+
 - Added support for correlated scalar sub-queries within the select list of a
   query. See :ref:`Scalar subquery <sql-scalar-subquery>`.
 

--- a/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -206,12 +206,12 @@ public class DateTruncFunction extends Scalar<Long, Object> {
         return rounding.round(ts);
     }
 
-    private DateTimeUnit intervalAsUnit(String interval) {
+    private static DateTimeUnit intervalAsUnit(String interval) {
         if (interval == null) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                 "invalid interval NULL for scalar '%s'", NAME));
         }
-        DateTimeUnit intervalAsUnit = DATE_FIELD_PARSERS.get(interval);
+        DateTimeUnit intervalAsUnit = DATE_FIELD_PARSERS.get(interval.toLowerCase(Locale.ENGLISH));
         if (intervalAsUnit == null) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                 "invalid interval '%s' for scalar '%s'", interval, NAME));

--- a/server/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
@@ -104,6 +104,11 @@ public class DateTruncFunctionTest extends ScalarTestCase {
                        TIMESTAMP); // Fri Jan  1 00:00:00.000 UTC 1999
     }
 
+    @Test
+    public void test_interval_is_case_insensitive() {
+        assertEvaluate("date_trunc('dAy', timestamp_tz)", 919900800000L, TIMESTAMP);
+    }
+
 
     @Test
     public void testDateTruncWithLongDataType() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/12875


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
