### PR TITLE
Improve pg compatibility with string representations of boolean values

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,11 @@ Deprecations
 Changes
 =======
 
+- Added support for ``'YES'``, ``'ON'`` and ``'1'`` as alternative way to
+  specify a ``TRUE`` boolean constant and ``'NO'``, ``'OFF'`` and ``'0'`` as
+  alternative way to specify ``FALSE`` boolean constant improving compatibility
+  with PostgreSQL.
+
 - Changed the ``interval`` parameter of ``date_trunc`` to be case insensitive.
 
 - Added support for correlated scalar sub-queries within the select list of a

--- a/server/src/main/java/io/crate/types/BooleanType.java
+++ b/server/src/main/java/io/crate/types/BooleanType.java
@@ -75,8 +75,16 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
     private static final Map<String, Boolean> BOOLEAN_MAP = Map.ofEntries(
         Map.entry("f", false),
         Map.entry("false", false),
+        Map.entry("n", false),
+        Map.entry("no", false),
+        Map.entry("off", false),
+        Map.entry("0", false),
         Map.entry("t", true),
-        Map.entry("true", true)
+        Map.entry("true", true),
+        Map.entry("y", true),
+        Map.entry("yes", true),
+        Map.entry("on", true),
+        Map.entry("1", true)
     );
 
     @Override

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1853,7 +1853,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         relation = executor.analyze("select try_cast(['fd', '3', '5'] as array(integer)) from users");
         assertThat(relation.outputs().get(0), isLiteral(Arrays.asList(null, 3, 5)));
 
-        relation = executor.analyze("select try_cast('1' as boolean) from users");
+        relation = executor.analyze("select try_cast('2' as boolean) from users");
         assertThat(relation.outputs().get(0), isLiteral(null));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -45,7 +45,7 @@ public class CastIntegrationTest extends IntegTestCase {
 
     @Test
     public void testTryCastNotValidLiteralCasting() {
-        execute("select try_cast('2e' as integer), try_cast('1' as boolean), try_cast(128 as byte) from sys.cluster");
+        execute("select try_cast('2e' as integer), try_cast('2' as boolean), try_cast(128 as byte) from sys.cluster");
         assertThat(response.rowCount(), is(1L));
         assertThat(response.rows()[0][0], is(nullValue()));
         assertThat(response.rows()[0][1], is(nullValue()));

--- a/server/src/test/java/io/crate/types/BooleanTypeTest.java
+++ b/server/src/test/java/io/crate/types/BooleanTypeTest.java
@@ -35,14 +35,36 @@ public class BooleanTypeTest extends ESTestCase {
     @Test
     public void test_cast_text_to_boolean() {
         assertThat(BooleanType.INSTANCE.implicitCast("t"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("T"), is(true));
         assertThat(BooleanType.INSTANCE.implicitCast("false"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("fAlSe"), is(false));
         assertThat(BooleanType.INSTANCE.implicitCast("FALSE"), is(false));
         assertThat(BooleanType.INSTANCE.implicitCast("f"), is(false));
         assertThat(BooleanType.INSTANCE.implicitCast("F"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("no"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("nO"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("NO"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("n"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("N"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("off"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("Off"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("OFF"), is(false));
+        assertThat(BooleanType.INSTANCE.implicitCast("0"), is(false));
+
         assertThat(BooleanType.INSTANCE.implicitCast("true"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("trUe"), is(true));
         assertThat(BooleanType.INSTANCE.implicitCast("TRUE"), is(true));
         assertThat(BooleanType.INSTANCE.implicitCast("t"), is(true));
         assertThat(BooleanType.INSTANCE.implicitCast("T"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("yes"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("yEs"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("YES"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("y"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("Y"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("on"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("On"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("ON"), is(true));
+        assertThat(BooleanType.INSTANCE.implicitCast("1"), is(true));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Improve pg compatibility with string representations of boolean values, by adding support for ``'YES'``, ``'ON'`` and ``'1'`` as alternative way to  specifiy a ``TRUE`` boolean constant and ``'NO'``, ``'OFF'`` and ``'0'`` as
  alternative way to specify ``FALSE`` boolean constant.

String representations of ``'true'``, ``'t'``, ``'false'``, ``'f'`` were already casted to `boolean` before, this only extends the list of accepted string representations.


see: https://www.postgresql.org/docs/14/datatype-boolean.html

> The datatype input function for type boolean accepts these string representations for the “true” state:
>
> - true
> - yes
> - on
> - 1
> and these representations for the “false” state:
> - false
> - no
> - off
> - 0
> Unique prefixes of these strings are also accepted, for example t or n. Leading or trailing whitespace is ignored, and case does not matter.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
