### PR TITLE
Fix fd leak in getCgroupHierarchy

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -110,6 +110,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed a file descriptor leak that was triggered by querying the ``os`` column
+  of the ``sys.nodes`` table.
+
 - Fixed an issue that could lead to a ``NoSuchElementException`` when using the
   JDBC client and mixing different DML statements using the ``addBatch``
   functionality.

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -481,13 +482,16 @@ public class OsProbe {
         if (V1_FILES.stream().allMatch(fileExists)) {
             return CGroupHierarchy.V1;
         }
+        Path cgroupPath = Paths.get("/sys/fs/cgroup");
         for (String v2Glob : V2_FILE_GLOBS) {
             PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher(v2Glob);
-            Iterator<Path> it = Files.walk(Paths.get("/sys/fs/cgroup")).iterator();
-            while (it.hasNext()) {
-                Path path = it.next();
-                if (pathMatcher.matches(path)) {
-                    return CGroupHierarchy.V2;
+            try (Stream<Path> walk = Files.walk(cgroupPath)) {
+                Iterator<Path> it = walk.iterator();
+                while (it.hasNext()) {
+                    Path path = it.next();
+                    if (pathMatcher.matches(path)) {
+                        return CGroupHierarchy.V2;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`Files.walk` returns a stream that must be closed to avoid leaks.

    crash -c "select os from sys.nodes"; lsof -a -p $(jps | awk '/CrateDB/ { print $1 }') | wc -l

Closes https://github.com/crate/crate/issues/13027

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
