### PR TITLE
bp: Ensure not to open directory reader on transport thread

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -418,7 +418,7 @@ should be crossed out as well.
 - [ ] db7eb8e8fff Remove Redundant CS Update on Snapshot Finalization (#55276) (#55528)
 - [ ] be60d504520 Allow searching of snapshot taken while indexing (#55511)
 - [ ] 3cc4e0dd09b Retry follow task when remote connection queue full (#55314)
-- [ ] 9e3b813b629 Ensure not to open directory reader on transport thread (#55419)
+- [x] 9e3b813b629 Ensure not to open directory reader on transport thread (#55419)
 - [ ] a0763d958d1 Make RepositoryData Less Memory Heavy (#55293) (#55468)
 - [ ] 4d543a569fa Add Snapshot Resiliency Test for Master Failover during Delete (#54866) (#55456)
 - [ ] 258f4b3be3c Fix Incorrect Concurrent SnapshotException on Master Failover (#54877) (#55448)

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -167,6 +167,7 @@ public class ReadOnlyEngine extends Engine {
     }
 
     protected DirectoryReader open(IndexCommit commit) throws IOException {
+        assert Transports.assertNotTransportThread("opening index commit of a read-only engine");
         return DirectoryReader.open(commit);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change adds an assertion making sure that we won't accidentally open directory readers using transport threads.

https://github.com/elastic/elasticsearch/commit/9e3b813b6299727279f70d4a896e9dc3e1272677



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
