### PR TITLE
Add support for SET TIME ZONE as no-op

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,9 @@ Deprecations
 Changes
 =======
 
+- Added support for ``SET TIME ZONE`` to improve PostgreSQL Compatibility.
+  Timezone will be ignored on the server side.
+
 - Added support for the ``EXISTS`` expression.
 
 - Added support for ``'YES'``, ``'ON'`` and ``'1'`` as alternative way to

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -67,6 +67,7 @@ statement
     | SET GLOBAL (PERSISTENT | TRANSIENT)?
         setGlobalAssignment (',' setGlobalAssignment)*                               #setGlobal
     | SET LICENSE stringLiteral                                                      #setLicense
+    | SET TIME ZONE (LOCAL | DEFAULT | stringLiteral)                                #setTimeZone
     | KILL (ALL | jobId=parameterOrString)                                           #kill
     | INSERT INTO table ('(' ident (',' ident)* ')')? insertSource
         onConflict?

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -750,6 +750,20 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
+    public Node visitSetTimeZone(SqlBaseParser.SetTimeZoneContext ctx) {
+        Expression value;
+        if (ctx.DEFAULT() != null) {
+            value = new StringLiteral((ctx.DEFAULT().getText()));
+        } else if (ctx.LOCAL() != null) {
+            value = new StringLiteral((ctx.LOCAL().getText()));
+        } else {
+            value = (Expression) visit(ctx.stringLiteral());
+        }
+        Assignment<Expression> assignment = new Assignment<>(new StringLiteral("time zone"), value);
+        return new SetStatement<>(SetStatement.Scope.TIME_ZONE, List.of(assignment));
+    }
+
+    @Override
     public Node visitSetTransaction(SetTransactionContext ctx) {
         List<TransactionMode> modes = Lists2.map(ctx.transactionMode(), AstBuilder::getTransactionMode);
         return new SetTransactionStatement(modes);

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 public class SetStatement<T> extends Statement {
 
     public enum Scope {
-        GLOBAL, SESSION, LOCAL, LICENSE
+        GLOBAL, SESSION, LOCAL, LICENSE, TIME_ZONE
     }
 
     public enum SettingType {

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -583,6 +583,30 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void test_set_timezone_value() {
+        SetStatement<?> stmt = (SetStatement<?>) SqlParser.createStatement("SET TIME ZONE 'Europe/Vienna'");
+        assertThat(stmt.scope()).isEqualTo(SetStatement.Scope.TIME_ZONE);
+        assertThat(stmt.assignments()).hasSize(1);
+        assertThat(stmt.assignments().get(0).expressions().get(0).toString()).isEqualTo("'Europe/Vienna'");
+    }
+
+    @Test
+    public void test_set_timezone_local() {
+        SetStatement<?> stmt = (SetStatement<?>) SqlParser.createStatement("SET TIME ZONE LOCAL");
+        assertThat(stmt.scope()).isEqualTo(SetStatement.Scope.TIME_ZONE);
+        assertThat(stmt.assignments()).hasSize(1);
+        assertThat(stmt.assignments().get(0).expressions().get(0).toString()).isEqualTo("'LOCAL'");
+    }
+
+    @Test
+    public void test_set_timezone_default() {
+        SetStatement<?> stmt = (SetStatement<?>) SqlParser.createStatement("SET TIME ZONE DEFAULT");
+        assertThat(stmt.scope()).isEqualTo(SetStatement.Scope.TIME_ZONE);
+        assertThat(stmt.assignments()).hasSize(1);
+        assertThat(stmt.assignments().get(0).expressions().get(0).toString()).isEqualTo("'DEFAULT'");
+    }
+
+    @Test
     public void testResetGlobalStmtBuilder() {
         printStatement("reset global some_setting['nested'], other_setting");
     }

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -435,6 +435,12 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     @Override
     public Plan visitSetStatement(AnalyzedSetStatement setStatement, PlannerContext context) {
         switch (setStatement.scope()) {
+            case TIME_ZONE:
+                var settings = setStatement.settings();
+                if (!settings.get(0).expression().toString().equalsIgnoreCase("'utc'")) {
+                    LOGGER.warn("SET TIME ZONE `{}` statement will be ignored. ", settings);
+                }
+                return NoopPlan.INSTANCE;
             case LICENSE:
                 throw new AssertionError(
                     "`AnalyzedSetStatement` with scope `LICENSE` should have been converted to `AnalyzedSetLicenseStatement` by the analyzer");

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -79,6 +79,12 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testSetTimeZone() throws Exception {
+        Plan plan = e.plan("SET TIME ZONE 'Europe/Vienna'");
+        assertThat(plan, instanceOf(NoopPlan.class));
+    }
+
+    @Test
     public void testExecutionPhaseIdSequence() throws Exception {
         PlannerContext plannerContext = new PlannerContext(
             clusterService.state(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Resolves https://github.com/crate/crate/issues/12363

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
