### PR TITLE
bp: Rename `MetaData` to `Metadata`

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -446,7 +446,7 @@ should be crossed out as well.
 - [ ] 5fb76022276 Disallow changing 'enabled' on the root mapper. (#54681)
 - [ ] 6d976e14684 Resolve some coordination-layer TODOs (#54511)
 - [ ] 5e3b6ab82b8 Use VotingConfiguration#of where possible (#54507)
-- [ ] 63e5f2b765f Rename META_DATA to METADATA
+- [x] 63e5f2b765f Rename META_DATA to METADATA
 - [sa] 5fcda57b37f Rename MetaData to Metadata in all of the places (#54519)
 - [s] c9db2de41da [7.x] Comprehensively test supported/unsupported field type:agg combinations (#54451)
 - [s] c38e125425e Remove Redundant Documentation on SnapshotsService (#54482) (#54505)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -447,9 +447,9 @@ should be crossed out as well.
 - [ ] 6d976e14684 Resolve some coordination-layer TODOs (#54511)
 - [ ] 5e3b6ab82b8 Use VotingConfiguration#of where possible (#54507)
 - [ ] 63e5f2b765f Rename META_DATA to METADATA
-- [ ] 5fcda57b37f Rename MetaData to Metadata in all of the places (#54519)
-- [ ] c9db2de41da [7.x] Comprehensively test supported/unsupported field type:agg combinations (#54451)
-- [ ] c38e125425e Remove Redundant Documentation on SnapshotsService (#54482) (#54505)
+- [sa] 5fcda57b37f Rename MetaData to Metadata in all of the places (#54519)
+- [s] c9db2de41da [7.x] Comprehensively test supported/unsupported field type:agg combinations (#54451)
+- [s] c38e125425e Remove Redundant Documentation on SnapshotsService (#54482) (#54505)
 - [x] 915435bbe48 Fix issue with pipeline releasing bytes early (#54474)
 - [ ] 9392fca36a0 Improve Snapshot Abort Behavior (#54256) (#54410)
 - [x] 2ccddbfa88e Move transport decoding and aggregation to server (#54360)

--- a/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
@@ -94,11 +94,11 @@ public class GetFileChunkAction extends ActionType<GetFileChunkAction.Response> 
             var bytesRead = 0;
 
             store.incRef();
-            var fileMetaData = request.storeFileMetadata();
+            var fileMetadata = request.storeFileMetadata();
             try (var currentInput = publisherRestoreService.openInputStream(
-                request.restoreUUID(), request, fileMetaData.name(), fileMetaData.length())) {
+                request.restoreUUID(), request, fileMetadata.name(), fileMetadata.length())) {
                 var offset = request.offset();
-                if (offset < fileMetaData.length()) {
+                if (offset < fileMetadata.length()) {
                     currentInput.skip(offset);
                     bytesRead = currentInput.read(buffer);
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -106,13 +106,13 @@ public final class AutoExpandReplicas {
         return Math.min(maxReplicas, numDataNodes - 1);
     }
 
-    private OptionalInt getDesiredNumberOfReplicas(IndexMetadata indexMetaData, RoutingAllocation allocation) {
+    private OptionalInt getDesiredNumberOfReplicas(IndexMetadata indexMetadata, RoutingAllocation allocation) {
         if (enabled) {
             int numMatchingDataNodes = 0;
             // Only start using new logic once all nodes are migrated to 4.4.0, avoiding disruption during an upgrade
             if (allocation.nodes().getMinNodeVersion().onOrAfter(Version.V_4_4_0)) {
                 for (ObjectCursor<DiscoveryNode> cursor : allocation.nodes().getDataNodes().values()) {
-                    Decision decision = allocation.deciders().shouldAutoExpandToNode(indexMetaData, cursor.value, allocation);
+                    Decision decision = allocation.deciders().shouldAutoExpandToNode(indexMetadata, cursor.value, allocation);
                     if (decision.type() != Decision.Type.NO) {
                         numMatchingDataNodes ++;
                     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1289,14 +1289,14 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
      * State format for {@link Metadata} to write to and load from disk
      */
 
-    public static final MetadataStateFormat<Metadata> FORMAT = createMetaDataStateFormat(false);
+    public static final MetadataStateFormat<Metadata> FORMAT = createMetadataStateFormat(false);
 
     /**
      * Special state format for {@link Metadata} to write to and load from disk, preserving unknown customs
      */
-    public static final MetadataStateFormat<Metadata> FORMAT_PRESERVE_CUSTOMS = createMetaDataStateFormat(true);
+    public static final MetadataStateFormat<Metadata> FORMAT_PRESERVE_CUSTOMS = createMetadataStateFormat(true);
 
-    private static MetadataStateFormat<Metadata> createMetaDataStateFormat(boolean preserveUnknownCustoms) {
+    private static MetadataStateFormat<Metadata> createMetadataStateFormat(boolean preserveUnknownCustoms) {
         return new MetadataStateFormat<Metadata>(GLOBAL_STATE_FILE_PREFIX) {
 
             @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -137,10 +137,10 @@ public class AllocationDeciders extends AllocationDecider {
     }
 
     @Override
-    public Decision shouldAutoExpandToNode(IndexMetadata indexMetaData, DiscoveryNode node, RoutingAllocation allocation) {
+    public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {
-            Decision decision = allocationDecider.shouldAutoExpandToNode(indexMetaData, node, allocation);
+            Decision decision = allocationDecider.shouldAutoExpandToNode(indexMetadata, node, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
                 if (!allocation.debugDecision()) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -161,9 +161,9 @@ public class EnableAllocationDecider extends AllocationDecider {
         }
 
         if (enableRebalance == Rebalance.NONE) {
-            for (IndexMetadata indexMetaData : allocation.metadata()) {
-                if (INDEX_ROUTING_REBALANCE_ENABLE_SETTING.exists(indexMetaData.getSettings())
-                    && INDEX_ROUTING_REBALANCE_ENABLE_SETTING.get(indexMetaData.getSettings()) != Rebalance.NONE) {
+            for (IndexMetadata indexMetadata : allocation.metadata()) {
+                if (INDEX_ROUTING_REBALANCE_ENABLE_SETTING.exists(indexMetadata.getSettings())
+                    && INDEX_ROUTING_REBALANCE_ENABLE_SETTING.get(indexMetadata.getSettings()) != Rebalance.NONE) {
                     return allocation.decision(Decision.YES, NAME, "rebalancing is permitted on one or more indices");
                 }
             }

--- a/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -48,8 +48,8 @@ public class MetaStateService {
     private final NamedXContentRegistry namedXContentRegistry;
 
     // we allow subclasses in tests to redefine formats, e.g. to inject failures
-    protected MetadataStateFormat<Metadata> META_DATA_FORMAT = Metadata.FORMAT;
-    protected MetadataStateFormat<IndexMetadata> INDEX_META_DATA_FORMAT = IndexMetadata.FORMAT;
+    protected MetadataStateFormat<Metadata> METADATA_FORMAT = Metadata.FORMAT;
+    protected MetadataStateFormat<IndexMetadata> INDEX_METADATA_FORMAT = IndexMetadata.FORMAT;
     protected MetadataStateFormat<Manifest> MANIFEST_FORMAT = Manifest.FORMAT;
 
     public MetaStateService(NodeEnvironment nodeEnv, NamedXContentRegistry namedXContentRegistry) {
@@ -78,7 +78,7 @@ public class MetaStateService {
         if (manifest.isGlobalGenerationMissing()) {
             metadataBuilder = Metadata.builder();
         } else {
-            final Metadata globalMetadata = META_DATA_FORMAT.loadGeneration(LOGGER, namedXContentRegistry, manifest.getGlobalGeneration(),
+            final Metadata globalMetadata = METADATA_FORMAT.loadGeneration(LOGGER, namedXContentRegistry, manifest.getGlobalGeneration(),
                     nodeEnv.nodeDataPaths());
             if (globalMetadata != null) {
                 metadataBuilder = Metadata.builder(globalMetadata);
@@ -91,7 +91,7 @@ public class MetaStateService {
             final Index index = entry.getKey();
             final long generation = entry.getValue();
             final String indexFolderName = index.getUUID();
-            final IndexMetadata indexMetadata = INDEX_META_DATA_FORMAT.loadGeneration(LOGGER, namedXContentRegistry, generation,
+            final IndexMetadata indexMetadata = INDEX_METADATA_FORMAT.loadGeneration(LOGGER, namedXContentRegistry, generation,
                     nodeEnv.resolveIndexFolder(indexFolderName));
             if (indexMetadata != null) {
                 metadataBuilder.put(indexMetadata, false);
@@ -112,7 +112,7 @@ public class MetaStateService {
         Metadata.Builder metadataBuilder;
 
         Tuple<Metadata, Long> metadataAndGeneration =
-                META_DATA_FORMAT.loadLatestStateWithGeneration(LOGGER, namedXContentRegistry, nodeEnv.nodeDataPaths());
+                METADATA_FORMAT.loadLatestStateWithGeneration(LOGGER, namedXContentRegistry, nodeEnv.nodeDataPaths());
         Metadata globalMetadata = metadataAndGeneration.v1();
         long globalStateGeneration = metadataAndGeneration.v2();
 
@@ -126,7 +126,7 @@ public class MetaStateService {
 
         for (String indexFolderName : nodeEnv.availableIndexFolders()) {
             Tuple<IndexMetadata, Long> indexMetadataAndGeneration =
-                    INDEX_META_DATA_FORMAT.loadLatestStateWithGeneration(LOGGER, namedXContentRegistry,
+                    INDEX_METADATA_FORMAT.loadLatestStateWithGeneration(LOGGER, namedXContentRegistry,
                             nodeEnv.resolveIndexFolder(indexFolderName));
             // TODO https://github.com/elastic/elasticsearch/issues/38556
             // assert Version.CURRENT.major < 8 : "failed to find manifest file, which is mandatory staring with Elasticsearch version 8.0";
@@ -149,7 +149,7 @@ public class MetaStateService {
      */
     @Nullable
     public IndexMetadata loadIndexState(Index index) throws IOException {
-        return INDEX_META_DATA_FORMAT.loadLatestState(LOGGER, namedXContentRegistry, nodeEnv.indexPaths(index));
+        return INDEX_METADATA_FORMAT.loadLatestState(LOGGER, namedXContentRegistry, nodeEnv.indexPaths(index));
     }
 
     /**
@@ -160,7 +160,7 @@ public class MetaStateService {
         for (String indexFolderName : nodeEnv.availableIndexFolders(excludeIndexPathIdsPredicate)) {
             assert excludeIndexPathIdsPredicate.test(indexFolderName) == false :
                     "unexpected folder " + indexFolderName + " which should have been excluded";
-            IndexMetadata indexMetadata = INDEX_META_DATA_FORMAT.loadLatestState(LOGGER, namedXContentRegistry,
+            IndexMetadata indexMetadata = INDEX_METADATA_FORMAT.loadLatestState(LOGGER, namedXContentRegistry,
                     nodeEnv.resolveIndexFolder(indexFolderName));
             if (indexMetadata != null) {
                 final String indexPathId = indexMetadata.getIndex().getUUID();
@@ -180,7 +180,7 @@ public class MetaStateService {
      * Loads the global state, *without* index state, see {@link #loadFullState()} for that.
      */
     Metadata loadGlobalState() throws IOException {
-        return META_DATA_FORMAT.loadLatestState(LOGGER, namedXContentRegistry, nodeEnv.nodeDataPaths());
+        return METADATA_FORMAT.loadLatestState(LOGGER, namedXContentRegistry, nodeEnv.nodeDataPaths());
     }
 
     /**
@@ -211,7 +211,7 @@ public class MetaStateService {
         final Index index = indexMetadata.getIndex();
         LOGGER.trace("[{}] writing state, reason [{}]", index, reason);
         try {
-            long generation = INDEX_META_DATA_FORMAT.write(indexMetadata,
+            long generation = INDEX_METADATA_FORMAT.write(indexMetadata,
                     nodeEnv.indexPaths(indexMetadata.getIndex()));
             LOGGER.trace("[{}] state written", index);
             return generation;
@@ -229,7 +229,7 @@ public class MetaStateService {
     long writeGlobalState(String reason, Metadata metadata) throws WriteStateException {
         LOGGER.trace("[_global] writing state, reason [{}]", reason);
         try {
-            long generation = META_DATA_FORMAT.write(metadata, nodeEnv.nodeDataPaths());
+            long generation = METADATA_FORMAT.write(metadata, nodeEnv.nodeDataPaths());
             LOGGER.trace("[_global] state written");
             return generation;
         } catch (WriteStateException ex) {
@@ -243,7 +243,7 @@ public class MetaStateService {
      * @param currentGeneration current state generation to keep in the directory.
      */
     void cleanupGlobalState(long currentGeneration) {
-        META_DATA_FORMAT.cleanupOldFiles(currentGeneration, nodeEnv.nodeDataPaths());
+        METADATA_FORMAT.cleanupOldFiles(currentGeneration, nodeEnv.nodeDataPaths());
     }
 
     /**
@@ -253,7 +253,7 @@ public class MetaStateService {
      * @param currentGeneration current state generation to keep in the index directory.
      */
     public void cleanupIndex(Index index, long currentGeneration) {
-        INDEX_META_DATA_FORMAT.cleanupOldFiles(currentGeneration, nodeEnv.indexPaths(index));
+        INDEX_METADATA_FORMAT.cleanupOldFiles(currentGeneration, nodeEnv.indexPaths(index));
     }
 
     /**
@@ -262,7 +262,7 @@ public class MetaStateService {
      */
     public void unreferenceAll() throws IOException {
         MANIFEST_FORMAT.writeAndCleanup(Manifest.empty(), nodeEnv.nodeDataPaths()); // write empty file so that indices become unreferenced
-        META_DATA_FORMAT.cleanupOldFiles(Long.MAX_VALUE, nodeEnv.nodeDataPaths());
+        METADATA_FORMAT.cleanupOldFiles(Long.MAX_VALUE, nodeEnv.nodeDataPaths());
     }
 
     public void deleteAll() throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -167,7 +167,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
 
     public enum IndexCreationContext {
         CREATE_INDEX,
-        META_DATA_VERIFICATION
+        METADATA_VERIFICATION
     }
 
     public IndexEventListener getIndexEventListener() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -246,10 +246,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return internalMerge(mappingSource, reason);
     }
 
-    private synchronized DocumentMapper internalMerge(IndexMetadata indexMetaData,
+    private synchronized DocumentMapper internalMerge(IndexMetadata indexMetadata,
                                                       MergeReason reason,
                                                       boolean onlyUpdateIfNeeded) {
-        MappingMetadata mappingMetadata = indexMetaData.mapping();
+        MappingMetadata mappingMetadata = indexMetadata.mapping();
         if (mappingMetadata != null) {
             if (onlyUpdateIfNeeded) {
                 DocumentMapper existingMapper = documentMapper();

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -458,7 +458,7 @@ public class IndicesService extends AbstractLifecycleComponent
             closeables.add(indicesQueryCache);
             // this will also fail if some plugin fails etc. which is nice since we can verify that early
             final IndexService service = createIndexService(
-                IndexCreationContext.META_DATA_VERIFICATION,
+                IndexCreationContext.METADATA_VERIFICATION,
                 metadata,
                 indicesQueryCache,
                 emptyList()

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -420,7 +420,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     @Override
     public void cleanFiles(int totalTranslogOps,
                            long globalCheckpoint,
-                           Store.MetadataSnapshot sourceMetaData,
+                           Store.MetadataSnapshot sourceMetadata,
                            ActionListener<Void> listener) {
         ActionListener.completeWith(listener, () -> {
             state().getTranslog().totalOperations(totalTranslogOps);
@@ -431,7 +431,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
             final Store store = store();
             store.incRef();
             try {
-                store.cleanupAndVerify("recovery CleanFilesRequestHandler", sourceMetaData);
+                store.cleanupAndVerify("recovery CleanFilesRequestHandler", sourceMetadata);
                 final String translogUUID = Translog.createEmptyTranslog(
                     indexShard.shardPath().resolveTranslog(), globalCheckpoint, shardId, indexShard.getPendingPrimaryTerm());
                 store.associateIndexWithNewTranslog(translogUUID);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -928,11 +928,11 @@ public class Node implements Closeable {
         if (Assertions.ENABLED) {
             try {
                 assert injector.getInstance(MetaStateService.class).loadFullState().v1().isEmpty();
-                final NodeMetadata nodeMetaData = NodeMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY,
+                final NodeMetadata nodeMetadata = NodeMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY,
                                                                                       nodeEnvironment.nodeDataPaths());
-                assert nodeMetaData != null;
-                assert nodeMetaData.nodeVersion().equals(Version.CURRENT);
-                assert nodeMetaData.nodeId().equals(localNodeFactory.getNode().getId());
+                assert nodeMetadata != null;
+                assert nodeMetadata.nodeVersion().equals(Version.CURRENT);
+                assert nodeMetadata.nodeId().equals(localNodeFactory.getNode().getId());
             } catch (IOException e) {
                 assert false : e;
             }

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -163,13 +163,13 @@ public interface Repository extends LifecycleComponent {
      * @param shardFailures         list of shard failures
      * @param repositoryStateId     the unique id identifying the state of the repository when the snapshot began
      * @param includeGlobalState    include cluster global state
-     * @param clusterMetaData       cluster metadata
+     * @param clusterMetadata       cluster metadata
      * @param repositoryMetaVersion version of the updated repository metadata to write
      * @param listener              listener to be called on completion of the snapshot
      */
     void finalizeSnapshot(SnapshotId snapshotId, ShardGenerations shardGenerations, long startTime, String failure,
                           int totalShards, List<SnapshotShardFailure> shardFailures, long repositoryStateId,
-                          boolean includeGlobalState, Metadata clusterMetaData,
+                          boolean includeGlobalState, Metadata clusterMetadata,
                           Version repositoryMetaVersion, ActionListener<SnapshotInfo> listener);
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1612,9 +1612,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         for (final SnapshotsInProgress.Entry entry : snapshots.entries()) {
             if (entry.partial() == false) {
                 for (IndexId index : entry.indices()) {
-                    IndexMetadata indexMetaData = currentState.metadata().index(index.getName());
-                    if (indexMetaData != null && indicesToCheck.contains(indexMetaData.getIndex())) {
-                        indices.add(indexMetaData.getIndex());
+                    IndexMetadata indexMetadata = currentState.metadata().index(index.getName());
+                    if (indexMetadata != null && indicesToCheck.contains(indexMetadata.getIndex())) {
+                        indices.add(indexMetadata.getIndex());
                     }
                 }
             }

--- a/server/src/test/java/io/crate/license/LicenseCustomMetadataUpgraderTest.java
+++ b/server/src/test/java/io/crate/license/LicenseCustomMetadataUpgraderTest.java
@@ -51,7 +51,7 @@ public class LicenseCustomMetadataUpgraderTest {
 
     @Test
     public void test_remove_license_custom_metadata() {
-        var metadata = randomMetadata(new LicenseCustomMetaData("license_key"));
+        var metadata = randomMetadata(new LicenseCustomMetadata("license_key"));
         var customMetadataUpgraderLoader = new CustomMetadataUpgraderLoader(Settings.EMPTY);
         var metadataUpgrader = new MetadataUpgrader(
             List.of(customs -> customMetadataUpgraderLoader.apply(customs)),
@@ -60,13 +60,13 @@ public class LicenseCustomMetadataUpgraderTest {
         var upgrade = GatewayMetaState.upgradeMetadata(metadata, new GatewayMetaStateTests.MockMetadataIndexUpgradeService(false), metadataUpgrader);
         assertThat(upgrade != metadata, is(true));
         assertThat(Metadata.isGlobalStateEquals(upgrade, metadata), is(false));
-        assertThat(upgrade.custom(LicenseCustomMetaData.TYPE), is(nullValue()));
+        assertThat(upgrade.custom(LicenseCustomMetadata.TYPE), is(nullValue()));
     }
 
-    private static class LicenseCustomMetaData extends TestCustomMetadata {
+    private static class LicenseCustomMetadata extends TestCustomMetadata {
         public static final String TYPE = License.WRITEABLE_TYPE;
 
-        protected LicenseCustomMetaData(String data) {
+        protected LicenseCustomMetadata(String data) {
             super(data);
         }
 

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -171,63 +171,63 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_remove_all_tables() throws Exception {
         var state = docTablesByName("t1", "t2", "t3", "t4");
-        var prevMetaData = publicationsMetadata("pub1", true, List.of());
-        var newMetaData = publicationsMetadata("pub1", false, List.of());
+        var prevMetadata = publicationsMetadata("pub1", true, List.of());
+        var newMetadata = publicationsMetadata("pub1", false, List.of());
 
-        assertThat(getTablesAffectedByPublicationsChange(prevMetaData, newMetaData, state), containsInAnyOrder("t1", "t2", "t3", "t4"));
+        assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state), containsInAnyOrder("t1", "t2", "t3", "t4"));
     }
 
     @Test
     public void test_add_and_remove_tables() throws Exception {
         var state = docTablesByName("t1", "t2", "t3", "t4");
         // publish t3, t4 drop t1, t2
-        var prevMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2"));
-        var newMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2", "t3", "t4"));
+        var prevMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2"));
+        var newMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2", "t3", "t4"));
 
-        assertThat(getTablesAffectedByPublicationsChange(prevMetaData, newMetaData, state), containsInAnyOrder("t3", "t4"));
+        assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state), containsInAnyOrder("t3", "t4"));
 
         // publish t3, t4 drop t2
-        prevMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2"));
-        newMetaData = publicationsMetadata("pub1", false, List.of("t1", "t3", "t4"));
+        prevMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2"));
+        newMetadata = publicationsMetadata("pub1", false, List.of("t1", "t3", "t4"));
 
-        assertThat(getTablesAffectedByPublicationsChange(prevMetaData, newMetaData, state), containsInAnyOrder("t2", "t3", "t4"));
+        assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state), containsInAnyOrder("t2", "t3", "t4"));
     }
 
     @Test
     public void test_publish_all_tables_when_tables_have_been_previously_published() throws Exception {
         var state = docTablesByName("t1", "t2", "t3", "t4");
         // publish t3, t4 drop t1, t2
-        var prevMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2"));
-        var newMetaData = publicationsMetadata("pub1", true, List.of());
+        var prevMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2"));
+        var newMetadata = publicationsMetadata("pub1", true, List.of());
 
-        assertThat(getTablesAffectedByPublicationsChange(prevMetaData, newMetaData, state), containsInAnyOrder("t3", "t4"));
+        assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state), containsInAnyOrder("t3", "t4"));
     }
 
     @Test
     public void test_unpublish_all_tables_when_tables_have_been_previously_published() throws Exception {
         var state = docTablesByName("t1", "t2", "t3", "t4");
-        var prevMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2"));
-        var newMetaData = publicationsMetadata("pub1", false, List.of());
+        var prevMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2"));
+        var newMetadata = publicationsMetadata("pub1", false, List.of());
 
-        assertThat(getTablesAffectedByPublicationsChange(prevMetaData, newMetaData, state), containsInAnyOrder("t1", "t2"));
+        assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state), containsInAnyOrder("t1", "t2"));
     }
 
     @Test
     public void test_drop_all_previous_published_tables() throws Exception {
         var state = docTablesByName("t1", "t2", "t3", "t4");
-        var prevMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2"));
-        var newMetaData = publicationsMetadata("pub1", false, List.of());
+        var prevMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2"));
+        var newMetadata = publicationsMetadata("pub1", false, List.of());
 
-        assertThat(getTablesAffectedByPublicationsChange(prevMetaData, newMetaData, state), containsInAnyOrder("t1", "t2"));
+        assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state), containsInAnyOrder("t1", "t2"));
     }
 
     @Test
     public void test_nothing_changed() throws Exception {
         var state = docTablesByName("t1", "t2", "t3", "t4");
-        var prevMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2"));
-        var newMetaData = publicationsMetadata("pub1", false, List.of("t1", "t2"));
+        var prevMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2"));
+        var newMetadata = publicationsMetadata("pub1", false, List.of("t1", "t2"));
 
-        assertThat(getTablesAffectedByPublicationsChange(prevMetaData, newMetaData, state), containsInAnyOrder());
+        assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state), containsInAnyOrder());
         assertThat(getTablesAffectedByPublicationsChange(null, null, state), containsInAnyOrder());
     }
 

--- a/server/src/test/java/io/crate/user/metadata/CustomMetadataTest.java
+++ b/server/src/test/java/io/crate/user/metadata/CustomMetadataTest.java
@@ -47,7 +47,7 @@ import io.crate.metadata.view.ViewsMetadataTest;
 public class CustomMetadataTest {
 
     @Test
-    public void testAllMetaDataXContentRoundtrip() throws IOException {
+    public void testAllMetadataXContentRoundtrip() throws IOException {
         Metadata metadata = Metadata.builder()
             .putCustom(UsersMetadata.TYPE,
                 new UsersMetadata(UserDefinitions.DUMMY_USERS))

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateApiTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateApiTests.java
@@ -34,7 +34,7 @@ import io.crate.common.unit.TimeValue;
 public class ClusterStateApiTests extends IntegTestCase {
 
     @Test
-    public void testWaitForMetaDataVersion() throws Exception {
+    public void testWaitForMetadataVersion() throws Exception {
         ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.waitForTimeout(TimeValue.timeValueHours(1));
         CompletableFuture<ClusterStateResponse> future1 = client().admin().cluster().state(clusterStateRequest);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -273,11 +273,11 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
         setState(clusterService, clusterState);
 
         IndexShardRoutingTable shardRoutingTable = clusterState.routingTable().index(index).shard(shardId.id());
-        IndexMetadata indexMetaData = clusterState.getMetadata().index(index);
+        IndexMetadata indexMetadata = clusterState.getMetadata().index(index);
         ShardRouting primaryRouting = shardRoutingTable.primaryShard();
-        long primaryTerm = indexMetaData.primaryTerm(0);
+        long primaryTerm = indexMetadata.primaryTerm(0);
 
-        Set<String> inSyncAllocationIds = indexMetaData.inSyncAllocationIds(0);
+        Set<String> inSyncAllocationIds = indexMetadata.inSyncAllocationIds(0);
         Set<String> trackedShards = shardRoutingTable.getAllAllocationIds();
 
         List<ShardRouting> unavailableShards = randomSubsetOf(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -76,7 +76,7 @@ public class AllocationDecidersTests extends ESTestCase {
             }
 
             @Override
-            public Decision canAllocate(IndexMetadata indexMetaData, RoutingNode node, RoutingAllocation allocation) {
+            public Decision canAllocate(IndexMetadata indexMetadata, RoutingNode node, RoutingAllocation allocation) {
                 return Decision.YES;
             }
 
@@ -86,7 +86,7 @@ public class AllocationDecidersTests extends ESTestCase {
             }
 
             @Override
-            public Decision shouldAutoExpandToNode(IndexMetadata indexMetaData, DiscoveryNode node, RoutingAllocation allocation) {
+            public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
                 return Decision.YES;
             }
 

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -346,8 +346,8 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 
         MetaStateServiceWithFailures(int invertedFailRate, NodeEnvironment nodeEnv, NamedXContentRegistry namedXContentRegistry) {
             super(nodeEnv, namedXContentRegistry);
-            META_DATA_FORMAT = wrap(Metadata.FORMAT);
-            INDEX_META_DATA_FORMAT = wrap(IndexMetadata.FORMAT);
+            METADATA_FORMAT = wrap(Metadata.FORMAT);
+            INDEX_METADATA_FORMAT = wrap(IndexMetadata.FORMAT);
             MANIFEST_FORMAT = wrap(Manifest.FORMAT);
             failRandomly = false;
             this.invertedFailRate = invertedFailRate;

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -173,15 +173,15 @@ public class IndexSettingsTests extends ESTestCase {
         settings.getScopedSettings().addSettingsUpdateConsumer(notUpdated, builder::append);
         assertThat(integer.get(), is(0));
         assertThat(builder.toString(), is(""));
-        IndexMetadata newMetaData = newIndexMeta(
+        IndexMetadata newMetadata = newIndexMeta(
             "index",
             Settings.builder()
                 .put(settings.getIndexMetadata().getSettings())
                 .put("index.test.setting.int", 42)
                 .build()
         );
-        assertTrue(settings.updateIndexMetadata(newMetaData));
-        assertSame(settings.getIndexMetadata(), newMetaData);
+        assertTrue(settings.updateIndexMetadata(newMetadata));
+        assertSame(settings.getIndexMetadata(), newMetadata);
         assertThat(integer.get(), is(42));
         assertThat(builder.toString(), is(""));
         integer.set(0);

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeasesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeasesTests.java
@@ -101,7 +101,7 @@ public class RetentionLeasesTests extends ESTestCase {
         }
     }
 
-    public void testRetentionLeasesMetaDataStateFormat() throws IOException {
+    public void testRetentionLeasesMetadataStateFormat() throws IOException {
         final Path path = createTempDir();
         final RetentionLeases retentionLeases = randomRetentionLeases(true);
         RetentionLeases.FORMAT.writeAndCleanup(retentionLeases, path);

--- a/server/src/testFixtures/java/org/elasticsearch/indices/recovery/AsyncRecoveryTarget.java
+++ b/server/src/testFixtures/java/org/elasticsearch/indices/recovery/AsyncRecoveryTarget.java
@@ -98,19 +98,19 @@ public class AsyncRecoveryTarget implements RecoveryTargetHandler {
     @Override
     public void cleanFiles(int totalTranslogOps,
                            long globalCheckpoint,
-                           Store.MetadataSnapshot sourceMetaData,
+                           Store.MetadataSnapshot sourceMetadata,
                            ActionListener<Void> listener) {
-        executor.execute(() -> target.cleanFiles(totalTranslogOps, globalCheckpoint, sourceMetaData, listener));
+        executor.execute(() -> target.cleanFiles(totalTranslogOps, globalCheckpoint, sourceMetadata, listener));
     }
 
     @Override
-    public void writeFileChunk(StoreFileMetadata fileMetaData,
+    public void writeFileChunk(StoreFileMetadata fileMetadata,
                                long position,
                                BytesReference content,
                                boolean lastChunk,
                                int totalTranslogOps,
                                ActionListener<Void> listener) {
         final BytesReference copy = new BytesArray(BytesRef.deepCopyOf(content.toBytesRef()));
-        executor.execute(() -> target.writeFileChunk(fileMetaData, position, copy, lastChunk, totalTranslogOps, listener));
+        executor.execute(() -> target.writeFileChunk(fileMetadata, position, copy, lastChunk, totalTranslogOps, listener));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Rename remaining `MetaData` to `Metadata` and `META_DATA` to `METADATA`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
