### PR TITLE
Fix for UPDATE to preserve the implied column order

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -141,3 +141,6 @@ Fixes
 
 - Fixed a column positions issue that caused an ``INSERT`` or any other
   statements that adds columns dynamically to throw an exception.
+
+- Fixed ``UPDATE`` to preserve the column order implied by its ``SET`` clause
+  when adding columns dynamically.

--- a/server/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
@@ -21,8 +21,8 @@
 
 package io.crate.analyze;
 
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
@@ -34,7 +34,7 @@ import io.crate.metadata.Reference;
 public final class AnalyzedUpdateStatement implements AnalyzedStatement {
 
     private final AbstractTableRelation<?> table;
-    private final Map<Reference, Symbol> assignmentByTargetCol;
+    private final LinkedHashMap<Reference, Symbol> assignmentByTargetCol;
     private final Symbol query;
 
     /**
@@ -44,7 +44,7 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
     private final List<Symbol> returnValues;
 
     public AnalyzedUpdateStatement(AbstractTableRelation<?> table,
-                                   Map<Reference, Symbol> assignmentByTargetCol,
+                                   LinkedHashMap<Reference, Symbol> assignmentByTargetCol,
                                    Symbol query,
                                    @Nullable List<Symbol> returnValues) {
         this.table = table;
@@ -57,7 +57,7 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
         return table;
     }
 
-    public Map<Reference, Symbol> assignmentByTargetCol() {
+    public LinkedHashMap<Reference, Symbol> assignmentByTargetCol() {
         return assignmentByTargetCol;
     }
 

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -21,9 +21,8 @@
 
 package io.crate.analyze;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.function.Predicate;
@@ -115,7 +114,7 @@ public final class UpdateAnalyzer {
         );
         ExpressionAnalysisContext exprCtx = new ExpressionAnalysisContext(txnCtx.sessionSettings());
 
-        Map<Reference, Symbol> assignmentByTargetCol = getAssignments(
+        LinkedHashMap<Reference, Symbol> assignmentByTargetCol = getAssignments(
             update.assignments(), typeHints, txnCtx, table, normalizer, subqueryAnalyzer, sourceExprAnalyzer, exprCtx);
 
         Symbol query = Objects.requireNonNullElse(
@@ -140,15 +139,15 @@ public final class UpdateAnalyzer {
         );
     }
 
-    private HashMap<Reference, Symbol> getAssignments(List<Assignment<Expression>> assignments,
-                                                      ParamTypeHints typeHints,
-                                                      CoordinatorTxnCtx txnCtx,
-                                                      AbstractTableRelation<?> table,
-                                                      EvaluatingNormalizer normalizer,
-                                                      SubqueryAnalyzer subqueryAnalyzer,
-                                                      ExpressionAnalyzer sourceExprAnalyzer,
-                                                      ExpressionAnalysisContext exprCtx) {
-        HashMap<Reference, Symbol> assignmentByTargetCol = new HashMap<>();
+    private LinkedHashMap<Reference, Symbol> getAssignments(List<Assignment<Expression>> assignments,
+                                                            ParamTypeHints typeHints,
+                                                            CoordinatorTxnCtx txnCtx,
+                                                            AbstractTableRelation<?> table,
+                                                            EvaluatingNormalizer normalizer,
+                                                            SubqueryAnalyzer subqueryAnalyzer,
+                                                            ExpressionAnalyzer sourceExprAnalyzer,
+                                                            ExpressionAnalysisContext exprCtx) {
+        LinkedHashMap<Reference, Symbol> assignmentByTargetCol = new LinkedHashMap<>();
         ExpressionAnalyzer targetExprAnalyzer = new ExpressionAnalyzer(
             txnCtx,
             nodeCtx,

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -368,7 +369,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                                        UpdateSourceGen updateSourceGen) throws Exception {
         assert updateSourceGen != null : "UpdateSourceGen must not be null";
         Doc fetchedDoc = getDocument(indexShard, item.id(), item.version(), item.seqNo(), item.primaryTerm());
-        Map<String, Object> source = updateSourceGen.generateSource(
+        LinkedHashMap<String, Object> source = updateSourceGen.generateSource(
             fetchedDoc,
             item.updateAssignments(),
             item.insertValues()

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateSourceGen.java
@@ -23,6 +23,7 @@ package io.crate.execution.dml.upsert;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import io.crate.common.collections.Maps;
@@ -105,7 +106,7 @@ final class UpdateSourceGen {
         }
     }
 
-    Map<String, Object> generateSource(Doc result, Symbol[] updateAssignments, Object[] insertValues) {
+    LinkedHashMap<String, Object> generateSource(Doc result, Symbol[] updateAssignments, Object[] insertValues) {
         /* We require a new HashMap because all evaluations of the updateAssignments need to be based on the
          * values *before* the update. For example:
          *
@@ -115,7 +116,7 @@ final class UpdateSourceGen {
          * Must result in y = 10, not 15
          */
         Values values = new Values(result, insertValues);
-        HashMap<String, Object> updatedSource = new HashMap<>(result.getSource());
+        LinkedHashMap<String, Object> updatedSource = new LinkedHashMap<>(result.getSource());
         Doc updatedDoc = result.withUpdatedSource(updatedSource);
         for (int i = 0; i < updateColumns.size(); i++) {
             Reference ref = updateColumns.get(i);

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariableOfAnyType;
+import static io.crate.types.TypeSignature.parseTypeSignature;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
@@ -30,12 +32,8 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-
-import static io.crate.metadata.functions.TypeVariableConstraint.typeVariableOfAnyType;
-import static io.crate.types.TypeSignature.parseTypeSignature;
 
 /**
  * _map(k, v, [...]) -> object
@@ -92,7 +90,7 @@ public class MapFunction extends Scalar<Object, Object> {
     @SafeVarargs
     @Override
     public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
-        Map<String, Object> m = new HashMap<>(args.length / 2, 1.0f);
+        LinkedHashMap<String, Object> m = new LinkedHashMap<>(args.length / 2, 1.0f);
         for (int i = 0; i < args.length - 1; i += 2) {
             m.put((String) args[i].value(), args[i + 1].value());
         }

--- a/server/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
+++ b/server/src/main/java/io/crate/expression/symbol/LiteralValueFormatter.java
@@ -83,7 +83,6 @@ public class LiteralValueFormatter {
         var it = map
             .entrySet()
             .stream()
-            .sorted(Map.Entry.comparingByKey())
             .iterator();
         while (it.hasNext()) {
             var entry = it.next();

--- a/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -25,6 +25,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -124,7 +125,7 @@ public final class UpdatePlanner {
     }
 
     private static Plan plan(DocTableRelation docTable,
-                             Map<Reference, Symbol> assignmentByTargetCol,
+                             LinkedHashMap<Reference, Symbol> assignmentByTargetCol,
                              Symbol query,
                              PlannerContext plannerCtx,
                              @Nullable List<Symbol> returnValues) {
@@ -251,7 +252,7 @@ public final class UpdatePlanner {
 
     private static ExecutionPlan updateByQuery(PlannerContext plannerCtx,
                                                DocTableRelation table,
-                                               Map<Reference, Symbol> assignmentByTargetCol,
+                                               LinkedHashMap<Reference, Symbol> assignmentByTargetCol,
                                                WhereClauseOptimizer.DetailedQuery detailedQuery,
                                                Row params,
                                                SubQueryResults subQueryResults,

--- a/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.node.dml;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -59,7 +60,7 @@ public final class UpdateById implements Plan {
     private final Symbol[] returnValues;
 
     public UpdateById(DocTableInfo table,
-                      Map<Reference, Symbol> assignmentByTargetCol,
+                      LinkedHashMap<Reference, Symbol> assignmentByTargetCol,
                       DocKeys docKeys,
                       @Nullable List<Symbol> returnValues,
                       NodeContext nodeCtx) {

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -203,7 +204,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     public Map<String, Object> readValueFrom(StreamInput in) throws IOException {
         if (in.readBoolean()) {
             int size = in.readInt();
-            HashMap<String, Object> m = new HashMap<>(size);
+            LinkedHashMap<String, Object> m = new LinkedHashMap<>(size);
             for (int i = 0; i < size; i++) {
                 String key = in.readString();
                 DataType innerType = innerTypes.getOrDefault(key, UndefinedType.INSTANCE);
@@ -278,7 +279,8 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     public ObjectType(StreamInput in) throws IOException {
         int typesSize = in.readVInt();
-        Map<String, DataType<?>> builder = new HashMap<>();
+        // recover the order it was streamed out
+        LinkedHashMap<String, DataType<?>> builder = new LinkedHashMap<>();
         for (int i = 0; i < typesSize; i++) {
             String key = in.readString();
             DataType<?> type = DataTypes.fromStream(in);

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertThat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -217,12 +218,12 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testObjectLiteral() {
-        Literal<Map<String, Object>> l = Literal.of(Map.ofEntries(
-            Map.entry("field", "value"),
-            Map.entry("array", List.of(1, 2, 3)),
-            Map.entry("nestedMap", Map.of("inner", -0.00005d))
-        ));
-        assertPrint(l, "{\"array\"=[1, 2, 3], \"field\"='value', \"nestedMap\"={\"inner\"=-5.0E-5}}");
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("field", "value");
+        map.put("array", List.of(1, 2, 3));
+        map.put("nestedMap", Map.of("inner", -0.00005d));
+        Literal<Map<String, Object>> l = Literal.of(map);
+        assertPrint(l, "{\"field\"='value', \"array\"=[1, 2, 3], \"nestedMap\"={\"inner\"=-5.0E-5}}");
     }
 
     @Test
@@ -292,16 +293,15 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNativeArray() {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("type", "Point");
+        map.put("coordinates", new double[] {1.0d, 2.0d});
         assertPrint(
             Literal.of(
                 DataTypes.GEO_SHAPE,
-                DataTypes.GEO_SHAPE.sanitizeValue(
-                    Map.of(
-                        "type", "Point",
-                        "coordinates", new double[] {1.0d, 2.0d})
-                )
+                DataTypes.GEO_SHAPE.sanitizeValue(map)
             ),
-            "{\"coordinates\"=[1.0, 2.0], \"type\"='Point'}"
+            "{\"type\"='Point', \"coordinates\"=[1.0, 2.0]}"
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -159,24 +159,13 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         execute("update t set o = {q={r={s=1}}}");
 
         execute("select column_name, ordinal_position from information_schema.columns where table_name = 't'");
-        assertThat(printedTable(response.rows())).containsAnyOf(
+        assertThat(printedTable(response.rows())).isEqualTo(
             """
             id| 1
             name| 2
             o| 3
             o['a']| 4
             o['b']| 5
-            o['a']['b']| 6
-            o['q']| 7
-            o['q']['r']| 8
-            o['q']['r']['s']| 9
-            """,
-            """
-            id| 1
-            name| 2
-            o| 3
-            o['b']| 4
-            o['a']| 5
             o['a']['b']| 6
             o['q']| 7
             o['q']['r']| 8

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -191,24 +191,13 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         execute("alter table t add column o['q']['r']['s'] int");
 
         execute("select column_name, ordinal_position from information_schema.columns where table_name = 't'");
-        assertThat(printedTable(response.rows())).containsAnyOf(
+        assertThat(printedTable(response.rows())).isEqualTo(
             """
             id| 1
             name| 2
             o| 3
             o['a']| 4
             o['b']| 5
-            o['a']['b']| 6
-            o['q']| 7
-            o['q']['r']| 8
-            o['q']['r']['s']| 9
-            """,
-            """
-            id| 1
-            name| 2
-            o| 3
-            o['b']| 4
-            o['a']| 5
             o['a']['b']| 6
             o['q']| 7
             o['q']['r']| 8


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

part of #12880

fixes the top-level column order as well as the sub column order

```
cr> create table t (x int) with (column_policy='dynamic');                                                                                                               
CREATE OK, 1 row affected  (1.693 sec)
cr> insert into t values (1);                                                                                                                                            
INSERT OK, 1 row affected  (0.043 sec)
cr> update t set b=1, a=1, d=1, c=1; // top level column order to preserve                                                                                                                                    
UPDATE OK, 1 row affected  (0.157 sec)
cr> select * from t;                                                                                                                                                     
+---+---+---+---+---+
| x | b | a | d | c |
+---+---+---+---+---+
| 1 | 1 | 1 | 1 | 1 |
+---+---+---+---+---+
SELECT 1 row in set (0.018 sec)
```


```
cr> create table doc.t (id int primary key) with (column_policy='dynamic');                                                                                              
CREATE OK, 1 row affected  (1.690 sec)
cr> insert into doc.t values (1);                                                                                                                                        
INSERT OK, 1 row affected  (0.126 sec)
cr> update doc.t set o = {c=1, a={d=1, b=1, c=1, a=1}, b=1}; // sub column order to preserve                                                                                                            
UPDATE OK, 1 row affected  (0.271 sec)
cr> show create table doc.t;                                                                                                                                             
+-----------------------------------------------------+
| SHOW CREATE TABLE doc.t                             |
+-----------------------------------------------------+
| CREATE TABLE IF NOT EXISTS "doc"."t" (              |
|    "id" INTEGER NOT NULL,                           |
|    "o" OBJECT(DYNAMIC) AS (                         |
|       "c" BIGINT,                                   |
|       "a" OBJECT(DYNAMIC) AS (                      |
|          "d" BIGINT,                                |
|          "b" BIGINT,                                |
|          "c" BIGINT,                                |
|          "a" BIGINT                                 |
|       ),                                            |
|       "b" BIGINT                                    |
|    ),                                               |
|    PRIMARY KEY ("id")                               |
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
