### PR TITLE
Remove warning suppression from BatchIterators.collect

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/BatchIterators.java
+++ b/libs/dex/src/main/java/io/crate/data/BatchIterators.java
@@ -54,12 +54,11 @@ public class BatchIterators {
      * @param <R> result type
      * @return future containing the result, this is the future that has been provided as argument.
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
     public static <T, A, R> CompletableFuture<R> collect(BatchIterator<T> it,
                                                          A state,
                                                          Collector<T, A, R> collector,
                                                          CompletableFuture<R> resultFuture) {
-        var biCollector = new BiCollector(it, state, collector, resultFuture);
+        var biCollector = new BiCollector<>(it, state, collector, resultFuture);
         biCollector.collect();
         return resultFuture;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Forgot to adjust this in https://github.com/crate/crate/pull/12939
Was a leftover from a intermediate iteration

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
