### PR TITLE
Fix pgJDBC documentation links

### DIFF
--- a/docs/admin/ssl.rst
+++ b/docs/admin/ssl.rst
@@ -200,7 +200,7 @@ By default, ``psql`` attempts to use SSL if available on the node. For further
 information including the different SSL modes please visit the
 `PSQL documentation`_.
 
-.. _JDBC SSL documentation: https://jdbc.postgresql.org/documentation/head/ssl-client.html
+.. _JDBC SSL documentation: https://jdbc.postgresql.org/documentation/ssl/#configuring-the-client
 .. _PSQL documentation: https://www.postgresql.org/docs/current/static/app-psql.html
 
 

--- a/docs/appendices/release-notes/4.1.0.rst
+++ b/docs/appendices/release-notes/4.1.0.rst
@@ -51,7 +51,7 @@ Breaking Changes
   correctly mapped to the PostgreSQL ``point`` type. This means that
   applications using clients like ``JDBC`` will have to be adapted to use
   ``PgPoint``. (See `Geometric DataTypes in JDBC
-  <https://jdbc.postgresql.org/documentation/head/geometric.html>`_)
+  <https://jdbc.postgresql.org/documentation/server-prepare/#geometric-data-types>`_)
 
 - Changed the behavior of ``unnest`` to fully unnest multi dimensional arrays
   to their innermost type to be compatible with PostgreSQL.

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -576,8 +576,8 @@ CrateDB and we love to hear feedback.
 .. _PostgreSQL Arrays: https://www.postgresql.org/docs/14/static/arrays.html
 .. _PostgreSQL extended query: https://www.postgresql.org/docs/14/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 .. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/14/static/functions-textsearch.html
-.. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/head/connect.html#connection-failover
-.. _PostgreSQL JDBC Query docs: https://jdbc.postgresql.org/documentation/head/query.html
+.. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/use/#connection-fail-over
+.. _PostgreSQL JDBC Query docs: https://jdbc.postgresql.org/documentation/query
 .. _PostgreSQL simple query: https://www.postgresql.org/docs/14/static/protocol-flow.html#id-1.10.5.7.4
 .. _PostgreSQL value expressions: https://www.postgresql.org/docs/14/static/sql-expressions.html
 .. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/14/static/protocol.html


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The documentation of the PostgreSQL JDBC driver was restructured resulting in broken links pointing to the old structure.



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
