### PR TITLE
Increase assertBusy maxWaitTime for test_subscription_state_order

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -23,8 +23,8 @@ package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.TestingHelpers.printedTable;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -469,14 +469,15 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         assertBusy(
             () -> {
                 synchronized (subscriptionStates) {
-                    assertThat(
-                        subscriptionStates,
-                        contains(Subscription.State.INITIALIZING,
-                                Subscription.State.RESTORING,
-                                Subscription.State.MONITORING)
+                    assertThat(subscriptionStates).contains(
+                        Subscription.State.INITIALIZING,
+                        Subscription.State.RESTORING,
+                        Subscription.State.MONITORING
                     );
                 }
-            }
+            },
+            30,
+            TimeUnit.SECONDS
         );
 
         // check final exposed `r`(MONITORING) state


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The test is currently flaky. This increases the maxWaitTime mostly to
rule out slow CI as a potential cause.

Currently the test durations look like this:

![image](https://user-images.githubusercontent.com/38700/188588722-90f0cfcd-d804-4d6c-9c94-1be3207472ad.png)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
