### PR TITLE
bp: Remove Redundant Cluster State during Snapshot INIT + Master Failover

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -431,7 +431,7 @@ should be crossed out as well.
 - [ ] 2f91e2aab78 Fix Race in Snapshot Abort (#54873) (#55233)
 - [ ] d8b43c62838 Make Snapshot Deletes Less Racy (#54765) (#55226)
 - [x] 156e5aa77f0 Fix testKeepTranslogAfterGlobalCheckpoint (#55868)
-- [ ] e164c9aaee5 Remove Redundant Cluster State during Snapshot INIT + Master Failover (#54420) (#55208)
+- [x] e164c9aaee5 Remove Redundant Cluster State during Snapshot INIT + Master Failover (#54420) (#55208)
 - [x] 48048646e79 Move Snapshot Status Related Method to Appropriate Places (#54558) (#55209)
 - [s] a610513ec76 Provide repository-level stats for searchable snapshots (#55051)
 - [s] 52bebec51f6 NodeInfo response should use a collection rather than fields (#54460) (#55132)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
    
Similar to #54395 we know that a snapshot in INIT state has not
written anything to the repository yet. If we see one from a master
failover, there is no point in moving it to ABORTED before removing it
from the cluster state in a subsequent CS update.
Instead, we can simply remove its job from the CS the first time
we see it on master failover and be done with it.

https://github.com/elastic/elasticsearch/commit/e164c9aaee549af930af12a373ec4080113d377e

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
