### PR TITLE
 Fix DateType casts from string and numeric values 

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -147,3 +147,9 @@ Fixes
 
 - Fixed ``UPDATE``, ``INSERT`` and ``COPY FROM`` to preserve the implied column
   order when columns are added.
+
+- Fixed casts of strings to the ``DATE`` type, any possible time parts
+  of a timestamp formatted will be ignored instead of raising a cast error.
+
+- Fixed casts of numeric and timestamp values to the ``DATE`` type, any time
+  values weren't removed from the returning epoch in milliseconds.

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -21,11 +21,9 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
-import io.crate.common.StringUtils;
-
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -39,9 +37,11 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 import java.util.function.Function;
 
-import static java.time.ZoneOffset.UTC;
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.Streamer;
+import io.crate.common.StringUtils;
 
 public final class TimestampType extends DataType<Long>
     implements FixedWidthType, Streamer<Long> {
@@ -196,7 +196,7 @@ public final class TimestampType extends DataType<Long>
         return localDateTime.toInstant(UTC).toEpochMilli();
     }
 
-    private static final DateTimeFormatter TIMESTAMP_PARSER = new DateTimeFormatterBuilder()
+    public static final DateTimeFormatter TIMESTAMP_PARSER = new DateTimeFormatterBuilder()
         .parseCaseInsensitive()
         .append(ISO_LOCAL_DATE)
         .optionalStart()

--- a/server/src/test/java/io/crate/types/DateTypeTest.java
+++ b/server/src/test/java/io/crate/types/DateTypeTest.java
@@ -22,9 +22,7 @@
 package io.crate.types;
 
 import static io.crate.testing.Asserts.assertThrowsMatches;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -39,30 +37,26 @@ public class DateTypeTest {
 
     @Test
     public void testCastString() {
-        assertThat(DateType.INSTANCE.implicitCast("123"), is(123L));
+        assertThat(DateType.INSTANCE.implicitCast("123")).isEqualTo(123L);
     }
 
     @Test
     public void testCastDateString() {
-        assertThat(DateType.INSTANCE.implicitCast("2020-02-09"), is(1581206400000L));
+        assertThat(DateType.INSTANCE.implicitCast("2020-02-09")).isEqualTo(1581206400000L);
     }
 
     @Test
     public void testCastFloatValue() {
-        assertThat(DateType.INSTANCE.implicitCast(123.123f), is(123123L));
+        assertThat(DateType.INSTANCE.implicitCast(123.123f)).isEqualTo(123123L);
     }
 
     @Test
     public void testCastNumericNonFloatValue() {
-        assertThat(DateType.INSTANCE.implicitCast(123), is(123L));
+        assertThat(DateType.INSTANCE.implicitCast(123)).isEqualTo(123L);
     }
 
     @Test
     public void testCastNull() {
-        assertThat(DateType.INSTANCE.implicitCast(null), is(nullValue()));
+        assertThat(DateType.INSTANCE.implicitCast(null)).isNull();
     }
-
-
-
-
 }

--- a/server/src/test/java/io/crate/types/DateTypeTest.java
+++ b/server/src/test/java/io/crate/types/DateTypeTest.java
@@ -37,22 +37,25 @@ public class DateTypeTest {
 
     @Test
     public void testCastString() {
-        assertThat(DateType.INSTANCE.implicitCast("123")).isEqualTo(123L);
+        assertThat(DateType.INSTANCE.implicitCast("86500000")).isEqualTo(86400000L);
     }
 
     @Test
     public void testCastDateString() {
         assertThat(DateType.INSTANCE.implicitCast("2020-02-09")).isEqualTo(1581206400000L);
+        assertThat(DateType.INSTANCE.implicitCast("2020-02-09T17:50:44")).isEqualTo(1581206400000L);
     }
 
     @Test
     public void testCastFloatValue() {
-        assertThat(DateType.INSTANCE.implicitCast(123.123f)).isEqualTo(123123L);
+        assertThat(DateType.INSTANCE.implicitCast(1422294644.581f)).isEqualTo(1422230400000L);
     }
 
     @Test
     public void testCastNumericNonFloatValue() {
-        assertThat(DateType.INSTANCE.implicitCast(123)).isEqualTo(123L);
+        assertThat(DateType.INSTANCE.implicitCast(123)).isEqualTo(0L);
+        assertThat(DateType.INSTANCE.implicitCast(86500000)).isEqualTo(86400000L);
+        assertThat(DateType.INSTANCE.implicitCast(1422294644581L)).isEqualTo(1422230400000L);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Support timestamp string format, ignore any containing time parts.
Strip the time part of any numeric value so the returning long
value reflects a date.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
