### PR TITLE
Reduce shared state in CorrelatedJoinProjector

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
+++ b/libs/dex/src/main/java/io/crate/data/CapturingRowConsumer.java
@@ -31,14 +31,6 @@ public final class CapturingRowConsumer implements RowConsumer {
     private final CompletableFuture<?> completionFuture;
     private final boolean requiresScroll;
 
-    public CapturingRowConsumer(boolean requiresScroll,
-                                CompletableFuture<BatchIterator<Row>> batchIterator,
-                                CompletableFuture<?> completionFuture) {
-        this.batchIterator = batchIterator;
-        this.completionFuture = completionFuture;
-        this.requiresScroll = requiresScroll;
-    }
-
     public CapturingRowConsumer(boolean requiresScroll, CompletableFuture<?> completionFuture) {
         this.batchIterator = new CompletableFuture<>();
         this.completionFuture = completionFuture;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

To rule this out as a cause of flaky tests.

This also replaces `CapturingRowConsumer` with `CollectingRowConsumer`,
which is used in the multi-phase execution for uncorrelated sub-queries.

Once tests are stable we can try to re-optimize this.
(If it's even worth doing, creating a row instance is cheap compared to
what `subQueryPlan.execute` is already doing)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
