### PR TITLE
Remove copy operations from AbstractProjectionsPhase.addProjection

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/phases/AbstractProjectionsPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/AbstractProjectionsPhase.java
@@ -41,14 +41,14 @@ public abstract class AbstractProjectionsPhase implements ExecutionPhase {
     private UUID jobId;
     private int executionPhaseId;
     private String name;
-    protected List<Projection> projections = List.of();
+    protected final List<Projection> projections;
     protected List<DataType<?>> outputTypes = List.of();
 
     protected AbstractProjectionsPhase(UUID jobId, int executionPhaseId, String name, List<Projection> projections) {
         this.jobId = jobId;
         this.executionPhaseId = executionPhaseId;
         this.name = name;
-        this.projections = projections;
+        this.projections = projections == null ? new ArrayList<>() : new ArrayList<>(projections);
     }
 
     protected static List<DataType<?>> extractOutputTypes(List<Symbol> outputs, List<Projection> projections) {
@@ -75,7 +75,7 @@ public abstract class AbstractProjectionsPhase implements ExecutionPhase {
     }
 
     public boolean hasProjections() {
-        return projections != null && projections.size() > 0;
+        return projections.size() > 0;
     }
 
     public List<Projection> projections() {
@@ -83,9 +83,7 @@ public abstract class AbstractProjectionsPhase implements ExecutionPhase {
     }
 
     public void addProjection(Projection projection) {
-        List<Projection> projections = new ArrayList<>(this.projections);
-        projections.add(projection);
-        this.projections = List.copyOf(projections);
+        this.projections.add(projection);
         outputTypes = Symbols.typeView(projection.outputs());
     }
 
@@ -120,6 +118,8 @@ public abstract class AbstractProjectionsPhase implements ExecutionPhase {
             for (int i = 0; i < numProjections; i++) {
                 projections.add(Projection.fromStream(in));
             }
+        } else {
+            projections = List.of();
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There were two copy operations, at least one would be unnecessary, but I
think it is even acceptable to remove both, given that `addProjection`
would create another copy, and replace the reference - partially
canceling out the mutation protection.

![image](https://user-images.githubusercontent.com/38700/187178189-d6dec285-4ef4-42b5-8183-c48f946559e1.png)



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
