### PR TITLE
bp: Add Snapshot Resiliency Test for Master Failover during Delete

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -421,7 +421,7 @@ should be crossed out as well.
 - [ ] 9e3b813b629 Ensure not to open directory reader on transport thread (#55419)
 - [ ] a0763d958d1 Make RepositoryData Less Memory Heavy (#55293) (#55468)
 - [ ] 4d543a569fa Add Snapshot Resiliency Test for Master Failover during Delete (#54866) (#55456)
-- [ ] 258f4b3be3c Fix Incorrect Concurrent SnapshotException on Master Failover (#54877) (#55448)
+- [x] 258f4b3be3c Fix Incorrect Concurrent SnapshotException on Master Failover (#54877) (#55448)
 - [ ] 60b8a5dabab Exclude Snapshot Shard Status Update Requests from Circuit Breaker (#55376) (#55383)
 - [ ] 417d5f20099 Make data streams in APIs resolvable. (#55337)
 - [ ] 22c55180c11 [7.x] Backport ValuesSourceRegistry and related work (#54922)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -426,7 +426,7 @@ should be crossed out as well.
 - [ ] 417d5f20099 Make data streams in APIs resolvable. (#55337)
 - [ ] 22c55180c11 [7.x] Backport ValuesSourceRegistry and related work (#54922)
 - [ ] d7cded8d7a5 Fix updating include_in_parent/include_in_root of nested field. (#55326)
-- [ ] 7941f4a47e4 Add RepositoriesService to createComponents() args (#54814)
+- [x] 7941f4a47e4 Add RepositoriesService to createComponents() args (#54814)
 - [x] 8a565c4fa61 Voting config exclusions should work with absent nodes (#55291)
 - [x] 2f91e2aab78 Fix Race in Snapshot Abort (#54873) (#55233)
 - [x] d8b43c62838 Make Snapshot Deletes Less Racy (#54765) (#55226)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -420,7 +420,7 @@ should be crossed out as well.
 - [ ] 3cc4e0dd09b Retry follow task when remote connection queue full (#55314)
 - [ ] 9e3b813b629 Ensure not to open directory reader on transport thread (#55419)
 - [ ] a0763d958d1 Make RepositoryData Less Memory Heavy (#55293) (#55468)
-- [ ] 4d543a569fa Add Snapshot Resiliency Test for Master Failover during Delete (#54866) (#55456)
+- [x] 4d543a569fa Add Snapshot Resiliency Test for Master Failover during Delete (#54866) (#55456)
 - [x] 258f4b3be3c Fix Incorrect Concurrent SnapshotException on Master Failover (#54877) (#55448)
 - [ ] 60b8a5dabab Exclude Snapshot Shard Status Update Requests from Circuit Breaker (#55376) (#55383)
 - [ ] 417d5f20099 Make data streams in APIs resolvable. (#55337)

--- a/plugins/es-analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/plugins/es-analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -19,6 +19,16 @@
 
 package org.elasticsearch.analysis.common;
 
+import static org.elasticsearch.plugins.AnalysisPlugin.requiresAnalysisSettings;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -128,25 +138,18 @@ import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.tartarus.snowball.ext.DutchStemmer;
 import org.tartarus.snowball.ext.FrenchStemmer;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-import static org.elasticsearch.plugins.AnalysisPlugin.requiresAnalysisSettings;
 
 public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin {
 
     @Override
     public Collection<Object> createComponents(Client client, ClusterService clusterService, ThreadPool threadPool,
                                                NamedXContentRegistry xContentRegistry, Environment environment,
-                                               NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry) {
+                                               NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry,
+                                               Supplier<RepositoriesService> repositoriesServiceSupplier) {
         return Collections.emptyList();
     }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -514,10 +514,11 @@ public class Node implements Closeable {
                 forbidPrivateIndexSettings
             );
 
+            final SetOnce<RepositoriesService> repositoriesServiceReference = new SetOnce<>();
             final Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class).stream()
                 .flatMap(p -> p.createComponents(client, clusterService, threadPool,
                                                  xContentRegistry, environment, nodeEnvironment,
-                                                 namedWriteableRegistry).stream())
+                                                 namedWriteableRegistry, repositoriesServiceReference::get).stream())
                 .collect(Collectors.toList());
 
             ActionModule actionModule = new ActionModule(
@@ -642,6 +643,7 @@ public class Node implements Closeable {
             modules.add(copyModule);
 
             RepositoriesService repositoryService = repositoriesModule.repositoryService();
+            repositoriesServiceReference.set(repositoryService);
             logicalReplicationService.repositoriesService(repositoryService);
 
             final SnapshotsService snapshotsService = new SnapshotsService(

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import org.elasticsearch.bootstrap.BootstrapCheck;
@@ -48,6 +49,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 /**
@@ -96,10 +98,13 @@ public abstract class Plugin implements Closeable {
      * @param environment the environment for path and setting configurations
      * @param nodeEnvironment the node environment used coordinate access to the data paths
      * @param namedWriteableRegistry the registry for {@link NamedWriteable} object parsing
+     * @param repositoriesServiceSupplier A supplier for the service that manages snapshot repositories; will return null when this method
+     *                                   is called, but will return the repositories service once the node is initialized.
      */
     public Collection<Object> createComponents(Client client, ClusterService clusterService, ThreadPool threadPool,
                                                NamedXContentRegistry xContentRegistry, Environment environment,
-                                               NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry) {
+                                               NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry,
+                                               Supplier<RepositoriesService> repositoriesServiceSupplier) {
         return Collections.emptyList();
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.repositories.RepositoriesModule;
 import org.elasticsearch.repositories.Repository;
 
 /**
@@ -60,12 +59,4 @@ public interface RepositoryPlugin {
         return Collections.emptyMap();
     }
 
-    /**
-     * Passes down the current {@link RepositoriesModule} to repository plugins.
-     *
-     * @param module the current {@link RepositoriesModule}
-     */
-    default void onRepositoriesModule(RepositoriesModule module) {
-        // NORELEASE
-    }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
@@ -102,7 +102,6 @@ public class RepositoriesModule extends AbstractModule {
 
         Map<String, Repository.Factory> repositoryTypes = Collections.unmodifiableMap(factories);
         repositoriesService = new RepositoriesService(env.settings(), clusterService, transportService, repositoryTypes, threadPool);
-        repoPlugins.forEach(rp -> rp.onRepositoriesModule(this));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -637,6 +637,19 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         } catch (Exception e) {
             LOGGER.warn("Failed to update snapshot state ", e);
         }
+        assert assertConsistentWithClusterState(event.state());
+    }
+
+    private boolean assertConsistentWithClusterState(ClusterState state) {
+        final SnapshotsInProgress snapshotsInProgress = state.custom(SnapshotsInProgress.TYPE);
+        if (snapshotsInProgress != null && snapshotsInProgress.entries().isEmpty() == false) {
+            final Set<Snapshot> runningSnapshots =
+                snapshotsInProgress.entries().stream().map(SnapshotsInProgress.Entry::snapshot).collect(Collectors.toSet());
+            final Set<Snapshot> snapshotListenerKeys = snapshotCompletionListeners.keySet();
+            assert runningSnapshots.containsAll(snapshotListenerKeys) : "Saw completion listeners for unknown snapshots in "
+                + snapshotListenerKeys + " but running snapshots are " + runningSnapshots;
+        }
+        return true;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -195,7 +195,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         "cannot snapshot while a snapshot deletion is in-progress in [" + deletionsInProgress + "]");
                 }
                 SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE);
-                if (snapshots != null && snapshots.entries().isEmpty() == false) {
+                // Fail if there are any concurrently running snapshots. The only exception to this being a snapshot in INIT state from a
+                // previous master that we can simply ignore and remove from the cluster state because we would clean it up from the
+                // cluster state anyway in #applyClusterState.
+                if (snapshots != null && snapshots.entries().stream().anyMatch(entry ->
+                    (entry.state() == State.INIT && initializingSnapshots.contains(entry.snapshot()) == false) == false)) {
                     throw new ConcurrentSnapshotExecutionException(repositoryName, snapshotName, " a snapshot is already running");
                 }
                 // Store newSnapshot here to be processed in clusterStateProcessed

--- a/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/server/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -44,6 +44,7 @@ import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty4.Netty4Transport;
 
@@ -82,7 +83,8 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
                                                NamedXContentRegistry xContentRegistry,
                                                Environment environment,
                                                NodeEnvironment nodeEnvironment,
-                                               NamedWriteableRegistry namedWriteableRegistry) {
+                                               NamedWriteableRegistry namedWriteableRegistry,
+                                               Supplier<RepositoriesService> repositoriesServiceSupplier) {
         // pipelineRegistry is returned here so that it's bound in guice and can be injected in other places
         return Collections.singletonList(pipelineRegistry);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We only have very indirect coverage of master failovers during snaphot delete
at the moment. This comment adds a direct test of this scenario and also
an assertion that makes sure we are not leaking any snapshot completion listeners
in the snapshots service in this scenario.

This gives us better coverage of scenarios like #54256 and makes the diff
to the upcoming more consistent snapshot delete implementation in #54705
smaller.

https://github.com/elastic/elasticsearch/commit/4d543a569fabba130390b9ce787aa4b962e373d4

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
