### PR TITLE
bp: Fix Race in Snapshot Abort

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -428,7 +428,7 @@ should be crossed out as well.
 - [ ] d7cded8d7a5 Fix updating include_in_parent/include_in_root of nested field. (#55326)
 - [ ] 7941f4a47e4 Add RepositoriesService to createComponents() args (#54814)
 - [ ] 8a565c4fa61 Voting config exclusions should work with absent nodes (#55291)
-- [ ] 2f91e2aab78 Fix Race in Snapshot Abort (#54873) (#55233)
+- [x] 2f91e2aab78 Fix Race in Snapshot Abort (#54873) (#55233)
 - [x] d8b43c62838 Make Snapshot Deletes Less Racy (#54765) (#55226)
 - [x] 156e5aa77f0 Fix testKeepTranslogAfterGlobalCheckpoint (#55868)
 - [x] e164c9aaee5 Remove Redundant Cluster State during Snapshot INIT + Master Failover (#54420) (#55208)

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -68,6 +68,7 @@ import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusters;
 
+import io.crate.common.collections.Tuple;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.SQLExceptions;
@@ -270,7 +271,7 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                                  boolean includeGlobalState,
                                  Metadata clusterMetadata,
                                  Version repositoryMetaVersion,
-                                 ActionListener<SnapshotInfo> listener) {
+                                 ActionListener<Tuple<RepositoryData, SnapshotInfo>> listener) {
         throw new UnsupportedOperationException("Operation not permitted");
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -48,6 +48,7 @@ import org.elasticsearch.snapshots.SnapshotShardFailure;
 
 import io.crate.action.FutureActionListener;
 import io.crate.analyze.repositories.TypeSettings;
+import io.crate.common.collections.Tuple;
 
 /**
  * An interface for interacting with a repository in snapshot and restore.
@@ -167,12 +168,13 @@ public interface Repository extends LifecycleComponent {
      * @param includeGlobalState    include cluster global state
      * @param clusterMetadata       cluster metadata
      * @param repositoryMetaVersion version of the updated repository metadata to write
-     * @param listener              listener to be called on completion of the snapshot
+     * @param listener              listener to be invoked with the new {@link RepositoryData} and the snapshot's {@link SnapshotInfo}
+     *                              completion of the snapshot
      */
     void finalizeSnapshot(SnapshotId snapshotId, ShardGenerations shardGenerations, long startTime, String failure,
                           int totalShards, List<SnapshotShardFailure> shardFailures, long repositoryStateId,
                           boolean includeGlobalState, Metadata clusterMetadata,
-                          Version repositoryMetaVersion, ActionListener<SnapshotInfo> listener);
+                          Version repositoryMetaVersion, ActionListener<Tuple<RepositoryData, SnapshotInfo>> listener);
 
     /**
      * Deletes snapshot

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -895,7 +895,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                  final boolean includeGlobalState,
                                  final Metadata clusterMetadata,
                                  Version repositoryMetaVersion,
-                                 final ActionListener<SnapshotInfo> listener) {
+                                 final ActionListener<Tuple<RepositoryData, SnapshotInfo>> listener) {
         assert repositoryStateId > RepositoryData.UNKNOWN_REPO_GEN :
             "Must finalize based on a valid repository generation but received [" + repositoryStateId + "]";
         final Collection<IndexId> indices = shardGenerations.indices();
@@ -913,11 +913,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 getRepositoryData(ActionListener.wrap(existingRepositoryData -> {
                     final RepositoryData updatedRepositoryData =
                         existingRepositoryData.addSnapshot(snapshotId, snapshotInfo.state(), Version.CURRENT, shardGenerations);
-                    writeIndexGen(updatedRepositoryData, repositoryStateId, writeShardGens, ActionListener.wrap(v -> {
+                    writeIndexGen(updatedRepositoryData, repositoryStateId, writeShardGens, ActionListener.wrap(writtenRepoData -> {
                         if (writeShardGens) {
                             cleanupOldShardGens(existingRepositoryData, updatedRepositoryData);
                         }
-                        listener.onResponse(snapshotInfo);
+                        listener.onResponse(new Tuple<>(writtenRepoData, snapshotInfo));
                     }, onUpdateFailure));
                 }, onUpdateFailure));
             }, onUpdateFailure), 2 + indices.size());
@@ -1326,7 +1326,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param writeShardGens whether to write {@link ShardGenerations} to the new {@link RepositoryData} blob
      * @param listener       completion listener
      */
-    protected void writeIndexGen(RepositoryData repositoryData, long expectedGen, boolean writeShardGens, ActionListener<Void> listener) {
+    protected void writeIndexGen(RepositoryData repositoryData, long expectedGen, boolean writeShardGens,
+                                 ActionListener<RepositoryData> listener) {
         assert isReadOnly() == false; // can not write to a read only repository
         final long currentGen = repositoryData.getGenId();
         if (currentGen != expectedGen) {
@@ -1489,8 +1490,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
                     @Override
                     public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        cacheRepositoryData(filteredRepositoryData.withGenId(newGen));
-                        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.run(listener, () -> {
+                        final RepositoryData writtenRepositoryData = filteredRepositoryData.withGenId(newGen);
+                        cacheRepositoryData(writtenRepositoryData);
+                        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
                             // Delete all now outdated index files up to 1000 blobs back from the new generation.
                             // If there are more than 1000 dangling index-N cleanup functionality on repo delete will take care of them.
                             // Deleting one older than the current expectedGen is done for BwC reasons as older versions used to keep
@@ -1504,6 +1506,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             } catch (IOException e) {
                                 LOGGER.warn("Failed to clean up old index blobs {}", oldIndexN);
                             }
+                            return writtenRepositoryData;
                         }));
                     }
                 });

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
@@ -183,7 +183,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
     }
 
     private static void writeIndexGen(BlobStoreRepository repository, RepositoryData repositoryData, long generation) {
-        final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        final PlainActionFuture<RepositoryData> future = PlainActionFuture.newFuture();
         repository.writeIndexGen(repositoryData, generation, true, future);
         future.actionGet();
     }

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
@@ -38,12 +38,15 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.ShardGenerations;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.test.ESTestCase;
+
+import io.crate.common.collections.Tuple;
 
 public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
 
@@ -136,7 +139,7 @@ public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
         }
     }
 
-    public void testOverwriteSnapshotInfoBlob() {
+    public void testOverwriteSnapshotInfoBlob() throws Exception {
         MockEventuallyConsistentRepository.Context blobStoreContext = new MockEventuallyConsistentRepository.Context();
         final RepositoryMetadata metaData = new RepositoryMetadata("testRepo", "mockEventuallyConsistent", Settings.EMPTY);
         final ClusterService clusterService = BlobStoreTestUtil.mockClusterService(metaData);
@@ -148,30 +151,24 @@ public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
             repository.start();
 
             // We create a snap- blob for snapshot "foo" in the first generation
-            final PlainActionFuture<SnapshotInfo> future = PlainActionFuture.newFuture();
             final SnapshotId snapshotId = new SnapshotId("foo", UUIDs.randomBase64UUID());
-            // We try to write another snap- blob for "foo" in the next generation. It fails because the content differs.
-            repository.finalizeSnapshot(snapshotId, ShardGenerations.EMPTY, 1L, null, 5, Collections.emptyList(),
-                                        -1L, false, Metadata.EMPTY_METADATA, Version.CURRENT, future);
-            future.actionGet();
+            PlainActionFuture.<Tuple<RepositoryData, SnapshotInfo>, Exception>get(f ->
+                // We try to write another snap- blob for "foo" in the next generation. It fails because the content differs.
+                repository.finalizeSnapshot(snapshotId, ShardGenerations.EMPTY, 1L, null, 5, Collections.emptyList(),
+                    -1L, false, Metadata.EMPTY_METADATA, Version.CURRENT, f));
 
             // We try to write another snap- blob for "foo" in the next generation. It fails because the content differs.
             final AssertionError assertionError = expectThrows(AssertionError.class,
-                                                               () -> {
-                                                                   final PlainActionFuture<SnapshotInfo> fut = PlainActionFuture.newFuture();
-                                                                   repository.finalizeSnapshot(
-                                                                       snapshotId, ShardGenerations.EMPTY, 1L, null, 6, Collections.emptyList(),
-                                                                       0, false, Metadata.EMPTY_METADATA,  Version.CURRENT, fut);
-                                                                   fut.actionGet();
-                                                               });
+                () -> PlainActionFuture.<Tuple<RepositoryData, SnapshotInfo>, Exception>get(f ->
+                    repository.finalizeSnapshot(snapshotId, ShardGenerations.EMPTY, 1L, null, 6, Collections.emptyList(),
+                        0, false, Metadata.EMPTY_METADATA, Version.CURRENT, f)));
             assertThat(assertionError.getMessage(), equalTo("\nExpected: <6>\n     but: was <5>"));
 
             // We try to write yet another snap- blob for "foo" in the next generation.
             // It passes cleanly because the content of the blob except for the timestamps.
-            final PlainActionFuture<SnapshotInfo> future2 = PlainActionFuture.newFuture();
-            repository.finalizeSnapshot(snapshotId, ShardGenerations.EMPTY, 1L, null, 5, Collections.emptyList(),
-                                        0, false, Metadata.EMPTY_METADATA, Version.CURRENT, future2);
-            future2.actionGet();
+            PlainActionFuture.<Tuple<RepositoryData, SnapshotInfo>, Exception>get(f ->
+                repository.finalizeSnapshot(snapshotId, ShardGenerations.EMPTY, 1L, null, 5, Collections.emptyList(),
+                    0, false, Metadata.EMPTY_METADATA, Version.CURRENT, f));
         }
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -52,6 +52,8 @@ import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
 
 import javax.annotation.Nullable;
 
+import io.crate.common.collections.Tuple;
+
 public abstract class RestoreOnlyRepository implements Repository {
 
     private final String indexName;
@@ -108,7 +110,7 @@ public abstract class RestoreOnlyRepository implements Repository {
                                  boolean includeGlobalState,
                                  Metadata clusterMetadata,
                                  Version repositoryMetaVersion,
-                                 ActionListener<SnapshotInfo> listener) {
+                                 ActionListener<Tuple<RepositoryData, SnapshotInfo>> listener) {
         listener.onResponse(null);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
    
We can be a little more efficient when aborting a snapshot. Since we know the new repository
data after finalizing the aborted snapshot when can pass it down to the snapshot completion listeners.
This way, we don't have to fork off to the snapshot threadpool to get the repository data when the listener completes and can directly submit the delete task with high priority straight from the cluster state thread.

https://github.com/elastic/elasticsearch/commit/2f91e2aab7867c8a180e90f7f42de123889aad09

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
