### PR TITLE
Fix issue with aggregate functions on literals

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -94,6 +94,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue causing ``IndexOutOfBoundsException`` when applying
+  aggregations on literals, i.e.::
+
+    SELECT SUM(10) FROM test HAVING COUNT(1) > 0
+
 - Fixed an issue, preventing users from defining a constraint on a generated
   column, when creating a table or when adding a generated column, i.e.::
 

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -167,6 +167,9 @@ public class DocValuesAggregates {
                 throw new IllegalStateException(
                     "Expected an aggregationFunction for " + aggregation + " got: " + func);
             }
+            if (aggregationReferences.isEmpty()) {
+                return null;
+            }
             DocValueAggregator<?> docValueAggregator = aggFunc.getDocValueAggregator(
                 aggregationReferences,
                 table,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When applying an aggregate function (SUM, MIN, AVG, etc.) on literals an
`IndexOutOfBoundsException` was thrown since we were trying to get an
aggregationReference from an empty list. i.e.:
```
SELECT SUM(10) FROM test HAVING COUNT(1) > 0
```
Guard the call to `AggregateFunction#getDocValueAggregator()` with a
check and return a null if literals are used.

Closes: #12879

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
