### PR TITLE
bp: Merge feature/searchable-snapshots branch into 7.x

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -441,7 +441,7 @@ should be crossed out as well.
 - [s] 475b210eec4 Improve guidance on removing default mappings. (#54915)
 - [x] c7053ef824f Use TransportChannel in TransportHandshaker (#54921)
 - [x] 9cf2406cf14 Move network stats marking into InboundPipeline (#54908)
-- [ ] 4d36917e526  Merge feature/searchable-snapshots branch into 7.x (#54803)  (#54825)
+- [x] 4d36917e526  Merge feature/searchable-snapshots branch into 7.x (#54803)  (#54825)
 - [s] 2fdbed7797a Broadcast cancellation to only nodes have outstanding child tasks (#54312)
 - [s] 5fb76022276 Disallow changing 'enabled' on the root mapper. (#54681)
 - [x] 6d976e14684 Resolve some coordination-layer TODOs (#54511)

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.repositories.azure;
 
+import com.microsoft.azure.storage.Constants;
 import com.microsoft.azure.storage.LocationMode;
 import com.microsoft.azure.storage.StorageException;
 import org.apache.logging.log4j.LogManager;
@@ -61,10 +62,8 @@ public class AzureBlobContainer extends AbstractBlobContainer {
         return false;
     }
 
-    @Override
-    public InputStream readBlob(String blobName) throws IOException {
-        logger.trace("readBlob({})", blobName);
-
+    private InputStream openInputStream(String blobName, long position, @Nullable Long length) throws IOException {
+        logger.trace("readBlob({}) from position [{}] with length [{}]", blobName, position, length != null ? length : "unlimited");
         if (blobStore.getLocationMode() == LocationMode.SECONDARY_ONLY && !blobExists(blobName)) {
             // On Azure, if the location path is a secondary location, and the blob does not
             // exist, instead of returning immediately from the getInputStream call below
@@ -74,9 +73,8 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             // stream to it.
             throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
         }
-
         try {
-            return blobStore.getInputStream(buildKey(blobName));
+            return blobStore.getInputStream(buildKey(blobName), position, length);
         } catch (StorageException e) {
             if (e.getHttpStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                 throw new NoSuchFileException(e.getMessage());
@@ -85,6 +83,21 @@ public class AzureBlobContainer extends AbstractBlobContainer {
         } catch (URISyntaxException e) {
             throw new IOException(e);
         }
+    }
+
+    @Override
+    public InputStream readBlob(String blobName) throws IOException {
+        return openInputStream(blobName, 0L, null);
+    }
+
+    @Override
+    public InputStream readBlob(String blobName, long position, long length) throws IOException {
+        return openInputStream(blobName, position, length);
+    }
+
+    @Override
+    public long readBlobPreferredLength() {
+        return Constants.DEFAULT_MINIMUM_READ_SIZE_IN_BYTES;
     }
 
     @Override

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -19,15 +19,6 @@
 
 package org.elasticsearch.repositories.azure;
 
-import com.microsoft.azure.storage.LocationMode;
-import com.microsoft.azure.storage.StorageException;
-import org.elasticsearch.cluster.metadata.RepositoryMetadata;
-import org.elasticsearch.common.blobstore.BlobContainer;
-import org.elasticsearch.common.blobstore.BlobMetadata;
-import org.elasticsearch.common.blobstore.BlobPath;
-import org.elasticsearch.common.blobstore.BlobStore;
-import org.elasticsearch.repositories.azure.AzureRepository.Repository;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -35,6 +26,18 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetadata;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.repositories.azure.AzureRepository.Repository;
+
+import com.microsoft.azure.storage.LocationMode;
+import com.microsoft.azure.storage.StorageException;
 
 public class AzureBlobStore implements BlobStore {
 
@@ -98,8 +101,10 @@ public class AzureBlobStore implements BlobStore {
             Collectors.toMap(Function.identity(), name -> new AzureBlobContainer(path.add(name), this))));
     }
 
-    public InputStream getInputStream(String blob) throws URISyntaxException, StorageException, IOException {
-        return service.getInputStream(container, blob);
+    public InputStream getInputStream(String blob, long position, @Nullable Long length)
+        throws URISyntaxException, StorageException, IOException {
+
+        return service.getInputStream(container, blob, position, length);
     }
 
     public Map<String, BlobMetadata> listBlobsByPrefix(String keyPath, String prefix)

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 /**
  * In memory storage for unit tests
  */
@@ -73,7 +75,9 @@ public class AzureStorageServiceMock extends AzureStorageService {
     }
 
     @Override
-    public InputStream getInputStream(String container, String blob) throws IOException {
+    public InputStream getInputStream(String container, String blob, long position, @Nullable Long length)
+        throws IOException {
+
         if (!blobExists(container, blob)) {
             throw new NoSuchFileException("missing blob [" + blob + "]");
         }

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.repositories.s3;
 
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.MAX_RETRIES_SETTING;
+
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.StorageClass;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
@@ -64,6 +66,10 @@ class S3BlobStore implements BlobStore {
 
     public AmazonS3Reference clientReference() {
         return service.client(metadata);
+    }
+
+    int getMaxRetries() {
+        return MAX_RETRIES_SETTING.get(metadata.settings());
     }
 
     public String bucket() {

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.Version;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crate.common.io.IOUtils;
+
+/**
+ * Wrapper around an S3 object that will retry the {@link GetObjectRequest} if the download fails part-way through, resuming from where
+ * the failure occurred. This should be handled by the SDK but it isn't today. This should be revisited in the future (e.g. before removing
+ * the {@link Version#V_7_0_0} version constant) and removed when the SDK handles retries itself.
+ *
+ * See https://github.com/aws/aws-sdk-java/issues/856 for the related SDK issue
+ */
+class S3RetryingInputStream extends InputStream {
+
+    private static final Logger LOGGER = LogManager.getLogger(S3RetryingInputStream.class);
+
+    static final int MAX_SUPPRESSED_EXCEPTIONS = 10;
+
+    private final S3BlobStore blobStore;
+    private final String blobKey;
+    private final long start;
+    private final long end;
+    private final int maxAttempts;
+
+    private InputStream currentStream;
+    private int attempt = 1;
+    private List<IOException> failures = new ArrayList<>(MAX_SUPPRESSED_EXCEPTIONS);
+    private long currentOffset;
+    private boolean closed;
+
+    S3RetryingInputStream(S3BlobStore blobStore, String blobKey) throws IOException {
+        this(blobStore, blobKey, 0, Long.MAX_VALUE - 1);
+    }
+
+    // both start and end are inclusive bounds, following the definition in GetObjectRequest.setRange
+    S3RetryingInputStream(S3BlobStore blobStore, String blobKey, long start, long end) throws IOException {
+        if (start < 0L) {
+            throw new IllegalArgumentException("start must be non-negative");
+        }
+        if (end < start || end == Long.MAX_VALUE) {
+            throw new IllegalArgumentException("end must be >= start and not Long.MAX_VALUE");
+        }
+        this.blobStore = blobStore;
+        this.blobKey = blobKey;
+        this.maxAttempts = blobStore.getMaxRetries() + 1;
+        this.start = start;
+        this.end = end;
+        currentStream = openStream();
+    }
+
+    private InputStream openStream() throws IOException {
+        try (AmazonS3Reference clientReference = blobStore.clientReference()) {
+            final GetObjectRequest getObjectRequest = new GetObjectRequest(blobStore.bucket(), blobKey);
+            if (currentOffset > 0 || start > 0 || end < Long.MAX_VALUE - 1) {
+                assert start + currentOffset <= end :
+                    "requesting beyond end, start = " + start + " offset=" + currentOffset + " end=" + end;
+                getObjectRequest.setRange(Math.addExact(start, currentOffset), end);
+            }
+            final S3Object s3Object = clientReference.client().getObject(getObjectRequest);
+            return s3Object.getObjectContent();
+        } catch (final AmazonClientException e) {
+            if (e instanceof AmazonS3Exception) {
+                if (404 == ((AmazonS3Exception) e).getStatusCode()) {
+                    throw addSuppressedExceptions(new NoSuchFileException("Blob object [" + blobKey + "] not found: " + e.getMessage()));
+                }
+            }
+            throw addSuppressedExceptions(e);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        ensureOpen();
+        while (true) {
+            try {
+                final int result = currentStream.read();
+                currentOffset += 1;
+                return result;
+            } catch (IOException e) {
+                reopenStreamOrFail(e);
+            }
+        }
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        ensureOpen();
+        while (true) {
+            try {
+                final int bytesRead = currentStream.read(b, off, len);
+                if (bytesRead == -1) {
+                    return -1;
+                }
+                currentOffset += bytesRead;
+                return bytesRead;
+            } catch (IOException e) {
+                reopenStreamOrFail(e);
+            }
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            assert false : "using S3RetryingInputStream after close";
+            throw new IllegalStateException("using S3RetryingInputStream after close");
+        }
+    }
+
+    private void reopenStreamOrFail(IOException e) throws IOException {
+        if (attempt >= maxAttempts) {
+            LOGGER.debug(new ParameterizedMessage("failed reading [{}/{}] at offset [{}], attempt [{}] of [{}], giving up",
+                                                  blobStore.bucket(), blobKey, start + currentOffset, attempt, maxAttempts), e);
+            throw addSuppressedExceptions(e);
+        }
+        LOGGER.debug(new ParameterizedMessage("failed reading [{}/{}] at offset [{}], attempt [{}] of [{}], retrying",
+                                              blobStore.bucket(), blobKey, start + currentOffset, attempt, maxAttempts), e);
+        attempt += 1;
+        if (failures.size() < MAX_SUPPRESSED_EXCEPTIONS) {
+            failures.add(e);
+        }
+        try {
+            Streams.consumeFully(currentStream);
+        } catch (Exception e2) {
+            LOGGER.trace("Failed to fully consume stream on close", e);
+        }
+        IOUtils.closeWhileHandlingException(currentStream);
+        currentStream = openStream();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            Streams.consumeFully(currentStream);
+        } catch (Exception e) {
+            LOGGER.trace("Failed to fully consume stream on close", e);
+        }
+        currentStream.close();
+        closed = true;
+    }
+
+    @Override
+    public long skip(long n) {
+        throw new UnsupportedOperationException("S3RetryingInputStream does not support seeking");
+    }
+
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException("S3RetryingInputStream does not support seeking");
+    }
+
+    private <T extends Exception> T addSuppressedExceptions(T e) {
+        for (IOException failure : failures) {
+            e.addSuppressed(failure);
+        }
+        return e;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotResponse.java
@@ -41,7 +41,7 @@ public class RestoreSnapshotResponse extends TransportResponse implements ToXCon
     @Nullable
     private final RestoreInfo restoreInfo;
 
-    RestoreSnapshotResponse(@Nullable RestoreInfo restoreInfo) {
+    public RestoreSnapshotResponse(@Nullable RestoreInfo restoreInfo) {
         this.restoreInfo = restoreInfo;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -42,6 +42,7 @@ import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.routing.DelayedAllocationService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
@@ -91,11 +92,13 @@ public class ClusterModule extends AbstractModule {
     private final ClusterService clusterService;
     private final AllocationDeciders allocationDeciders;
     private final AllocationService allocationService;
+    private final List<ClusterPlugin> clusterPlugins;
     private final Collection<AllocationDecider> deciderList;
     private final ShardsAllocator shardsAllocator;
 
     public ClusterModule(Settings settings, ClusterService clusterService, List<ClusterPlugin> clusterPlugins,
                          ClusterInfoService clusterInfoService) {
+        this.clusterPlugins = clusterPlugins;
         this.deciderList = createAllocationDeciders(settings, clusterService.getClusterSettings(), clusterPlugins);
         this.allocationDeciders = new AllocationDeciders(deciderList);
         this.shardsAllocator = createShardsAllocator(settings, clusterService.getClusterSettings(), clusterPlugins);
@@ -250,4 +253,22 @@ public class ClusterModule extends AbstractModule {
         bind(AllocationDeciders.class).toInstance(allocationDeciders);
         bind(ShardsAllocator.class).toInstance(shardsAllocator);
     }
+
+    public void setExistingShardsAllocators(GatewayAllocator gatewayAllocator) {
+        final Map<String, ExistingShardsAllocator> existingShardsAllocators = new HashMap<>();
+        existingShardsAllocators.put(GatewayAllocator.ALLOCATOR_NAME, gatewayAllocator);
+
+        for (ClusterPlugin clusterPlugin : clusterPlugins) {
+            for (Map.Entry<String, ExistingShardsAllocator> existingShardsAllocatorEntry
+                : clusterPlugin.getExistingShardsAllocators().entrySet()) {
+                final String allocatorName = existingShardsAllocatorEntry.getKey();
+                if (existingShardsAllocators.put(allocatorName, existingShardsAllocatorEntry.getValue()) != null) {
+                    throw new IllegalArgumentException("ExistingShardsAllocator [" + allocatorName + "] from [" +
+                        clusterPlugin.getClass().getName() + "] was already defined");
+                }
+            }
+        }
+        allocationService.setExistingShardsAllocators(existingShardsAllocators);
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -19,28 +19,9 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.cluster.ClusterInfoService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.RestoreInProgress;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.cluster.health.ClusterStateHealth;
-import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.routing.RoutingNode;
-import org.elasticsearch.cluster.routing.RoutingNodes;
-import org.elasticsearch.cluster.routing.RoutingTable;
-import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
-import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
-import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.gateway.GatewayAllocator;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,10 +34,31 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterStateHealth;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.gateway.GatewayAllocator;
+import org.elasticsearch.gateway.PriorityComparator;
 
 /**
  * This service manages the node allocation of a cluster. For this reason the
@@ -69,28 +71,31 @@ public class AllocationService {
     private static final Logger LOGGER = LogManager.getLogger(AllocationService.class);
 
     private final AllocationDeciders allocationDeciders;
-    private GatewayAllocator gatewayAllocator;
+    private Map<String, ExistingShardsAllocator> existingShardsAllocators;
     private final ShardsAllocator shardsAllocator;
     private final ClusterInfoService clusterInfoService;
 
-    public AllocationService(AllocationDeciders allocationDeciders,
-                             GatewayAllocator gatewayAllocator,
-                             ShardsAllocator shardsAllocator,
-                             ClusterInfoService clusterInfoService) {
+    // only for tests that use the GatewayAllocator as the unique ExistingShardsAllocator
+    public AllocationService(AllocationDeciders allocationDeciders, GatewayAllocator gatewayAllocator,
+                             ShardsAllocator shardsAllocator, ClusterInfoService clusterInfoService) {
         this(allocationDeciders, shardsAllocator, clusterInfoService);
-        setGatewayAllocator(gatewayAllocator);
+        setExistingShardsAllocators(Collections.singletonMap(GatewayAllocator.ALLOCATOR_NAME, gatewayAllocator));
     }
 
-    public AllocationService(AllocationDeciders allocationDeciders,
-                             ShardsAllocator shardsAllocator,
+    public AllocationService(AllocationDeciders allocationDeciders, ShardsAllocator shardsAllocator,
                              ClusterInfoService clusterInfoService) {
         this.allocationDeciders = allocationDeciders;
         this.shardsAllocator = shardsAllocator;
         this.clusterInfoService = clusterInfoService;
     }
 
-    public void setGatewayAllocator(GatewayAllocator gatewayAllocator) {
-        this.gatewayAllocator = gatewayAllocator;
+    /**
+     * Inject the {@link ExistingShardsAllocator}s to use. May only be called once.
+     */
+    public void setExistingShardsAllocators(Map<String, ExistingShardsAllocator> existingShardsAllocators) {
+        assert this.existingShardsAllocators == null : "cannot set allocators " + existingShardsAllocators + " twice";
+        assert existingShardsAllocators.isEmpty() == false : "must add at least one ExistingShardsAllocator";
+        this.existingShardsAllocators = Collections.unmodifiableMap(existingShardsAllocators);
     }
 
     /**
@@ -100,6 +105,7 @@ public class AllocationService {
      * If the same instance of the {@link ClusterState} is returned, then no change has been made.</p>
      */
     public ClusterState applyStartedShards(ClusterState clusterState, List<ShardRouting> startedShards) {
+        assert assertInitialized();
         if (startedShards.isEmpty()) {
             return clusterState;
         }
@@ -110,9 +116,11 @@ public class AllocationService {
             clusterInfoService.getClusterInfo(), currentNanoTime());
         // as starting a primary relocation target can reinitialize replica shards, start replicas first
         startedShards = new ArrayList<>(startedShards);
-        Collections.sort(startedShards, Comparator.comparing(ShardRouting::primary));
+        startedShards.sort(Comparator.comparing(ShardRouting::primary));
         applyStartedShards(allocation, startedShards);
-        gatewayAllocator.applyStartedShards(allocation, startedShards);
+        for (final ExistingShardsAllocator allocator : existingShardsAllocators.values()) {
+            allocator.applyStartedShards(startedShards, allocation);
+        }
         assert RoutingNodes.assertShardStats(allocation.routingNodes());
         String startedShardsAsString
             = firstListElementsToCommaDelimitedString(startedShards, s -> s.shardId().toString(), LOGGER.isDebugEnabled());
@@ -173,6 +181,7 @@ public class AllocationService {
      */
     public ClusterState applyFailedShards(final ClusterState clusterState, final List<FailedShard> failedShards,
                                           final List<StaleShard> staleShards) {
+        assert assertInitialized();
         if (staleShards.isEmpty() && failedShards.isEmpty()) {
             return clusterState;
         }
@@ -218,7 +227,9 @@ public class AllocationService {
                 LOGGER.trace("{} shard routing failed in an earlier iteration (routing: {})", shardToFail.shardId(), shardToFail);
             }
         }
-        gatewayAllocator.applyFailedShards(allocation, failedShards);
+        for (final ExistingShardsAllocator allocator : existingShardsAllocators.values()) {
+            allocator.applyFailedShards(failedShards, allocation);
+        }
 
         reroute(allocation);
         String failedShardsAsString
@@ -410,13 +421,41 @@ public class AllocationService {
         assert hasDeadNodes(allocation) == false : "dead nodes should be explicitly cleaned up. See deassociateDeadNodes";
         assert AutoExpandReplicas.getAutoExpandReplicaChanges(allocation.metadata(), allocation).isEmpty() :
             "auto-expand replicas out of sync with number of nodes in the cluster";
+        assert assertInitialized();
 
         removeDelayMarkers(allocation);
-        // try to allocate existing shard copies first
-        gatewayAllocator.allocateUnassigned(allocation);
 
+        allocateExistingUnassignedShards(allocation);  // try to allocate existing shard copies first
         shardsAllocator.allocate(allocation);
         assert RoutingNodes.assertShardStats(allocation.routingNodes());
+    }
+
+    private void allocateExistingUnassignedShards(RoutingAllocation allocation) {
+        allocation.routingNodes().unassigned().sort(PriorityComparator.getAllocationComparator(allocation)); // sort for priority ordering
+
+        for (final ExistingShardsAllocator existingShardsAllocator : existingShardsAllocators.values()) {
+            existingShardsAllocator.beforeAllocation(allocation);
+        }
+
+        final RoutingNodes.UnassignedShards.UnassignedIterator primaryIterator = allocation.routingNodes().unassigned().iterator();
+        while (primaryIterator.hasNext()) {
+            final ShardRouting shardRouting = primaryIterator.next();
+            if (shardRouting.primary()) {
+                getAllocatorForShard(shardRouting, allocation).allocateUnassigned(shardRouting, allocation, primaryIterator);
+            }
+        }
+
+        for (final ExistingShardsAllocator existingShardsAllocator : existingShardsAllocators.values()) {
+            existingShardsAllocator.afterPrimariesBeforeReplicas(allocation);
+        }
+
+        final RoutingNodes.UnassignedShards.UnassignedIterator replicaIterator = allocation.routingNodes().unassigned().iterator();
+        while (replicaIterator.hasNext()) {
+            final ShardRouting shardRouting = replicaIterator.next();
+            if (shardRouting.primary() == false) {
+                getAllocatorForShard(shardRouting, allocation).allocateUnassigned(shardRouting, allocation, replicaIterator);
+            }
+        }
     }
 
     private void disassociateDeadNodes(RoutingAllocation allocation) {
@@ -456,9 +495,11 @@ public class AllocationService {
         }
     }
 
+    /**
+     * Create a mutable {@link RoutingNodes}. This is a costly operation so this must only be called once!
+     */
     private RoutingNodes getMutableRoutingNodes(ClusterState clusterState) {
-        RoutingNodes routingNodes = new RoutingNodes(clusterState, false); // this is a costly operation - only call this once!
-        return routingNodes;
+        return new RoutingNodes(clusterState, false);
     }
 
     /** override this to control time based decisions during allocation */
@@ -467,7 +508,103 @@ public class AllocationService {
     }
 
     public void cleanCaches() {
-        gatewayAllocator.cleanCaches();
+        assert assertInitialized();
+        existingShardsAllocators.values().forEach(ExistingShardsAllocator::cleanCaches);
+    }
+
+    public int getNumberOfInFlightFetches() {
+        assert assertInitialized();
+        return existingShardsAllocators.values().stream().mapToInt(ExistingShardsAllocator::getNumberOfInFlightFetches).sum();
+    }
+
+    public ShardAllocationDecision explainShardAllocation(ShardRouting shardRouting, RoutingAllocation allocation) {
+        assert allocation.debugDecision();
+        AllocateUnassignedDecision allocateDecision
+            = shardRouting.unassigned() ? explainUnassignedShardAllocation(shardRouting, allocation) : AllocateUnassignedDecision.NOT_TAKEN;
+        if (allocateDecision.isDecisionTaken()) {
+            return new ShardAllocationDecision(allocateDecision, MoveDecision.NOT_TAKEN);
+        } else {
+            return shardsAllocator.decideShardAllocation(shardRouting, allocation);
+        }
+    }
+
+    private AllocateUnassignedDecision explainUnassignedShardAllocation(ShardRouting shardRouting, RoutingAllocation routingAllocation) {
+        assert shardRouting.unassigned();
+        assert routingAllocation.debugDecision();
+        assert assertInitialized();
+        final ExistingShardsAllocator existingShardsAllocator = getAllocatorForShard(shardRouting, routingAllocation);
+        final AllocateUnassignedDecision decision
+            = existingShardsAllocator.explainUnassignedShardAllocation(shardRouting, routingAllocation);
+        if (decision.isDecisionTaken()) {
+            return decision;
+        }
+        return AllocateUnassignedDecision.NOT_TAKEN;
+    }
+
+    private ExistingShardsAllocator getAllocatorForShard(ShardRouting shardRouting, RoutingAllocation routingAllocation) {
+        assert assertInitialized();
+        final String allocatorName = ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.get(
+            routingAllocation.metadata().getIndexSafe(shardRouting.index()).getSettings());
+        final ExistingShardsAllocator existingShardsAllocator = existingShardsAllocators.get(allocatorName);
+        return existingShardsAllocator != null ? existingShardsAllocator : new NotFoundAllocator(allocatorName);
+    }
+
+    private boolean assertInitialized() {
+        assert existingShardsAllocators != null : "must have set allocators first";
+        return true;
+    }
+
+    private static class NotFoundAllocator implements ExistingShardsAllocator {
+        private final String allocatorName;
+
+        private NotFoundAllocator(String allocatorName) {
+            this.allocatorName = allocatorName;
+        }
+
+        @Override
+        public void beforeAllocation(RoutingAllocation allocation) {
+        }
+
+        @Override
+        public void afterPrimariesBeforeReplicas(RoutingAllocation allocation) {
+        }
+
+        @Override
+        public void allocateUnassigned(ShardRouting shardRouting, RoutingAllocation allocation,
+                                       UnassignedAllocationHandler unassignedAllocationHandler) {
+            unassignedAllocationHandler.removeAndIgnore(AllocationStatus.NO_VALID_SHARD_COPY, allocation.changes());
+        }
+
+        @Override
+        public AllocateUnassignedDecision explainUnassignedShardAllocation(ShardRouting unassignedShard, RoutingAllocation allocation) {
+            assert unassignedShard.unassigned();
+            assert allocation.debugDecision();
+            final List<NodeAllocationResult> nodeAllocationResults = new ArrayList<>(allocation.nodes().getSize());
+            for (DiscoveryNode discoveryNode : allocation.nodes()) {
+                nodeAllocationResults.add(new NodeAllocationResult(discoveryNode, null, allocation.decision(Decision.NO,
+                    "allocator_plugin", "finding the previous copies of this shard requires an allocator called [%s] but " +
+                        "that allocator was not found; perhaps the corresponding plugin is not installed",
+                    allocatorName)));
+            }
+            return AllocateUnassignedDecision.no(AllocationStatus.NO_VALID_SHARD_COPY, nodeAllocationResults);
+        }
+
+        @Override
+        public void cleanCaches() {
+        }
+
+        @Override
+        public void applyStartedShards(List<ShardRouting> startedShards, RoutingAllocation allocation) {
+        }
+
+        @Override
+        public void applyFailedShards(List<FailedShard> failedShards, RoutingAllocation allocation) {
+        }
+
+        @Override
+        public int getNumberOfInFlightFetches() {
+            return 0;
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ExistingShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ExistingShardsAllocator.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingChangesObserver;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.gateway.GatewayAllocator;
+
+/**
+ * Searches for, and allocates, shards for which there is an existing on-disk copy somewhere in the cluster. The default implementation is
+ * {@link GatewayAllocator}, but plugins can supply their own implementations too.
+ */
+public interface ExistingShardsAllocator {
+
+    /**
+     * Allows plugins to override how we allocate shards that may already exist on disk in the cluster.
+     */
+    Setting<String> EXISTING_SHARDS_ALLOCATOR_SETTING = Setting.simpleString(
+        "index.allocation.existing_shards_allocator", GatewayAllocator.ALLOCATOR_NAME,
+        Setting.Property.IndexScope, Setting.Property.PrivateIndex);
+
+    /**
+     * Called before starting a round of allocation, allowing the allocator to invalidate some caches if appropriate.
+     */
+    void beforeAllocation(RoutingAllocation allocation);
+
+    /**
+     * Called during a round of allocation after attempting to allocate all the primaries but before any replicas, allowing the allocator
+     * to prepare for replica allocation.
+     */
+    void afterPrimariesBeforeReplicas(RoutingAllocation allocation);
+
+    /**
+     * Allocate any unassigned shards in the given {@link RoutingAllocation} for which this {@link ExistingShardsAllocator} is responsible.
+     */
+    void allocateUnassigned(ShardRouting shardRouting, RoutingAllocation allocation,
+                            UnassignedAllocationHandler unassignedAllocationHandler);
+
+    /**
+     * Returns an explanation for a single unassigned shard.
+     */
+    AllocateUnassignedDecision explainUnassignedShardAllocation(ShardRouting unassignedShard, RoutingAllocation routingAllocation);
+
+    /**
+     * Called when this node becomes the elected master and when it stops being the elected master, so that implementations can clean up any
+     * in-flight activity from an earlier mastership.
+     */
+    void cleanCaches();
+
+    /**
+     * Called when the given shards have started, so that implementations can invalidate caches and clean up any in-flight activity for
+     * those shards.
+     */
+    void applyStartedShards(List<ShardRouting> startedShards, RoutingAllocation allocation);
+
+    /**
+     * Called when the given shards have failed, so that implementations can invalidate caches and clean up any in-flight activity for
+     * those shards.
+     */
+    void applyFailedShards(List<FailedShard> failedShards, RoutingAllocation allocation);
+
+    /**
+     * @return the number of in-flight fetches under this allocator's control.
+     */
+    int getNumberOfInFlightFetches();
+
+    /**
+     * Used by {@link ExistingShardsAllocator#allocateUnassigned} to handle its allocation decisions. A restricted interface to
+     * {@link RoutingNodes.UnassignedShards.UnassignedIterator} to limit what allocators can do.
+     */
+    interface UnassignedAllocationHandler {
+
+        /**
+         * Initializes the current unassigned shard and moves it from the unassigned list.
+         *
+         * @param existingAllocationId allocation id to use. If null, a fresh allocation id is generated.
+         */
+        ShardRouting initialize(String nodeId, @Nullable String existingAllocationId, long expectedShardSize,
+                                RoutingChangesObserver routingChangesObserver);
+
+        /**
+         * Removes and ignores the unassigned shard (will be ignored for this run, but
+         * will be added back to unassigned once the metadata is constructed again).
+         * Typically this is used when an allocation decision prevents a shard from being allocated such
+         * that subsequent consumers of this API won't try to allocate this shard again.
+         *
+         * @param attempt the result of the allocation attempt
+         */
+        void removeAndIgnore(UnassignedInfo.AllocationStatus attempt, RoutingChangesObserver changes);
+
+        /**
+         * updates the unassigned info and recovery source on the current unassigned shard
+         *
+         * @param  unassignedInfo the new unassigned info to use
+         * @param  recoverySource the new recovery source to use
+         * @return the shard with unassigned info updated
+         */
+        ShardRouting updateUnassigned(UnassignedInfo unassignedInfo, RecoverySource recoverySource, RoutingChangesObserver changes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -50,6 +50,40 @@ public interface BlobContainer {
     InputStream readBlob(String blobName) throws IOException;
 
     /**
+     * Creates a new {@link InputStream} that can be used to read the given blob starting from
+     * a specific {@code position} in the blob. The {@code length} is an indication of the
+     * number of bytes that are expected to be read from the {@link InputStream}.
+     *
+     * @param blobName The name of the blob to get an {@link InputStream} for.
+     * @param position The position in the blob where the next byte will be read.
+     * @param length   An indication of the number of bytes to be read.
+     * @return The {@code InputStream} to read the blob.
+     * @throws NoSuchFileException if the blob does not exist
+     * @throws IOException         if the blob can not be read.
+     */
+    default InputStream readBlob(final String blobName, final long position, final long length) throws IOException {
+        throw new UnsupportedOperationException(); // NORELEASE
+    }
+
+    /**
+     * Provides a hint to clients for a suitable length to use with {@link BlobContainer#readBlob(String, long, long)}.
+     *
+     * Some blob containers have nontrivial costs attached to each readBlob call, so it is a good idea for consumers to speculatively
+     * request more data than they need right now and to re-use this stream for future needs if possible.
+     *
+     * Also, some blob containers return streams that are expensive to close before the stream has been fully consumed, and the cost may
+     * depend on the length of the data that was left unconsumed. For these containers it's best to bound the cost of a partial read by
+     * bounding the length of the data requested.
+     *
+     * @return a hint to consumers regarding the length of data to request if there is a good chance that future reads can be satisfied from
+     * the same stream.
+     *
+     */
+    default long readBlobPreferredLength() {
+        throw new UnsupportedOperationException(); // NORELEASE
+    }
+
+    /**
      * Reads blob content from the input stream and writes it to the container in a new blob with the given name.
      * This method assumes the container does not already contain a blob of the same blobName.  If a blob by the
      * same name already exists, the operation will fail and an {@link IOException} will be thrown.

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -33,6 +33,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitResult;
@@ -134,14 +136,34 @@ public class FsBlobContainer extends AbstractBlobContainer {
         IOUtils.rm(blobNames.stream().map(path::resolve).toArray(Path[]::new));
     }
 
+    private InputStream bufferedInputStream(InputStream inputStream) {
+        return new BufferedInputStream(inputStream, blobStore.bufferSizeInBytes());
+    }
+
     @Override
     public InputStream readBlob(String name) throws IOException {
         final Path resolvedPath = path.resolve(name);
         try {
-            return new BufferedInputStream(Files.newInputStream(resolvedPath), blobStore.bufferSizeInBytes());
+            return bufferedInputStream(Files.newInputStream(resolvedPath));
         } catch (FileNotFoundException fnfe) {
             throw new NoSuchFileException("[" + name + "] blob not found");
         }
+    }
+
+    @Override
+    public InputStream readBlob(String blobName, long position, long length) throws IOException {
+        final SeekableByteChannel channel = Files.newByteChannel(path.resolve(blobName));
+        if (position > 0L) {
+            channel.position(position);
+        }
+        assert channel.position() == position;
+        return bufferedInputStream(org.elasticsearch.common.io.Streams.limitStream(Channels.newInputStream(channel), length));
+    }
+
+    @Override
+    public long readBlobPreferredLength() {
+        // This container returns streams that are cheap to close early, so we can tell consumers to request as much data as possible.
+        return Long.MAX_VALUE;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
@@ -120,6 +121,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         Setting.groupSetting("index.analysis.", Property.IndexScope),
         BlobIndicesService.SETTING_INDEX_BLOBS_ENABLED,
         BlobIndicesService.SETTING_INDEX_BLOBS_PATH,
+        ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING,
         LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME,
         LogicalReplicationSettings.PUBLISHER_INDEX_UUID
     );

--- a/server/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
@@ -22,10 +22,10 @@ package org.elasticsearch.gateway;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.routing.RoutingNode;
-import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.AllocationDecision;
+import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationResult;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
@@ -45,40 +45,37 @@ public abstract class BaseGatewayShardAllocator {
     protected final Logger logger = LogManager.getLogger(this.getClass());
 
     /**
-     * Allocate unassigned shards to nodes (if any) where valid copies of the shard already exist.
+     * Allocate an unassigned shard to nodes (if any) where valid copies of the shard already exist.
      * It is up to the individual implementations of {@link #makeAllocationDecision(ShardRouting, RoutingAllocation, Logger)}
      * to make decisions on assigning shards to nodes.
-     *
+     * @param shardRouting the shard to allocate
      * @param allocation the allocation state container object
+     * @param unassignedAllocationHandler handles the allocation of the current shard
      */
-    public void allocateUnassigned(RoutingAllocation allocation) {
-        final RoutingNodes routingNodes = allocation.routingNodes();
-        final RoutingNodes.UnassignedShards.UnassignedIterator unassignedIterator = routingNodes.unassigned().iterator();
-        while (unassignedIterator.hasNext()) {
-            final ShardRouting shard = unassignedIterator.next();
-            final AllocateUnassignedDecision allocateUnassignedDecision = makeAllocationDecision(shard, allocation, logger);
+    public void allocateUnassigned(ShardRouting shardRouting, RoutingAllocation allocation,
+                                   ExistingShardsAllocator.UnassignedAllocationHandler unassignedAllocationHandler) {
+        final AllocateUnassignedDecision allocateUnassignedDecision = makeAllocationDecision(shardRouting, allocation, logger);
 
-            if (allocateUnassignedDecision.isDecisionTaken() == false) {
-                // no decision was taken by this allocator
-                continue;
-            }
+        if (allocateUnassignedDecision.isDecisionTaken() == false) {
+            // no decision was taken by this allocator
+            return;
+        }
 
-            if (allocateUnassignedDecision.getAllocationDecision() == AllocationDecision.YES) {
-                unassignedIterator.initialize(allocateUnassignedDecision.getTargetNode().getId(),
-                    allocateUnassignedDecision.getAllocationId(),
-                    shard.primary() ? ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE :
-                                      allocation.clusterInfo().getShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE),
-                    allocation.changes());
-            } else {
-                unassignedIterator.removeAndIgnore(allocateUnassignedDecision.getAllocationStatus(), allocation.changes());
-            }
+        if (allocateUnassignedDecision.getAllocationDecision() == AllocationDecision.YES) {
+            unassignedAllocationHandler.initialize(allocateUnassignedDecision.getTargetNode().getId(),
+                allocateUnassignedDecision.getAllocationId(),
+                shardRouting.primary() ? ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE :
+                                         allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE),
+                allocation.changes());
+        } else {
+            unassignedAllocationHandler.removeAndIgnore(allocateUnassignedDecision.getAllocationStatus(), allocation.changes());
         }
     }
 
     /**
      * Make a decision on the allocation of an unassigned shard.  This method is used by
-     * {@link #allocateUnassigned(RoutingAllocation)} to make decisions about whether or not
-     * the shard can be allocated by this allocator and if so, to which node it will be allocated.
+     * {@link #allocateUnassigned(ShardRouting, RoutingAllocation, ExistingShardsAllocator.UnassignedAllocationHandler)} to make decisions
+     * about whether or not the shard can be allocated by this allocator and if so, to which node it will be allocated.
      *
      * @param unassignedShard  the unassigned shard to allocate
      * @param allocation       the current routing state

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -31,9 +31,9 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RerouteService;
-import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
+import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Priority;
@@ -54,7 +54,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class GatewayAllocator {
+public class GatewayAllocator implements ExistingShardsAllocator {
+
+    public static final String ALLOCATOR_NAME = "gateway_allocator";
 
     private static final Logger LOGGER = LogManager.getLogger(GatewayAllocator.class);
 
@@ -76,6 +78,7 @@ public class GatewayAllocator {
         this.replicaShardAllocator = new InternalReplicaShardAllocator(client);
     }
 
+    @Override
     public void cleanCaches() {
         Releasables.close(asyncFetchStarted.values());
         asyncFetchStarted.clear();
@@ -90,7 +93,8 @@ public class GatewayAllocator {
         this.replicaShardAllocator = null;
     }
 
-    public int getNumberOfInFlightFetch() {
+    @Override
+    public int getNumberOfInFlightFetches() {
         int count = 0;
         for (AsyncShardFetch<NodeGatewayStartedShards> fetch : asyncFetchStarted.values()) {
             count += fetch.getNumberOfInFlightFetches();
@@ -101,47 +105,64 @@ public class GatewayAllocator {
         return count;
     }
 
-    public void applyStartedShards(final RoutingAllocation allocation, final List<ShardRouting> startedShards) {
+    @Override
+    public void applyStartedShards(final List<ShardRouting> startedShards, final RoutingAllocation allocation) {
         for (ShardRouting startedShard : startedShards) {
             Releasables.close(asyncFetchStarted.remove(startedShard.shardId()));
             Releasables.close(asyncFetchStore.remove(startedShard.shardId()));
         }
     }
 
-    public void applyFailedShards(final RoutingAllocation allocation, final List<FailedShard> failedShards) {
+    @Override
+    public void applyFailedShards(final List<FailedShard> failedShards, final RoutingAllocation allocation) {
         for (FailedShard failedShard : failedShards) {
             Releasables.close(asyncFetchStarted.remove(failedShard.getRoutingEntry().shardId()));
             Releasables.close(asyncFetchStore.remove(failedShard.getRoutingEntry().shardId()));
         }
     }
 
-    public void allocateUnassigned(final RoutingAllocation allocation) {
+    @Override
+    public void beforeAllocation(final RoutingAllocation allocation) {
         assert primaryShardAllocator != null;
         assert replicaShardAllocator != null;
         ensureAsyncFetchStorePrimaryRecency(allocation);
-        innerAllocatedUnassigned(allocation, primaryShardAllocator, replicaShardAllocator);
+    }
+
+    @Override
+    public void afterPrimariesBeforeReplicas(RoutingAllocation allocation) {
+        assert replicaShardAllocator != null;
+        if (allocation.routingNodes().hasInactiveShards()) {
+            // cancel existing recoveries if we have a better match
+            replicaShardAllocator.processExistingRecoveries(allocation);
+        }
+    }
+
+    @Override
+    public void allocateUnassigned(ShardRouting shardRouting, final RoutingAllocation allocation,
+                                   UnassignedAllocationHandler unassignedAllocationHandler) {
+        assert primaryShardAllocator != null;
+        assert replicaShardAllocator != null;
+        innerAllocatedUnassigned(allocation, primaryShardAllocator, replicaShardAllocator, shardRouting, unassignedAllocationHandler);
     }
 
     // allow for testing infra to change shard allocators implementation
     protected static void innerAllocatedUnassigned(RoutingAllocation allocation,
                                                    PrimaryShardAllocator primaryShardAllocator,
-                                                   ReplicaShardAllocator replicaShardAllocator) {
-        RoutingNodes.UnassignedShards unassigned = allocation.routingNodes().unassigned();
-        unassigned.sort(PriorityComparator.getAllocationComparator(allocation)); // sort for priority ordering
-
-        primaryShardAllocator.allocateUnassigned(allocation);
-        if (allocation.routingNodes().hasInactiveShards()) {
-            // cancel existing recoveries if we have a better match
-            replicaShardAllocator.processExistingRecoveries(allocation);
+                                                   ReplicaShardAllocator replicaShardAllocator,
+                                                   ShardRouting shardRouting,
+                                                   ExistingShardsAllocator.UnassignedAllocationHandler unassignedAllocationHandler) {
+        assert shardRouting.unassigned();
+        if (shardRouting.primary()) {
+            primaryShardAllocator.allocateUnassigned(shardRouting, allocation, unassignedAllocationHandler);
+        } else {
+            replicaShardAllocator.allocateUnassigned(shardRouting, allocation, unassignedAllocationHandler);
         }
-        replicaShardAllocator.allocateUnassigned(allocation);
     }
 
-    /**
-     * Computes and returns the design for allocating a single unassigned shard.  If called on an assigned shard,
-     * {@link AllocateUnassignedDecision#NOT_TAKEN} is returned.
-     */
-    public AllocateUnassignedDecision decideUnassignedShardAllocation(ShardRouting unassignedShard, RoutingAllocation routingAllocation) {
+    @Override
+    public AllocateUnassignedDecision explainUnassignedShardAllocation(ShardRouting unassignedShard, RoutingAllocation routingAllocation) {
+        assert unassignedShard.unassigned();
+        assert routingAllocation.debugDecision();
         if (unassignedShard.primary()) {
             assert primaryShardAllocator != null;
             return primaryShardAllocator.makeAllocationDecision(unassignedShard, routingAllocation, LOGGER);

--- a/server/src/main/java/org/elasticsearch/gateway/PriorityComparator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PriorityComparator.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.gateway;
 
+import java.util.Comparator;
+
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
-
-import java.util.Comparator;
 
 /**
  * A comparator that compares ShardRouting based on it's indexes priority (index.priority),

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
@@ -195,4 +195,15 @@ public interface IndexEventListener {
      */
     default void beforeIndexSettingsChangesApplied(IndexShard indexShard, Settings oldSettings, Settings newSettings) {
     }
+
+    /**
+     * Called before the index shard starts to recover.
+     * Note: unlike all other methods in this class, this method is not called using the cluster state update thread. When this method is
+     * called the shard already transitioned to the RECOVERING state.
+     *
+     * @param indexShard    the shard that is about to recover
+     * @param indexSettings the shard's index settings
+     */
+    default void beforeIndexShardRecovery(IndexShard indexShard, IndexSettings indexSettings) {
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1193,6 +1193,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
+    public void preRecovery() {
+        final IndexShardState currentState = this.state; // single volatile read
+        if (currentState == IndexShardState.CLOSED) {
+            throw new IndexShardNotRecoveringException(shardId, currentState);
+        }
+        assert currentState == IndexShardState.RECOVERING : "expected a recovering shard " + shardId + " but got " + currentState;
+        indexEventListener.beforeIndexShardRecovery(this, indexSettings);
+    }
+
     public void postRecovery(String reason) throws IndexShardStartedException, IndexShardRelocatedException, IndexShardClosedException {
         synchronized (postRecoveryMutex) {
             // we need to refresh again to expose all operations that were index until now. Otherwise

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -380,6 +380,7 @@ final class StoreRecovery {
      * Recovers the state of the shard from the store.
      */
     private void internalRecoverFromStore(IndexShard indexShard) throws IndexShardRecoveryException {
+        indexShard.preRecovery();
         final RecoveryState recoveryState = indexShard.recoveryState();
         final boolean indexShouldExists =
             recoveryState.getRecoverySource().getType() != RecoverySource.Type.EMPTY_STORE;
@@ -474,6 +475,7 @@ final class StoreRecovery {
     private void restore(IndexShard indexShard, Repository repository, SnapshotRecoverySource restoreSource,
                          ActionListener<Boolean> listener) {
         logger.debug("restoring from {} ...", indexShard.recoveryState().getRecoverySource());
+        indexShard.preRecovery();
         final RecoveryState.Translog translogState = indexShard.recoveryState().getTranslog();
         if (restoreSource == null) {
             listener.onFailure(new IndexShardRestoreFailedException(shardId, "empty restore source"));

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -205,10 +205,12 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             timer = recoveryTarget.state().getTimer();
             cancellableThreads = recoveryTarget.cancellableThreads();
             try {
+                final IndexShard indexShard = recoveryTarget.indexShard();
+                indexShard.preRecovery();
                 assert recoveryTarget.sourceNode() != null : "can not do a recovery without a source node";
                 LOGGER.trace("{} preparing shard for peer recovery", recoveryTarget.shardId());
-                recoveryTarget.indexShard().prepareForIndexRecovery();
-                final long startingSeqNo = recoveryTarget.indexShard().recoverLocallyUpToGlobalCheckpoint();
+                indexShard.prepareForIndexRecovery();
+                final long startingSeqNo = indexShard.recoverLocallyUpToGlobalCheckpoint();
                 assert startingSeqNo == UNASSIGNED_SEQ_NO || recoveryTarget.state().getStage() == RecoveryState.Stage.TRANSLOG :
                     "unexpected recovery stage [" + recoveryTarget.state().getStage() + "] starting seqno [ " + startingSeqNo + "]";
                 request = getStartRecoveryRequest(LOGGER, clusterService.localNode(), recoveryTarget, startingSeqNo);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -752,8 +752,12 @@ public class Node implements Closeable {
             );
             injector = modules.createInjector();
 
-            // TODO hack around circular dependencies problems in AllocationService
-            clusterModule.getAllocationService().setGatewayAllocator(injector.getInstance(GatewayAllocator.class));
+            // We allocate copies of existing shards by looking for a viable copy of the shard in the cluster and assigning the shard there.
+            // The search for viable copies is triggered by an allocation attempt (i.e. a reroute) and is performed asynchronously. When it
+            // completes we trigger another reroute to try the allocation again. This means there is a circular dependency: the allocation
+            // service needs access to the existing shards allocators (e.g. the GatewayAllocator) which need to be able to trigger a
+            // reroute, which needs to call into the allocation service. We close the loop here:
+            clusterModule.setExistingShardsAllocators(injector.getInstance(GatewayAllocator.class));
 
             List<LifecycleComponent> pluginLifecycleComponents = pluginComponents.stream()
                 .filter(p -> p instanceof LifecycleComponent)

--- a/server/src/main/java/org/elasticsearch/plugins/ClusterPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ClusterPlugin.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -57,6 +58,15 @@ public interface ClusterPlugin {
      * @return A map of allocator implementations
      */
     default Map<String, Supplier<ShardsAllocator>> getShardsAllocators(Settings settings, ClusterSettings clusterSettings) {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Return {@link ExistingShardsAllocator} implementations added by this plugin; the index setting
+     * {@link ExistingShardsAllocator#EXISTING_SHARDS_ALLOCATOR_SETTING} sets the key of the allocator to use to allocate its shards. The
+     * default allocator is {@link org.elasticsearch.gateway.GatewayAllocator}.
+     */
+    default Map<String, ExistingShardsAllocator> getExistingShardsAllocators() {
         return Collections.emptyMap();
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.repositories.RepositoriesModule;
 import org.elasticsearch.repositories.Repository;
 
 /**
@@ -44,5 +45,27 @@ public interface RepositoryPlugin {
                                                             ClusterService clusterService) {
         return Collections.emptyMap();
     }
-    
+
+    /**
+     * Returns internal repository types added by this plugin. Internal repositories cannot be registered
+     * through the external API.
+     *
+     * @param env The environment for the local node, which may be used for the local settings and path.repo
+     *
+     * The key of the returned {@link Map} is the type name of the repository and
+     * the value is a factory to construct the {@link Repository} interface.
+     */
+    default Map<String, Repository.Factory> getInternalRepositories(Environment env, NamedXContentRegistry namedXContentRegistry,
+                                                                    ClusterService clusterService) {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Passes down the current {@link RepositoriesModule} to repository plugins.
+     *
+     * @param module the current {@link RepositoriesModule}
+     */
+    default void onRepositoriesModule(RepositoriesModule module) {
+        // NORELEASE
+    }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
@@ -102,6 +102,7 @@ public class RepositoriesModule extends AbstractModule {
 
         Map<String, Repository.Factory> repositoryTypes = Collections.unmodifiableMap(factories);
         repositoriesService = new RepositoriesService(env.settings(), clusterService, transportService, repositoryTypes, threadPool);
+        repoPlugins.forEach(rp -> rp.onRepositoriesModule(this));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1022,7 +1022,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         return blobStore().blobContainer(indicesPath().add(indexId.getId()).add(Integer.toString(shardId.getId())));
     }
 
-    private BlobContainer shardContainer(IndexId indexId, int shardId) {
+    public BlobContainer shardContainer(IndexId indexId, int shardId) {
         return blobStore().blobContainer(indicesPath().add(indexId.getId()).add(Integer.toString(shardId)));
     }
 
@@ -1044,10 +1044,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     protected void assertSnapshotOrGenericThread() {
-        assert Thread.currentThread().getName().contains(ThreadPool.Names.SNAPSHOT)
-            || Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC)
-            || Thread.currentThread().getName().contains(ThreadPool.Names.SEARCH) :
-                "Expected current thread [" + Thread.currentThread() + "] to be the snapshot or generic thread.";
+        assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.SNAPSHOT + ']')
+               || Thread.currentThread().getName().contains('[' + ThreadPool.Names.SEARCH + ']')
+               || Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC) :
+            "Expected current thread [" + Thread.currentThread() + "] to be the snapshot or generic thread.";
     }
 
     @Override
@@ -2017,7 +2017,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     /**
      * Loads information about shard snapshot
      */
-    private BlobStoreIndexShardSnapshot loadShardSnapshot(BlobContainer shardContainer, SnapshotId snapshotId) {
+    public BlobStoreIndexShardSnapshot loadShardSnapshot(BlobContainer shardContainer, SnapshotId snapshotId) {
         try {
             return indexShardSnapshotFormat.read(shardContainer, snapshotId.getUUID());
         } catch (IOException ex) {

--- a/server/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
@@ -44,8 +44,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.gateway.GatewayAllocator;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
@@ -129,7 +129,7 @@ public class PrimaryAllocationIT extends IntegTestCase {
         logger.info("--> check that old primary shard does not get promoted to primary again");
         // kick reroute and wait for all shard states to be fetched
         client(master).admin().cluster().execute(ClusterRerouteAction.INSTANCE, new ClusterRerouteRequest()).get();
-        assertBusy(() -> assertThat(internalCluster().getInstance(GatewayAllocator.class, master).getNumberOfInFlightFetch(),
+        assertBusy(() -> assertThat(internalCluster().getInstance(AllocationService.class, master).getNumberOfInFlightFetches(),
             equalTo(0)));
         // kick reroute a second time and check that all shards are unassigned
         var clusterRerouteResponse = client(master).admin().cluster().execute(ClusterRerouteAction.INSTANCE, new ClusterRerouteRequest()).get();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -18,16 +18,54 @@
  */
 package org.elasticsearch.cluster.routing.allocation;
 
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus.DECIDERS_NO;
+import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.EmptyClusterInfoService;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.gateway.GatewayAllocator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.junit.Test;
 
 public class AllocationServiceTests extends ESTestCase {
@@ -75,4 +113,249 @@ public class AllocationServiceTests extends ESTestCase {
         assertThat(abbreviated, containsString("formatted"));
         assertThat(abbreviated, not(containsString("original")));
     }
+
+    public void testAssignsPrimariesInPriorityOrderThenReplicas() {
+        // throttle (incoming) recoveries in order to observe the order of operations, but do not throttle outgoing recoveries since
+        // the effects of that depend on the earlier (random) allocations
+        final Settings settings = Settings.builder()
+            .put(CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING.getKey(), 1)
+            .put(CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING.getKey(), 1)
+            .put(CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(), Integer.MAX_VALUE)
+            .build();
+        final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final AllocationService allocationService = new AllocationService(
+            new AllocationDeciders(Arrays.asList(
+                new SameShardAllocationDecider(settings, clusterSettings),
+                new ThrottlingAllocationDecider(settings, clusterSettings))),
+            new ShardsAllocator() {
+                @Override
+                public void allocate(RoutingAllocation allocation) {
+                    // all primaries are handled by existing shards allocators in these tests; even the invalid allocator prevents shards
+                    // from falling through to here
+                    assertThat(allocation.routingNodes().unassigned().getNumPrimaries(), equalTo(0));
+                }
+
+                @Override
+                public ShardAllocationDecision decideShardAllocation(ShardRouting shard, RoutingAllocation allocation) {
+                    return ShardAllocationDecision.NOT_TAKEN;
+                }
+            }, EmptyClusterInfoService.INSTANCE);
+
+        final String unrealisticAllocatorName = "unrealistic";
+        final Map<String, ExistingShardsAllocator> allocatorMap = new HashMap<>();
+        final TestGatewayAllocator testGatewayAllocator = new TestGatewayAllocator();
+        allocatorMap.put(GatewayAllocator.ALLOCATOR_NAME, testGatewayAllocator);
+        allocatorMap.put(unrealisticAllocatorName, new UnrealisticAllocator());
+        allocationService.setExistingShardsAllocators(allocatorMap);
+
+        final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        nodesBuilder.add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT));
+        nodesBuilder.add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT));
+        nodesBuilder.add(new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT));
+
+        // Need to add a UUID otherwise "_na_" will be used which will result to getting the same metadata (same prio)
+        // through PriorityComparator.getAllocationComparator()->allocation.metadata().getIndexSafe()->IndexMetadata.index()
+        // which gets the index by UUID from the map
+        final Metadata.Builder metaData = Metadata.builder()
+            // create 3 indices with different priorities. The high and low priority indices use the default allocator which (in this test)
+            // does not allocate any replicas, whereas the medium priority one uses the unrealistic allocator which does allocate replicas
+            .put(indexMetadata("highPriority", Settings.builder()
+                .put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                .put(IndexMetadata.SETTING_PRIORITY, 10)))
+            .put(indexMetadata("mediumPriority", Settings.builder()
+                .put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                .put(IndexMetadata.SETTING_PRIORITY, 5)
+                .put(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), unrealisticAllocatorName)))
+            .put(indexMetadata("lowPriority", Settings.builder()
+                .put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                .put(IndexMetadata.SETTING_PRIORITY, 3)))
+
+            // also create a 4th index with arbitrary priority and an invalid allocator that we expect to ignore
+            .put(indexMetadata("invalid", Settings.builder()
+                .put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                .put(IndexMetadata.SETTING_PRIORITY, between(0, 15))
+                .put(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), "unknown")));
+
+        final RoutingTable.Builder routingTableBuilder = RoutingTable.builder()
+            .addAsRecovery(metaData.get("highPriority"))
+            .addAsRecovery(metaData.get("mediumPriority"))
+            .addAsRecovery(metaData.get("lowPriority"))
+            .addAsRecovery(metaData.get("invalid"));
+
+        final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(nodesBuilder)
+            .metadata(metaData)
+            .routingTable(routingTableBuilder.build())
+            .build();
+
+        // permit the testGatewayAllocator to allocate primaries to every node
+        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+                final ShardRouting primaryShard = indexShardRoutingTable.primaryShard();
+                for (DiscoveryNode node : clusterState.nodes()) {
+                    testGatewayAllocator.addKnownAllocation(primaryShard.initialize(node.getId(), FAKE_IN_SYNC_ALLOCATION_ID, 0L));
+                }
+            }
+        }
+
+        final ClusterState reroutedState1 = rerouteAndStartShards(allocationService, clusterState);
+        final RoutingTable routingTable1 = reroutedState1.routingTable();
+        // the test harness only permits one recovery per node, so we must have allocated all the high-priority primaries and one of the
+        // medium-priority ones
+        assertThat(routingTable1.shardsWithState(ShardRoutingState.INITIALIZING), empty());
+        assertThat(routingTable1.shardsWithState(ShardRoutingState.RELOCATING), empty());
+        assertTrue(routingTable1.shardsWithState(ShardRoutingState.STARTED).stream().allMatch(ShardRouting::primary));
+        assertThat(routingTable1.index("highPriority").primaryShardsActive(), equalTo(2));
+        assertThat(routingTable1.index("mediumPriority").primaryShardsActive(), equalTo(1));
+        assertThat(routingTable1.index("lowPriority").shardsWithState(ShardRoutingState.STARTED), empty());
+        assertThat(routingTable1.index("invalid").shardsWithState(ShardRoutingState.STARTED), empty());
+
+        final ClusterState reroutedState2 = rerouteAndStartShards(allocationService, reroutedState1);
+        final RoutingTable routingTable2 = reroutedState2.routingTable();
+        // this reroute starts the one remaining medium-priority primary and both of the low-priority ones, but no replicas
+        assertThat(routingTable2.shardsWithState(ShardRoutingState.INITIALIZING), empty());
+        assertThat(routingTable2.shardsWithState(ShardRoutingState.RELOCATING), empty());
+        assertTrue(routingTable2.shardsWithState(ShardRoutingState.STARTED).stream().allMatch(ShardRouting::primary));
+        assertTrue(routingTable2.index("highPriority").allPrimaryShardsActive());
+        assertTrue(routingTable2.index("mediumPriority").allPrimaryShardsActive());
+        assertTrue(routingTable2.index("lowPriority").allPrimaryShardsActive());
+        assertThat(routingTable2.index("invalid").shardsWithState(ShardRoutingState.STARTED), empty());
+
+        final ClusterState reroutedState3 = rerouteAndStartShards(allocationService, reroutedState2);
+        final RoutingTable routingTable3 = reroutedState3.routingTable();
+        // this reroute starts the two medium-priority replicas since their allocator permits this
+        assertThat(routingTable3.shardsWithState(ShardRoutingState.INITIALIZING), empty());
+        assertThat(routingTable3.shardsWithState(ShardRoutingState.RELOCATING), empty());
+        assertTrue(routingTable3.index("highPriority").allPrimaryShardsActive());
+        assertThat(routingTable3.index("mediumPriority").shardsWithState(ShardRoutingState.UNASSIGNED), empty());
+        assertTrue(routingTable3.index("lowPriority").allPrimaryShardsActive());
+        assertThat(routingTable3.index("invalid").shardsWithState(ShardRoutingState.STARTED), empty());
+    }
+
+    public void testExplainsNonAllocationOfShardWithUnknownAllocator() {
+        final AllocationService allocationService = new AllocationService(null, null, null);
+        allocationService.setExistingShardsAllocators(
+            Collections.singletonMap(GatewayAllocator.ALLOCATOR_NAME, new TestGatewayAllocator()));
+
+        final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        nodesBuilder.add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT));
+        nodesBuilder.add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT));
+
+        final Metadata.Builder metadata = Metadata.builder().put(indexMetadata("index", Settings.builder()
+            .put(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), "unknown")));
+
+        final RoutingTable.Builder routingTableBuilder = RoutingTable.builder().addAsRecovery(metadata.get("index"));
+
+        final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(nodesBuilder)
+            .metadata(metadata)
+            .routingTable(routingTableBuilder.build())
+            .build();
+
+        final RoutingAllocation allocation = new RoutingAllocation(new AllocationDeciders(Collections.emptyList()),
+            clusterState.getRoutingNodes(), clusterState, ClusterInfo.EMPTY, 0L);
+        allocation.setDebugMode(randomBoolean() ? RoutingAllocation.DebugMode.ON : RoutingAllocation.DebugMode.EXCLUDE_YES_DECISIONS);
+
+        final ShardAllocationDecision shardAllocationDecision
+            = allocationService.explainShardAllocation(clusterState.routingTable().index("index").shard(0).primaryShard(), allocation);
+
+        assertTrue(shardAllocationDecision.isDecisionTaken());
+        assertThat(shardAllocationDecision.getAllocateDecision().getAllocationStatus(),
+            equalTo(UnassignedInfo.AllocationStatus.NO_VALID_SHARD_COPY));
+        assertThat(shardAllocationDecision.getAllocateDecision().getAllocationDecision(),
+            equalTo(AllocationDecision.NO_VALID_SHARD_COPY));
+        assertThat(shardAllocationDecision.getAllocateDecision().getExplanation(), equalTo("cannot allocate because a previous copy of " +
+            "the primary shard existed but can no longer be found on the nodes in the cluster"));
+
+        for (NodeAllocationResult nodeAllocationResult : shardAllocationDecision.getAllocateDecision().nodeDecisions) {
+            assertThat(nodeAllocationResult.getNodeDecision(), equalTo(AllocationDecision.NO));
+            assertThat(nodeAllocationResult.getCanAllocateDecision().type(), equalTo(Decision.Type.NO));
+            assertThat(nodeAllocationResult.getCanAllocateDecision().label(), equalTo("allocator_plugin"));
+            assertThat(nodeAllocationResult.getCanAllocateDecision().getExplanation(), equalTo("finding the previous copies of this " +
+                "shard requires an allocator called [unknown] but that allocator was not found; perhaps the corresponding plugin is " +
+                "not installed"));
+        }
+    }
+
+    private static final String FAKE_IN_SYNC_ALLOCATION_ID = "_in_sync_"; // so we can allocate primaries anywhere
+
+    private static IndexMetadata.Builder indexMetadata(String name, Settings.Builder settings) {
+        return IndexMetadata.builder(name)
+            .settings(settings(Version.CURRENT).put(settings.build()))
+            .numberOfShards(2).numberOfReplicas(1)
+            .putInSyncAllocationIds(0, Collections.singleton(FAKE_IN_SYNC_ALLOCATION_ID))
+            .putInSyncAllocationIds(1, Collections.singleton(FAKE_IN_SYNC_ALLOCATION_ID));
+    }
+
+    /**
+     * Allocates shards to nodes regardless of whether there's already a shard copy there.
+     */
+    private static class UnrealisticAllocator implements ExistingShardsAllocator {
+
+        @Override
+        public void beforeAllocation(RoutingAllocation allocation) {
+        }
+
+        @Override
+        public void afterPrimariesBeforeReplicas(RoutingAllocation allocation) {
+        }
+
+        @Override
+        public void allocateUnassigned(ShardRouting shardRouting, RoutingAllocation allocation,
+                                       UnassignedAllocationHandler unassignedAllocationHandler) {
+            final AllocateUnassignedDecision allocateUnassignedDecision = explainUnassignedShardAllocation(shardRouting, allocation);
+            if (allocateUnassignedDecision.getAllocationDecision() == AllocationDecision.YES) {
+                unassignedAllocationHandler.initialize(allocateUnassignedDecision.getTargetNode().getId(),
+                    shardRouting.primary() ? FAKE_IN_SYNC_ALLOCATION_ID : null, 0L, allocation.changes());
+            } else {
+                unassignedAllocationHandler.removeAndIgnore(allocateUnassignedDecision.getAllocationStatus(), allocation.changes());
+            }
+        }
+
+        @Override
+        public AllocateUnassignedDecision explainUnassignedShardAllocation(ShardRouting shardRouting, RoutingAllocation allocation) {
+            boolean throttled = false;
+
+            for (final RoutingNode routingNode : allocation.routingNodes()) {
+                final Decision decision = allocation.deciders().canAllocate(shardRouting, routingNode, allocation);
+                if (decision.type() == Decision.Type.YES) {
+                    return AllocateUnassignedDecision.yes(routingNode.node(), null, null, false);
+                } else {
+                    if (shardRouting.index().getName().equals("mediumPriority") && shardRouting.primary() == false
+                        && decision.type() == Decision.Type.THROTTLE) {
+                        allocation.deciders().canAllocate(shardRouting, routingNode, allocation);
+                    }
+                }
+
+                throttled = throttled || decision.type() == Decision.Type.THROTTLE;
+            }
+
+            return throttled ? AllocateUnassignedDecision.throttle(null)
+                : AllocateUnassignedDecision.no(DECIDERS_NO, null);
+        }
+
+        @Override
+        public void cleanCaches() {
+        }
+
+        @Override
+        public void applyStartedShards(List<ShardRouting> startedShards, RoutingAllocation allocation) {
+        }
+
+        @Override
+        public void applyFailedShards(List<FailedShard> failedShards, RoutingAllocation allocation) {
+        }
+
+        @Override
+        public int getNumberOfInFlightFetches() {
+            return 0;
+        }
+    }
+
+    private static ClusterState rerouteAndStartShards(final AllocationService allocationService, final ClusterState clusterState) {
+        final ClusterState reroutedState = allocationService.reroute(clusterState, "test");
+        return allocationService.applyStartedShards(reroutedState,
+            reroutedState.routingTable().shardsWithState(ShardRoutingState.INITIALIZING));
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInputTests.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.store;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ByteArrayIndexInputTests extends ESIndexInputTestCase {
+    public void testRandomReads() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(StandardCharsets.UTF_8);
+            ByteArrayIndexInput indexInput = new ByteArrayIndexInput("test", input);
+            assertEquals(input.length, indexInput.length());
+            assertEquals(0, indexInput.getFilePointer());
+            byte[] output = randomReadAndSlice(indexInput, input.length);
+            assertArrayEquals(input, output);
+        }
+    }
+
+    public void testRandomOverflow() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(StandardCharsets.UTF_8);
+            ByteArrayIndexInput indexInput = new ByteArrayIndexInput("test", input);
+            int firstReadLen = randomIntBetween(0, input.length - 1);
+            randomReadAndSlice(indexInput, firstReadLen);
+            int bytesLeft = input.length - firstReadLen;
+            try {
+                // read using int size
+                int secondReadLen = bytesLeft + randomIntBetween(1, 100);
+                indexInput.readBytes(new byte[secondReadLen], 0, secondReadLen);
+                fail();
+            } catch (IOException ex) {
+                assertThat(ex.getMessage(), containsString("EOF"));
+            }
+        }
+    }
+
+    public void testSeekOverflow() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(StandardCharsets.UTF_8);
+            ByteArrayIndexInput indexInput = new ByteArrayIndexInput("test", input);
+            int firstReadLen = randomIntBetween(0, input.length - 1);
+            randomReadAndSlice(indexInput, firstReadLen);
+            try {
+                switch (randomIntBetween(0, 2)) {
+                    case 0:
+                        indexInput.seek(Integer.MAX_VALUE + 4L);
+                        break;
+                    case 1:
+                        indexInput.seek(-randomIntBetween(1, 10));
+                        break;
+                    case 2:
+                        int seek = input.length + randomIntBetween(1, 100);
+                        indexInput.seek(seek);
+                        break;
+                    default:
+                        fail();
+                }
+                fail();
+            } catch (IOException ex) {
+                assertThat(ex.getMessage(), containsString("EOF"));
+            } catch (IllegalArgumentException ex) {
+                assertThat(ex.getMessage(), containsString("negative position"));
+            }
+        }
+    }
+
+}
+

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -1,0 +1,527 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.apache.lucene.index.CorruptIndexException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterStateHealth;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.ShardLockObtainFailedException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.routing.UnassignedInfo.Reason.CLUSTER_RECOVERED;
+import static org.elasticsearch.cluster.routing.UnassignedInfo.Reason.INDEX_CREATED;
+import static org.elasticsearch.cluster.routing.UnassignedInfo.Reason.INDEX_REOPENED;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import javax.annotation.Nullable;
+
+public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
+
+    private final ShardId shardId = new ShardId("test", "_na_", 0);
+    private final DiscoveryNode node1 = newNode("node1");
+    private final DiscoveryNode node2 = newNode("node2");
+    private final DiscoveryNode node3 = newNode("node3");
+    private TestAllocator testAllocator;
+
+    @Before
+    public void buildTestAllocator() {
+        this.testAllocator = new TestAllocator();
+    }
+
+    private void allocateAllUnassigned(final RoutingAllocation allocation) {
+        final RoutingNodes.UnassignedShards.UnassignedIterator iterator = allocation.routingNodes().unassigned().iterator();
+        while (iterator.hasNext()) {
+            testAllocator.allocateUnassigned(iterator.next(), allocation, iterator);
+        }
+    }
+
+    @Test
+    public void testNoProcessPrimaryNotAllocatedBefore() {
+        final RoutingAllocation allocation;
+        // with old version, we can't know if a shard was allocated before or not
+        allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(),
+            randomFrom(INDEX_CREATED, CLUSTER_RECOVERED, INDEX_REOPENED));
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(false));
+        assertThat(allocation.routingNodes().unassigned().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().iterator().next().shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when async fetch returns that there is no data, the shard will not be allocated.
+     */
+    @Test
+    public void testNoAsyncFetchData() {
+        final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), CLUSTER_RECOVERED,
+            "allocId");
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests when the node returns that no data was found for it (null for allocation id),
+     * it will be moved to ignore unassigned.
+     */
+    @Test
+    public void testNoAllocationFound() {
+        final RoutingAllocation allocation =
+            routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), CLUSTER_RECOVERED, "allocId");
+        testAllocator.addData(node1, null, randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests when the node returns data with a shard allocation id that does not match active allocation ids, it will be moved to ignore
+     * unassigned.
+     */
+    @Test
+    public void testNoMatchingAllocationIdFound() {
+        RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), CLUSTER_RECOVERED, "id2");
+        testAllocator.addData(node1, "id1", randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests when the node returns that no data was found for it, it will be moved to ignore unassigned.
+     */
+    @Test
+    public void testStoreException() {
+        final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), CLUSTER_RECOVERED,
+            "allocId1");
+        testAllocator.addData(node1, "allocId1", randomBoolean(), new CorruptIndexException("test", "test"));
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when the node returns a ShardLockObtainFailedException, it will be considered as a valid shard copy
+     */
+    @Test
+    public void testShardLockObtainFailedException() {
+        final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), CLUSTER_RECOVERED,
+            "allocId1");
+        testAllocator.addData(node1, "allocId1", randomBoolean(), new ShardLockObtainFailedException(shardId, "test"));
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(),
+            equalTo(node1.getId()));
+        // check that allocation id is reused
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).allocationId().getId(),
+            equalTo("allocId1"));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when one node returns a ShardLockObtainFailedException and another properly loads the store, it will
+     * select the second node as target
+     */
+    @Test
+    public void testShardLockObtainFailedExceptionPreferOtherValidCopies() {
+        String allocId1 = randomAlphaOfLength(10);
+        String allocId2 = randomAlphaOfLength(10);
+        final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), CLUSTER_RECOVERED,
+            allocId1, allocId2);
+        testAllocator.addData(node1, allocId1, randomBoolean(),
+            new ShardLockObtainFailedException(shardId, "test"));
+        testAllocator.addData(node2, allocId2, randomBoolean(), null);
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(),
+            equalTo(node2.getId()));
+        // check that allocation id is reused
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).allocationId().getId(),
+            equalTo(allocId2));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when there is a node to allocate the shard to, it will be allocated to it.
+     */
+    @Test
+    public void testFoundAllocationAndAllocating() {
+        final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(),
+            randomFrom(CLUSTER_RECOVERED, INDEX_REOPENED), "allocId1");
+        testAllocator.addData(node1, "allocId1", randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(),
+            equalTo(node1.getId()));
+        // check that allocation id is reused
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).allocationId().getId(),
+            equalTo("allocId1"));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when the nodes with prior copies of the given shard all return a decision of NO, but
+     * {@link AllocationDecider#canForceAllocatePrimary(ShardRouting, RoutingNode, RoutingAllocation)}
+     * returns a YES decision for at least one of those NO nodes, then we force allocate to one of them
+     */
+    @Test
+    public void testForceAllocatePrimary() {
+        testAllocator.addData(node1, "allocId1", randomBoolean());
+        AllocationDeciders deciders = new AllocationDeciders(Arrays.asList(
+            // since the deciders return a NO decision for allocating a shard (due to the guaranteed NO decision from the second decider),
+            // the allocator will see if it can force assign the primary, where the decision will be YES
+            new TestAllocateDecision(randomBoolean() ? Decision.YES : Decision.NO), getNoDeciderThatAllowsForceAllocate()
+        ));
+        RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(deciders, CLUSTER_RECOVERED, "allocId1");
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertTrue(allocation.routingNodes().unassigned().ignored().isEmpty());
+        assertEquals(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), 1);
+        assertEquals(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), node1.getId());
+    }
+
+    /**
+     * Tests that when the nodes with prior copies of the given shard all return a decision of NO, and
+     * {@link AllocationDecider#canForceAllocatePrimary(ShardRouting, RoutingNode, RoutingAllocation)}
+     * returns a NO or THROTTLE decision for a node, then we do not force allocate to that node.
+     */
+    @Test
+    public void testDontAllocateOnNoOrThrottleForceAllocationDecision() {
+        testAllocator.addData(node1, "allocId1", randomBoolean());
+        boolean forceDecisionNo = randomBoolean();
+        AllocationDeciders deciders = new AllocationDeciders(Arrays.asList(
+            // since both deciders here return a NO decision for allocating a shard,
+            // the allocator will see if it can force assign the primary, where the decision will be either NO or THROTTLE,
+            // so the shard will remain un-initialized
+            new TestAllocateDecision(Decision.NO), forceDecisionNo ? getNoDeciderThatDeniesForceAllocate() :
+                                                                     getNoDeciderThatThrottlesForceAllocate()
+        ));
+        RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(deciders, CLUSTER_RECOVERED, "allocId1");
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        List<ShardRouting> ignored = allocation.routingNodes().unassigned().ignored();
+        assertEquals(ignored.size(), 1);
+        assertEquals(ignored.get(0).unassignedInfo().getLastAllocationStatus(),
+            forceDecisionNo ? AllocationStatus.DECIDERS_NO : AllocationStatus.DECIDERS_THROTTLED);
+        assertTrue(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).isEmpty());
+    }
+
+    /**
+     * Tests that when the nodes with prior copies of the given shard return a THROTTLE decision,
+     * then we do not force allocate to that node but instead throttle.
+     */
+    @Test
+    public void testDontForceAllocateOnThrottleDecision() {
+        testAllocator.addData(node1, "allocId1", randomBoolean());
+        AllocationDeciders deciders = new AllocationDeciders(Arrays.asList(
+            // since we have a NO decision for allocating a shard (because the second decider returns a NO decision),
+            // the allocator will see if it can force assign the primary, and in this case,
+            // the TestAllocateDecision's decision for force allocating is to THROTTLE (using
+            // the default behavior) so despite the other decider's decision to return YES for
+            // force allocating the shard, we still THROTTLE due to the decision from TestAllocateDecision
+            new TestAllocateDecision(Decision.THROTTLE), getNoDeciderThatAllowsForceAllocate()
+        ));
+        RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(deciders, CLUSTER_RECOVERED, "allocId1");
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        List<ShardRouting> ignored = allocation.routingNodes().unassigned().ignored();
+        assertEquals(ignored.size(), 1);
+        assertEquals(ignored.get(0).unassignedInfo().getLastAllocationStatus(), AllocationStatus.DECIDERS_THROTTLED);
+        assertTrue(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).isEmpty());
+    }
+
+    /**
+     * Tests that when there was a node that previously had the primary, it will be allocated to that same node again.
+     */
+    @Test
+    public void testPreferAllocatingPreviousPrimary() {
+        String primaryAllocId = UUIDs.randomBase64UUID();
+        String replicaAllocId = UUIDs.randomBase64UUID();
+        RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(),
+            randomFrom(CLUSTER_RECOVERED, INDEX_REOPENED), primaryAllocId, replicaAllocId);
+        boolean node1HasPrimaryShard = randomBoolean();
+        testAllocator.addData(node1, node1HasPrimaryShard ? primaryAllocId : replicaAllocId, node1HasPrimaryShard);
+        testAllocator.addData(node2, node1HasPrimaryShard ? replicaAllocId : primaryAllocId, !node1HasPrimaryShard);
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        DiscoveryNode allocatedNode = node1HasPrimaryShard ? node1 : node2;
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(),
+            equalTo(allocatedNode.getId()));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when there is a node to allocate to, but it is throttling (and it is the only one),
+     * it will be moved to ignore unassigned until it can be allocated to.
+     */
+    @Test
+    public void testFoundAllocationButThrottlingDecider() {
+        final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(throttleAllocationDeciders(), CLUSTER_RECOVERED,
+            "allocId1");
+        testAllocator.addData(node1, "allocId1", randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when there is a node to be allocated to, but it the decider said "no", we still
+     * force the allocation to it.
+     */
+    @Test
+    public void testFoundAllocationButNoDecider() {
+        final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(noAllocationDeciders(), CLUSTER_RECOVERED,
+            "allocId1");
+        testAllocator.addData(node1, "allocId1", randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(),
+            equalTo(node1.getId()));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when restoring from a snapshot and we find a node with a shard copy and allocation
+     * deciders say yes, we allocate to that node.
+     */
+    @Test
+    public void testRestore() {
+        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), "allocId");
+        testAllocator.addData(node1, "some allocId", randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when restoring from a snapshot and we find a node with a shard copy and allocation
+     * deciders say throttle, we add it to ignored shards.
+     */
+    @Test
+    public void testRestoreThrottle() {
+        RoutingAllocation allocation = getRestoreRoutingAllocation(throttleAllocationDeciders(), "allocId");
+        testAllocator.addData(node1, "some allocId", randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(false));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when restoring from a snapshot and we find a node with a shard copy but allocation
+     * deciders say no, we still allocate to that node.
+     */
+    @Test
+    public void testRestoreForcesAllocateIfShardAvailable() {
+        RoutingAllocation allocation = getRestoreRoutingAllocation(noAllocationDeciders(), "allocId");
+        testAllocator.addData(node1, "some allocId", randomBoolean());
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    /**
+     * Tests that when restoring from a snapshot and we don't find a node with a shard copy, the shard will remain in
+     * the unassigned list to be allocated later.
+     */
+    @Test
+    public void testRestoreDoesNotAssignIfNoShardAvailable() {
+        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), "allocId");
+        testAllocator.addData(node1, null, false);
+        allocateAllUnassigned(allocation);
+        assertThat(allocation.routingNodesChanged(), equalTo(false));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().size(), equalTo(1));
+        assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
+    }
+
+    private RoutingAllocation getRestoreRoutingAllocation(AllocationDeciders allocationDeciders, String... allocIds) {
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder(shardId.getIndexName()).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0)
+                .putInSyncAllocationIds(0, Set.of(allocIds)))
+            .build();
+
+        final Snapshot snapshot = new Snapshot("test", new SnapshotId("test", UUIDs.randomBase64UUID()));
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsRestore(metadata.index(shardId.getIndex()),
+                new SnapshotRecoverySource(UUIDs.randomBase64UUID(), snapshot, Version.CURRENT,
+                    new IndexId(shardId.getIndexName(), UUIDs.randomBase64UUID(random()))))
+            .build();
+        ClusterState state = ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTable)
+            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3)).build();
+        return new RoutingAllocation(allocationDeciders, new RoutingNodes(state, false), state, null, System.nanoTime());
+    }
+
+    private RoutingAllocation routingAllocationWithOnePrimaryNoReplicas(AllocationDeciders deciders, UnassignedInfo.Reason reason,
+                                                                        String... activeAllocationIds) {
+        Metadata metadata = Metadata.builder()
+                .put(IndexMetadata.builder(shardId.getIndexName()).settings(settings(Version.CURRENT))
+                    .numberOfShards(1).numberOfReplicas(0).putInSyncAllocationIds(shardId.id(), Set.of(activeAllocationIds)))
+                .build();
+        RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
+        switch (reason) {
+
+            case INDEX_CREATED:
+                routingTableBuilder.addAsNew(metadata.index(shardId.getIndex()));
+                break;
+            case CLUSTER_RECOVERED:
+                routingTableBuilder.addAsRecovery(metadata.index(shardId.getIndex()));
+                break;
+            case INDEX_REOPENED:
+                routingTableBuilder.addAsFromCloseToOpen(metadata.index(shardId.getIndex()));
+                break;
+            default:
+                throw new IllegalArgumentException("can't do " + reason + " for you. teach me");
+        }
+        ClusterState state = ClusterState.builder(org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(routingTableBuilder.build())
+                .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3)).build();
+        return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, null, System.nanoTime());
+    }
+
+    private void assertClusterHealthStatus(RoutingAllocation allocation, ClusterHealthStatus expectedStatus) {
+        RoutingTable oldRoutingTable = allocation.routingTable();
+        RoutingNodes newRoutingNodes = allocation.routingNodes();
+        final RoutingTable newRoutingTable = new RoutingTable.Builder()
+                                                             .updateNodes(oldRoutingTable.version(), newRoutingNodes)
+                                                             .build();
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster"))
+                                                .routingTable(newRoutingTable)
+                                                .build();
+        ClusterStateHealth clusterStateHealth = new ClusterStateHealth(clusterState);
+        assertThat(clusterStateHealth.getStatus().ordinal(), lessThanOrEqualTo(expectedStatus.ordinal()));
+    }
+
+    private AllocationDecider getNoDeciderThatAllowsForceAllocate() {
+        return getNoDeciderWithForceAllocate(Decision.YES);
+    }
+
+    private AllocationDecider getNoDeciderThatThrottlesForceAllocate() {
+        return getNoDeciderWithForceAllocate(Decision.THROTTLE);
+    }
+
+    private AllocationDecider getNoDeciderThatDeniesForceAllocate() {
+        return getNoDeciderWithForceAllocate(Decision.NO);
+    }
+
+    private AllocationDecider getNoDeciderWithForceAllocate(final Decision forceAllocateDecision) {
+        return new TestAllocateDecision(Decision.NO) {
+            @Override
+            public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                assert shardRouting.primary() : "cannot force allocate a non-primary shard " + shardRouting;
+                return forceAllocateDecision;
+            }
+        };
+    }
+
+    class TestAllocator extends PrimaryShardAllocator {
+
+        private Map<DiscoveryNode, TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> data;
+
+        public TestAllocator clear() {
+            data = null;
+            return this;
+        }
+
+        public TestAllocator addData(DiscoveryNode node, String allocationId, boolean primary) {
+            return addData(node, allocationId, primary, null);
+        }
+
+        public TestAllocator addData(DiscoveryNode node, String allocationId, boolean primary, @Nullable Exception storeException) {
+            if (data == null) {
+                data = new HashMap<>();
+            }
+            data.put(node,
+                new TransportNodesListGatewayStartedShards.NodeGatewayStartedShards(node, allocationId, primary, storeException));
+            return this;
+        }
+
+        @Override
+        protected AsyncShardFetch.FetchResult<TransportNodesListGatewayStartedShards.NodeGatewayStartedShards>
+                                                                        fetchData(ShardRouting shard, RoutingAllocation allocation) {
+            return new AsyncShardFetch.FetchResult<>(shardId, data, Collections.<String>emptySet());
+        }
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+package org.elasticsearch.common.lucene.store;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Test harness for verifying {@link IndexInput} implementations.
+ */
+public class ESIndexInputTestCase extends ESTestCase {
+
+    private static EsThreadPoolExecutor executor;
+
+    @BeforeClass
+    public static void createExecutor() {
+        final String name = "TEST-" + getTestClass().getSimpleName() + "#randomReadAndSlice";
+        executor = EsExecutors.newFixed(name, 10, 0, EsExecutors.daemonThreadFactory(name));
+    }
+
+    @AfterClass
+    public static void destroyExecutor() {
+        executor.shutdown();
+    }
+
+    /**
+     * Reads the contents of an {@link IndexInput} from {@code indexInput.getFilePointer()} to {@code length} using a wide variety of
+     * different access methods. Returns an array of length {@code length} containing the bytes that were read starting at index
+     * {@code indexInput.getFilePointer()}. The bytes of the returned array with indices below the initial value of
+     * {@code indexInput.getFilePointer()} may contain anything. The final value of {@code indexInput.getFilePointer()} is {@code length}.
+     */
+    protected byte[] randomReadAndSlice(IndexInput indexInput, int length) throws IOException {
+        int readPos = (int) indexInput.getFilePointer();
+        byte[] output = new byte[length];
+        while (readPos < length) {
+            switch (randomIntBetween(0, 5)) {
+                case 0:
+                    // Read by one byte at a time
+                    output[readPos++] = indexInput.readByte();
+                    break;
+                case 1:
+                    // Read several bytes into target
+                    int len = randomIntBetween(1, length - readPos);
+                    indexInput.readBytes(output, readPos, len);
+                    readPos += len;
+                    break;
+                case 2:
+                    // Read several bytes into 0-offset target
+                    len = randomIntBetween(1, length - readPos);
+                    byte[] temp = new byte[len];
+                    indexInput.readBytes(temp, 0, len);
+                    System.arraycopy(temp, 0, output, readPos, len);
+                    readPos += len;
+                    break;
+                case 3:
+                    // Read using slice
+                    len = randomIntBetween(1, length - readPos);
+                    IndexInput slice = indexInput.slice("slice (" + readPos + ", " + len + ") of " + indexInput, readPos, len);
+                    temp = randomReadAndSlice(slice, len);
+                    // assert that position in the original input didn't change
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    System.arraycopy(temp, 0, output, readPos, len);
+                    readPos += len;
+                    indexInput.seek(readPos);
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    break;
+                case 4:
+                    // Seek at a random position and read a single byte,
+                    // then seek back to original position
+                    final int lastReadPos = readPos;
+                    readPos = randomIntBetween(0, length - 1);
+                    indexInput.seek(readPos);
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    final int bytesToRead = 1;
+                    temp = randomReadAndSlice(indexInput, readPos + bytesToRead);
+                    System.arraycopy(temp, readPos, output, readPos, bytesToRead);
+                    readPos = lastReadPos;
+                    indexInput.seek(readPos);
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    break;
+                case 5:
+                    // Read clone or slice concurrently
+                    final int cloneCount = between(1, 3);
+                    final CountDownLatch startLatch = new CountDownLatch(1 + cloneCount);
+                    final CountDownLatch finishLatch = new CountDownLatch(cloneCount);
+
+                    final PlainActionFuture<byte[]> mainThreadResultFuture = new PlainActionFuture<>();
+                    final int mainThreadReadStart = readPos;
+                    final int mainThreadReadEnd = randomIntBetween(readPos + 1, length);
+
+                    for (int i = 0; i < cloneCount; i++) {
+                        executor.execute(new AbstractRunnable() {
+                            @Override
+                            public void onFailure(Exception e) {
+                                throw new AssertionError(e);
+                            }
+
+                            @Override
+                            protected void doRun() throws Exception {
+                                final IndexInput clone;
+                                final int readStart = between(0, length);
+                                final int readEnd = between(readStart, length);
+                                if (randomBoolean()) {
+                                    clone = indexInput.clone();
+                                } else {
+                                    final int sliceEnd = between(readEnd, length);
+                                    clone = indexInput.slice("concurrent slice (0, " + sliceEnd + ") of " + indexInput, 0L, sliceEnd);
+                                }
+                                startLatch.countDown();
+                                startLatch.await();
+                                clone.seek(readStart);
+                                final byte[] cloneResult = randomReadAndSlice(clone, readEnd);
+                                if (randomBoolean()) {
+                                    clone.close();
+                                }
+
+                                // the read from the clone should agree with the read from the main input on their overlap
+                                final int maxStart = Math.max(mainThreadReadStart, readStart);
+                                final int minEnd = Math.min(mainThreadReadEnd, readEnd);
+                                if (maxStart < minEnd) {
+                                    final byte[] mainThreadResult = mainThreadResultFuture.actionGet();
+                                    final int overlapLen = minEnd - maxStart;
+                                    final byte[] fromMainThread = new byte[overlapLen];
+                                    final byte[] fromClone = new byte[overlapLen];
+                                    System.arraycopy(mainThreadResult, maxStart, fromMainThread, 0, overlapLen);
+                                    System.arraycopy(cloneResult, maxStart, fromClone, 0, overlapLen);
+                                    assertArrayEquals(fromMainThread, fromClone);
+                                }
+                            }
+
+                            @Override
+                            public void onAfter() {
+                                finishLatch.countDown();
+                            }
+
+                            @Override
+                            public void onRejection(Exception e) {
+                                // all threads are busy, and queueing can lead this test to deadlock, so we need take no action
+                                startLatch.countDown();
+                            }
+                        });
+                    }
+
+                    try {
+                        startLatch.countDown();
+                        startLatch.await();
+                        ActionListener.completeWith(mainThreadResultFuture, () -> randomReadAndSlice(indexInput, mainThreadReadEnd));
+                        System.arraycopy(mainThreadResultFuture.actionGet(), readPos, output, readPos, mainThreadReadEnd - readPos);
+                        readPos = mainThreadReadEnd;
+                        finishLatch.await();
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                    break;
+                default:
+                    fail();
+            }
+            assertEquals(readPos, indexInput.getFilePointer());
+        }
+        assertEquals(length, indexInput.getFilePointer());
+        return output;
+    }
+
+}

--- a/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -46,6 +46,16 @@ public class BlobContainerWrapper implements BlobContainer {
     }
 
     @Override
+    public InputStream readBlob(String blobName, long position, long length) throws IOException {
+        return delegate.readBlob(blobName, position, length);
+    }
+
+    @Override
+    public long readBlobPreferredLength() {
+        return delegate.readBlobPreferredLength();
+    }
+
+    @Override
     public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
         delegate.writeBlob(blobName, inputStream, blobSize, failIfAlreadyExists);
     }

--- a/server/src/testFixtures/java/org/elasticsearch/test/gateway/TestGatewayAllocator.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/gateway/TestGatewayAllocator.java
@@ -99,13 +99,13 @@ public class TestGatewayAllocator extends GatewayAllocator {
     }
 
     @Override
-    public void applyStartedShards(RoutingAllocation allocation, List<ShardRouting> startedShards) {
+    public void applyStartedShards(List<ShardRouting> startedShards, RoutingAllocation allocation) {
         currentNodes = allocation.nodes();
         allocation.routingNodes().shards(ShardRouting::active).forEach(this::addKnownAllocation);
     }
 
     @Override
-    public void applyFailedShards(RoutingAllocation allocation, List<FailedShard> failedShards) {
+    public void applyFailedShards(List<FailedShard> failedShards, RoutingAllocation allocation) {
         currentNodes = allocation.nodes();
         for (FailedShard failedShard : failedShards) {
             final ShardRouting failedRouting = failedShard.getRoutingEntry();
@@ -120,9 +120,18 @@ public class TestGatewayAllocator extends GatewayAllocator {
     }
 
     @Override
-    public void allocateUnassigned(RoutingAllocation allocation) {
+    public void beforeAllocation(RoutingAllocation allocation) {
+    }
+
+    @Override
+    public void afterPrimariesBeforeReplicas(RoutingAllocation allocation) {
+    }
+
+    @Override
+    public void allocateUnassigned(ShardRouting shardRouting, RoutingAllocation allocation,
+                                   UnassignedAllocationHandler unassignedAllocationHandler) {
         currentNodes = allocation.nodes();
-        innerAllocatedUnassigned(allocation, primaryShardAllocator, replicaShardAllocator);
+        innerAllocatedUnassigned(allocation, primaryShardAllocator, replicaShardAllocator, shardRouting, unassignedAllocationHandler);
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a backport of #54803 for 7.x.

This pull request cherry picks the squashed commit from #54803 with the additional commits:

    6f50c92 which adjusts master code to 7.x
    a114549 to mute a failing ILM test (#54818)
    48cbca1 and 50186b2 that cleans up and fixes the previous test
    aae12bb that adds a missing feature flag (#54861)
    6f330e3 that adds missing serialization bits (#54864)
    bf72c02 that adjust the version in YAML tests
    a51955f that adds some plumbing for the transport client used in integration tests

https://github.com/elastic/elasticsearch/commit/4d36917e526113c0dff628c36269c25a9664af9d

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
