### PR TITLE
Fix for #12754: BWC compatibility with nodes < 5.1

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -435,8 +435,9 @@ public class DocIndexMetadata {
 
             boolean nullable = !notNullColumns.contains(newIdent) && !primaryKey.contains(newIdent);
             columnProperties = furtherColumnProperties(columnProperties);
-            assert columnProperties.containsKey("position") : "Column position is missing: " + newIdent.fqn();
-            int position = (int) columnProperties.get("position");
+            assert columnProperties.containsKey("position") && columnProperties.get("position") != null : "Column position is missing: " + newIdent.fqn();
+            // BWC compatibility with nodes < 5.1, position could be NULL if column is created on that nodes
+            int position = (int) columnProperties.getOrDefault("position", 0);
             assert !takenPositions.containsKey(position) : "Duplicate column position assigned to " + newIdent.fqn() + " and " + takenPositions.get(position);
             takenPositions.put(position, newIdent.fqn());
             String defaultExpression = (String) columnProperties.getOrDefault("default_expr", null);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

BWC compatibility with nodes < 5.1, position could be NULL if column is created on that nodes

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
