### PR TITLE
Don't add order operator to correlated sub-queries

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -674,7 +674,7 @@ public class ExpressionAnalyzer {
             SelectSymbol selectSymbol = new SelectSymbol(
                 relation,
                 new ArrayType<>(innerType),
-                SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES
+                SelectSymbol.ResultType.SINGLE_COLUMN_EXISTS
             );
             return allocateFunction(ExistsOperator.NAME, List.of(selectSymbol), context);
         }

--- a/server/src/main/java/io/crate/execution/engine/FirstColumnConsumers.java
+++ b/server/src/main/java/io/crate/execution/engine/FirstColumnConsumers.java
@@ -126,6 +126,7 @@ public class FirstColumnConsumers {
         return switch (resultType) {
             case SINGLE_COLUMN_MULTIPLE_VALUES -> AllValues.INSTANCE;
             case SINGLE_COLUMN_SINGLE_VALUE -> SingleValue.INSTANCE;
+            case SINGLE_COLUMN_EXISTS -> AllValues.INSTANCE;
         };
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
@@ -42,7 +42,8 @@ public class SelectSymbol implements Symbol {
 
     public enum ResultType {
         SINGLE_COLUMN_SINGLE_VALUE,
-        SINGLE_COLUMN_MULTIPLE_VALUES
+        SINGLE_COLUMN_MULTIPLE_VALUES,
+        SINGLE_COLUMN_EXISTS
     }
 
     public SelectSymbol(AnalyzedRelation relation, ArrayType<?> dataType, ResultType resultType) {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -207,6 +207,9 @@ public class LogicalPlanner {
     // See issue https://github.com/crate/crate/issues/6755
     // If the output values are already sorted (even in desc order) no optimization is needed
     private LogicalPlan tryOptimizeForInSubquery(SelectSymbol selectSymbol, AnalyzedRelation relation, LogicalPlan planBuilder) {
+        if (selectSymbol.isCorrelated()) {
+            return planBuilder;
+        }
         if (selectSymbol.getResultType() == SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES && relation instanceof QueriedSelectRelation) {
             QueriedSelectRelation queriedRelation = (QueriedSelectRelation) relation;
             OrderBy relationOrderBy = queriedRelation.orderBy();

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -209,7 +209,8 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "        └ TableFunction[generate_series | [generate_series] | true]\n" +
             "      └ SubPlan\n" +
             "        └ Eval[x]\n" +
-            "          └ TableFunction[empty_row | [] | true]\n");
+            "          └ Limit[1;0]\n" +
+            "            └ TableFunction[empty_row | [] | true]\n");
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
             "1\n" +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
