### PR TITLE
Allow addressing columns of parent scope without alias

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/ParentRelations.java
+++ b/server/src/main/java/io/crate/analyze/relations/ParentRelations.java
@@ -64,6 +64,13 @@ public class ParentRelations {
         return parent.get(relationName);
     }
 
+    public Iterable<AnalyzedRelation> getParents() {
+        if (sourcesTree.isEmpty() || sourcesTree.size() < 2) {
+            return Collections.emptyList();
+        }
+        return sourcesTree.get(sourcesTree.size() - 2).values();
+    }
+
     @Nullable
     public AnalyzedRelation getAncestor(RelationName relationName) {
         AnalyzedRelation relation = null;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes https://github.com/crate/crate/issues/12859

The TypeORM query mentioned in the issue still doesn't work. It requires
more missing features:

- pg_catalog.col_description scalar
- oid type
- regclass type

It also uncovered an issue that correlated subqueries currently don't work in
join conditions (I think the outer column isn't detected by the split visitor).
I'll follow up on this in a dedicated PR.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
