### PR TITLE
Turn off translog retention only when shard started

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -365,7 +365,7 @@ should be crossed out as well.
 - [ ] dde75b0f64e Fix Confusing Exception on Shard Snapshot Abort (#57116) (#57117)
 - [x] 5569137ae3c Flatten ReleaseableBytesReference Object Trees (#57092) (#57109)
 - [ ] 9fa60f7367b Add History UUID Index Setting (#56930) (#57104)
-- [ ] d8165a3439b Turn off translog retention only when shard started (#57063)
+- [x] d8165a3439b Turn off translog retention only when shard started (#57063)
 - [x] 1dabdd9a201 Close channel on handshake error with old version (#56989) (#57025)
 - [s] 99f7115f228 Revert "Close channel on handshake error with old version (#56989)"
 - [s] c81a189da95 Close channel on handshake error with old version (#56989)

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -534,7 +534,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             indexEventListener.shardRoutingChanged(this, currentRouting, newRouting);
         }
 
-        if (indexSettings.isSoftDeleteEnabled() && useRetentionLeasesInPeerRecovery == false) {
+        if (indexSettings.isSoftDeleteEnabled() && useRetentionLeasesInPeerRecovery == false && state() == IndexShardState.STARTED) {
             final RetentionLeases retentionLeases = replicationTracker.getRetentionLeases();
             final Set<ShardRouting> shardRoutings = new HashSet<>(routingTable.getShards());
             shardRoutings.addAll(routingTable.assignedShards()); // include relocation targets


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We should only turn off the translog retention when a shard is started; otherwise, we can issue unnecessary warn logs.

Backport of https://github.com/elastic/elasticsearch/commit/d8165a3439b

Closes #12828.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
