### PR TITLE
Fix usage of `CapturingRowConsumer` in correlated subqueries

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
+++ b/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
@@ -21,8 +21,9 @@
 
 package io.crate.data;
 
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
 
 public final class CapturingRowConsumer implements RowConsumer {
 
@@ -30,9 +31,11 @@ public final class CapturingRowConsumer implements RowConsumer {
     private final CompletableFuture<?> completionFuture;
     private final boolean requiresScroll;
 
-    public CapturingRowConsumer(boolean requiresScroll) {
-        this.batchIterator = new CompletableFuture<>();
-        this.completionFuture = batchIterator;
+    public CapturingRowConsumer(boolean requiresScroll,
+                                CompletableFuture<BatchIterator<Row>> batchIterator,
+                                CompletableFuture<?> completionFuture) {
+        this.batchIterator = batchIterator;
+        this.completionFuture = completionFuture;
         this.requiresScroll = requiresScroll;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, the `completionFuture` of the consumer was pointing to
the `batchIterator` CompletableFuture, while the
`CorrelatedJoinProject#apply()` was returning the composed future.
Create the `batchIterator` future beforehand, apply the composition
and set the composed future as the `completionFuture` of the consumer.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
