### PR TITLE
Use assertj for assertions in `buildSrc` (partial backport #12846)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,4 +10,5 @@ dependencies {
     implementation 'org.apache.commons:commons-compress:1.20'
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.27.0"
+    testImplementation "org.assertj:assertj-core:3.23.1"
 }

--- a/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
+++ b/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkDownloadPluginFunctionalTest.java
@@ -22,6 +22,8 @@
 package io.crate.gradle.plugins.jdk;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+
+import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.Test;
@@ -39,9 +41,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Note: the downloading of the JDK bundles are not covered by the test,
@@ -85,10 +85,14 @@ public class JdkDownloadPluginFunctionalTest {
                                          String version) {
         runBuild(task, result -> {
             Matcher matcher = JDK_HOME_LOG.matcher(result.getOutput());
-            assertThat("could not find jdk home in: " + result.getOutput(), matcher.find(), is(true));
+            Assertions.assertThat(matcher.find())
+                .as("could not find jdk home in: " + result.getOutput())
+                .isTrue();
             String jdkHome = matcher.group(1);
             Path javaPath = Paths.get(jdkHome, javaBin);
-            assertThat(javaPath.toString(), Files.exists(javaPath), is(true));
+            Assertions.assertThat(Files.exists(javaPath))
+                .as(javaPath.toString())
+                .isTrue();
         }, os, arch, vendor, version);
     }
 

--- a/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkTest.java
+++ b/buildSrc/src/test/java/io/crate/gradle/plugins/jdk/JdkTest.java
@@ -20,18 +20,15 @@
  */
 package io.crate.gradle.plugins.jdk;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class JdkTest {
-
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     private static Project rootProject;
 
@@ -42,112 +39,116 @@ public class JdkTest {
 
     @Test
     public void testMissingArch() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "architecture is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            null,
-            "11.0.2+33",
-            "linux",
-            null
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     null,
+                     "11.0.2+33",
+                     "linux",
+                     null
+           ))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("architecture is not specified for jdk [testjdk]");
     }
 
     @Test
     public void testUnknownArch() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "unknown architecture [x86] for jdk [testjdk], must be one of [x64, aarch64]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "11.0.2+33",
-            "windows",
-            "x86"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "11.0.2+33",
+                     "windows",
+                     "x86"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("unknown architecture [x86] for jdk [testjdk], must be one of [x64, aarch64]");
+
     }
 
     @Test
     public void testMissingVendor() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "vendor is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            null,
-            "11.0.2+33",
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     null,
+                     "11.0.2+33",
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("vendor is not specified for jdk [testjdk]");
     }
 
     @Test
     public void testUnknownVendor() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "unknown vendor [unknown] for jdk [testjdk], must be one of [adoptopenjdk, adoptium]");
-        createJdk(createProject(),
-            "testjdk",
-            "unknown",
-            "11.0.2+33",
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "unknown",
+                     "11.0.2+33",
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("unknown vendor [unknown] for jdk [testjdk], must be one of [adoptopenjdk, adoptium]");
     }
 
     @Test
     public void testMissingVersion() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("version is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            null,
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     null,
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("version is not specified for jdk [testjdk]");
+
     }
 
     @Test
     public void testBadVersionFormat() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("malformed version [badversion] for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "badversion",
-            "linux",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "badversion",
+                     "linux",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("malformed version [badversion] for jdk [testjdk]");
     }
 
     @Test
     public void testMissingOS() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("OS is not specified for jdk [testjdk]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "11.0.2+33",
-            null,
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "11.0.2+33",
+                     null,
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("OS is not specified for jdk [testjdk]");
     }
 
     @Test
     public void testUnknownOS() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "unknown OS [unknown] for jdk [testjdk], " +
-            "must be one of [linux, windows, mac]");
-        createJdk(createProject(),
-            "testjdk",
-            "adoptopenjdk",
-            "11.0.2+33",
-            "unknown",
-            "x64"
-        );
+        assertThatThrownBy(() ->
+           createJdk(createProject(),
+                     "testjdk",
+                     "adoptopenjdk",
+                     "11.0.2+33",
+                     "unknown",
+                     "x64"
+           ))
+           .isExactlyInstanceOf(IllegalArgumentException.class)
+           .hasMessage("unknown OS [unknown] for jdk [testjdk], must be one of [linux, windows, mac]");
     }
 
     private void createJdk(Project project,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

(cherry picked from commit d517806f57e9a7ffa5844e6e27db1401147ca991)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
