### PR TITLE
Fix `INSERT`/`COPY FROM` to preserve the implied column order

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -142,8 +142,8 @@ Fixes
 - Fixed a column positions issue that caused an ``INSERT`` or any other
   statements that adds columns dynamically to throw an exception.
 
-- Fixed ``UPDATE`` to preserve the column order implied by its ``SET`` clause
-  when adding columns dynamically.
-
 - Updated the Admin UI to version 1.22.2. It includes a fix for a rendering
   issue causing jumping behavior on selected views in view list.
+
+- Fixed ``UPDATE``, ``INSERT`` and ``COPY FROM`` to preserve the implied column
+  order when columns are added.

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/support/ParameterizedXContentParser.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/support/ParameterizedXContentParser.java
@@ -21,13 +21,11 @@
 
 package org.elasticsearch.common.xcontent.support;
 
-import static org.elasticsearch.common.xcontent.support.AbstractXContentParser.SIMPLE_MAP_FACTORY;
 import static org.elasticsearch.common.xcontent.support.AbstractXContentParser.readValue;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Map;
-
-import org.elasticsearch.common.xcontent.XContentParser;
+import java.util.LinkedHashMap;
 
 public class ParameterizedXContentParser {
 
@@ -39,8 +37,8 @@ public class ParameterizedXContentParser {
      * Replication of {@link AbstractXContentParser#readMap(XContentParser, AbstractXContentParser.MapFactory)}
      * with an additional field parsing before inserting into the resulting map.
      */
-    public static Map<String, Object> parse(XContentParser parser, FieldParser fieldParser) throws IOException {
-        Map<String, Object> map = SIMPLE_MAP_FACTORY.newMap();
+    public static LinkedHashMap<String, Object> parse(XContentParser parser, FieldParser fieldParser) throws IOException {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
         XContentParser.Token token = parser.currentToken();
         if (token == null) {
             token = parser.nextToken();
@@ -53,7 +51,7 @@ public class ParameterizedXContentParser {
             String fieldName = parser.currentName();
             // And then the value...
             token = parser.nextToken();
-            Object value = readValue(parser, SIMPLE_MAP_FACTORY, token);
+            Object value = readValue(parser, LinkedHashMap::new, token);
             map.put(fieldName, fieldParser.parse(fieldName, value));
         }
         return map;

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -22,7 +22,7 @@
 package io.crate.execution.dml.upsert;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -108,7 +108,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         row.firstCells(values);
         evaluateDefaultValues();
 
-        HashMap<String, Object> source = new HashMap<>();
+        LinkedHashMap<String, Object> source = new LinkedHashMap<>();
         for (int i = 0; i < targets.size(); i++) {
             Reference target = targets.get(i);
             Object valueForInsert = target

--- a/server/src/main/java/io/crate/execution/dml/upsert/RawInsertSource.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/RawInsertSource.java
@@ -43,6 +43,6 @@ public class RawInsertSource implements InsertSourceGen {
             NamedXContentRegistry.EMPTY,
             DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
             new BytesArray(((String) values[0])).array()
-        ).map();
+        ).mapOrdered();
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.indexing;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -185,6 +186,7 @@ public class IndexWriterProjector implements Projector {
             if (value == null) {
                 return null;
             }
+            assert value instanceof LinkedHashMap<String, Object> : "the raw source order should be preserved";
             Map<String, Object> filteredMap = XContentMapValues.filter(value, includes, excludes);
             try {
                 BytesReference bytes = BytesReference.bytes(new XContentBuilder(XContentType.JSON.xContent(),

--- a/server/src/main/java/io/crate/expression/reference/file/SourceAsMapLineExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceAsMapLineExpression.java
@@ -24,6 +24,7 @@ package io.crate.expression.reference.file;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class SourceAsMapLineExpression extends LineCollectorExpression<Map<String, Object>> {
@@ -32,7 +33,7 @@ public class SourceAsMapLineExpression extends LineCollectorExpression<Map<Strin
     private LineContext context;
 
     @Override
-    public Map<String, Object> value() {
+    public LinkedHashMap<String, Object> value() {
         return context.sourceAsMap();
     }
 

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -164,7 +164,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
             return map;
         }
 
-        HashMap<String, Object> newMap = new HashMap<>(map);
+        HashMap<String, Object> newMap = (map instanceof LinkedHashMap<String, Object>) ? new LinkedHashMap<>(map) : new HashMap<>(map);
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String key = entry.getKey();
             DataType<?> targetType = innerTypes.getOrDefault(key, UndefinedType.INSTANCE);

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.regex.Regex;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -197,7 +198,7 @@ public class XContentMapValues {
             CharacterRunAutomaton includeAutomaton, int initialIncludeState,
             CharacterRunAutomaton excludeAutomaton, int initialExcludeState,
             CharacterRunAutomaton matchAllAutomaton) {
-        Map<String, Object> filtered = new HashMap<>();
+        Map<String, Object> filtered = (map instanceof LinkedHashMap) ? new LinkedHashMap<>() : new HashMap<>();
         for (Map.Entry<String, ?> entry : map.entrySet()) {
             String key = entry.getKey();
 

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -27,6 +27,7 @@ import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -41,6 +42,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import com.carrotsearch.randomizedtesting.LifecycleScope;
+import io.crate.testing.SQLResponse;
+import io.crate.testing.UseJdbc;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -60,16 +68,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
-
-import org.elasticsearch.test.IntegTestCase;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
-import com.carrotsearch.randomizedtesting.LifecycleScope;
-
-import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
 public class CopyIntegrationTest extends SQLHttpIntegrationTest {
@@ -1079,5 +1077,68 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         assertThat(response.rows()[0][2], is(2L));
         assertThat(response.rows()[0][3], is(9L));
 
+    }
+
+    @Test
+    public void test_copy_preserves_implied_top_level_column_order() throws IOException {
+        execute(
+            """
+                create table t (
+                    p int
+                ) partitioned by (p) with (column_policy = 'dynamic');
+                """
+        );
+        var lines = List.of(
+            """
+            {"b":1, "a":1, "d":1, "c":1}
+            """
+        );
+        var file = folder.newFile(UUID.randomUUID().toString());
+        Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
+        execute("copy t from ? ", new Object[]{Paths.get(file.toURI()).toUri().toString()});
+        execute("refresh table t");
+        execute("select * from t");
+        assertThat(response.cols())
+            // follow the same order as provided by '{"b":1, "a":1, "d":1, "c":1}'
+            .isEqualTo(new String[] {"p", "b", "a", "d", "c"});
+    }
+
+    @Test
+    public void test_copy_preserves_the_implied_sub_column_order() throws IOException {
+        execute(
+            """
+                create table doc.t (
+                    p int,
+                    o object
+                ) partitioned by (p) with (column_policy = 'dynamic');
+                """
+        );
+        var lines = List.of(
+            """
+            {"o":{"c":1, "a":{"d":1, "b":1, "c":1, "a":1}, "b":1}}
+            """
+        );
+        var file = folder.newFile(UUID.randomUUID().toString());
+        Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
+        execute("copy doc.t from ? ", new Object[]{Paths.get(file.toURI()).toUri().toString()});
+        execute("refresh table doc.t");
+        execute("show create table doc.t");
+        assertThat(printedTable(response.rows()))
+            // follow the same order as provided by '{"o":{"c":1, "a":{"d":1, "b":1, "c":1, "a":1}, "b":1}}'
+            .contains(
+                "CREATE TABLE IF NOT EXISTS \"doc\".\"t\" (\n" +
+                "   \"p\" INTEGER,\n" +
+                "   \"o\" OBJECT(DYNAMIC) AS (\n" +
+                "      \"c\" BIGINT,\n" +
+                "      \"a\" OBJECT(DYNAMIC) AS (\n" +
+                "         \"d\" BIGINT,\n" +
+                "         \"b\" BIGINT,\n" +
+                "         \"c\" BIGINT,\n" +
+                "         \"a\" BIGINT\n" +
+                "      ),\n" +
+                "      \"b\" BIGINT\n" +
+                "   )\n" +
+                ")"
+            );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -160,7 +160,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
                 """);
         assertThrowsMatches(
             () -> execute("INSERT INTO test(col1) VALUES(0)"),
-            isSQLError(startsWith("Failed CONSTRAINT gt_zero CHECK (\"col2\" > 0) and values {col2=0, col1=0}"),
+            isSQLError(startsWith("Failed CONSTRAINT gt_zero CHECK (\"col2\" > 0) and values {col1=0, col2=0}"),
                        INTERNAL_ERROR,
                        BAD_REQUEST,
                        4000));

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -400,7 +400,7 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("alter table t add column bazinga integer constraint bazinga_check check(bazinga <> 42)");
         execute("insert into t(id, qty, bazinga) values(0, 1, 100)");
         assertThrowsMatches(() -> execute("insert into t(id, qty, bazinga) values(0, 1, 42)"),
-                     isSQLError(containsString("Failed CONSTRAINT bazinga_check CHECK (\"bazinga\" <> 42) and values {qty=1, id=0, bazinga=42}"),
+                     isSQLError(containsString("Failed CONSTRAINT bazinga_check CHECK (\"bazinga\" <> 42) and values {id=0, qty=1, bazinga=42}"),
                                 INTERNAL_ERROR,
                                 BAD_REQUEST,
                                 4000));
@@ -434,7 +434,7 @@ public class DDLIntegrationTest extends IntegTestCase {
         ));
         execute("insert into t(id, qty) values(-42, 100)");
         assertThrowsMatches(() -> execute("insert into t(id, qty) values(0, 0)"),
-                     isSQLError(is("Failed CONSTRAINT check_qty_gt_zero CHECK (\"qty\" > 0) and values {qty=0, id=0}"),
+                     isSQLError(is("Failed CONSTRAINT check_qty_gt_zero CHECK (\"qty\" > 0) and values {id=0, qty=0}"),
                          INTERNAL_ERROR,
                          BAD_REQUEST,
                          4000));

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -305,7 +305,7 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         execute("refresh table t");
 
         execute("select column_name, ordinal_position from information_schema.columns where table_name='t' order by ordinal_position");
-        assertThat(printedTable(response.rows())).containsAnyOf(
+        assertThat(printedTable(response.rows())).isEqualTo(
             """
             tb| 1
             p| 2
@@ -318,20 +318,6 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
             o| 9
             o['a']| 10
             o['b']| 11
-            o['a']['b']| 12
-            """,
-            """
-            tb| 1
-            p| 2
-            tb['t1']| 3
-            tb['t2']| 4
-            tb['t1']['t3']| 5
-            tb['t1']['t6']| 6
-            tb['t1']['t3']['t4']| 7
-            tb['t1']['t3']['t4']['t5']| 8
-            o| 9
-            o['b']| 10
-            o['a']| 11
             o['a']['b']| 12
             """);
     }

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -237,7 +237,7 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         execute("refresh table t");
         execute("select column_name, ordinal_position, data_type from information_schema.columns where table_name = 't' order by 2");
 
-        assertThat(printedTable(response.rows())).containsAnyOf(
+        assertThat(printedTable(response.rows())).isEqualTo(
             """
             tb| 1| object_array
             p| 2| integer
@@ -250,20 +250,6 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
             o| 9| object
             o['a']| 10| object
             o['b']| 11| bigint
-            o['a']['b']| 12| bigint
-            """,
-            """
-            tb| 1| object_array
-            p| 2| integer
-            tb['t1']| 3| object_array
-            tb['t2']| 4| object
-            tb['t1']['t3']| 5| object
-            tb['t1']['t6']| 6| bigint_array
-            tb['t1']['t3']['t4']| 7| object
-            tb['t1']['t3']['t4']['t5']| 8| bigint
-            o| 9| object
-            o['b']| 10| bigint
-            o['a']| 11| object
             o['a']['b']| 12| bigint
             """
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

fixes part of #12880

fixes the top-level column order as well as the sub column order of `INSERT` and `COPY FROM`

see the attached integration tests for detailed scenarios.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
