### PR TITLE
bp: Fix Snapshot Completion Listener Lost on Master Failover

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -453,7 +453,7 @@ should be crossed out as well.
 - [x] 915435bbe48 Fix issue with pipeline releasing bytes early (#54474)
 - [ ] 9392fca36a0 Improve Snapshot Abort Behavior (#54256) (#54410)
 - [x] 2ccddbfa88e Move transport decoding and aggregation to server (#54360)
-- [ ] 14b5daad7c9 Fix Snapshot Completion Listener Lost on Master Failover (#54286) (#54330)
+- [x] 14b5daad7c9 Fix Snapshot Completion Listener Lost on Master Failover (#54286) (#54330)
 - [x] 0d30b48613a Disallow negative TimeValues (#53913)
 - [s] 3b4751bdb72 Avoid I/O operations when rewriting shard search request (#54044) (#54139)
 - [s] 381d7586e40 Introduce formal role for remote cluster client (#54138)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

If master fails over before (or we run into any other exception) when removing
the snapshot from the CS we must still resolve all the completion listeners for
the snapshot.

https://github.com/elastic/elasticsearch/commit/14b5daad7c9b4ca77169e742706b44e078c65531

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
