### PR TITLE
Ensure Collect operator can be re-used with different subQueryValues

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -310,7 +310,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                ((Collect) source).tableInfo instanceof DocTableInfo &&
                GroupByConsumer.groupedByClusteredColumnOrPrimaryKeys(
                    ((DocTableInfo) ((Collect) source).tableInfo),
-                   ((Collect) source).where,
+                   ((Collect) source).mutableBoundWhere,
                    groupKeys);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `Collect` operator changed `where` on `.build()`. That's important
for some optimizations to work, but for upcoming correlated sub-query
changes it's important to be able to call `.build()` multiple times on
the same instance without side effects.

(More specifically: It would bind & freeze sub-query values the first time, but sub-sequent calls would re-use the first bound value, instead of the new sub-query valules)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
