### PR TITLE
Make CollectTask.toString synchronized

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -223,14 +223,16 @@ public class CollectTask implements Task {
 
     @Override
     public String toString() {
-        return "CollectTask{" +
-               "id=" + collectPhase.phaseId() +
-               ", sharedContexts=" + sharedShardContexts +
-               ", consumer=" + consumer +
-               ", searchContexts=" + searchers.keys() +
-               ", batchIterator=" + batchIterator +
-               ", finished=" + consumerCompleted.isDone() +
-               '}';
+        synchronized (searchers) {
+            return "CollectTask{" +
+                "id=" + collectPhase.phaseId() +
+                ", sharedContexts=" + sharedShardContexts +
+                ", consumer=" + consumer +
+                ", searchContexts=" + searchers.keys() +
+                ", batchIterator=" + batchIterator +
+                ", finished=" + consumerCompleted.isDone() +
+                '}';
+        }
     }
 
     public TransactionContext txnCtx() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Not a production issue, but in the test layer we dump the tasks if
they're still open on teardown, and that could lead to an error:

    java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
    	at __randomizedtesting.SeedInfo.seed([12BCA9D9708564B5:BE9EF56F6AA270C1]:0)
    	at com.carrotsearch.hppc.AbstractIntCollection.toArray(AbstractIntCollection.java:68)
    	at com.carrotsearch.hppc.IntObjectHashMap$KeysContainer.toArray(IntObjectHashMap.java:758)
    	at com.carrotsearch.hppc.AbstractIntCollection.toString(AbstractIntCollection.java:80)
    	at com.carrotsearch.hppc.IntObjectHashMap$KeysContainer.toString(IntObjectHashMap.java:758)
    	at java.base/java.lang.StringConcatHelper.stringOf(StringConcatHelper.java:453)
    	at io.crate.execution.engine.collect.CollectTask.toString(CollectTask.java:232)
    	at java.base/java.lang.String.valueOf(String.java:4213)
    	at java.base/java.lang.StringBuilder.append(StringBuilder.java:173)
    	at java.base/java.util.AbstractCollection.toString(AbstractCollection.java:457)
    	at java.base/java.lang.StringConcatHelper.stringOf(StringConcatHelper.java:453)
    	at io.crate.execution.jobs.RootTask.toString(RootTask.java:319)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
