### PR TITLE
Don't leak _exists function name; print as EXISTS

### DIFF
--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.exceptions.ConversionException;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.expression.operator.ExistsOperator;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.any.AnyOperator;
 import io.crate.expression.predicate.IsNullPredicate;
@@ -246,6 +247,11 @@ public class Function implements Symbol, Cloneable {
 
             case SubscriptRecordFunction.NAME:
                 printSubscriptRecord(builder, style);
+                break;
+
+            case ExistsOperator.NAME:
+                builder.append("EXISTS ");
+                builder.append(arguments.get(0).toString(style));
                 break;
 
             case "current_user":

--- a/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -304,4 +304,9 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> analyze("select * from sys.summits where EXISTS (select 1, 2)"))
             .hasMessage("Subqueries with more than 1 column are not supported");
     }
+
+    @Test
+    public void test_exists_is_printed_as_exists_keyword() {
+        QueriedSelectRelation relation = analyze("select * from sys.summits where EXISTS (select 1)");
+        assertThat(relation.where().toString(), is("EXISTS (SELECT 1 FROM (empty_row))")); }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/12900

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
