### PR TITLE
Fix `ExplainPlan` to utilize cast optimization on sub plans.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -110,4 +110,6 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed ``EXPLAIN`` plan output for queries with a ``WHERE`` clause containing
+  implicit cast symbols. A possible optimization of our planner/optimizer was
+  not used, resulting in different output than actually used on plan execution.

--- a/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -21,12 +21,7 @@
 
 package io.crate.planner;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -71,9 +66,9 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testExplain() {
         for (String statement : EXPLAIN_TEST_STATEMENTS) {
             ExplainPlan plan = e.plan("EXPLAIN " + statement);
-            assertNotNull(plan);
-            assertNotNull(plan.subPlan());
-            assertFalse(plan.doAnalyze());
+            assertThat(plan).isNotNull();
+            assertThat(plan.subPlan()).isNotNull();
+            assertThat(plan.doAnalyze()).isFalse();
         }
     }
 
@@ -81,9 +76,9 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testExplainAnalyze() {
         for (String statement : EXPLAIN_TEST_STATEMENTS) {
             ExplainPlan plan = e.plan("EXPLAIN ANALYZE " + statement);
-            assertNotNull(plan);
-            assertNotNull(plan.subPlan());
-            assertTrue(plan.doAnalyze());
+            assertThat(plan).isNotNull();
+            assertThat(plan.subPlan()).isNotNull();
+            assertThat(plan.doAnalyze()).isTrue();
         }
     }
 
@@ -111,8 +106,8 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
             }
         }, Row.EMPTY, SubQueryResults.EMPTY);
 
-        assertNull(itRef.get());
-        assertNotNull(failureRef.get());
-        assertThat(failureRef.get().getMessage(), containsString("EXPLAIN ANALYZE does not support profiling multi-phase plans, such as queries with scalar subselects."));
+        assertThat(itRef.get()).isNull();
+        assertThat(failureRef.get()).isNotNull();
+        assertThat(failureRef.get().getMessage()).isEqualTo("EXPLAIN ANALYZE does not support profiling multi-phase plans, such as queries with scalar subselects.");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Cast optimizations inside WHERE clauses are done while building an `ExceutionPlan` of a COLLECT plan to take subquery results and parameter symbols into account.
As the `ExplainPlan` (without the ANALYZE step) prints out a plan without execution it, these cast optimizations aren't applied. To fix this and such print out the same plan which is used for execution, these cast optimizations are explicitly called while executing the `ExplainPlan`.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
