### PR TITLE
bp: Describe STALE_STATE_CONFIG in ClusterFormationFH

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -466,20 +466,20 @@ should be crossed out as well.
 - [ ] 960d1fb578d Revert "Introduce system index APIs for Kibana (#53035)" (#53992)
 - [ ] 5b9864db2c3 Better Incrementality for Snapshots of Unchanged Shards (#52182) (#53984)
 - [ ] efd18382066 Handle properly indexing rectangles that crosses the dateline (#53810) (#53947)
-- [ ] 879e26ec067 Describe STALE_STATE_CONFIG in ClusterFormationFH (#53878)
-- [ ] adfeb50a534 Use consistent threadpools in CoordinatorTests (#53868)
-- [ ] 4e6bbf6e3c5 Execute retention lease syncs under system context (#53838)
-- [ ] 7d3ac4f57d3 Revert "Apply cluster states in system context (#53785)"
-- [ ] 4178c57410f Apply cluster states in system context (#53785)
-- [ ] 4f1b2fd2b15 Add support for distance queries on geo_shape queries (#53466) (#53795)
-- [ ] b0884baf466 Geo shape query vs geo point backport (#53774)
+- [x] 879e26ec067 Describe STALE_STATE_CONFIG in ClusterFormationFH (#53878)
+- [s] adfeb50a534 Use consistent threadpools in CoordinatorTests (#53868)
+- [s] 4e6bbf6e3c5 Execute retention lease syncs under system context (#53838)
+- [s] 7d3ac4f57d3 Revert "Apply cluster states in system context (#53785)"
+- [s] 4178c57410f Apply cluster states in system context (#53785)
+- [s] 4f1b2fd2b15 Add support for distance queries on geo_shape queries (#53466) (#53795)
+- [s] b0884baf466 Geo shape query vs geo point backport (#53774)
 - [x] 1615c4b3790 Fix testKeepTranslogAfterGlobalCheckpoint (#53704)
-- [ ] 9b3b08318d3 Remove unused import
-- [ ] bc5dae2713b Fix compilation in RoutingNode
+- [s] 9b3b08318d3 Remove unused import
+- [s] bc5dae2713b Fix compilation in RoutingNode
 - [x] 90ab949415e Improve performance of shards limits decider (#53577)
 - [s] 6cc564d677a Restore off-heap loading for term dictionary in ReadOnlyEngine (#53713)
 - [x] e7ae9ae596e Deprecate delaying state recovery for master nodes (#53646)
-- [ ] 71b703edd1e Rename AtomicFieldData to LeafFieldData (#53554)
+- [s] 71b703edd1e Rename AtomicFieldData to LeafFieldData (#53554)
 - [x] 01d2339883d Invoke response handler on failure to send (#53631)
 - [s] 881d0bfa8a8 Add server name to remote info API (#53634)
 - [s] a906f8a0e4a Highlighters skip ignored keyword values (#53408) (#53604)

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import io.crate.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 
@@ -205,7 +206,12 @@ public class ClusterFormationFailureHelper {
             assert requiredNodes <= realNodeIds.size() : nodeIds;
 
             if (nodeIds.size() == 1) {
-                return "a node with id " + realNodeIds;
+                if (nodeIds.contains(GatewayMetaState.STALE_STATE_CONFIG_NODE_ID)) {
+                    return "one or more nodes that have already participated as master-eligible nodes in the cluster but this node was " +
+                        "not master-eligible the last time it joined the cluster";
+                } else {
+                    return "a node with id " + realNodeIds;
+                }
             } else if (nodeIds.size() == 2) {
                 return "two nodes with ids " + realNodeIds;
             } else {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.test.ESTestCase;
 
 public class ClusterFormationFailureHelperTests extends ESTestCase {
@@ -380,6 +381,14 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
             "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + otherMasterNode + ", " + localNode +
+                "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
+
+        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, GatewayMetaState.STALE_STATE_CONFIG_NODE_ID), emptyList(),
+                emptyList(), 0L).getDescription(),
+            is("master not discovered or elected yet, an election requires one or more nodes that have already participated as " +
+                "master-eligible nodes in the cluster but this node was not master-eligible the last time it joined the cluster, " +
+                "have discovered [] which is not a quorum; " +
+                "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We mark cluster states persisted on master-ineligible nodes as
potentially-stale using the voting configuration `{STALE_STATE_CONFIG}` which
prevents these nodes from being elected as master if they are restarted as
master-eligible. Today we do not handle this special voting configuration
differently in the `ClusterFormationFailureHandler`, leading to a mysterious
message `an election requires a node with id [STALE_STATE_CONFIG]` if the
election does not succeed.

This commit adds a special case description for this situation to explain
better why this node cannot win an election.

https://github.com/elastic/elasticsearch/commit/879e26ec067280c461449eae9902bf822c10c937

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
