### PR TITLE
Add parser support for DECLARE, FETCH and CLOSE

### DIFF
--- a/docs/general/builtins/table-functions.rst
+++ b/docs/general/builtins/table-functions.rst
@@ -382,10 +382,10 @@ The result rows have three columns:
     +----------+---------+------------+
     | word     | catcode | catdesc    |
     +----------+---------+------------+
+    | absolute | U       | unreserved |
     | add      | R       | reserved   |
     | alias    | U       | unreserved |
     | all      | R       | reserved   |
-    | allocate | U       | unreserved |
     +----------+---------+------------+
     SELECT 4 rows in set (... sec)
 

--- a/libs/sql-parser/src/main/antlr/SqlBase.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBase.g4
@@ -90,6 +90,10 @@ statement
     | DEALLOCATE (PREPARE)? (ALL | prepStmt=stringLiteralOrIdentifierOrQname)        #deallocate
     | ANALYZE                                                                        #analyze
     | DISCARD (ALL | PLANS | SEQUENCES | TEMPORARY | TEMP)                           #discard
+    | DECLARE ident declareCursorParams
+        CURSOR ((WITH | WITHOUT) HOLD)? FOR queryNoWith                              #declare
+    | FETCH (direction)? (IN | FROM)? ident                                          #fetch
+    | CLOSE (ident | ALL)                                                            #close
     ;
 
 dropStmt
@@ -727,6 +731,29 @@ isolationLevel
     | READ UNCOMMITTED
     ;
 
+direction
+    : NEXT
+    | PRIOR
+    | FIRST
+    | LAST
+    | ABSOLUTE integerLiteral
+    | RELATIVE integerLiteral
+    | integerLiteral
+    | ALL
+    | FORWARD
+    | FORWARD integerLiteral
+    | FORWARD ALL
+    | BACKWARD
+    | BACKWARD integerLiteral
+    | BACKWARD ALL
+    ;
+
+// https://www.postgresql.org/docs/current/sql-declare.html
+// The key words ASENSITIVE, BINARY, INSENSITIVE, and SCROLL can appear in any order.
+declareCursorParams
+    : (ASENSITIVE | BINARY | INSENSITIVE | (NO)? SCROLL)*
+    ;
+
 nonReserved
     : ALIAS | ANALYZE | ANALYZER | AT | AUTHORIZATION | BERNOULLI | BLOB | CATALOGS | CHAR_FILTERS | CHECK | CLUSTERED
     | COLUMNS | COPY | CURRENT |  DAY | DEALLOCATE | DISTRIBUTED | DUPLICATE | DYNAMIC | EXPLAIN
@@ -746,7 +773,8 @@ nonReserved
     | REPLACE | RETURNING | SWAP | GC | DANGLING | ARTIFACTS | DECOMMISSION | LEADING | TRAILING | BOTH | TRIM
     | CURRENT_SCHEMA | PROMOTE | CHARACTER | VARYING | SUBSTRING
     | DISCARD | PLANS | SEQUENCES | TEMPORARY | TEMP | METADATA
-    | PUBLICATION | SUBSCRIPTION | ENABLE | DISABLE | CONNECTION
+    | PUBLICATION | SUBSCRIPTION | ENABLE | DISABLE | CONNECTION | DECLARE | CURSOR | HOLD | FORWARD | BACKWARD
+    | RELATIVE | PRIOR | ASENSITIVE | INSENSITIVE | BINARY | NO | SCROLL | ABSOLUTE
     ;
 
 AUTHORIZATION: 'AUTHORIZATION';
@@ -1025,6 +1053,20 @@ SUBSCRIPTION: 'SUBSCRIPTION';
 CONNECTION: 'CONNECTION';
 ENABLE: 'ENABLE';
 DISABLE: 'DISABLE';
+
+DECLARE: 'DECLARE';
+CURSOR: 'CURSOR';
+ASENSITIVE: 'ASENSITIVE';
+INSENSITIVE: 'INSENSITIVE';
+BINARY: 'BINARY';
+NO: 'NO';
+SCROLL: 'SCROLL';
+HOLD: 'HOLD';
+ABSOLUTE: 'ABSOLUTE';
+FORWARD: 'FORWARD';
+BACKWARD: 'BACKWARD';
+RELATIVE: 'RELATIVE';
+PRIOR: 'PRIOR';
 
 EQ  : '=';
 NEQ : '<>' | '!=';

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -675,4 +675,16 @@ public abstract class AstVisitor<R, C> {
     public R visitWith(With with, C context) {
         return visitStatement(with, context);
     }
+
+    public R visitDeclare(Declare declare, C context) {
+        return visitStatement(declare, context);
+    }
+
+    public R visitFetch(Fetch fetch, C context) {
+        return visitStatement(fetch, context);
+    }
+
+    public R visitClose(Close close, C context) {
+        return visitStatement(close, context);
+    }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Close.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Close.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+public final class Close extends Statement {
+
+    private final String cursorName;
+
+    /**
+     * @param cursorName name of cursor to close; null implies ALL
+     */
+    public Close(@Nullable String cursorName) {
+        this.cursorName = cursorName;
+    }
+
+    @Nullable
+    public String cursorName() {
+        return cursorName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitClose(this, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(cursorName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Close other = (Close) obj;
+        return Objects.equals(cursorName, other.cursorName);
+    }
+
+    @Override
+    public String toString() {
+        return "Close{cursorName=" + cursorName + "}";
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Declare.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Declare.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.Objects;
+
+public final class Declare extends Statement {
+
+    public enum Hold {
+        WITH,
+        WITHOUT
+    }
+
+    private final String cursorName;
+    private final Hold hold;
+    private final boolean binary;
+    private final boolean scroll;
+    private final Query query;
+
+    public Declare(String cursorName,
+                   Hold hold,
+                   boolean binary,
+                   boolean scroll,
+                   Query query) {
+        this.cursorName = cursorName;
+        this.hold = hold;
+        this.binary = binary;
+        this.scroll = scroll;
+        this.query = query;
+    }
+
+    public String cursorName() {
+        return cursorName;
+    }
+
+    public Hold hold() {
+        return hold;
+    }
+
+    public boolean binary() {
+        return binary;
+    }
+
+    public boolean scroll() {
+        return scroll;
+    }
+
+    public Query query() {
+        return query;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitDeclare(this, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(binary, cursorName, hold, query, scroll);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Declare other = (Declare) obj;
+        return binary == other.binary && Objects.equals(cursorName, other.cursorName) && hold == other.hold
+                && Objects.equals(query, other.query) && scroll == other.scroll;
+    }
+
+    @Override
+    public String toString() {
+        return "Declare{binary=" + binary + ", cursorName=" + cursorName + ", hold=" + hold + ", query=" + query
+                + ", scroll=" + scroll + "}";
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Fetch.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Fetch.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.Objects;
+
+public final class Fetch extends Statement {
+
+    /**
+     * Normalized direction
+     *
+     * <pre>
+     * {@code
+     *      NEXT                        relative +1
+     *      PRIOR                       relative -1
+     *      FIRST                       absolute 1
+     *      LAST                        absolute -1
+     *      ABSOLUTE integerLiteral     absolute <count>
+     *      RELATIVE integerLiteral     relative <count>
+     *      integerLiteral              relative <count>
+     *      ALL                         relative Long.MAX_VALUE
+     *      FORWARD                     relative 1
+     *      FORWARD integerLiteral      relative <count>
+     *      FORWARD ALL                 relative Long.MAX_VALUE
+     *      BACKWARD                    relative -1
+     *      BACKWARD integerLiteral     relative (<count> * - 1)
+     *      BACKWARD ALL                relative - Long.MAX_VALUE
+     * }
+     * </pre>
+     */
+    public enum ScrollMode {
+        RELATIVE,
+        ABSOLUTE
+    }
+
+    private final ScrollMode scrollMode;
+    private final long count;
+    private final String cursorName;
+
+    /**
+     * @param scollMode normalized direction. See {@link ScrollMode}
+     */
+    public Fetch(ScrollMode scollMode, long count, String cursorName) {
+        this.scrollMode = scollMode;
+        this.count = count;
+        this.cursorName = cursorName;
+    }
+
+    public ScrollMode scrollMode() {
+        return scrollMode;
+    }
+
+    public long count() {
+        return count;
+    }
+
+    public String cursorName() {
+        return cursorName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitFetch(this, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(count, cursorName, scrollMode);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Fetch other = (Fetch) obj;
+        return count == other.count && Objects.equals(cursorName, other.cursorName) && scrollMode == other.scrollMode;
+    }
+
+    @Override
+    public String toString() {
+        return "Fetch{count=" + count + ", cursorName=" + cursorName + ", scrollMode=" + scrollMode + "}";
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -43,6 +43,7 @@ import io.crate.sql.tree.ArrayLikePredicate;
 import io.crate.sql.tree.ArrayLiteral;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.BeginStatement;
+import io.crate.sql.tree.Close;
 import io.crate.sql.tree.CommitStatement;
 import io.crate.sql.tree.ComparisonExpression;
 import io.crate.sql.tree.CopyFrom;
@@ -52,6 +53,7 @@ import io.crate.sql.tree.CreateSubscription;
 import io.crate.sql.tree.CreateTable;
 import io.crate.sql.tree.CreateUser;
 import io.crate.sql.tree.DeallocateStatement;
+import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.DenyPrivilege;
 import io.crate.sql.tree.DropAnalyzer;
@@ -66,6 +68,7 @@ import io.crate.sql.tree.DropUser;
 import io.crate.sql.tree.DropView;
 import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.Fetch;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.GCDanglingArtifacts;
 import io.crate.sql.tree.GrantPrivilege;
@@ -113,6 +116,36 @@ public class TestStatementBuilder {
         statements = SqlParser.createStatements("SET extra_float_digits = 3");
         assertThat(statements).hasSize(1);
         assertThat(statements.get(0)).isExactlyInstanceOf(SetStatement.class);
+    }
+
+    @Test
+    public void test_declare() {
+        printStatement("DECLARE c1 CURSOR FOR select 1");
+        printStatement("DECLARE c1 BINARY CURSOR FOR select 1");
+        printStatement("DECLARE c1 INSENSITIVE CURSOR FOR select 1");
+        printStatement("DECLARE c1 ASENSITIVE CURSOR FOR select 1");
+        printStatement("DECLARE c1 SCROLL CURSOR FOR select 1");
+        printStatement("DECLARE c1 NO SCROLL CURSOR FOR select 1");
+        printStatement("DECLARE c1 NO SCROLL BINARY ASENSITIVE CURSOR FOR select 1");
+    }
+
+    @Test
+    public void test_fetch() {
+        printStatement("FETCH FROM c1");
+        printStatement("FETCH IN c1");
+        printStatement("FETCH FIRST FROM c1");
+        printStatement("FETCH LAST FROM c1");
+        printStatement("FETCH ALL FROM c1");
+        printStatement("FETCH FORWARD FROM c1");
+        printStatement("FETCH FORWARD 4 FROM c1");
+        printStatement("FETCH ABSOLUTE 3 FROM c1");
+        printStatement("FETCH BACKWARD 4 FROM c1");
+    }
+
+    @Test
+    public void test_close() {
+        printStatement("CLOSE ALL");
+        printStatement("CLOSE c1");
     }
 
     @Test
@@ -1963,7 +1996,10 @@ public class TestStatementBuilder {
             statement instanceof CreateSubscription ||
             statement instanceof DropSubscription ||
             statement instanceof AlterSubscription ||
-            statement instanceof With) {
+            statement instanceof With ||
+            statement instanceof Declare ||
+            statement instanceof Fetch ||
+            statement instanceof Close) {
 
             println(SqlFormatter.formatSql(statement));
             println("");

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -44,6 +44,7 @@ import io.crate.sql.tree.AlterUser;
 import io.crate.sql.tree.AnalyzeStatement;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.BeginStatement;
+import io.crate.sql.tree.Close;
 import io.crate.sql.tree.CommitStatement;
 import io.crate.sql.tree.CopyFrom;
 import io.crate.sql.tree.CopyTo;
@@ -59,6 +60,7 @@ import io.crate.sql.tree.CreateTableAs;
 import io.crate.sql.tree.CreateUser;
 import io.crate.sql.tree.CreateView;
 import io.crate.sql.tree.DeallocateStatement;
+import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.DecommissionNodeStatement;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.DenyPrivilege;
@@ -76,6 +78,7 @@ import io.crate.sql.tree.DropUser;
 import io.crate.sql.tree.DropView;
 import io.crate.sql.tree.Explain;
 import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.Fetch;
 import io.crate.sql.tree.GCDanglingArtifacts;
 import io.crate.sql.tree.GrantPrivilege;
 import io.crate.sql.tree.Insert;
@@ -680,6 +683,21 @@ public class Analyzer {
         public AnalyzedStatement visitAlterSubscription(AlterSubscription alterSubscription,
                                                         Analysis context) {
             return logicalReplicationAnalyzer.analyze(alterSubscription, context.sessionSettings());
+        }
+
+        @Override
+        public AnalyzedStatement visitDeclare(Declare declare, Analysis context) {
+            throw new UnsupportedOperationException("DECLARE is not supported");
+        }
+
+        @Override
+        public AnalyzedStatement visitClose(Close close, Analysis context) {
+            throw new UnsupportedOperationException("CLOSE is not supported");
+        }
+
+        @Override
+        public AnalyzedStatement visitFetch(Fetch fetch, Analysis context) {
+            throw new UnsupportedOperationException("FETCH is not supported");
         }
     }
 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -3042,4 +3042,25 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analyzed.outputs().size(), is(1));
         assertThat(analyzed.outputs().get(0), isFunction("subscript", isField("obj"), isLiteral("unknown")));
     }
+
+    @Test
+    public void test_declare_is_not_supported() {
+        var executor = SQLExecutor.builder(clusterService).build();
+        assertThatThrownBy(() -> executor.analyze("declare c1 cursor for select 1"))
+            .hasMessage("DECLARE is not supported");
+    }
+
+    @Test
+    public void test_fetch_is_not_supported() {
+        var executor = SQLExecutor.builder(clusterService).build();
+        assertThatThrownBy(() -> executor.analyze("fetch from c1"))
+            .hasMessage("FETCH is not supported");
+    }
+
+    @Test
+    public void test_close_is_not_supported() {
+        var executor = SQLExecutor.builder(clusterService).build();
+        assertThatThrownBy(() -> executor.analyze("CLOSE ALL"))
+            .hasMessage("CLOSE is not supported");
+    }
 }

--- a/server/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/PgGetKeywordsFunctionTest.java
@@ -43,11 +43,11 @@ public class PgGetKeywordsFunctionTest extends AbstractTableFunctionsTest {
             rows.add(new RowN(it.next().materialize()));
         }
         rows.sort(Comparator.comparing(x -> ((String) x.get(0))));
-        assertThat(rows.size(), is(255));
+        assertThat(rows.size(), is(268));
         Row row = rows.get(0);
 
-        assertThat(row.get(0), is("add"));
-        assertThat(row.get(1), is("R"));
-        assertThat(row.get(2), is("reserved"));
+        assertThat(row.get(0), is("absolute"));
+        assertThat(row.get(1), is("U"));
+        assertThat(row.get(2), is("unreserved"));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -169,7 +169,7 @@ public class TableFunctionITest extends IntegTestCase {
                 throw new IllegalArgumentException("Unexpected value " + value);
             }
         }));
-        assertThat(rows.get(0)[0], is("(add,R,reserved)"));
+        assertThat(rows.get(0)[0], is("(absolute,U,unreserved)"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Subset of https://github.com/crate/crate/pull/12597
Made some small modifications:

- Direction of fetch is normalized into ABSOLUTE or RELATIVE
- Shorter class names
- DECLARE/FETCH form no hierarchy


(Not sure if this should go into a feature branch. Imho there's no harm merging this directly to master)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
