### PR TITLE
Debug CI

### DIFF
--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -6,7 +6,7 @@ Altering tables
 
 .. NOTE::
 
-   ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported.
+   ``DROP COLUMN`` actions are not currently supported.
    See :ref:`appendix-compatibility`.
 
 .. rubric:: Table of contents

--- a/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
@@ -21,17 +21,22 @@
 
 package io.crate.action.sql;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.exceptions.SQLExceptions;
 
-import javax.annotation.Nullable;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-
 public class RowConsumerToResultReceiver implements RowConsumer {
 
+    private static final Logger LOGGER = LogManager.getLogger(RowConsumerToResultReceiver.class);
     private final CompletableFuture<?> completionFuture = new CompletableFuture<>();
     private ResultReceiver<?> resultReceiver;
     private int maxRows;
@@ -48,6 +53,7 @@ public class RowConsumerToResultReceiver implements RowConsumer {
 
     @Override
     public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
+        LOGGER.debug("accept iterator={} failure={}", iterator, failure);
         if (failure == null) {
             consumeIt(iterator);
         } else {

--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
@@ -138,7 +138,7 @@ public class DistributingConsumer implements RowConsumer {
         }
     }
 
-    private void forwardFailure(@Nullable final BatchIterator it, final Throwable f) {
+    private void forwardFailure(@Nullable final BatchIterator<?> it, final Throwable f) {
         Throwable failure = SQLExceptions.unwrap(f); // make sure it's streamable
         AtomicInteger numActiveRequests = new AtomicInteger(downstreams.size());
         var builder = new DistributedResultRequest.Builder(jobId, targetPhaseId, inputId, bucketIdx, failure, false);
@@ -178,7 +178,7 @@ public class DistributingConsumer implements RowConsumer {
         }
     }
 
-    private void countdownAndMaybeCloseIt(AtomicInteger numActiveRequests, @Nullable BatchIterator it) {
+    private void countdownAndMaybeCloseIt(AtomicInteger numActiveRequests, @Nullable BatchIterator<?> it) {
         if (numActiveRequests.decrementAndGet() == 0) {
             if (it != null) {
                 it.close();

--- a/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -168,6 +168,8 @@ public class TransportDistributedResultAction extends TransportAction<NodeReques
         Throwable throwable = request.throwable();
         if (throwable == null) {
             SendResponsePageResultListener pageResultListener = new SendResponsePageResultListener();
+            LOGGER.debug("pageBucketReceiver.setBucket receiver={}, bucket={}",
+                pageBucketReceiver, request.bucketIdx());
             pageBucketReceiver.setBucket(
                 request.bucketIdx(),
                 request.readRows(pageBucketReceiver.streamers()),
@@ -176,6 +178,8 @@ public class TransportDistributedResultAction extends TransportAction<NodeReques
             );
             return pageResultListener.future;
         } else {
+            LOGGER.debug("received failure={}",
+                pageBucketReceiver, request.bucketIdx());
             pageBucketReceiver.kill(throwable);
             return CompletableFuture.completedFuture(new DistributedResultResponse(false));
         }

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -651,6 +651,7 @@ public class JobSetup {
             });
 
             if (upstreamOnSameNode && phase.numInputs() == 1) {
+                LOGGER.error("Using same node optimization");
                 RowConsumer projectingRowConsumer = ProjectingRowConsumer.create(
                     finalRowConsumer,
                     phase.projections(),

--- a/server/src/main/java/io/crate/execution/jobs/RootTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/RootTask.java
@@ -37,6 +37,7 @@ import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.crate.common.annotations.VisibleForTesting;
@@ -50,6 +51,7 @@ import io.crate.profile.Timer;
 
 public class RootTask implements CompletionListenable<Void> {
 
+    private static final Logger LOGGER = LogManager.getLogger(RootTask.class);
     private final UUID jobId;
     private final AtomicInteger numActiveTasks;
     private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -200,6 +202,7 @@ public class RootTask implements CompletionListenable<Void> {
                     return started.thenCompose(ignored -> start(taskIndex + 1));
                 }
             } catch (Throwable t) {
+                LOGGER.error("start failed={}", t);
                 return CompletableFuture.failedFuture(t);
             }
         }

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -275,6 +275,8 @@ public class PostgresWireProtocol {
                                         || (t != null && t.getCause() instanceof ClientInterrupted);
             if (!clientInterrupted) {
                 sendReadyForQuery(channel, transactionState);
+            } else {
+                LOGGER.debug("Got ClientInterrupted exception, not firing ready-for-query");
             }
         }
     }
@@ -650,7 +652,7 @@ public class PostgresWireProtocol {
             return;
         }
         List<? extends DataType> outputTypes = session.getOutputTypes(portalName);
-        ResultReceiver resultReceiver;
+        ResultReceiver<?> resultReceiver;
         if (outputTypes == null) {
             // this is a DML query
             maxRows = 0;

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -226,7 +226,7 @@ public abstract class ESTestCase extends CrateLuceneTestCase {
         System.setProperty("log4j2.disable.jmx", "true");
 
         // Enable Netty leak detection and monitor logger for logged leak errors
-        System.setProperty("io.netty.leakDetection.level", "paranoid");
+        //System.setProperty("io.netty.leakDetection.level", "paranoid");
     }
 
     protected final Logger logger = LogManager.getLogger(getClass());

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -329,7 +329,7 @@ public abstract class IntegTestCase extends ESTestCase {
     private static Long SUITE_SEED = null;
 
     @Rule
-    public Timeout globalTimeout = new Timeout(5, TimeUnit.MINUTES);
+    public Timeout globalTimeout = new Timeout(2, TimeUnit.MINUTES);
 
     @Rule
     public TestName testName = new TestName();


### PR DESCRIPTION
👷 🔎 🐛

    until-error ./gradlew :server:test --tests "io.crate.integrationtests.CastIntegrationTest.testTryCastReturnNullWhenCastingFailsOnRows*" -Dtests.seed=CE024A4DBA58B34 -Dtests.nightly=true -Dtests.locale=yue-HK -Dtests.timezone=America/Indiana/Petersburg -Dtests.iters=50 --fail-fast


Tests fails with:

```
org.junit.runners.model.TestTimedOutException: test timed out after 5 minutes
	at __randomizedtesting.SeedInfo.seed([CE024A4DBA58B34:E90146F577C49B7F]:0)
	at java.base@18.0.2/sun.nio.ch.SocketDispatcher.read0(Native Method)
	at java.base@18.0.2/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:47)
	at java.base@18.0.2/sun.nio.ch.NioSocketImpl.tryRead(NioSocketImpl.java:258)
	at java.base@18.0.2/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:309)
	at java.base@18.0.2/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:347)
	at java.base@18.0.2/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:800)
	at java.base@18.0.2/java.net.Socket$SocketInputStream.read(Socket.java:966)
	at app//org.postgresql.core.VisibleBufferedInputStream.readMore(VisibleBufferedInputStream.java:161)
	at app//org.postgresql.core.VisibleBufferedInputStream.ensureBytes(VisibleBufferedInputStream.java:128)
	at app//org.postgresql.core.VisibleBufferedInputStream.ensureBytes(VisibleBufferedInputStream.java:113)
	at app//org.postgresql.core.VisibleBufferedInputStream.read(VisibleBufferedInputStream.java:73)
	at app//org.postgresql.core.PGStream.receiveChar(PGStream.java:453)
	at app//org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2120)
	at app//org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356)
	at app//org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:496)
	at app//org.postgresql.jdbc.PgStatement.execute(PgStatement.java:413)
	at app//org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:190)
	at app//org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:177)
	at app//io.crate.testing.SQLTransportExecutor.executeAndConvertResult(SQLTransportExecutor.java:389)
	at app//io.crate.testing.SQLTransportExecutor.executeWithPg(SQLTransportExecutor.java:340)
	at app//io.crate.testing.SQLTransportExecutor.executeTransportOrJdbc(SQLTransportExecutor.java:182)
	at app//io.crate.testing.SQLTransportExecutor.exec(SQLTransportExecutor.java:139)
	at app//org.elasticsearch.test.IntegTestCase.execute(IntegTestCase.java:1733)
	at app//org.elasticsearch.test.IntegTestCase.execute(IntegTestCase.java:1862)
	at app//io.crate.integrationtests.CastIntegrationTest.testTryCastReturnNullWhenCastingFailsOnRows(CastIntegrationTest.java:61)
```


Looks like the collect task is only starting on one node. `CollectTask.start` only occurs once in the output:


```
[node_s0][netty-worker][T#1]]] method=execute ... executing query portal=Portal{portalName=, preparedStmt=select try_cast(i as integer), try_cast(str as integer), try_cast(arr as array(byte)) from types order by i asc}
[node_s0][netty-worker][T#1]]] plan.execute
[node_s0][netty-worker][T#1]]] Building context for nodeOp without downstream: NodeOp{ phase{id=2/fetchPhase, nodes=[S65DGSuPTTqxV0Qpg6mIYg, iW7E2FYERAm5A_1KZibDUQ]}, downstreamNodes=[], downstreamPhase=2147483647, downstreamInputId=0}

NodeOp{
  phase{
    id=2/fetchPhase,
    nodes=[S65DGSuPTTqxV0Qpg6mIYg, iW7E2FYERAm5A_1KZibDUQ]},
    downstreamNodes=[],
    downstreamPhase=2147483647,
    downstreamInputId=0
}


[node_s0][netty-worker][T#1]]] prepareOnHandler: nodeOperations=[NodeOp{ phase{id=0/collect, nodes=[S65DGSuPTTqxV0Qpg6mIYg, iW7E2FYERAm5A_1KZibDUQ], dist=BROADCAST}, downstreamNodes=[S65DGSuPTTqxV0Qpg6mIYg], downstreamPhase=1, downstreamInputId=0}, NodeOp{ phase{id=2/fetchPhase, nodes=[S65DGSuPTTqxV0Qpg6mIYg, iW7E2FYERAm5A_1KZibDUQ]}, downstreamNodes=[], downstreamPhase=2147483647, downstreamInputId=0}], handlerPhases=[Tuple [v1=MergePhase{executionPhaseId=1, name=mergeOnHandler, projections=[io.crate.execution.dsl.projection.FetchProjection@2], outputTypes=[integer, integer, byte_array], jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, numUpstreams=2, numInputs=1, nodeOperations=[S65DGSuPTTqxV0Qpg6mIYg], inputTypes=[bigint, integer], orderBy=OrderByPositions{indices=[1], reverseFlags=[false], nullsFirst=[false]}}, v2=InterceptingBatchConsumer{consumerInvokedAndJobInitialized=2, jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, consumer=RowConsumerToResultReceiver{resultReceiver=RetryOnFailureResultReceiver{delegate=io.crate.protocols.postgres.ResultSetReceiver@1689ffe1, jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, attempt=1}, maxRows=0, rowCount=0, activeIt=null}, rowReceiverDone=false, failure=null}]], targetSourceMap=[1=>[0]]

nodeOperations=[
  NodeOp{
    phase{
      id=0/collect,
      nodes=[S65DGSuPTTqxV0Qpg6mIYg, iW7E2FYERAm5A_1KZibDUQ],
      dist=BROADCAST
    },
    downstreamNodes=[
      S65DGSuPTTqxV0Qpg6mIYg
    ],
    downstreamPhase=1,
    downstreamInputId=0
  },
  NodeOp{
    phase{
      id=2/fetchPhase,
      nodes=[S65DGSuPTTqxV0Qpg6mIYg, iW7E2FYERAm5A_1KZibDUQ]
    },
    downstreamNodes=[],
    downstreamPhase=2147483647,
    downstreamInputId=0
  }
],

handlerPhases=[Tuple [
  v1=MergePhase{
    executionPhaseId=1,
    name=mergeOnHandler,
    projections=[io.crate.execution.dsl.projection.FetchProjection@2],
    outputTypes=[integer, integer, byte_array],
    jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41,
    numUpstreams=2,
    numInputs=1,
    nodeOperations=[S65DGSuPTTqxV0Qpg6mIYg],
    inputTypes=[bigint, integer],
    orderBy=OrderByPositions{indices=[1], reverseFlags=[false], nullsFirst=[false]}
  },
  v2=InterceptingBatchConsumer{
    consumerInvokedAndJobInitialized=2,
    jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41,
    consumer=RowConsumerToResultReceiver{
      resultReceiver=RetryOnFailureResultReceiver{delegate=io.crate.protocols.postgres.ResultSetReceiver@1689ffe1, jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, attempt=1},
      maxRows=0,
      rowCount=0,
      activeIt=null
    },
    rowReceiverDone=false,
    failure=null
  }
]],

[2022-09-07T08:08:00,678][TRACE][i.c.e.j.JobSetup         ] [[cratedb[node_s0][netty-worker][T#1]]] Using BatchConsumer InterceptingBatchConsumer{consumerInvokedAndJobInitialized=2, jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, consumer=RowConsumerToResultReceiver{resultReceiver=RetryOnFailureResultReceiver{delegate=io.crate.protocols.postgres.ResultSetReceiver@1689ffe1, jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, attempt=1}, maxRows=0, rowCount=0, activeIt=null}, rowReceiverDone=false, failure=null} for phase 1, this is a leaf/handlerPhase
[2022-09-07T08:08:00,678][TRACE][i.c.e.j.JobSetup         ] [[cratedb[node_s0][netty-worker][T#1]]] action=getRowReceiver, distributionType=BROADCAST, phase=0, targetConsumer=DistributingConsumer{jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, targetPhaseId=1, inputId=0, bucketIdx=0, downstreams=[Downstream{S65DGSuPTTqxV0Qpg6mIYg', needsMoreData=true}]}, target=1/0,
[2022-09-07T08:08:00,678][TRACE][i.c.e.j.TasksService     ] [[cratedb[node_s0][netty-worker][T#1]]] Task created for job 857cd1d4-aa90-1bf2-5390-f03f03371f41,  activeTasks: 1
[2022-09-07T08:08:00,678][DEBUG][i.c.e.e.c.CollectTask    ] [[cratedb[node_s0][netty-worker][T#1]]] CollectTask.start
[2022-09-07T08:08:00,678][DEBUG][i.c.e.e.c.s.ShardCollectSource] [[cratedb[node_s2][clusterApplierService#updateTask][T#1]]] removing shard upon close in io.crate.execution.engine.collect.sources.ShardCollectSource@58705ef0 shard=[jvdyfescwlyditrkvudg.types][5] numShards=5
[2022-09-07T08:08:00,678][TRACE][i.c.e.e.c.LuceneShardCollectorProvider] [[cratedb[node_s0][netty-worker][T#1]]] [S65DGSuPTTqxV0Qpg6mIYg][[jvdyfescwlyditrkvudg.types][0]] creating LuceneOrderedDocCollector. Expected number of rows to be collected: 750000
[2022-09-07T08:08:00,678][DEBUG][i.c.e.e.c.CollectTask    ] [[cratedb[node_s0][netty-worker][T#1]]] futureIt completed it=io.crate.execution.engine.distribution.merge.BatchPagingIterator@2e5a26a0 err=null
[2022-09-07T08:08:00,678][DEBUG][i.c.e.e.c.CollectTask    ] [[cratedb[node_s0][search][T#2]]] collectOperation.launch consumer.accept(it, null) it=io.crate.execution.engine.distribution.merge.BatchPagingIterator@2e5a26a0, consumer=DistributingConsumer{jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, targetPhaseId=1, inputId=0, bucketIdx=0, downstreams=[Downstream{S65DGSuPTTqxV0Qpg6mIYg', needsMoreData=true}]}
[2022-09-07T08:08:00,678][TRACE][i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=S msgLength=0 readableBytes=0
[2022-09-07T08:08:00,678][DEBUG][i.c.a.s.SQLOperations    ] [[cratedb[node_s0][netty-worker][T#1]]] method=sync returning activeExection=java.util.concurrent.CompletableFuture@794c82bd[Not completed, 1 dependents]
[2022-09-07T08:08:00,678][TRACE][i.c.e.e.d.DistributingConsumer] [[cratedb[node_s0][search][T#1]]] forwardResults targetNode=S65DGSuPTTqxV0Qpg6mIYg jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41 targetPhase=1/0 bucket=0 isLast=true
[2022-09-07T08:08:00,678][DEBUG][i.c.e.e.d.TransportDistributedResultAction] [[cratedb[node_s0][search][T#1]]] pageBucketReceiver.setBucket receiver=CumulativePageBucketReceiver{nodeName='node_s0', phaseId=1, numBuckets=2, consumer=io.crate.execution.engine.pipeline.ProjectingRowConsumer@2436bb98}, bucket=0
[2022-09-07T08:08:00,678][TRACE][i.c.e.e.d.TransportDistributedResultAction] [[cratedb[node_s0][search][T#1]]] sending needMore response, need more? false
[2022-09-07T08:08:00,678][TRACE][i.c.e.j.CumulativePageBucketReceiver] [[cratedb[node_s0][search][T#1]]] method=setBucket phaseId=1 bucket=0 istLast=true
[2022-09-07T08:08:00,678][TRACE][i.c.e.j.TasksService     ] [[cratedb[node_s0][search][T#1]]] Task completed id=0 task=CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[[jvdyfescwlyditrkvudg.types][0]]}, consumer=DistributingConsumer{jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, targetPhaseId=1, inputId=0, bucketIdx=0, downstreams=[Downstream{S65DGSuPTTqxV0Qpg6mIYg', needsMoreData=false}]}, searchContexts=[], batchIterator=java.util.concurrent.CompletableFuture@1f623549[Completed normally], finished=true} error=null
[2022-09-07T08:08:00,678][TRACE][i.c.e.j.JobSetup         ] [[cratedb[node_s2][search][T#2]]] Building context for nodeOp without downstream: NodeOp{ phase{id=2/fetchPhase, nodes=[iW7E2FYERAm5A_1KZibDUQ, S65DGSuPTTqxV0Qpg6mIYg]}, downstreamNodes=[], downstreamPhase=2147483647, downstreamInputId=0}
[2022-09-07T08:08:00,679][TRACE][i.c.e.j.JobSetup         ] [[cratedb[node_s2][search][T#2]]] prepareOnRemote: nodeOperations=[NodeOp{ phase{id=0/collect, nodes=[S65DGSuPTTqxV0Qpg6mIYg, iW7E2FYERAm5A_1KZibDUQ], dist=BROADCAST}, downstreamNodes=[S65DGSuPTTqxV0Qpg6mIYg], downstreamPhase=1, downstreamInputId=0}, NodeOp{ phase{id=2/fetchPhase, nodes=[iW7E2FYERAm5A_1KZibDUQ, S65DGSuPTTqxV0Qpg6mIYg]}, downstreamNodes=[], downstreamPhase=2147483647, downstreamInputId=0}], targetSourceMap=[1=>[0]]
[2022-09-07T08:08:00,679][TRACE][i.c.e.j.JobSetup         ] [[cratedb[node_s2][search][T#2]]] action=getRowReceiver, distributionType=BROADCAST, phase=0, targetConsumer=DistributingConsumer{jobId=857cd1d4-aa90-1bf2-5390-f03f03371f41, targetPhaseId=1, inputId=0, bucketIdx=1, downstreams=[Downstream{S65DGSuPTTqxV0Qpg6mIYg', needsMoreData=true}]}, target=1/0,
[2022-09-07T08:08:00,679][TRACE][i.c.e.j.TasksService     ] [[cratedb[node_s2][search][T#2]]] Task created for job 857cd1d4-aa90-1bf2-5390-f03f03371f41,  activeTasks: 1
```


Digging deeper I found that in `RootTask.start` there are failures:

```
[2022-09-07T08:49:40,319][ERROR][i.c.e.j.RootTask         ] [[cratedb[node_s1][search][T#4]]] start failed={}
org.elasticsearch.index.shard.ShardNotFoundException: no such shard
        at org.elasticsearch.index.IndexService.getShard(IndexService.java:201) ~[crate-server.jar:?]
        at io.crate.execution.jobs.SharedShardContexts.maybeRefreshReaders(SharedShardContexts.java:85) ~[crate-server.jar:?]
        at io.crate.execution.engine.fetch.FetchTask.start(FetchTask.java:229) ~[crate-server.jar:?]
        at io.crate.execution.jobs.RootTask.start(RootTask.java:200) ~[crate-server.jar:?]
        at io.crate.execution.jobs.RootTask.start(RootTask.java:186) ~[crate-server.jar:?]
        at io.crate.execution.jobs.transport.TransportJobAction.nodeOperation(TransportJobAction.java:107) ~[crate-server.jar:?]
        at io.crate.execution.support.NodeActionRequestHandler.messageReceived(NodeActionRequestHandler.java:48) ~[crate-server.jar:?]
        at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:59) ~[crate-server.jar:?]
        at org.elasticsearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:281) ~[crate-server.jar:?]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[crate-server.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

I suspect it doesn't get propagated?
