### PR TITLE
Fix error handling in FetchTask.start

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -110,6 +110,8 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could lead to stuck queries.
+
 - Fixed ``EXPLAIN`` plan output for queries with a ``WHERE`` clause containing
   implicit cast symbols. A possible optimization of our planner/optimizer was
   not used, resulting in different output than actually used on plan execution.

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -226,7 +226,12 @@ public class FetchTask implements Task {
             for (Routing routing : routingIterable) {
                 Map<String, Map<String, IntIndexedContainer>> locations = routing.locations();
                 Map<String, IntIndexedContainer> indexShards = locations.get(localNodeId);
-                refreshActions.add(sharedShardContexts.maybeRefreshReaders(metadata, indexShards, phase.bases()));
+                try {
+                    refreshActions.add(sharedShardContexts.maybeRefreshReaders(metadata, indexShards, phase.bases()));
+                } catch (Throwable t) {
+                    result.completeExceptionally(t);
+                    throw t;
+                }
             }
             return CompletableFuture.allOf(refreshActions.toArray(CompletableFuture[]::new))
                 .thenApply(ignored -> {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`sharedShardContexts.maybeRefreshReaders` can throw a
ShardNotFoundException.

The completionFuture of the `FetchTask` wasn't completed in that case,
which prevented the error propagation to other tasks.

Fixes flaky
`CastIntegrationTest.testTryCastReturnNullWhenCastingFailsOnRows`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
