### PR TITLE
Fix issue with LEFT join and subquery in WHERE

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -113,6 +113,7 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue causing
 - Fixed a file descriptor leak that was triggered by querying the ``os`` column
   of the ``sys.nodes`` table.
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -113,7 +113,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-- Fixed an issue causing
+- Fixed an issue causing an ``IllegalArgumentException`` to be thrown when the
+  optimizer attempts to convert a ``LEFT JOIN`` to an ``INNER JOIN`` and there
+  is also a subquery in the ``WHERE`` clause.
+
 - Fixed a file descriptor leak that was triggered by querying the ``os`` column
   of the ``sys.nodes`` table.
 

--- a/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -45,7 +45,7 @@ import io.crate.types.DataType;
  *
  * This does not handle Columns/InputColumns, only Functions, Literals, ParameterSymbols and SubQuery values
  */
-public class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> {
+public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> {
 
 
     private final SubQueryResults subQueryResults;

--- a/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -45,7 +45,7 @@ import io.crate.types.DataType;
  *
  * This does not handle Columns/InputColumns, only Functions, Literals, ParameterSymbols and SubQuery values
  */
-public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> {
+public class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> {
 
 
     private final SubQueryResults subQueryResults;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/NullSymbolEvaluator.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/NullSymbolEvaluator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import io.crate.data.Input;
+import io.crate.expression.BaseImplementationSymbolVisitor;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.ParameterSymbol;
+import io.crate.expression.symbol.ScopedSymbol;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.TransactionContext;
+
+final class NullSymbolEvaluator extends BaseImplementationSymbolVisitor<Void> {
+
+    public NullSymbolEvaluator(TransactionContext txnCtx, NodeContext nodeCtx) {
+        super(txnCtx, nodeCtx);
+    }
+
+    @Override
+    public Input<?> visitField(ScopedSymbol field, Void context) {
+        return Literal.NULL;
+    }
+
+    @Override
+    public Input<?> visitReference(Reference symbol, Void context) {
+        return Literal.NULL;
+    }
+
+    @Override
+    public Input<?> visitParameterSymbol(ParameterSymbol parameterSymbol, Void context) {
+        return Literal.NULL;
+    }
+
+    @Override
+    public Input<?> visitSelectSymbol(SelectSymbol selectSymbol, Void context) {
+        return Literal.NULL;
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -30,16 +30,10 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import io.crate.analyze.SymbolEvaluator;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.data.Input;
-import io.crate.data.Row;
 import io.crate.expression.operator.AndOperator;
-import io.crate.expression.symbol.FieldReplacer;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.RefReplacer;
-import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
@@ -48,7 +42,6 @@ import io.crate.planner.node.dql.join.JoinType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
-import io.crate.planner.operators.SubQueryResults;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
@@ -127,7 +120,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx) {
-        final var symbolEvaluator = new RuleSymbolEvaluator(txnCtx, nodeCtx);
+        final var symbolEvaluator = new NullSymbolEvaluator(txnCtx, nodeCtx);
         NestedLoopJoin nl = captures.get(nlCapture);
         Symbol query = filter.query();
         Map<Set<RelationName>, Symbol> splitQueries = QuerySplitter.split(query);
@@ -270,40 +263,11 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
     }
 
     private static boolean couldMatchOnNull(@Nullable Symbol query,
-                                            SymbolEvaluator evaluator) {
+                                            NullSymbolEvaluator evaluator) {
         if (query == null) {
             return false;
         }
-        Symbol queryWithNulls = RefReplacer.replaceRefs(
-            FieldReplacer.replaceFields(query, ignored -> Literal.NULL),
-            ignored -> Literal.NULL
-        );
-
-        Input<?> input = queryWithNulls.accept(evaluator, ALL_NULL_ROW);
+        Input<?> input = query.accept(evaluator, null);
         return WhereClause.canMatch(input);
-    }
-
-    private static Row ALL_NULL_ROW = new Row() {
-
-        @Override
-        public int numColumns() {
-            return Integer.MAX_VALUE;
-        }
-
-        @Override
-        public Object get(int index) {
-            return null;
-        }
-    };
-
-    private static class RuleSymbolEvaluator extends SymbolEvaluator {
-        public RuleSymbolEvaluator(TransactionContext txnCtx, NodeContext nodeCtx) {
-            super(txnCtx, nodeCtx, SubQueryResults.EMPTY);
-        }
-
-        @Override
-        public Input<?> visitSelectSymbol(SelectSymbol selectSymbol, Row context) {
-            return Literal.NULL;
-        }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When trying a `LEFT` to an `INNER` join, a `SymbolEvaluator` is
used, with empty `subQueryResults` which will cause an
`IllegalArgumentException` to be thrown when calling `getSafe()`
on the subquery results.

Use a subclass of `SymbolEvaluator` for this purpose which returns
a `null` Literal when visiting subquery `SelectSymbol`s.

Fixes: #13003
Follows: #12071

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
