### PR TITLE
Re-use LogicalPlan.execute for correlated subquery execution

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/projection/CorrelatedJoinProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/CorrelatedJoinProjection.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.data.Row;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.planner.DependencyCarrier;
@@ -41,7 +40,6 @@ public class CorrelatedJoinProjection extends Projection {
     private final LogicalPlan subQueryPlan;
     private final SelectSymbol correlatedSubQuery;
     private final PlannerContext plannerContext;
-    private final ProjectionBuilder projectionBuilder;
     private final SubQueryResults subQueryResults;
     private final Row params;
     private final List<Symbol> inputPlanOutputs;
@@ -51,7 +49,6 @@ public class CorrelatedJoinProjection extends Projection {
                                     LogicalPlan subQueryPlan,
                                     SelectSymbol correlatedSubQuery,
                                     PlannerContext plannerContext,
-                                    ProjectionBuilder projectionBuilder,
                                     SubQueryResults subQueryResults,
                                     Row params,
                                     List<Symbol> inputPlanOutputs,
@@ -60,7 +57,6 @@ public class CorrelatedJoinProjection extends Projection {
         this.subQueryPlan = subQueryPlan;
         this.correlatedSubQuery = correlatedSubQuery;
         this.plannerContext = plannerContext;
-        this.projectionBuilder = projectionBuilder;
         this.subQueryResults = subQueryResults;
         this.params = params;
         this.inputPlanOutputs = inputPlanOutputs;
@@ -77,10 +73,6 @@ public class CorrelatedJoinProjection extends Projection {
 
     public PlannerContext plannerContext() {
         return plannerContext;
-    }
-
-    public ProjectionBuilder projectionBuilder() {
-        return projectionBuilder;
     }
 
     public SubQueryResults subQueryResults() {

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -716,7 +716,6 @@ public class ProjectionToProjectorVisitor
             correlatedJoin.subQueryPlan(),
             correlatedJoin.correlatedSubQuery(),
             correlatedJoin.plannerContext(),
-            correlatedJoin.projectionBuilder(),
             correlatedJoin.executor(),
             correlatedJoin.subQueryResults(),
             correlatedJoin.params(),

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -111,7 +111,6 @@ public class CorrelatedJoin implements LogicalPlan {
             subQueryPlan,
             selectSymbol,
             plannerContext,
-            projectionBuilder,
             subQueryResults,
             params,
             inputPlan.outputs(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We created two new jobIds. `PlannerContext.forSubPlan` creates a new
jobId and we had one additional manual call.

Not sure if that was a real problem (maybe cause for flakyness?).

## Checklist

- [x] Added an entry in `CHANGES.txt` for user facing changes
- [x] Updated documentation & `sql_features` table for user facing changes
- [x] Touched code is covered by tests
- [x] [CLA](https://crate.io/community/contribute/cla/) is signed
- [x] This does not contain breaking changes, or if it does:
  - It is released within a major release
  - It is recorded in ``CHANGES.txt``
  - It was marked as deprecated in an earlier release if possible
  - You've thought about the consequences and other components are adapted
    (E.g. AdminUI)
