### PR TITLE
bp: Better Incrementality for Snapshots of Unchanged Shards

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -464,7 +464,7 @@ should be crossed out as well.
 - [s] 1c1730facd4 Mask wildcard query special characters on keyword queries (#53127) (#53512)
 - [s] d3cc5bff17d Give helpful message on remote connections disabled (#53690)
 - [s] 960d1fb578d Revert "Introduce system index APIs for Kibana (#53035)" (#53992)
-- [ ] 5b9864db2c3 Better Incrementality for Snapshots of Unchanged Shards (#52182) (#53984)
+- [x] 5b9864db2c3 Better Incrementality for Snapshots of Unchanged Shards (#52182) (#53984)
 - [s] efd18382066 Handle properly indexing rectangles that crosses the dateline (#53810) (#53947)
 - [x] 879e26ec067 Describe STALE_STATE_CONFIG in ClusterFormationFH (#53878)
 - [s] adfeb50a534 Use consistent threadpools in CoordinatorTests (#53868)

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexCommit;
@@ -306,6 +308,7 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                               SnapshotId snapshotId,
                               IndexId indexId,
                               IndexCommit snapshotIndexCommit,
+                              @Nullable String shardStateIdentifier,
                               IndexShardSnapshotStatus snapshotStatus,
                               Version repositoryMetaVersion,
                               ActionListener<String> listener) {

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -135,6 +135,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
 
     static final class ParseFields {
         static final ParseField FILES = new ParseField("files");
+        static final ParseField SHARD_STATE_ID = new ParseField("shard_state_id");
         static final ParseField SNAPSHOTS = new ParseField("snapshots");
     }
 
@@ -207,6 +208,9 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                 builder.value(fileInfo.name());
             }
             builder.endArray();
+            if (snapshot.shardStateIdentifier() != null) {
+                builder.field(ParseFields.SHARD_STATE_ID.getPreferredName(), snapshot.shardStateIdentifier());
+            }
             builder.endObject();
         }
         builder.endObject();
@@ -219,6 +223,8 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
             token = parser.nextToken();
         }
         Map<String, List<String>> snapshotsMap = new HashMap<>();
+        Map<String, String> historyUUIDs = new HashMap<>();
+        Map<String, Long> globalCheckpoints = new HashMap<>();
         Map<String, FileInfo> files = new HashMap<>();
         if (token == XContentParser.Token.START_OBJECT) {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -250,15 +256,16 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                             if (token == XContentParser.Token.FIELD_NAME) {
                                 currentFieldName = parser.currentName();
-                                if (parser.nextToken() == XContentParser.Token.START_ARRAY) {
-                                    if (ParseFields.FILES.match(currentFieldName, parser.getDeprecationHandler()) == false) {
-                                        throw new ElasticsearchParseException("unknown array [{}]", currentFieldName);
-                                    }
+                                if (ParseFields.FILES.match(currentFieldName, parser.getDeprecationHandler()) &&
+                                    parser.nextToken() == XContentParser.Token.START_ARRAY) {
                                     List<String> fileNames = new ArrayList<>();
                                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                                         fileNames.add(parser.text());
                                     }
                                     snapshotsMap.put(snapshot, fileNames);
+                                } else if (ParseFields.SHARD_STATE_ID.match(currentFieldName, parser.getDeprecationHandler())) {
+                                    parser.nextToken();
+                                    historyUUIDs.put(snapshot, parser.text());
                                 }
                             }
                         }
@@ -277,7 +284,8 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                 assert fileInfo != null;
                 fileInfosBuilder.add(fileInfo);
             }
-            snapshots.add(new SnapshotFiles(entry.getKey(), Collections.unmodifiableList(fileInfosBuilder)));
+            snapshots.add(new SnapshotFiles(entry.getKey(), Collections.unmodifiableList(fileInfosBuilder),
+                historyUUIDs.get(entry.getKey())));
         }
         return new BlobStoreIndexShardSnapshots(files, Collections.unmodifiableList(snapshots));
     }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 /**
  * Contains a list of files participating in a snapshot
  */
@@ -33,6 +35,9 @@ public class SnapshotFiles {
     private final String snapshot;
 
     private final List<FileInfo> indexFiles;
+
+    @Nullable
+    private final String shardStateIdentifier;
 
     private Map<String, FileInfo> physicalFiles = null;
 
@@ -46,12 +51,23 @@ public class SnapshotFiles {
     }
 
     /**
-     * @param snapshot   snapshot name
-     * @param indexFiles index files
+     * @param snapshot             snapshot name
+     * @param indexFiles           index files
+     * @param shardStateIdentifier unique identifier for the state of the shard that this snapshot was taken from
      */
-    public SnapshotFiles(String snapshot, List<FileInfo> indexFiles) {
+    public SnapshotFiles(String snapshot, List<FileInfo> indexFiles, @Nullable String shardStateIdentifier) {
         this.snapshot = snapshot;
         this.indexFiles = indexFiles;
+        this.shardStateIdentifier = shardStateIdentifier;
+    }
+
+    /**
+     * Returns an identifier for the shard state that can be used to check whether a shard has changed between
+     * snapshots or not.
+     */
+    @Nullable
+    public String shardStateIdentifier() {
+        return shardStateIdentifier;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.apache.lucene.index.IndexCommit;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -227,12 +229,16 @@ public interface Repository extends LifecycleComponent {
      * @param snapshotId            snapshot id
      * @param indexId               id for the index being snapshotted
      * @param snapshotIndexCommit   commit point
+     * @param shardStateIdentifier  a unique identifier of the state of the shard that is stored with the shard's snapshot and used
+     *                              to detect if the shard has changed between snapshots. If {@code null} is passed as the identifier
+     *                              snapshotting will be done by inspecting the physical files referenced by {@code snapshotIndexCommit}
      * @param snapshotStatus        snapshot status
      * @param repositoryMetaVersion version of the updated repository metadata to write
      * @param listener              listener invoked on completion
      */
     void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId, IndexCommit snapshotIndexCommit,
-                       IndexShardSnapshotStatus snapshotStatus, Version repositoryMetaVersion, ActionListener<String> listener);
+                       @Nullable String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus, Version repositoryMetaVersion,
+                       ActionListener<String> listener);
 
     /**
      * Restores snapshot of the shard.

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1587,7 +1588,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     @Override
     public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
-                              IndexCommit snapshotIndexCommit, IndexShardSnapshotStatus snapshotStatus,
+                              IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
                               Version repositoryMetaVersion, ActionListener<String> listener) {
         final ShardId shardId = store.shardId();
         final long startTime = threadPool.absoluteTimeInMillis();
@@ -1614,75 +1615,92 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 throw new IndexShardSnapshotFailedException(shardId, "Duplicate snapshot name [" + snapshotId.getName() + "] detected, aborting");
             }
 
-            final List<BlobStoreIndexShardSnapshot.FileInfo> indexCommitPointFiles = new ArrayList<>();
-            final BlockingQueue<BlobStoreIndexShardSnapshot.FileInfo> filesToSnapshot = new LinkedBlockingQueue<>();
-            store.incRef();
-            final Collection<String> fileNames;
-            final Store.MetadataSnapshot metadataFromStore;
-            try {
-                // TODO apparently we don't use the MetadataSnapshot#.recoveryDiff(...) here but we should
-                try {
-                    LOGGER.trace(
-                        "[{}] [{}] Loading store metadata using index commit [{}]", shardId, snapshotId, snapshotIndexCommit);
-                    metadataFromStore = store.getMetadata(snapshotIndexCommit);
-                    fileNames = snapshotIndexCommit.getFileNames();
-                } catch (IOException e) {
-                    throw new IndexShardSnapshotFailedException(shardId, "Failed to get store file metadata", e);
+            // First inspect all known SegmentInfos instances to see if we already have an equivalent commit in the repository
+            final List<BlobStoreIndexShardSnapshot.FileInfo> filesFromSegmentInfos = Optional.ofNullable(shardStateIdentifier).map(id -> {
+                for (SnapshotFiles snapshotFileSet : snapshots.snapshots()) {
+                    if (id.equals(snapshotFileSet.shardStateIdentifier())) {
+                        return snapshotFileSet.indexFiles();
+                    }
                 }
-            } finally {
-                store.decRef();
-            }
+                return null;
+            }).orElse(null);
+
+            final List<BlobStoreIndexShardSnapshot.FileInfo> indexCommitPointFiles;
             int indexIncrementalFileCount = 0;
             int indexTotalNumberOfFiles = 0;
             long indexIncrementalSize = 0;
-            long indexTotalFileCount = 0;
-            for (String fileName : fileNames) {
-                if (snapshotStatus.isAborted()) {
-                    LOGGER.debug("[{}] [{}] Aborted on the file [{}], exiting", shardId, snapshotId, fileName);
-                    throw new IndexShardSnapshotFailedException(shardId, "Aborted");
+            long indexTotalFileSize = 0;
+            final BlockingQueue<BlobStoreIndexShardSnapshot.FileInfo> filesToSnapshot = new LinkedBlockingQueue<>();
+            // If we did not find a set of files that is equal to the current commit we determine the files to upload by comparing files
+            // in the commit with files already in the repository
+            if (filesFromSegmentInfos == null) {
+                indexCommitPointFiles = new ArrayList<>();
+                store.incRef();
+                final Collection<String> fileNames;
+                final Store.MetadataSnapshot metadataFromStore;
+                try {
+                    // TODO apparently we don't use the MetadataSnapshot#.recoveryDiff(...) here but we should
+                    try {
+                        LOGGER.trace(
+                            "[{}] [{}] Loading store metadata using index commit [{}]", shardId, snapshotId, snapshotIndexCommit);
+                        metadataFromStore = store.getMetadata(snapshotIndexCommit);
+                        fileNames = snapshotIndexCommit.getFileNames();
+                    } catch (IOException e) {
+                        throw new IndexShardSnapshotFailedException(shardId, "Failed to get store file metadata", e);
+                    }
+                } finally {
+                    store.decRef();
                 }
+                for (String fileName : fileNames) {
+                    if (snapshotStatus.isAborted()) {
+                        LOGGER.debug("[{}] [{}] Aborted on the file [{}], exiting", shardId, snapshotId, fileName);
+                        throw new IndexShardSnapshotFailedException(shardId, "Aborted");
+                    }
 
-                LOGGER.trace("[{}] [{}] Processing [{}]", shardId, snapshotId, fileName);
-                final StoreFileMetadata md = metadataFromStore.get(fileName);
-                BlobStoreIndexShardSnapshot.FileInfo existingFileInfo = null;
-                List<BlobStoreIndexShardSnapshot.FileInfo> filesInfo = snapshots.findPhysicalIndexFiles(fileName);
-                if (filesInfo != null) {
-                    for (BlobStoreIndexShardSnapshot.FileInfo fileInfo : filesInfo) {
-                        if (fileInfo.isSame(md)) {
-                            // a commit point file with the same name, size and checksum was already copied to repository
-                            // we will reuse it for this snapshot
-                            existingFileInfo = fileInfo;
-                            break;
+                    LOGGER.trace("[{}] [{}] Processing [{}]", shardId, snapshotId, fileName);
+                    final StoreFileMetadata md = metadataFromStore.get(fileName);
+                    BlobStoreIndexShardSnapshot.FileInfo existingFileInfo = null;
+                    List<BlobStoreIndexShardSnapshot.FileInfo> filesInfo = snapshots.findPhysicalIndexFiles(fileName);
+                    if (filesInfo != null) {
+                        for (BlobStoreIndexShardSnapshot.FileInfo fileInfo : filesInfo) {
+                            if (fileInfo.isSame(md)) {
+                                // a commit point file with the same name, size and checksum was already copied to repository
+                                // we will reuse it for this snapshot
+                                existingFileInfo = fileInfo;
+                                break;
+                            }
                         }
                     }
-                }
 
-                // We can skip writing blobs where the metadata hash is equal to the blob's contents because we store the hash/contents
-                // directly in the shard level metadata in this case
-                final boolean needsWrite = md.hashEqualsContents() == false;
-                indexTotalFileCount += md.length();
-                indexTotalNumberOfFiles++;
+                    // We can skip writing blobs where the metadata hash is equal to the blob's contents because we store the hash/contents
+                    // directly in the shard level metadata in this case
+                    final boolean needsWrite = md.hashEqualsContents() == false;
+                    indexTotalFileSize += md.length();
+                    indexTotalNumberOfFiles++;
 
-                if (existingFileInfo == null) {
-                    indexIncrementalFileCount++;
-                    indexIncrementalSize += md.length();
-                    // create a new FileInfo
-                    BlobStoreIndexShardSnapshot.FileInfo snapshotFileInfo =
-                        new BlobStoreIndexShardSnapshot.FileInfo(
-                            (needsWrite ? UPLOADED_DATA_BLOB_PREFIX : VIRTUAL_DATA_BLOB_PREFIX) + UUIDs.randomBase64UUID(),
-                            md, chunkSize());
-                    indexCommitPointFiles.add(snapshotFileInfo);
-                    if (needsWrite) {
-                        filesToSnapshot.add(snapshotFileInfo);
+                    if (existingFileInfo == null) {
+                        indexIncrementalFileCount++;
+                        indexIncrementalSize += md.length();
+                        // create a new FileInfo
+                        BlobStoreIndexShardSnapshot.FileInfo snapshotFileInfo =
+                            new BlobStoreIndexShardSnapshot.FileInfo(
+                                (needsWrite ? UPLOADED_DATA_BLOB_PREFIX : VIRTUAL_DATA_BLOB_PREFIX) + UUIDs.randomBase64UUID(),
+                                md, chunkSize());
+                        indexCommitPointFiles.add(snapshotFileInfo);
+                        if (needsWrite) {
+                            filesToSnapshot.add(snapshotFileInfo);
+                        }
+                        assert needsWrite || assertFileContentsMatchHash(snapshotFileInfo, store);
+                    } else {
+                        indexCommitPointFiles.add(existingFileInfo);
                     }
-                    assert needsWrite || assertFileContentsMatchHash(snapshotFileInfo, store);
-                } else {
-                    indexCommitPointFiles.add(existingFileInfo);
                 }
+            } else {
+                indexCommitPointFiles = filesFromSegmentInfos;
             }
 
             snapshotStatus.moveToStarted(startTime, indexIncrementalFileCount,
-                indexTotalNumberOfFiles, indexIncrementalSize, indexTotalFileCount);
+                indexTotalNumberOfFiles, indexIncrementalSize, indexTotalFileSize);
 
             final StepListener<Collection<Void>> allFilesUploadedListener = new StepListener<>();
             allFilesUploadedListener.whenComplete(v -> {
@@ -1708,7 +1726,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
                 // build a new BlobStoreIndexShardSnapshot, that includes this one and all the saved ones
                 List<SnapshotFiles> newSnapshotsList = new ArrayList<>();
-                newSnapshotsList.add(new SnapshotFiles(snapshot.snapshot(), snapshot.indexFiles()));
+                newSnapshotsList.add(new SnapshotFiles(snapshot.snapshot(), snapshot.indexFiles(), shardStateIdentifier));
                 for (SnapshotFiles point : snapshots) {
                     newSnapshotsList.add(point);
                 }
@@ -1798,7 +1816,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         final BlobContainer container = shardContainer(indexId, snapshotShardId);
         executor.execute(ActionRunnable.wrap(restoreListener, l -> {
             final BlobStoreIndexShardSnapshot snapshot = loadShardSnapshot(container, snapshotId);
-            final SnapshotFiles snapshotFiles = new SnapshotFiles(snapshot.snapshot(), snapshot.indexFiles());
+            final SnapshotFiles snapshotFiles = new SnapshotFiles(snapshot.snapshot(), snapshot.indexFiles(), null);
             new FileRestoreContext(metadata.name(), shardId, snapshotId, recoveryState) {
                 @Override
                 protected void restoreFiles(List<BlobStoreIndexShardSnapshot.FileInfo> filesToRecover, Store store,

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.index.IndexCommit;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -62,6 +63,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
@@ -336,8 +338,10 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             try {
                 // we flush first to make sure we get the latest writes snapshotted
                 snapshotRef = indexShard.acquireLastIndexCommit(true);
+                final IndexCommit snapshotIndexCommit = snapshotRef.getIndexCommit();
                 repository.snapshotShard(indexShard.store(), indexShard.mapperService(), snapshot.getSnapshotId(), indexId,
-                                         snapshotRef.getIndexCommit(), snapshotStatus, version, ActionListener.runBefore(listener, snapshotRef::close));
+                    snapshotRef.getIndexCommit(), getShardStateId(indexShard, snapshotIndexCommit), snapshotStatus, version,
+                    ActionListener.runBefore(listener, snapshotRef::close));
             } catch (Exception e) {
                 IOUtils.close(snapshotRef);
                 throw e;
@@ -345,6 +349,31 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         } catch (Exception e) {
             listener.onFailure(e);
         }
+    }
+
+    /**
+     * Generates an identifier from the current state of a shard that can be used to detect whether a shard's contents
+     * have changed between two snapshots.
+     * A shard is assumed to have unchanged contents if its global- and local checkpoint are equal, its maximum
+     * sequence number has not changed and its history- and force-merge-uuid have not changed.
+     * The method returns {@code null} if global and local checkpoint are different for a shard since no safe unique
+     * shard state id can be used in this case because of the possibility of a primary failover leading to different
+     * shard content for the same sequence number on a subsequent snapshot.
+     *
+     * @param indexShard          Shard
+     * @param snapshotIndexCommit IndexCommit for shard
+     * @return shard state id or {@code null} if none can be used
+     */
+    @Nullable
+    private static String getShardStateId(IndexShard indexShard, IndexCommit snapshotIndexCommit) throws IOException {
+        final Map<String, String> userCommitData = snapshotIndexCommit.getUserData();
+        final SequenceNumbers.CommitInfo seqNumInfo = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(userCommitData.entrySet());
+        final long maxSeqNo = seqNumInfo.maxSeqNo;
+        if (maxSeqNo != seqNumInfo.localCheckpoint || maxSeqNo != indexShard.getLastSyncedGlobalCheckpoint()) {
+            return null;
+        }
+        return userCommitData.get(Engine.HISTORY_UUID_KEY) + "-" +
+            userCommitData.getOrDefault(Engine.FORCE_MERGE_UUID_KEY, "na") + "-" + maxSeqNo;
     }
 
     /**
@@ -609,5 +638,4 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             return null;
         }
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -1,0 +1,425 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.snapshots;
+
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.SNAPSHOT_CODEC;
+import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.SNAPSHOT_NAME_FORMAT;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.repositories.blobstore.ChecksumBlobStoreFormat;
+import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakGroup;
+
+import io.crate.action.FutureActionListener;
+import io.crate.concurrent.CompletableFutures;
+import io.crate.testing.UseRandomizedSchema;
+
+@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST, numDataNodes = 0)
+@ThreadLeakGroup
+public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
+
+    /**
+     * Original defined at BlobStoreRepository, but removed as not used.
+     * Used by {@link #assertTwoIdenticalShardSnapshots(String, String, String, String)}
+     */
+    private static final ChecksumBlobStoreFormat<BlobStoreIndexShardSnapshot> INDEX_SHARD_SNAPSHOT_FORMAT =
+        new ChecksumBlobStoreFormat<>(
+            SNAPSHOT_CODEC, SNAPSHOT_NAME_FORMAT,
+            BlobStoreIndexShardSnapshot::fromXContent,
+            NamedXContentRegistry.EMPTY,
+            false
+        );
+
+    @ClassRule
+    public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("path.repo", TEMP_FOLDER.getRoot().getAbsolutePath())
+            .build();
+    }
+
+    // test needs to be reworked when: https://github.com/crate/crate/issues/12598 is implemented
+    // in order to match the original test from es (restore table with different names
+    // https://github.com/elastic/elasticsearch/commit/5b9864db2c318b5fd9699075b6e8e3ccab565675
+    @UseRandomizedSchema(random = false)
+    @Test
+    public void testIncrementalBehaviorOnPrimaryFailover() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
+        final String indexName = "test_index";
+        execute("CREATE TABLE " + indexName + "(a string) " +
+                "CLUSTERED INTO 1 SHARDS WITH(number_of_replicas=1,\"unassigned.node_left.delayed_timeout\"=0)");
+        ensureYellow();
+        final String newPrimary = internalCluster().startDataOnlyNode();
+        ensureGreen();
+
+        logger.info("--> adding some documents to test index");
+        List<Object[]> data = new ArrayList<>();
+        for (int j = 0; j < randomIntBetween(1, 10); ++j) {
+            for (int i = 0; i < scaledRandomIntBetween(1, 100); ++i) {
+                data.add(new Object[]{"foo" + j + "_bar" + i});
+            }
+        }
+        int documentCountOriginal = data.size();
+        execute("INSERT INTO " + indexName + "(a) VALUES(?)", data.toArray(new Object[][]{}));
+        refresh();
+
+        final String snapshot1 = "snap_1";
+        final String repo = "test_repo";
+        logger.info("--> creating repository");
+        execute("CREATE REPOSITORY " + repo  + " TYPE \"fs\" with (location=?)",
+                new Object[]{TEMP_FOLDER.newFolder().getAbsolutePath()});
+
+        logger.info("--> creating snapshot 1");
+        execute("CREATE SNAPSHOT " + repo + "." + snapshot1 + " TABLE " + indexName + " WITH (wait_for_completion = true)");
+
+        logger.info("--> Shutting down initial primary node [{}]", primaryNode);
+        stopNode(primaryNode);
+
+        ensureYellow();
+        final String snapshot2 = "snap_2";
+        logger.info("--> creating snapshot 2");
+        execute("CREATE SNAPSHOT " + repo + "." + snapshot2 + " TABLE doc." + indexName + " WITH (wait_for_completion = true)");
+
+        assertTwoIdenticalShardSnapshots(repo, snapshot1, snapshot2, newPrimary);
+        assertCountInIndexThenDelete(indexName, documentCountOriginal);
+
+        ensureRestoreSingleShardSuccessfully(repo, indexName, snapshot1, documentCountOriginal);
+        assertCountInIndexThenDelete(indexName, documentCountOriginal);
+
+        ensureRestoreSingleShardSuccessfully(repo, indexName, snapshot2, documentCountOriginal);
+        assertCountInIndexThenDelete(indexName, documentCountOriginal);
+
+        String newNewPrimary = internalCluster().startDataOnlyNode();
+        ensureGreen();
+
+        // Originally the test restores the index with different name, and here it deletes some
+        // docs from the index before the next round of snapshot/restore, see comment on the test
+        // method declaration.
+        // logger.info("--> delete some documents from test index");
+        logger.info("--> recreating test index with new set of docs");
+        execute("CREATE TABLE " + indexName + "(a string) " +
+                "CLUSTERED INTO 1 SHARDS WITH(number_of_replicas=1,\"unassigned.node_left.delayed_timeout\"=0)");
+        ensureYellow();
+        data = new ArrayList<>();
+        for (int j = 0; j < randomIntBetween(10, 20); ++j) {
+            for (int i = 0; i < scaledRandomIntBetween(100, 200); ++i) {
+                data.add(new Object[]{"foo" + j + "_bar" + i});
+            }
+        }
+        execute("INSERT INTO " + indexName + "(a) VALUES(?)", data.toArray(new Object[][]{}));
+        int countAfterRecreation = data.size();
+        refresh();
+
+        final String snapshot3 = "snap_3";
+        logger.info("--> creating snapshot 3");
+        execute("CREATE SNAPSHOT " + repo + "." + snapshot3 + " TABLE " + indexName + " WITH (wait_for_completion = true)");
+
+        logger.info("--> Shutting down new primary node [{}]", newPrimary);
+        stopNode(newPrimary);
+        ensureYellow();
+
+        final String snapshot4 = "snap_4";
+        logger.info("--> creating snapshot 4");
+        execute("CREATE SNAPSHOT " + repo + "." + snapshot4 + " TABLE " + indexName + " WITH (wait_for_completion = true)");
+
+        assertTwoIdenticalShardSnapshots(repo, snapshot3, snapshot4, newNewPrimary);
+        assertCountInIndexThenDelete(indexName, countAfterRecreation);
+
+        ensureRestoreSingleShardSuccessfully(repo, indexName, snapshot3, countAfterRecreation);
+        assertCountInIndexThenDelete(indexName, countAfterRecreation);
+
+        ensureRestoreSingleShardSuccessfully(repo, indexName, snapshot4, countAfterRecreation);
+        assertCountInIndexThenDelete(indexName, countAfterRecreation);
+    }
+
+    @UseRandomizedSchema(random = false)
+    @Test
+    public void testForceMergeCausesFullSnapshot() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        final String indexName = "test_index";
+        execute("CREATE TABLE " + indexName + "(a string) CLUSTERED INTO 1 SHARDS");
+        ensureGreen();
+
+        logger.info("--> adding some documents to test index and flush in between to get at least two segments");
+        for (int j = 0; j < 5; j++) {
+            List<Object[]> data = new ArrayList<>();
+            for (int i = 0; i < scaledRandomIntBetween(1, 100); ++i) {
+                data.add(new Object[]{"foo" + j + "_bar" + i});
+            }
+            execute("INSERT INTO " + indexName + "(a) VALUES(?)", data.toArray(new Object[][]{}));
+            refresh();
+        }
+        execute("SELECT count(*) FROM sys.segments WHERE primary=true AND table_name=?", new Object[]{indexName});
+        assertThat((long) response.rows()[0][0]).isGreaterThan(1);
+
+        final String snapshot1 = "snap1";
+        final String repo = "test_repo";
+        logger.info("--> creating repository");
+        execute("CREATE REPOSITORY " + repo  + " TYPE \"fs\" with (location=?)",
+                new Object[]{TEMP_FOLDER.newFolder().getAbsolutePath()});
+
+        logger.info("--> creating snapshot 1");
+        execute("CREATE SNAPSHOT " + repo + "." + snapshot1 + " TABLE " + indexName + " WITH (wait_for_completion = true)");
+
+        logger.info("--> force merging down to a single segment");
+        execute("OPTIMIZE TABLE " + indexName + " WITH(max_num_segments=1)");
+        refresh();
+        execute("SELECT count(*) FROM sys.segments WHERE primary=true AND table_name=?", new Object[]{indexName});
+        assertThat((long) response.rows()[0][0]).isEqualTo(1);
+
+        final String snapshot2 = "snap2";
+        logger.info("--> creating snapshot 2");
+        execute("CREATE SNAPSHOT " + repo + "." + snapshot2 + " TABLE " + indexName + " WITH (wait_for_completion = true)");
+
+        logger.info("--> asserting that the two snapshots refer to different files in the repository");
+        final RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class);
+        final SnapshotInfo snapshotInfo2 = client().admin().cluster()
+            .execute(GetSnapshotsAction.INSTANCE, new GetSnapshotsRequest(repo, new String[] { snapshot2 }))
+            .get()
+            .getSnapshots().get(0);
+
+        assertBusy(() -> {
+            Map<ShardId, IndexShardSnapshotStatus> snapshotShards = getIndexShardSnapShotStates(
+                repositoriesService,
+                repo,
+                snapshotInfo2
+            );
+            assertThat(snapshotShards).isNotNull();
+            List<IndexShardSnapshotStatus.Copy> statusesSnapshot = snapshotShards
+                .values().stream().map(IndexShardSnapshotStatus::asCopy).toList();
+            assertThat(statusesSnapshot).hasSize(1);
+            IndexShardSnapshotStatus.Copy statusSnap = statusesSnapshot.get(0);
+
+            assertThat(statusSnap.getStage()).isEqualTo(IndexShardSnapshotStatus.Stage.DONE);
+            assertThat(statusSnap.getTotalFileCount()).isGreaterThan(0);
+            assertThat(statusSnap.getIncrementalFileCount()).isGreaterThan(0);
+        }, 30L, TimeUnit.SECONDS);
+    }
+
+    private void assertCountInIndexThenDelete(String index, long expectedCount) {
+        logger.info("--> asserting that index [{}] contains [{}] documents", index, expectedCount);
+        assertThat(getCountForIndex(index)).isEqualTo(expectedCount);
+        logger.info("--> deleting index [{}]", index);
+        execute("DROP TABLE " + index);
+    }
+
+    private void assertTwoIdenticalShardSnapshots(String repo, String snapshot1, String snapshot2, String dataNode)
+        throws Exception {
+        logger.info(
+            "--> asserting that snapshots [{}] and [{}] are referring to the same files in the repository", snapshot1, snapshot2);
+
+        final RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class, dataNode);
+        final SnapshotInfo snapshotInfo1 = client().admin().cluster()
+            .execute(GetSnapshotsAction.INSTANCE, new GetSnapshotsRequest(repo, new String[] { snapshot1 }))
+            .get()
+            .getSnapshots().get(0);
+        final int[] fileCount = new int[1];
+
+        assertBusy(() -> {
+            Map<ShardId, IndexShardSnapshotStatus> snapshotShards = getIndexShardSnapShotStates(
+                repositoriesService,
+                repo,
+                snapshotInfo1
+            );
+            assertThat(snapshotShards).isNotNull();
+            List<IndexShardSnapshotStatus.Copy> statusesSnapshot = snapshotShards
+                    .values().stream().map(IndexShardSnapshotStatus::asCopy).toList();
+            assertThat(statusesSnapshot).hasSize(1);
+            IndexShardSnapshotStatus.Copy statusSnap = statusesSnapshot.get(0);
+
+            assertThat(statusSnap.getStage()).isEqualTo(IndexShardSnapshotStatus.Stage.DONE);
+            assertThat(statusSnap.getTotalFileCount()).isGreaterThan(0);
+            fileCount[0] = statusSnap.getTotalFileCount();
+            assertThat(statusSnap.getIncrementalFileCount()).isEqualTo(statusSnap.getTotalFileCount());
+        }, 30L, TimeUnit.SECONDS);
+
+        final SnapshotInfo snapshotInfo2 = client().admin().cluster()
+            .execute(GetSnapshotsAction.INSTANCE, new GetSnapshotsRequest(repo, new String[] { snapshot2 }))
+            .get()
+            .getSnapshots().get(0);
+
+        assertBusy(() -> {
+            Map<ShardId, IndexShardSnapshotStatus> snapshotShards = getIndexShardSnapShotStates(
+                repositoriesService,
+                repo,
+                snapshotInfo2
+            );
+            assertThat(snapshotShards).isNotNull();
+            List<IndexShardSnapshotStatus.Copy> statusesSnapshot = snapshotShards
+                .values().stream().map(IndexShardSnapshotStatus::asCopy).toList();
+            assertThat(statusesSnapshot).hasSize(1);
+            IndexShardSnapshotStatus.Copy statusSnap = statusesSnapshot.get(0);
+
+            assertThat(statusSnap.getStage()).isEqualTo(IndexShardSnapshotStatus.Stage.DONE);
+            assertThat(statusSnap.getTotalFileCount()).isEqualTo(fileCount[0]);
+            assertThat(statusSnap.getIncrementalFileCount()).isZero();
+        }, 30L, TimeUnit.SECONDS);
+    }
+
+    private void ensureRestoreSingleShardSuccessfully(String repo, String indexName, String snapshot, long numDocs) {
+        logger.info("--> restoring [{}]", snapshot);
+        execute("RESTORE SNAPSHOT " + repo + "." + snapshot + " TABLE " + indexName + " WITH (wait_for_completion=true)");
+        execute("SELECT count(*) FROM sys.shards WHERE table_name=?", new Object[]{indexName});
+        assertThat(response.rows()[0][0]).isEqualTo(2L);
+        execute("SELECT num_docs FROM sys.shards WHERE primary=true AND table_name=?", new Object[]{indexName});
+        assertThat(response.rows()[0][0]).isEqualTo(numDocs);
+    }
+
+    private long getCountForIndex(String indexName) {
+        execute("SELECT COUNT(*) FROM " + indexName);
+        return (long) response.rows()[0][0];
+    }
+
+    /**
+     * Wrapper method to avoid assertions at the {@link BlobStoreRepository#blobStore()} which requires the current
+     * thread to be part of a defined ES thread pool.
+     */
+    private Map<ShardId, IndexShardSnapshotStatus> getIndexShardSnapShotStates(RepositoriesService repositoriesService,
+                                                                               final String repositoryName,
+                                                                               final SnapshotInfo snapshotInfo) throws Exception {
+        CompletableFuture<Map<ShardId, IndexShardSnapshotStatus>> future = new CompletableFuture<>();
+        var thread = EsExecutors.daemonThreadFactory(ThreadPool.Names.GENERIC).newThread(
+            () -> {
+                try {
+                    future.complete(snapshotShards(repositoriesService, repositoryName, snapshotInfo));
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                }
+            }
+        );
+        thread.start();
+        return future.get(10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Derived from Elasticsearch's TransportSnapshotsStatusAction.snapshotShards. The TransportSnapshotsStatusAction
+     * is not included at CrateDB as it's functionality is not exposed/used.
+     * https://github.com/elastic/elasticsearch/blob/7.10/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java#L341
+     */
+    private Map<ShardId, IndexShardSnapshotStatus> snapshotShards(RepositoriesService repositoriesService,
+                                                                  final String repositoryName,
+                                                                  final SnapshotInfo snapshotInfo) throws Exception {
+        BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(repositoryName);
+        RepositoryData repositoryData = getRepositoryData(repository);
+
+
+        List<FutureActionListener<IndexMetadata, IndexMetadata>> listeners = new ArrayList<>(snapshotInfo.indices().size());
+        for (String index : snapshotInfo.indices()) {
+            IndexId indexId = repositoryData.resolveIndexId(index);
+            FutureActionListener<IndexMetadata, IndexMetadata> indexMetadataListener = FutureActionListener.newInstance();
+            listeners.add(indexMetadataListener);
+            repository.getSnapshotIndexMetadata(snapshotInfo.snapshotId(), indexId, indexMetadataListener);
+        }
+
+        final Map<ShardId, IndexShardSnapshotStatus> shardStatus = new HashMap<>();
+        for (IndexMetadata indexMetadata : CompletableFutures.allAsList(listeners).get(10, TimeUnit.SECONDS)) {
+            if (indexMetadata != null) {
+                int numberOfShards = indexMetadata.getNumberOfShards();
+                for (int i = 0; i < numberOfShards; i++) {
+                    ShardId shardId = new ShardId(indexMetadata.getIndex(), i);
+
+                    SnapshotShardFailure shardFailure = findShardFailure(snapshotInfo.shardFailures(), shardId);
+                    if (shardFailure != null) {
+                        shardStatus.put(shardId, IndexShardSnapshotStatus.newFailed(shardFailure.reason()));
+                    } else {
+                        final IndexShardSnapshotStatus shardSnapshotStatus;
+                        if (snapshotInfo.state() == SnapshotState.FAILED) {
+                            // If the snapshot failed, but the shard's snapshot does
+                            // not have an exception, it means that partial snapshots
+                            // were disabled and in this case, the shard snapshot will
+                            // *not* have any metadata, so attempting to read the shard
+                            // snapshot status will throw an exception.  Instead, we create
+                            // a status for the shard to indicate that the shard snapshot
+                            // could not be taken due to partial being set to false.
+                            shardSnapshotStatus = IndexShardSnapshotStatus.newFailed("skipped");
+                        } else {
+                            shardSnapshotStatus = getShardSnapshotStatus(
+                                repository,
+                                snapshotInfo.snapshotId(),
+                                repositoryData.resolveIndexId(shardId.getIndexName()),
+                                shardId);
+                        }
+                        shardStatus.put(shardId, shardSnapshotStatus);
+                    }
+                }
+            }
+        }
+        return unmodifiableMap(shardStatus);
+    }
+
+    /**
+     * Derived from ES's BlobStoreRepository.getShardSnapshotStatus. This method is removed at CrateDB as it's
+     * functionality is not exposed/used.
+     * See https://github.com/elastic/elasticsearch/blob/6492b9c9aa1cfb044952aaa194c08825fb63e2f4/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java#L2252
+     */
+    private static IndexShardSnapshotStatus getShardSnapshotStatus(BlobStoreRepository repository,
+                                                            SnapshotId snapshotId,
+                                                            IndexId indexId,
+                                                            ShardId shardId) throws IOException {
+        var indicesPath = repository.basePath().add("indices");
+        var shardContainer = repository.blobStore()
+            .blobContainer(indicesPath.add(indexId.getId()).add(Integer.toString(shardId.getId())));
+
+        BlobStoreIndexShardSnapshot snapshot = INDEX_SHARD_SNAPSHOT_FORMAT.read(shardContainer, snapshotId.getUUID());
+        return IndexShardSnapshotStatus.newDone(snapshot.startTime(), snapshot.time(),
+            snapshot.incrementalFileCount(), snapshot.totalFileCount(),
+            snapshot.incrementalSize(), snapshot.totalSize(), null); // Not adding a real generation here as it doesn't matter to callers
+    }
+
+    private static SnapshotShardFailure findShardFailure(List<SnapshotShardFailure> shardFailures, ShardId shardId) {
+        for (SnapshotShardFailure shardFailure : shardFailures) {
+            if (shardId.getIndexName().equals(shardFailure.index()) && shardId.getId() == shardFailure.shardId()) {
+                return shardFailure;
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -967,7 +967,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         final String shardGen;
         try (Engine.IndexCommitRef indexCommitRef = shard.acquireLastIndexCommit(true)) {
             repository.snapshotShard(shard.store(), shard.mapperService(), snapshot.getSnapshotId(), indexId,
-                                     indexCommitRef.getIndexCommit(), snapshotStatus, Version.CURRENT, future);
+                                     indexCommitRef.getIndexCommit(), null, snapshotStatus, Version.CURRENT, future);
             shardGen = future.actionGet();
         }
 

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -50,6 +50,8 @@ import java.util.Set;
 
 import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
 
+import javax.annotation.Nullable;
+
 public abstract class RestoreOnlyRepository implements Repository {
 
     private final String indexName;
@@ -144,6 +146,7 @@ public abstract class RestoreOnlyRepository implements Repository {
                               SnapshotId snapshotId,
                               IndexId indexId,
                               IndexCommit snapshotIndexCommit,
+                              @Nullable String shardStateIdentifier,
                               IndexShardSnapshotStatus snapshotStatus,
                               Version repositoryMetaVersion,
                               ActionListener<String> listener) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Use sequence numbers and force merge UUID to determine whether a shard has changed or not instead before falling back to comparing files to get incremental snapshots on primary fail-over.
    
https://github.com/elastic/elasticsearch/commit/5b9864db2c318b5fd9699075b6e8e3ccab565675

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
