### PR TITLE
bp: Use VotingConfiguration#of where possible

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -445,7 +445,7 @@ should be crossed out as well.
 - [ ] 2fdbed7797a Broadcast cancellation to only nodes have outstanding child tasks (#54312)
 - [ ] 5fb76022276 Disallow changing 'enabled' on the root mapper. (#54681)
 - [ ] 6d976e14684 Resolve some coordination-layer TODOs (#54511)
-- [ ] 5e3b6ab82b8 Use VotingConfiguration#of where possible (#54507)
+- [x] 5e3b6ab82b8 Use VotingConfiguration#of where possible (#54507)
 - [x] 63e5f2b765f Rename META_DATA to METADATA
 - [sa] 5fcda57b37f Rename MetaData to Metadata in all of the places (#54519)
 - [s] c9db2de41da [7.x] Comprehensively test supported/unsupported field type:agg combinations (#54451)

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -391,7 +391,6 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
         }
 
         public static VotingConfiguration of(DiscoveryNode... nodes) {
-            // this could be used in many more places - TODO use this where appropriate
             return new VotingConfiguration(Arrays.stream(nodes).map(DiscoveryNode::getId).collect(Collectors.toSet()));
         }
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTests.java
@@ -96,7 +96,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testSetInitialState() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         assertTrue(state1.getLastAcceptedConfiguration().hasQuorum(Collections.singleton(node1.getId())));
         assertTrue(state1.getLastCommittedConfiguration().hasQuorum(Collections.singleton(node1.getId())));
@@ -105,7 +105,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testSetInitialStateWhenAlreadySet() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         assertTrue(state1.getLastAcceptedConfiguration().hasQuorum(Collections.singleton(node1.getId())));
         assertTrue(state1.getLastCommittedConfiguration().hasQuorum(Collections.singleton(node1.getId())));
@@ -131,7 +131,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testStartJoinAfterBootstrap() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         assertTrue(state1.getLastAcceptedConfiguration().hasQuorum(Collections.singleton(node1.getId())));
         assertTrue(state1.getLastCommittedConfiguration().hasQuorum(Collections.singleton(node1.getId())));
@@ -180,7 +180,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinWithBadCurrentTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
 
@@ -193,7 +193,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinWithHigherAcceptedTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
 
@@ -211,7 +211,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinWithSameAcceptedTermButHigherVersion() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
 
@@ -229,7 +229,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinWithLowerLastAcceptedTermWinsElection() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
 
@@ -250,7 +250,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinWithSameLastAcceptedTermButLowerOrSameVersionWinsElection() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
 
@@ -271,7 +271,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinDoesNotWinElection() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
 
@@ -290,8 +290,8 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinDoesNotWinElectionWhenOnlyCommittedConfigQuorum() {
-        VotingConfiguration configNode1 = new VotingConfiguration(Collections.singleton(node1.getId()));
-        VotingConfiguration configNode2 = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration configNode1 = VotingConfiguration.of(node1);
+        VotingConfiguration configNode2 = VotingConfiguration.of(node2);
         ClusterState state1 = clusterState(0L, 0L, node1, configNode1, configNode2, 42L);
         cs1.setInitialState(state1);
 
@@ -304,8 +304,8 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testJoinDoesNotWinElectionWhenOnlyLastAcceptedConfigQuorum() {
-        VotingConfiguration configNode1 = new VotingConfiguration(Collections.singleton(node1.getId()));
-        VotingConfiguration configNode2 = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration configNode1 = VotingConfiguration.of(node1);
+        VotingConfiguration configNode2 = VotingConfiguration.of(node2);
         ClusterState state1 = clusterState(0L, 0L, node1, configNode2, configNode1, 42L);
         cs1.setInitialState(state1);
 
@@ -318,7 +318,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleClientValue() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -328,7 +328,7 @@ public class CoordinationStateTests extends ESTestCase {
         assertTrue(cs1.electionWon());
         assertTrue(cs1.handleJoin(v2));
 
-        VotingConfiguration newConfig = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration newConfig = VotingConfiguration.of(node2);
 
         ClusterState state2 = clusterState(startJoinRequest1.getTerm(), 2L, node1, initialConfig, newConfig, 42L);
         PublishRequest publishRequest = cs1.handleClientValue(state2);
@@ -341,7 +341,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleClientValueWhenElectionNotWon() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         if (randomBoolean()) {
             cs1.setInitialState(state1);
@@ -351,7 +351,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleClientValueDuringOngoingPublication() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -368,7 +368,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleClientValueWithBadTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(3, 5));
@@ -385,7 +385,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleClientValueWithOldVersion() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -399,7 +399,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleClientValueWithDifferentReconfigurationWhileAlreadyReconfiguring() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -409,18 +409,18 @@ public class CoordinationStateTests extends ESTestCase {
         assertTrue(cs1.electionWon());
         assertTrue(cs1.handleJoin(v2));
 
-        VotingConfiguration newConfig1 = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration newConfig1 = VotingConfiguration.of(node2);
         ClusterState state2 = clusterState(startJoinRequest1.getTerm(), 2L, node1, initialConfig, newConfig1, 42L);
         PublishRequest publishRequest = cs1.handleClientValue(state2);
         cs1.handlePublishRequest(publishRequest);
-        VotingConfiguration newConfig2 = new VotingConfiguration(Collections.singleton(node3.getId()));
+        VotingConfiguration newConfig2 = VotingConfiguration.of(node3);
         ClusterState state3 = clusterState(startJoinRequest1.getTerm(), 3L, node1, initialConfig, newConfig2, 42L);
         assertThat(expectThrows(CoordinationStateRejectedException.class, () -> cs1.handleClientValue(state3)).getMessage(),
             containsString("only allow reconfiguration while not already reconfiguring"));
     }
 
     public void testHandleClientValueWithSameReconfigurationWhileAlreadyReconfiguring() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -430,7 +430,7 @@ public class CoordinationStateTests extends ESTestCase {
         assertTrue(cs1.electionWon());
         assertTrue(cs1.handleJoin(v2));
 
-        VotingConfiguration newConfig1 = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration newConfig1 = VotingConfiguration.of(node2);
         ClusterState state2 = clusterState(startJoinRequest1.getTerm(), 2L, node1, initialConfig, newConfig1, 42L);
         PublishRequest publishRequest = cs1.handleClientValue(state2);
         cs1.handlePublishRequest(publishRequest);
@@ -440,7 +440,7 @@ public class CoordinationStateTests extends ESTestCase {
 
     public void testHandleClientValueWithIllegalCommittedConfigurationChange() {
         assumeTrue("test only works with assertions enabled", Assertions.ENABLED);
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -450,14 +450,14 @@ public class CoordinationStateTests extends ESTestCase {
         assertTrue(cs1.electionWon());
         assertTrue(cs1.handleJoin(v2));
 
-        VotingConfiguration newConfig = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration newConfig = VotingConfiguration.of(node2);
         ClusterState state2 = clusterState(startJoinRequest1.getTerm(), 2L, node1, newConfig, newConfig, 42L);
         assertThat(expectThrows(AssertionError.class, () -> cs1.handleClientValue(state2)).getMessage(),
             containsString("last committed configuration should not change"));
     }
 
     public void testHandleClientValueWithConfigurationChangeButNoJoinQuorum() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -465,14 +465,14 @@ public class CoordinationStateTests extends ESTestCase {
         assertTrue(cs1.handleJoin(v1));
         assertTrue(cs1.electionWon());
 
-        VotingConfiguration newConfig = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration newConfig = VotingConfiguration.of(node2);
         ClusterState state2 = clusterState(startJoinRequest1.getTerm(), 2L, node1, initialConfig, newConfig, 42L);
         assertThat(expectThrows(CoordinationStateRejectedException.class, () -> cs1.handleClientValue(state2)).getMessage(),
             containsString("only allow reconfiguration if joinVotes have quorum for new config"));
     }
 
     public void testHandlePublishRequest() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -493,7 +493,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishRequestWithBadTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -513,7 +513,7 @@ public class CoordinationStateTests extends ESTestCase {
 
     // scenario when handling a publish request from a master that we already received a newer state from
     public void testHandlePublishRequestWithSameTermButOlderOrSameVersion() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -533,7 +533,7 @@ public class CoordinationStateTests extends ESTestCase {
 
     // scenario when handling a publish request from a fresh master
     public void testHandlePublishRequestWithTermHigherThanLastAcceptedTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
         ClusterState state1 = clusterState(startJoinRequest1.getTerm(), randomLongBetween(2, 10), node1, initialConfig, initialConfig, 42L);
         cs2.handleStartJoin(startJoinRequest1);
@@ -546,7 +546,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishResponseWithCommit() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -564,7 +564,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishResponseWhenSteppedDownAsLeader() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -582,8 +582,8 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishResponseWithoutPublishConfigQuorum() {
-        VotingConfiguration configNode1 = new VotingConfiguration(Collections.singleton(node1.getId()));
-        VotingConfiguration configNode2 = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration configNode1 = VotingConfiguration.of(node1);
+        VotingConfiguration configNode2 = VotingConfiguration.of(node2);
         ClusterState state1 = clusterState(0L, 0L, node1, configNode1, configNode1, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -600,8 +600,8 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishResponseWithoutCommitedConfigQuorum() {
-        VotingConfiguration configNode1 = new VotingConfiguration(Collections.singleton(node1.getId()));
-        VotingConfiguration configNode2 = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration configNode1 = VotingConfiguration.of(node1);
+        VotingConfiguration configNode2 = VotingConfiguration.of(node2);
         ClusterState state1 = clusterState(0L, 0L, node1, configNode1, configNode1, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -618,7 +618,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishResponseWithoutCommit() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -633,7 +633,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishResponseWithBadTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -652,7 +652,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandlePublishResponseWithVersionMismatch() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -667,7 +667,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleCommit() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -676,7 +676,7 @@ public class CoordinationStateTests extends ESTestCase {
         assertTrue(cs1.electionWon());
         Join v2 = cs2.handleStartJoin(startJoinRequest1);
         assertTrue(cs1.handleJoin(v2));
-        VotingConfiguration newConfig = new VotingConfiguration(Collections.singleton(node2.getId()));
+        VotingConfiguration newConfig = VotingConfiguration.of(node2);
         ClusterState state2 = clusterState(startJoinRequest1.getTerm(), 2L, node1, initialConfig, newConfig, 7L);
         PublishRequest publishRequest = cs1.handleClientValue(state2);
         PublishResponse publishResponse = cs1.handlePublishRequest(publishRequest);
@@ -689,7 +689,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleCommitWithBadCurrentTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -709,7 +709,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleCommitWithBadLastAcceptedTerm() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -722,7 +722,7 @@ public class CoordinationStateTests extends ESTestCase {
     }
 
     public void testHandleCommitWithBadVersion() {
-        VotingConfiguration initialConfig = new VotingConfiguration(Collections.singleton(node1.getId()));
+        VotingConfiguration initialConfig = VotingConfiguration.of(node1);
         ClusterState state1 = clusterState(0L, 0L, node1, initialConfig, initialConfig, 42L);
         cs1.setInitialState(state1);
         StartJoinRequest startJoinRequest1 = new StartJoinRequest(node1, randomLongBetween(1, 5));
@@ -754,9 +754,9 @@ public class CoordinationStateTests extends ESTestCase {
         assertTrue(voteCollection.containsVoteFor(node1));
         assertTrue(voteCollection.containsVoteFor(node2));
         assertFalse(voteCollection.containsVoteFor(node3));
-        assertTrue(voteCollection.isQuorum(new VotingConfiguration(Set.of(node1.getId(), node2.getId()))));
-        assertTrue(voteCollection.isQuorum(new VotingConfiguration(Set.of(node1.getId()))));
-        assertFalse(voteCollection.isQuorum(new VotingConfiguration(Set.of(node3.getId()))));
+        assertTrue(voteCollection.isQuorum(VotingConfiguration.of(node1, node2)));
+        assertTrue(voteCollection.isQuorum(VotingConfiguration.of(node1)));
+        assertFalse(voteCollection.isQuorum(VotingConfiguration.of(node3)));
 
         EqualsHashCodeTestUtils.CopyFunction<CoordinationState.VoteCollection> copyFunction =
             vc -> {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -51,7 +51,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -781,8 +780,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             assertThat(exceptionMessage, containsString(coordinator.getLocalNode().toString()));
 
             // This is VERY BAD: setting a _different_ initial configuration. Yet it works if the first attempt will never be a quorum.
-            assertTrue(coordinator.setInitialConfiguration(
-                new VotingConfiguration(Collections.singleton(coordinator.getLocalNode().getId()))));
+            assertTrue(coordinator.setInitialConfiguration(VotingConfiguration.of(coordinator.getLocalNode())));
             cluster.stabilise();
         }
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -283,7 +283,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(randomFrom(node0, node1).getId()))));
+            VotingConfiguration.of(randomFrom(node0, node1))));
         assertFalse(isLocalNodeElectedMaster());
         assertNull(coordinator.getStateForMasterService().nodes().getMasterNodeId());
         long newTerm = initialTerm + randomLongBetween(1, 10);
@@ -303,7 +303,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node1.getId()))));
+            VotingConfiguration.of(node1)));
         assertFalse(isLocalNodeElectedMaster());
         long newTerm = initialTerm + randomLongBetween(1, 10);
         long higherVersion = initialVersion + randomLongBetween(1, 10);
@@ -319,7 +319,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node0.getId()))));
+            VotingConfiguration.of(node0)));
         assertFalse(isLocalNodeElectedMaster());
         long newTerm = initialTerm + randomLongBetween(1, 10);
         long higherVersion = initialVersion + randomLongBetween(1, 10);
@@ -333,7 +333,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node0.getId()))));
+            VotingConfiguration.of(node0)));
         assertFalse(isLocalNodeElectedMaster());
         long newTerm = initialTerm + randomLongBetween(1, 10);
         joinNodeAndRun(new JoinRequest(node0, newTerm, Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));
@@ -350,7 +350,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node0.getId()))));
+            VotingConfiguration.of(node0)));
         long newTerm = initialTerm + randomLongBetween(1, 10);
 
         joinNodeAndRun(new JoinRequest(node0, newTerm, Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));
@@ -369,7 +369,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node2.getId()))));
+            VotingConfiguration.of(node2)));
         assertFalse(isLocalNodeElectedMaster());
         long newTerm = initialTerm + randomLongBetween(1, 10);
         SimpleFuture futNode0 = joinNodeAsync(new JoinRequest(node0, newTerm, Optional.of(
@@ -396,7 +396,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node0.getId()))));
+            VotingConfiguration.of(node0)));
         long newTerm = initialTerm + randomLongBetween(1, 10);
         handleStartJoinFrom(node1, newTerm);
         handleFollowerCheckFrom(node1, newTerm);
@@ -452,7 +452,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node0.getId()))));
+            VotingConfiguration.of(node0)));
         long newTerm = initialTerm + randomLongBetween(1, 10);
         handleStartJoinFrom(node1, newTerm);
         handleFollowerCheckFrom(node1, newTerm);
@@ -468,7 +468,7 @@ public class NodeJoinTests extends ESTestCase {
         long initialTerm = randomLongBetween(1, 10);
         long initialVersion = randomLongBetween(1, 10);
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
-            new VotingConfiguration(Collections.singleton(node1.getId()))));
+            VotingConfiguration.of(node1)));
         long newTerm = initialTerm + randomLongBetween(1, 10);
         SimpleFuture fut = joinNodeAsync(new JoinRequest(node0, newTerm,
             Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
@@ -32,14 +32,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
@@ -140,8 +138,7 @@ public class PreVoteCollectorTests extends ESTestCase {
     }
 
     private ClusterState makeClusterState(DiscoveryNode[] votingNodes) {
-        final VotingConfiguration votingConfiguration
-            = new VotingConfiguration(Arrays.stream(votingNodes).map(DiscoveryNode::getId).collect(Collectors.toSet()));
+        final VotingConfiguration votingConfiguration = VotingConfiguration.of(votingNodes);
         return CoordinationStateTests.clusterState(lastAcceptedTerm, lastAcceptedVersion, localNode,
             votingConfiguration, votingConfiguration, 0);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
@@ -185,7 +185,7 @@ public class PublicationTests extends ESTestCase {
     }
 
     public void testSimpleClusterStatePublishing() throws InterruptedException {
-        VotingConfiguration singleNodeConfig = new VotingConfiguration(Set.of(n1.getId()));
+        VotingConfiguration singleNodeConfig = VotingConfiguration.of(n1);
         initializeCluster(singleNodeConfig);
 
         AssertingAckListener ackListener = new AssertingAckListener(nodes.size());
@@ -261,7 +261,7 @@ public class PublicationTests extends ESTestCase {
     }
 
     public void testClusterStatePublishingWithFaultyNodeBeforeCommit() throws InterruptedException {
-        VotingConfiguration singleNodeConfig = new VotingConfiguration(Set.of(n1.getId()));
+        VotingConfiguration singleNodeConfig = VotingConfiguration.of(n1);
         initializeCluster(singleNodeConfig);
 
         AssertingAckListener ackListener = new AssertingAckListener(nodes.size());
@@ -304,7 +304,7 @@ public class PublicationTests extends ESTestCase {
     }
 
     public void testClusterStatePublishingWithFaultyNodeAfterCommit() throws InterruptedException {
-        VotingConfiguration singleNodeConfig = new VotingConfiguration(Set.of(n1.getId()));
+        VotingConfiguration singleNodeConfig = VotingConfiguration.of(n1);
         initializeCluster(singleNodeConfig);
 
         AssertingAckListener ackListener = new AssertingAckListener(nodes.size());
@@ -357,7 +357,7 @@ public class PublicationTests extends ESTestCase {
     }
 
     public void testClusterStatePublishingFailsOrTimesOutBeforeCommit() throws InterruptedException {
-        VotingConfiguration config = new VotingConfiguration(Set.of(n1.getId(), n2.getId()));
+        VotingConfiguration config = VotingConfiguration.of(n1, n2);
         initializeCluster(config);
 
         AssertingAckListener ackListener = new AssertingAckListener(nodes.size());
@@ -396,7 +396,7 @@ public class PublicationTests extends ESTestCase {
     }
 
     public void testPublishingToMastersFirst() {
-        VotingConfiguration singleNodeConfig = new VotingConfiguration(Set.of(n1.getId()));
+        VotingConfiguration singleNodeConfig = VotingConfiguration.of(n1);
         initializeCluster(singleNodeConfig);
 
         DiscoveryNodes.Builder discoNodesBuilder = DiscoveryNodes.builder();
@@ -412,8 +412,7 @@ public class PublicationTests extends ESTestCase {
     }
 
     public void testClusterStatePublishingTimesOutAfterCommit() throws InterruptedException {
-        VotingConfiguration config = new VotingConfiguration(randomBoolean() ?
-            Set.of(n1.getId(), n2.getId()) : Set.of(n1.getId(), n2.getId(), n3.getId()));
+        VotingConfiguration config = randomBoolean() ? VotingConfiguration.of(n1, n2): VotingConfiguration.of(n1, n2, n3);
         initializeCluster(config);
 
         AssertingAckListener ackListener = new AssertingAckListener(nodes.size());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This resolves a longstanding TODO in the cluster coordination subsystem.

https://github.com/elastic/elasticsearch/commit/5e3b6ab82b8dc8f68f05818cc9e5706e4837c836

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
