### PR TITLE
bp: Voting config exclusions should work with absent nodes

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -427,7 +427,7 @@ should be crossed out as well.
 - [ ] 22c55180c11 [7.x] Backport ValuesSourceRegistry and related work (#54922)
 - [ ] d7cded8d7a5 Fix updating include_in_parent/include_in_root of nested field. (#55326)
 - [ ] 7941f4a47e4 Add RepositoriesService to createComponents() args (#54814)
-- [ ] 8a565c4fa61 Voting config exclusions should work with absent nodes (#55291)
+- [x] 8a565c4fa61 Voting config exclusions should work with absent nodes (#55291)
 - [x] 2f91e2aab78 Fix Race in Snapshot Abort (#54873) (#55233)
 - [x] d8b43c62838 Make Snapshot Deletes Less Racy (#54765) (#55226)
 - [x] 156e5aa77f0 Fix testKeepTranslogAfterGlobalCheckpoint (#55868)

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -19,69 +19,143 @@
 
 package org.elasticsearch.action.admin.cluster.configuration;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import io.crate.common.unit.TimeValue;
+import org.elasticsearch.common.logging.DeprecationLogger;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
+import io.crate.common.unit.TimeValue;
 
 /**
  * A request to add voting config exclusions for certain master-eligible nodes, and wait for these nodes to be removed from the voting
  * configuration.
  */
 public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotingConfigExclusionsRequest> {
+    public static final String DEPRECATION_MESSAGE = "nodeDescription is deprecated and will be removed, use nodeIds or nodeNames instead";
+    static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(
+                                                                        LogManager.getLogger(AddVotingConfigExclusionsRequest.class));
     private final String[] nodeDescriptions;
+    private final String[] nodeIds;
+    private final String[] nodeNames;
     private final TimeValue timeout;
 
     /**
-     * Construct a request to add voting config exclusions for master-eligible nodes matching the given descriptions, and wait for a
+     * Construct a request to add voting config exclusions for master-eligible nodes matching the given node names, and wait for a
      * default 30 seconds for these exclusions to take effect, removing the nodes from the voting configuration.
-     * @param nodeDescriptions Descriptions of the nodes to add - see {@link DiscoveryNodes#resolveNodes(String...)}
+     * @param nodeNames Names of the nodes to add - see {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}
      */
-    public AddVotingConfigExclusionsRequest(String[] nodeDescriptions) {
-        this(nodeDescriptions, TimeValue.timeValueSeconds(30));
+    public AddVotingConfigExclusionsRequest(String... nodeNames) {
+        this(Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY, nodeNames, TimeValue.timeValueSeconds(30));
     }
 
     /**
      * Construct a request to add voting config exclusions for master-eligible nodes matching the given descriptions, and wait for these
      * nodes to be removed from the voting configuration.
      * @param nodeDescriptions Descriptions of the nodes whose exclusions to add - see {@link DiscoveryNodes#resolveNodes(String...)}.
+     * @param nodeIds Ids of the nodes whose exclusions to add - see
+     *                  {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}.
+     * @param nodeNames Names of the nodes whose exclusions to add - see
+     *                  {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}.
      * @param timeout How long to wait for the added exclusions to take effect and be removed from the voting configuration.
      */
-    public AddVotingConfigExclusionsRequest(String[] nodeDescriptions, TimeValue timeout) {
+    public AddVotingConfigExclusionsRequest(String[] nodeDescriptions, String[] nodeIds, String[] nodeNames, TimeValue timeout) {
         if (timeout.compareTo(TimeValue.ZERO) < 0) {
             throw new IllegalArgumentException("timeout [" + timeout + "] must be non-negative");
         }
+
+        if (noneOrMoreThanOneIsSet(nodeDescriptions, nodeIds, nodeNames)) {
+            throw new IllegalArgumentException("Please set node identifiers correctly. " +
+                "One and only one of [node_name], [node_names] and [node_ids] has to be set");
+        }
+
+        System.out.println("nodeDescs: " + nodeDescriptions);
+        if (nodeDescriptions.length > 0) {
+            DEPRECATION_LOGGER.deprecatedAndMaybeLog("voting_config_exclusion", DEPRECATION_MESSAGE);
+        }
+
         this.nodeDescriptions = nodeDescriptions;
+        this.nodeIds = nodeIds;
+        this.nodeNames = nodeNames;
         this.timeout = timeout;
     }
 
     public AddVotingConfigExclusionsRequest(StreamInput in) throws IOException {
         super(in);
         nodeDescriptions = in.readStringArray();
+        if (in.getVersion().onOrAfter(Version.V_5_1_0)) {
+            nodeIds = in.readStringArray();
+            nodeNames = in.readStringArray();
+        } else {
+            nodeIds = Strings.EMPTY_ARRAY;
+            nodeNames = Strings.EMPTY_ARRAY;
+        }
         timeout = in.readTimeValue();
+
+        if (nodeDescriptions.length > 0) {
+            DEPRECATION_LOGGER.deprecatedAndMaybeLog("voting_config_exclusion",
+                "nodeDescription is deprecated and will be removed, use nodeIds or nodeNames instead");
+        }
+
     }
 
     Set<VotingConfigExclusion> resolveVotingConfigExclusions(ClusterState currentState) {
         final DiscoveryNodes allNodes = currentState.nodes();
-        final Set<VotingConfigExclusion> resolvedNodes = Arrays.stream(allNodes.resolveNodes(nodeDescriptions))
-                .map(allNodes::get).filter(DiscoveryNode::isMasterEligibleNode).map(VotingConfigExclusion::new).collect(Collectors.toSet());
+        Set<VotingConfigExclusion> newVotingConfigExclusions = new HashSet<>();
 
-        if (resolvedNodes.isEmpty()) {
-            throw new IllegalArgumentException("add voting config exclusions request for " + Arrays.asList(nodeDescriptions)
-                + " matched no master-eligible nodes");
+        if (nodeDescriptions.length >= 1) {
+            newVotingConfigExclusions = Arrays.stream(allNodes.resolveNodes(nodeDescriptions)).map(allNodes::get)
+                .filter(DiscoveryNode::isMasterEligibleNode).map(VotingConfigExclusion::new).collect(Collectors.toSet());
+
+            if (newVotingConfigExclusions.isEmpty()) {
+                throw new IllegalArgumentException("add voting config exclusions request for " + Arrays.asList(nodeDescriptions)
+                    + " matched no master-eligible nodes");
+            }
+        } else if (nodeIds.length >= 1) {
+            for (String nodeId : nodeIds) {
+                if (allNodes.nodeExists(nodeId)) {
+                    DiscoveryNode discoveryNode = allNodes.get(nodeId);
+                    if (discoveryNode.isMasterEligibleNode()) {
+                        newVotingConfigExclusions.add(new VotingConfigExclusion(discoveryNode));
+                    }
+                } else {
+                    newVotingConfigExclusions.add(new VotingConfigExclusion(nodeId, VotingConfigExclusion.MISSING_VALUE_MARKER));
+                }
+            }
+        } else {
+            assert nodeNames.length >= 1;
+            Map<String, DiscoveryNode> existingNodes = StreamSupport.stream(allNodes.spliterator(), false)
+                                                                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity()));
+
+            for (String nodeName : nodeNames) {
+                if (existingNodes.containsKey(nodeName)) {
+                    DiscoveryNode discoveryNode = existingNodes.get(nodeName);
+                    if (discoveryNode.isMasterEligibleNode()) {
+                        newVotingConfigExclusions.add(new VotingConfigExclusion(discoveryNode));
+                    }
+                } else {
+                    newVotingConfigExclusions.add(new VotingConfigExclusion(VotingConfigExclusion.MISSING_VALUE_MARKER, nodeName));
+                }
+            }
         }
 
-        resolvedNodes.removeIf(n -> currentState.getVotingConfigExclusions().contains(n));
-        return resolvedNodes;
+        newVotingConfigExclusions.removeIf(n -> currentState.getVotingConfigExclusions().contains(n));
+        return newVotingConfigExclusions;
     }
 
     Set<VotingConfigExclusion> resolveVotingConfigExclusionsAndCheckMaximum(ClusterState currentState, int maxExclusionsCount,
@@ -99,11 +173,35 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
         return resolvedExclusions;
     }
 
+    private boolean noneOrMoreThanOneIsSet(String[] deprecatedNodeDescription, String[] nodeIds, String[] nodeNames) {
+        if (deprecatedNodeDescription.length > 0) {
+            return nodeIds.length > 0 || nodeNames.length > 0;
+        } else if (nodeIds.length > 0) {
+            return nodeNames.length > 0;
+        } else {
+            return nodeNames.length > 0 == false;
+        }
+    }
+
     /**
      * @return descriptions of the nodes for whom to add voting config exclusions.
      */
     public String[] getNodeDescriptions() {
         return nodeDescriptions;
+    }
+
+    /**
+     * @return ids of the nodes for whom to add voting config exclusions.
+     */
+    public String[] getNodeIds() {
+        return nodeIds;
+    }
+
+    /**
+     * @return names of the nodes for whom to add voting config exclusions.
+     */
+    public String[] getNodeNames() {
+        return nodeNames;
     }
 
     /**
@@ -117,14 +215,20 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(nodeDescriptions);
+        if (out.getVersion().onOrAfter(Version.V_5_1_0)) {
+            out.writeStringArray(nodeIds);
+            out.writeStringArray(nodeNames);
+        }
         out.writeTimeValue(timeout);
     }
 
     @Override
     public String toString() {
         return "AddVotingConfigExclusionsRequest{" +
-            "nodeDescriptions=" + Arrays.asList(nodeDescriptions) +
-            ", timeout=" + timeout +
+            "nodeDescriptions=" + Arrays.asList(nodeDescriptions) + ", " +
+            "nodeIds=" + Arrays.asList(nodeIds) + ", " +
+            "nodeNames=" + Arrays.asList(nodeNames) + ", " +
+            "timeout=" + timeout +
             '}';
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -235,6 +235,7 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
     }
 
     public static class VotingConfigExclusion implements Writeable, ToXContentFragment {
+        public static final String MISSING_VALUE_MARKER = "_absent_";
         private final String nodeId;
         private final String nodeName;
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -871,6 +871,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     // Package-private for testing
     ClusterState improveConfiguration(ClusterState clusterState) {
         assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
+        assert validVotingConfigExclusionState(clusterState) : clusterState;
 
         // exclude any nodes whose ID is in the voting config exclusions list ...
         final Stream<String> excludedNodeIds = clusterState.getVotingConfigExclusions().stream().map(VotingConfigExclusion::getNodeId);
@@ -896,6 +897,31 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     .lastAcceptedConfiguration(newConfig).build())).build();
         }
         return clusterState;
+    }
+
+    /*
+    * Valid Voting Configuration Exclusion state criteria:
+    * 1. Every voting config exclusion with an ID of _absent_ should not match any nodes currently in the cluster by name
+    * 2. Every voting config exclusion with a name of _absent_ should not match any nodes currently in the cluster by ID
+     */
+    static boolean validVotingConfigExclusionState(ClusterState clusterState) {
+        Set<VotingConfigExclusion> votingConfigExclusions = clusterState.getVotingConfigExclusions();
+        Set<String> nodeNamesWithAbsentId = votingConfigExclusions.stream()
+                                                .filter(e -> e.getNodeId().equals(VotingConfigExclusion.MISSING_VALUE_MARKER))
+                                                .map(VotingConfigExclusion::getNodeName)
+                                                .collect(Collectors.toSet());
+        Set<String> nodeIdsWithAbsentName = votingConfigExclusions.stream()
+                                                .filter(e -> e.getNodeName().equals(VotingConfigExclusion.MISSING_VALUE_MARKER))
+                                                .map(VotingConfigExclusion::getNodeId)
+                                                .collect(Collectors.toSet());
+        for (DiscoveryNode node : clusterState.getNodes()) {
+            if (node.isMasterEligibleNode() &&
+                (nodeIdsWithAbsentName.contains(node.getId()) || nodeNamesWithAbsentId.contains(node.getName()))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private AtomicBoolean reconfigurationTaskScheduled = new AtomicBoolean();

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
@@ -37,8 +37,12 @@ import org.elasticsearch.common.Priority;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 
@@ -124,6 +128,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         // we only enforce major version transitions on a fully formed clusters
         final boolean enforceMajorVersion = currentState.getBlocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) == false;
         // processing any joins
+        Map<String, String> joiniedNodeNameIds = new HashMap<>();
         for (final Task joinTask : joiningNodes) {
             if (joinTask.isBecomeMasterTask() || joinTask.isFinishElectionTask()) {
                 // noop
@@ -143,6 +148,9 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
                     nodesChanged = true;
                     minClusterNodeVersion = Version.min(minClusterNodeVersion, node.getVersion());
                     maxClusterNodeVersion = Version.max(maxClusterNodeVersion, node.getVersion());
+                    if (node.isMasterEligibleNode()) {
+                        joiniedNodeNameIds.put(node.getName(), node.getId());
+                    }
                 } catch (IllegalArgumentException | IllegalStateException e) {
                     results.failure(joinTask, e);
                     continue;
@@ -150,10 +158,36 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
             }
             results.success(joinTask);
         }
+
         if (nodesChanged) {
             rerouteService.reroute("post-join reroute", Priority.HIGH, ActionListener.wrap(
                 r -> logger.trace("post-join reroute completed"),
                 e -> logger.debug("post-join reroute failed", e)));
+
+            if (joiniedNodeNameIds.isEmpty() == false) {
+                Set<CoordinationMetadata.VotingConfigExclusion> currentVotingConfigExclusions = currentState.getVotingConfigExclusions();
+                Set<CoordinationMetadata.VotingConfigExclusion> newVotingConfigExclusions = currentVotingConfigExclusions.stream()
+                    .map(e -> {
+                        // Update nodeId in VotingConfigExclusion when a new node with excluded node name joins
+                        if (CoordinationMetadata.VotingConfigExclusion.MISSING_VALUE_MARKER.equals(e.getNodeId()) &&
+                            joiniedNodeNameIds.containsKey(e.getNodeName())) {
+                            return new CoordinationMetadata.VotingConfigExclusion(joiniedNodeNameIds.get(e.getNodeName()), e.getNodeName());
+                        } else {
+                            return e;
+                        }
+                    }).collect(Collectors.toSet());
+
+                // if VotingConfigExclusions did get updated
+                if (newVotingConfigExclusions.equals(currentVotingConfigExclusions) == false) {
+                    CoordinationMetadata.Builder coordMetadataBuilder = CoordinationMetadata.builder(currentState.coordinationMetadata())
+                        .clearVotingConfigExclusions();
+                    newVotingConfigExclusions.forEach(coordMetadataBuilder::addVotingConfigExclusion);
+                    Metadata newMetadata = Metadata.builder(currentState.metadata())
+                                                    .coordinationMetadata(coordMetadataBuilder.build()).build();
+                    return results.build(allocationService.adaptAutoExpandReplicas(newState.nodes(nodesBuilder)
+                                                                                            .metadata(newMetadata).build()));
+                }
+            }
 
             return results.build(allocationService.adaptAutoExpandReplicas(newState.nodes(nodesBuilder).build()));
         } else {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
@@ -20,13 +20,13 @@ package org.elasticsearch.action.admin.cluster.configuration;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.util.Set;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
@@ -37,22 +37,54 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes.Builder;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 
 import io.crate.common.unit.TimeValue;
 
 public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
+    private static final String NODE_IDENTIFIERS_INCORRECTLY_SET_MSG = "Please set node identifiers correctly. " +
+                                                            "One and only one of [node_name], [node_names] and [node_ids] has to be set";
+
+    @Before
+    public void resetDeprecationLogger() {
+        AddVotingConfigExclusionsRequest.DEPRECATION_LOGGER.resetLRU();
+    }
+
     public void testSerialization() throws IOException {
-        int descriptionCount = between(0, 5);
+        int descriptionCount = between(1, 5);
         String[] descriptions = new String[descriptionCount];
         for (int i = 0; i < descriptionCount; i++) {
             descriptions[i] = randomAlphaOfLength(10);
         }
         TimeValue timeout = TimeValue.timeValueMillis(between(0, 30000));
-        final AddVotingConfigExclusionsRequest originalRequest = new AddVotingConfigExclusionsRequest(descriptions, timeout);
+        final AddVotingConfigExclusionsRequest originalRequest = new AddVotingConfigExclusionsRequest(descriptions, Strings.EMPTY_ARRAY,
+                                                                                                        Strings.EMPTY_ARRAY, timeout);
         final AddVotingConfigExclusionsRequest deserialized = copyWriteable(originalRequest, writableRegistry(),
             AddVotingConfigExclusionsRequest::new);
         assertThat(deserialized.getNodeDescriptions(), equalTo(originalRequest.getNodeDescriptions()));
+        assertThat(deserialized.getTimeout(), equalTo(originalRequest.getTimeout()));
+        assertWarnings(AddVotingConfigExclusionsRequest.DEPRECATION_MESSAGE);
+    }
+
+    public void testSerializationForNodeIdOrNodeName() throws IOException {
+        AddVotingConfigExclusionsRequest originalRequest = new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY,
+                                                                new String[]{"nodeId1", "nodeId2"}, Strings.EMPTY_ARRAY, TimeValue.ZERO);
+        AddVotingConfigExclusionsRequest deserialized = copyWriteable(originalRequest, writableRegistry(),
+                                                                        AddVotingConfigExclusionsRequest::new);
+
+        assertThat(deserialized.getNodeDescriptions(), equalTo(originalRequest.getNodeDescriptions()));
+        assertThat(deserialized.getNodeIds(), equalTo(originalRequest.getNodeIds()));
+        assertThat(deserialized.getNodeNames(), equalTo(originalRequest.getNodeNames()));
+        assertThat(deserialized.getTimeout(), equalTo(originalRequest.getTimeout()));
+
+        originalRequest = new AddVotingConfigExclusionsRequest("nodeName1", "nodeName2");
+        deserialized = copyWriteable(originalRequest, writableRegistry(), AddVotingConfigExclusionsRequest::new);
+
+        assertThat(deserialized.getNodeDescriptions(), equalTo(originalRequest.getNodeDescriptions()));
+        assertThat(deserialized.getNodeIds(), equalTo(originalRequest.getNodeIds()));
+        assertThat(deserialized.getNodeNames(), equalTo(originalRequest.getNodeNames()));
         assertThat(deserialized.getTimeout(), equalTo(originalRequest.getTimeout()));
     }
 
@@ -62,7 +94,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
                 "local",
                 buildNewFakeTransportAddress(),
                 emptyMap(),
-                Set.of(DiscoveryNodeRole.MASTER_ROLE),
+                singleton(DiscoveryNodeRole.MASTER_ROLE),
                 Version.CURRENT);
         final VotingConfigExclusion localNodeExclusion = new VotingConfigExclusion(localNode);
         final DiscoveryNode otherNode1 = new DiscoveryNode(
@@ -70,7 +102,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
                 "other1",
                 buildNewFakeTransportAddress(),
                 emptyMap(),
-                Set.of(DiscoveryNodeRole.MASTER_ROLE),
+                singleton(DiscoveryNodeRole.MASTER_ROLE),
                 Version.CURRENT);
         final VotingConfigExclusion otherNode1Exclusion = new VotingConfigExclusion(otherNode1);
         final DiscoveryNode otherNode2 = new DiscoveryNode(
@@ -78,7 +110,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
                 "other2",
                 buildNewFakeTransportAddress(),
                 emptyMap(),
-                Set.of(DiscoveryNodeRole.MASTER_ROLE),
+                singleton(DiscoveryNodeRole.MASTER_ROLE),
                 Version.CURRENT);
         final VotingConfigExclusion otherNode2Exclusion = new VotingConfigExclusion(otherNode2);
         final DiscoveryNode otherDataNode
@@ -87,18 +119,163 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
         final ClusterState clusterState = ClusterState.builder(new ClusterName("cluster")).nodes(new Builder()
             .add(localNode).add(otherNode1).add(otherNode2).add(otherDataNode).localNodeId(localNode.getId())).build();
 
-        assertThat(makeRequest().resolveVotingConfigExclusions(clusterState),
+        assertThat(makeRequestWithNodeDescriptions("_all").resolveVotingConfigExclusions(clusterState),
                 containsInAnyOrder(localNodeExclusion, otherNode1Exclusion, otherNode2Exclusion));
-        assertThat(makeRequest("_all").resolveVotingConfigExclusions(clusterState),
-                containsInAnyOrder(localNodeExclusion, otherNode1Exclusion, otherNode2Exclusion));
-        assertThat(makeRequest("_local").resolveVotingConfigExclusions(clusterState),
+        assertThat(makeRequestWithNodeDescriptions("_local").resolveVotingConfigExclusions(clusterState),
                 contains(localNodeExclusion));
-        assertThat(makeRequest("other*").resolveVotingConfigExclusions(clusterState),
+        assertThat(makeRequestWithNodeDescriptions("other*").resolveVotingConfigExclusions(clusterState),
                 containsInAnyOrder(otherNode1Exclusion, otherNode2Exclusion));
 
         assertThat(expectThrows(IllegalArgumentException.class,
-                () -> makeRequest("not-a-node").resolveVotingConfigExclusions(clusterState)).getMessage(),
-                    equalTo("add voting config exclusions request for [not-a-node] matched no master-eligible nodes"));
+            () -> makeRequestWithNodeDescriptions("not-a-node").resolveVotingConfigExclusions(clusterState)).getMessage(),
+            equalTo("add voting config exclusions request for [not-a-node] matched no master-eligible nodes"));
+        assertWarnings(AddVotingConfigExclusionsRequest.DEPRECATION_MESSAGE);
+    }
+
+    public void testResolveAllNodeIdentifiersNullOrEmpty() {
+        assertThat(expectThrows(IllegalArgumentException.class,
+            () -> new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY,
+                                                        Strings.EMPTY_ARRAY, TimeValue.ZERO)).getMessage(),
+            equalTo(NODE_IDENTIFIERS_INCORRECTLY_SET_MSG));
+    }
+
+    public void testResolveMoreThanOneNodeIdentifiersSet() {
+        assertThat(expectThrows(IllegalArgumentException.class,
+            () -> new AddVotingConfigExclusionsRequest(new String[]{"local"}, new String[]{"nodeId"},
+                                                        Strings.EMPTY_ARRAY, TimeValue.ZERO)).getMessage(),
+            equalTo(NODE_IDENTIFIERS_INCORRECTLY_SET_MSG));
+
+        assertThat(expectThrows(IllegalArgumentException.class,
+            () -> new AddVotingConfigExclusionsRequest(new String[]{"local"}, Strings.EMPTY_ARRAY,
+                                                        new String[]{"nodeName"}, TimeValue.ZERO)).getMessage(),
+            equalTo(NODE_IDENTIFIERS_INCORRECTLY_SET_MSG));
+
+        assertThat(expectThrows(IllegalArgumentException.class,
+            () -> new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[]{"nodeId"},
+                                                        new String[]{"nodeName"}, TimeValue.ZERO)).getMessage(),
+            equalTo(NODE_IDENTIFIERS_INCORRECTLY_SET_MSG));
+
+        assertThat(expectThrows(IllegalArgumentException.class,
+            () -> new AddVotingConfigExclusionsRequest(new String[]{"local"}, new String[]{"nodeId"},
+                                                        new String[]{"nodeName"}, TimeValue.ZERO)).getMessage(),
+            equalTo(NODE_IDENTIFIERS_INCORRECTLY_SET_MSG));
+    }
+
+    public void testResolveByNodeIds() {
+        final DiscoveryNode node1 = new DiscoveryNode(
+            "nodeName1",
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            singleton(DiscoveryNodeRole.MASTER_ROLE),
+            Version.CURRENT);
+        final VotingConfigExclusion node1Exclusion = new VotingConfigExclusion(node1);
+
+        final DiscoveryNode node2 = new DiscoveryNode(
+            "nodeName2",
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            singleton(DiscoveryNodeRole.MASTER_ROLE),
+            Version.CURRENT);
+        final VotingConfigExclusion node2Exclusion = new VotingConfigExclusion(node2);
+
+        final DiscoveryNode node3 = new DiscoveryNode(
+            "nodeName3",
+            "nodeId3",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            singleton(DiscoveryNodeRole.MASTER_ROLE),
+            Version.CURRENT);
+
+        final VotingConfigExclusion unresolvableVotingConfigExclusion = new VotingConfigExclusion("unresolvableNodeId",
+                                                                                                VotingConfigExclusion.MISSING_VALUE_MARKER);
+
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("cluster"))
+                    .nodes(new Builder().add(node1).add(node2).add(node3).localNodeId(node1.getId())).build();
+
+        assertThat(new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[]{"nodeId1", "nodeId2"},
+                                                        Strings.EMPTY_ARRAY, TimeValue.ZERO).resolveVotingConfigExclusions(clusterState),
+                    containsInAnyOrder(node1Exclusion, node2Exclusion));
+
+        assertThat(new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[]{"nodeId1", "unresolvableNodeId"},
+                                                        Strings.EMPTY_ARRAY, TimeValue.ZERO).resolveVotingConfigExclusions(clusterState),
+                    containsInAnyOrder(node1Exclusion, unresolvableVotingConfigExclusion));
+    }
+
+    public void testResolveByNodeNames() {
+        final DiscoveryNode node1 = new DiscoveryNode("nodeName1",
+                                                        "nodeId1",
+                                                        buildNewFakeTransportAddress(),
+                                                        emptyMap(),
+                                                        singleton(DiscoveryNodeRole.MASTER_ROLE),
+                                                        Version.CURRENT);
+        final VotingConfigExclusion node1Exclusion = new VotingConfigExclusion(node1);
+
+        final DiscoveryNode node2 = new DiscoveryNode("nodeName2",
+                                                        "nodeId2",
+                                                        buildNewFakeTransportAddress(),
+                                                        emptyMap(),
+                                                        singleton(DiscoveryNodeRole.MASTER_ROLE),
+                                                        Version.CURRENT);
+        final VotingConfigExclusion node2Exclusion = new VotingConfigExclusion(node2);
+
+        final DiscoveryNode node3 = new DiscoveryNode("nodeName3",
+                                                        "nodeId3",
+                                                        buildNewFakeTransportAddress(),
+                                                        emptyMap(),
+                                                        singleton(DiscoveryNodeRole.MASTER_ROLE),
+                                                        Version.CURRENT);
+
+        final VotingConfigExclusion unresolvableVotingConfigExclusion = new VotingConfigExclusion(
+                                                                        VotingConfigExclusion.MISSING_VALUE_MARKER, "unresolvableNodeName");
+
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("cluster"))
+                                                .nodes(new Builder().add(node1).add(node2).add(node3).localNodeId(node1.getId())).build();
+
+        assertThat(new AddVotingConfigExclusionsRequest("nodeName1", "nodeName2").resolveVotingConfigExclusions(clusterState),
+                    containsInAnyOrder(node1Exclusion, node2Exclusion));
+
+        assertThat(new AddVotingConfigExclusionsRequest("nodeName1", "unresolvableNodeName").resolveVotingConfigExclusions(clusterState),
+                    containsInAnyOrder(node1Exclusion, unresolvableVotingConfigExclusion));
+    }
+
+    public void testResolveRemoveExistingVotingConfigExclusions() {
+        final DiscoveryNode node1 = new DiscoveryNode("nodeName1",
+                                                        "nodeId1",
+                                                        buildNewFakeTransportAddress(),
+                                                        emptyMap(),
+                                                        singleton(DiscoveryNodeRole.MASTER_ROLE),
+                                                        Version.CURRENT);
+
+        final DiscoveryNode node2 = new DiscoveryNode("nodeName2",
+                                                        "nodeId2",
+                                                        buildNewFakeTransportAddress(),
+                                                        emptyMap(),
+                                                        singleton(DiscoveryNodeRole.MASTER_ROLE),
+                                                        Version.CURRENT);
+        final VotingConfigExclusion node2Exclusion = new VotingConfigExclusion(node2);
+
+        final DiscoveryNode node3 = new DiscoveryNode("nodeName3",
+                                                        "nodeId3",
+                                                        buildNewFakeTransportAddress(),
+                                                        emptyMap(),
+                                                        singleton(DiscoveryNodeRole.MASTER_ROLE),
+                                                        Version.CURRENT);
+
+        final VotingConfigExclusion existingVotingConfigExclusion = new VotingConfigExclusion(node1);
+
+        Metadata metadata = Metadata.builder()
+                                    .coordinationMetadata(CoordinationMetadata.builder()
+                                        .addVotingConfigExclusion(existingVotingConfigExclusion).build())
+                                    .build();
+
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("cluster")).metadata(metadata)
+                                                .nodes(new Builder().add(node1).add(node2).add(node3).localNodeId(node1.getId())).build();
+
+        assertThat(new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[]{"nodeId1", "nodeId2"},
+                                                        Strings.EMPTY_ARRAY, TimeValue.ZERO).resolveVotingConfigExclusions(clusterState),
+                    contains(node2Exclusion));
     }
 
     public void testResolveAndCheckMaximum() {
@@ -107,7 +284,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
                 "local",
                 buildNewFakeTransportAddress(),
                 emptyMap(),
-                Set.of(DiscoveryNodeRole.MASTER_ROLE),
+                singleton(DiscoveryNodeRole.MASTER_ROLE),
                 Version.CURRENT);
         final VotingConfigExclusion localNodeExclusion = new VotingConfigExclusion(localNode);
         final DiscoveryNode otherNode1 = new DiscoveryNode(
@@ -115,7 +292,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
                 "other1",
                 buildNewFakeTransportAddress(),
                 emptyMap(),
-                Set.of(DiscoveryNodeRole.MASTER_ROLE),
+                singleton(DiscoveryNodeRole.MASTER_ROLE),
                 Version.CURRENT);
         final VotingConfigExclusion otherNode1Exclusion = new VotingConfigExclusion(otherNode1);
         final DiscoveryNode otherNode2 = new DiscoveryNode(
@@ -123,7 +300,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
                 "other2",
                 buildNewFakeTransportAddress(),
                 emptyMap(),
-                Set.of(DiscoveryNodeRole.MASTER_ROLE),
+                singleton(DiscoveryNodeRole.MASTER_ROLE),
                 Version.CURRENT);
         final VotingConfigExclusion otherNode2Exclusion = new VotingConfigExclusion(otherNode2);
 
@@ -133,22 +310,18 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
                 .coordinationMetadata(CoordinationMetadata.builder().addVotingConfigExclusion(otherNode1Exclusion).build()));
         final ClusterState clusterState = builder.build();
 
-        assertThat(makeRequest().resolveVotingConfigExclusionsAndCheckMaximum(clusterState, 3, "setting.name"),
-                containsInAnyOrder(localNodeExclusion, otherNode2Exclusion));
-        assertThat(makeRequest("_local").resolveVotingConfigExclusionsAndCheckMaximum(clusterState, 2, "setting.name"),
+        assertThat(makeRequestWithNodeDescriptions("_local").resolveVotingConfigExclusionsAndCheckMaximum(clusterState, 2, "setting.name"),
                 contains(localNodeExclusion));
-
         assertThat(expectThrows(IllegalArgumentException.class,
-            () -> makeRequest().resolveVotingConfigExclusionsAndCheckMaximum(clusterState, 2, "setting.name")).getMessage(),
-            equalTo("add voting config exclusions request for [] would add [2] exclusions to the existing [1] which would exceed " +
-                "the maximum of [2] set by [setting.name]"));
-        assertThat(expectThrows(IllegalArgumentException.class,
-            () -> makeRequest("_local").resolveVotingConfigExclusionsAndCheckMaximum(clusterState, 1, "setting.name")).getMessage(),
+            () -> makeRequestWithNodeDescriptions("_local").resolveVotingConfigExclusionsAndCheckMaximum(clusterState, 1, "setting.name"))
+                .getMessage(),
             equalTo("add voting config exclusions request for [_local] would add [1] exclusions to the existing [1] which would " +
                 "exceed the maximum of [1] set by [setting.name]"));
+        assertWarnings(AddVotingConfigExclusionsRequest.DEPRECATION_MESSAGE);
     }
 
-    private static AddVotingConfigExclusionsRequest makeRequest(String... descriptions) {
-        return new AddVotingConfigExclusionsRequest(descriptions);
+    private static AddVotingConfigExclusionsRequest makeRequestWithNodeDescriptions(String... nodeDescriptions) {
+        return new AddVotingConfigExclusionsRequest(nodeDescriptions, Strings.EMPTY_ARRAY,
+                                                    Strings.EMPTY_ARRAY, TimeValue.timeValueSeconds(30));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.cluster.coordination;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.transport.TransportService.HANDSHAKE_ACTION_NAME;
 import static org.hamcrest.Matchers.containsString;
@@ -207,7 +208,7 @@ public class NodeJoinTests extends ESTestCase {
     protected DiscoveryNode newNode(int i, boolean master) {
         final Set<DiscoveryNodeRole> roles;
         if (master) {
-            roles = Set.of(DiscoveryNodeRole.MASTER_ROLE);
+            roles = singleton(DiscoveryNodeRole.MASTER_ROLE);
         } else {
             roles = Set.of();
         }
@@ -404,6 +405,45 @@ public class NodeJoinTests extends ESTestCase {
         joinNodeAndRun(new JoinRequest(node1, newerTerm,
             Optional.of(new Join(node1, node0, newerTerm, initialTerm, initialVersion))));
         assertTrue(isLocalNodeElectedMaster());
+    }
+
+    public void testJoinUpdateVotingConfigExclusion() throws Exception {
+        DiscoveryNode initialNode = newNode(0, true);
+        long initialTerm = randomLongBetween(1, 10);
+        long initialVersion = randomLongBetween(1, 10);
+
+        CoordinationMetadata.VotingConfigExclusion votingConfigExclusion = new CoordinationMetadata.VotingConfigExclusion(
+                                                        CoordinationMetadata.VotingConfigExclusion.MISSING_VALUE_MARKER, "knownNodeName");
+
+        setupFakeMasterServiceAndCoordinator(initialTerm, buildStateWithVotingConfigExclusion(initialNode, initialTerm,
+                                                                                                initialVersion, votingConfigExclusion));
+
+        DiscoveryNode knownJoiningNode = new DiscoveryNode("knownNodeName", "newNodeId", buildNewFakeTransportAddress(),
+                                                            emptyMap(), singleton(DiscoveryNodeRole.MASTER_ROLE), Version.CURRENT);
+        long newTerm = initialTerm + randomLongBetween(1, 10);
+        long newerTerm = newTerm + randomLongBetween(1, 10);
+
+        joinNodeAndRun(new JoinRequest(knownJoiningNode, initialTerm,
+            Optional.of(new Join(knownJoiningNode, initialNode, newerTerm, initialTerm, initialVersion))));
+
+        assertTrue(MasterServiceTests.discoveryState(masterService).getVotingConfigExclusions().stream().anyMatch(exclusion -> {
+            return "knownNodeName".equals(exclusion.getNodeName()) && "newNodeId".equals(exclusion.getNodeId());
+        }));
+    }
+
+    private ClusterState buildStateWithVotingConfigExclusion(DiscoveryNode initialNode,
+                                                             long initialTerm,
+                                                             long initialVersion,
+                                                             CoordinationMetadata.VotingConfigExclusion votingConfigExclusion) {
+        ClusterState initialState = initialState(initialNode, initialTerm, initialVersion,
+                                                    new VotingConfiguration(singleton(initialNode.getId())));
+        Metadata newMetadata = Metadata.builder(initialState.metadata())
+                                        .coordinationMetadata(CoordinationMetadata.builder(initialState.coordinationMetadata())
+                                                                                    .addVotingConfigExclusion(votingConfigExclusion)
+                                                                                    .build())
+                                        .build();
+
+        return ClusterState.builder(initialState).metadata(newMetadata).build();
     }
 
     private void handleStartJoinFrom(DiscoveryNode node, long term) throws Exception {

--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -1801,7 +1801,7 @@ public final class TestCluster implements Closeable {
 
     private Set<String> excludeMasters(Collection<NodeAndClient> nodeAndClients) {
         assert Thread.holdsLock(this);
-        final Set<String> excludedNodeIds = new HashSet<>();
+        final Set<String> excludedNodeNames = new HashSet<>();
         if (autoManageMasterNodes && nodeAndClients.size() > 0) {
 
             final long currentMasters = nodes.values().stream().filter(NodeAndClient::isMasterEligible).count();
@@ -1813,19 +1813,19 @@ public final class TestCluster implements Closeable {
                 // However, we do not yet have a way to be sure there's a majority left, because the voting configuration may not yet have
                 // been updated when the previous nodes shut down, so we must always explicitly withdraw votes.
                 // TODO add cluster health API to check that voting configuration is optimal so this isn't always needed
-                nodeAndClients.stream().filter(NodeAndClient::isMasterEligible).map(NodeAndClient::getName).forEach(excludedNodeIds::add);
-                assert excludedNodeIds.size() == stoppingMasters;
+                nodeAndClients.stream().filter(NodeAndClient::isMasterEligible).map(NodeAndClient::getName).forEach(excludedNodeNames::add);
+                assert excludedNodeNames.size() == stoppingMasters;
 
-                logger.info("adding voting config exclusions {} prior to restart/shutdown", excludedNodeIds);
+                logger.info("adding voting config exclusions {} prior to restart/shutdown", excludedNodeNames);
                 try {
                     client().execute(AddVotingConfigExclusionsAction.INSTANCE,
-                            new AddVotingConfigExclusionsRequest(excludedNodeIds.toArray(Strings.EMPTY_ARRAY))).get();
+                            new AddVotingConfigExclusionsRequest(excludedNodeNames.toArray(Strings.EMPTY_ARRAY))).get();
                 } catch (InterruptedException | ExecutionException e) {
                     throw new AssertionError("unexpected", e);
                 }
             }
         }
-        return excludedNodeIds;
+        return excludedNodeNames;
     }
 
     private void removeExclusions(Set<String> excludedNodeIds) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

    
Today the voting config exclusions API accepts node filters and resolves them
to a collection of node IDs against the current cluster membership.

This is problematic since we may want to exclude nodes that are not currently
members of the cluster. For instance:

- if attempting to remove a flaky node from the cluster you cannot reliably
exclude it from the voting configuration since it may not reliably be a
member of the cluster

- if `cluster.auto_shrink_voting_configuration: false` then naively shrinking
the cluster will remove some nodes but will leaving their node IDs in the
voting configuration. The only way to clean up the voting configuration is to
grow the cluster back to its original size (potentially replacing some of the
voting configuration) and then use the exclusions API.

This commit adds an alternative API that accepts node names and node IDs but
not node filters in general, and deprecates the current node-filters-based API.

https://github.com/elastic/elasticsearch/commit/8a565c4fa61a092eaf8ca4aed9492342a6012874


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
