### PR TITLE
Implement cursor support (declare, fetch, close analyzer + execution)

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,9 @@ Deprecations
 Changes
 =======
 
+- Added initial support for cursors. See :ref:`DECLARE <sql-declare>`,
+  :ref:`FETCH <sql-fetch>` and :ref:`CLOSE <sql-close>`.
+
 - Added support for ``SET TIME ZONE`` to improve PostgreSQL Compatibility.
   Timezone will be ignored on the server side.
 

--- a/docs/sql/statements/close.rst
+++ b/docs/sql/statements/close.rst
@@ -1,0 +1,31 @@
+.. highlight:: psql
+
+.. _sql-close:
+
+=========
+``CLOSE``
+=========
+
+Close a cursor
+
+
+.. contents::
+   :local:
+
+.. _sql-close-synopsis:
+
+Synopsis
+========
+
+::
+
+    CLOSE { name | ALL }
+
+
+Description
+===========
+
+Closes cursors created with :ref:`DECLARE <sql-declare>`
+
+``CLOSE ALL`` closes all cursors. ``CLOSE name`` closes the cursor identified by
+its name. ``CLOSE name`` on a cursor that does not exist results in an error.

--- a/docs/sql/statements/declare.rst
+++ b/docs/sql/statements/declare.rst
@@ -1,0 +1,81 @@
+.. highlight:: psql
+
+.. _sql-declare:
+
+
+===========
+``DECLARE``
+===========
+
+Create a cursor.
+
+.. contents::
+   :local:
+
+.. _sql-declare-synopsis:
+
+Synopsis
+========
+
+::
+
+    DECLARE name [ ASENSITIVE | INSENSITIVE ] [ [ NO ] SCROLL ]
+    CURSOR [ { WITH | WITHOUT } HOLD ] FOR query
+
+
+Where ``name`` is an arbitrary name for the cursor and ``query`` is a
+:ref:`SELECT <sql-select>` statement.
+
+
+Description
+===========
+
+A cursor is used to retrieve a small number of rows at a time from a query with
+a larger result set. After creating a cursor, rows are fetched using :ref:`FETCH
+<sql-fetch>`.
+
+
+.. SEEALSO::
+
+   :ref:`FETCH <sql-fetch>`
+   :ref:`CLOSE <sql-close>`
+
+Clauses
+-------
+
+.. _sql-declare-hold:
+
+``WITH | WITHOUT HOLD``
+.......................
+
+Defaults to ``WITHOUT HOLD``, causing a cursor to be bound to the life-time
+of a transaction. Using ``WITHOUT HOLD`` without active transaction (Started
+with ``BEGIN``) is an error.
+
+``WITH HOLD`` changes the life-time of a cursor to that of the connection.
+
+Committing a transaction closes all cursors created with ``WITHOUT HOLD``.
+Closing a connection closes all cursors created within that connection.
+
+
+.. NOTE::
+
+    CrateDB doesn't support full transactions. A transaction cannot be rolled
+    back and any write operations within a ``BEGIN`` clause may become visible
+    to other statements before committing the transaction.
+
+
+``[ ASENSITIVE | INSENSITIVE ]``
+................................
+
+This clause has no effect in CrateDB
+Cursors in CrateDB are always insensitive.
+
+
+``[ NO ] SCROLL``
+.................
+
+``NO SCROLL`` (the default) specifies that the cursor can only be used to move
+forward.
+
+``SCROLL`` is currently not supported.

--- a/docs/sql/statements/fetch.rst
+++ b/docs/sql/statements/fetch.rst
@@ -1,0 +1,81 @@
+.. highlight:: psql
+
+.. _sql-fetch:
+
+=========
+``FETCH``
+=========
+
+Fetch rows from a cursor.
+
+.. contents::
+   :local:
+
+.. _sql-fetch-synopsis:
+
+Synopsis
+========
+
+::
+
+    FETCH [ direction [ FROM | IN ] ] cursor_name
+
+Where direction can be empty or one of:
+
+    NEXT
+    RELATIVE count
+    count
+    ALL
+    FORWARD
+    FORWARD count
+    FORWARD ALL
+
+
+Description
+===========
+
+Fetches rows from a cursor created using :ref:`DECLARE <sql-declare>`.
+
+A cursor has a position and each time you use ``FETCH``, the position changes
+and the rows spanning the position change get returned.
+
+
+Parameters
+===========
+
+
+``direction``
+.............
+
+:NEXT:
+  Fetch the next row. This is the default
+
+:RELATIVE count:
+  Fetch ``count`` rows relative to the current position.
+
+:count:
+  Fetch the next ``count`` rows
+
+:ALL:
+  Fetch all remaining rows
+
+:FORWARD:
+  Same as ``NEXT``
+
+:FORWARD count:
+  Same as ``count``
+
+:FORWARD ALL:
+  Same as ``ALL``
+
+
+``count``
+.........
+
+A integer constant, determining which or how many rows to fetch
+
+
+``cursor_name``
+...............
+
+Name of the cursor to fetch rows from.

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -15,7 +15,7 @@ SQL Statements
     alter-user
     analyze
     begin
-    start-transaction
+    close
     commit
     copy-from
     copy-to
@@ -31,6 +31,7 @@ SQL Statements
     create-user
     create-view
     deallocate
+    declare
     delete
     deny
     discard
@@ -45,6 +46,7 @@ SQL Statements
     drop-view
     end
     explain
+    fetch
     grant
     insert
     kill
@@ -57,11 +59,12 @@ SQL Statements
     set-license
     set-session-authorization
     set-transaction
+    show
     show-columns
     show-create-table
     show-schemas
     show-tables
-    show
+    start-transaction
     update
     values
     with

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -321,6 +321,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             scrollMode = Fetch.ScrollMode.RELATIVE;
             if (direction.ALL() != null) {
                 count = Long.MAX_VALUE;
+            } else if (direction.integerLiteral() != null) {
+                count = Long.parseLong(direction.integerLiteral().getText());
             }
             if (direction.BACKWARD() != null) {
                 count = count * -1;

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -140,6 +140,9 @@ public class TestStatementBuilder {
         printStatement("FETCH FORWARD 4 FROM c1");
         printStatement("FETCH ABSOLUTE 3 FROM c1");
         printStatement("FETCH BACKWARD 4 FROM c1");
+
+        Fetch fetch = (Fetch) SqlParser.createStatement("FETCH FORWARD 3 FROM c1");
+        assertThat(fetch.count()).isEqualTo(3L);
     }
 
     @Test

--- a/server/src/main/java/io/crate/action/sql/Cursor.java
+++ b/server/src/main/java/io/crate/action/sql/Cursor.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.action.sql;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import io.crate.data.BatchIterator;
+import io.crate.data.ForwardingBatchIterator;
+import io.crate.data.LimitingBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowConsumer;
+import io.crate.expression.symbol.Symbol;
+import io.crate.sql.tree.Declare.Hold;
+import io.crate.sql.tree.Fetch.ScrollMode;
+
+public final class Cursor implements AutoCloseable {
+
+    private final Hold hold;
+    private final CompletableFuture<BatchIterator<Row>> queryIterator;
+    private final List<Symbol> outputs;
+
+    public Cursor(Hold hold,
+                  CompletableFuture<BatchIterator<Row>> queryIterator,
+                  List<Symbol> outputs) {
+        this.hold = hold;
+        this.queryIterator = queryIterator;
+        this.outputs = outputs;
+    }
+
+    public Hold hold() {
+        return hold;
+    }
+
+    public void fetch(RowConsumer consumer, ScrollMode scrollMode, long count) {
+        if (scrollMode == ScrollMode.ABSOLUTE) {
+            consumer.accept(null, new UnsupportedOperationException(
+                "Scrolling to an absolute position is not supported"));
+            return;
+        }
+        if (count < 0) {
+            consumer.accept(null, new UnsupportedOperationException("Cannot scroll backwards"));
+            return;
+        }
+        if (count == 0) {
+            consumer.accept(null, new UnsupportedOperationException("Scroll must move forward"));
+            return;
+        }
+        if (queryIterator.isDone()) {
+            try {
+                BatchIterator<Row> bi = queryIterator.join();
+                triggerConsumer(consumer, bi, count);
+            } catch (Throwable t) {
+                consumer.accept(null, t);
+                return;
+            }
+        } else {
+            queryIterator.whenComplete((bi, err) -> {
+                if (err == null) {
+                    triggerConsumer(consumer, bi, count);
+                } else {
+                    consumer.accept(null, err);
+                }
+            });
+        }
+    }
+
+    private void triggerConsumer(RowConsumer consumer, BatchIterator<Row> fullResult, long count) {
+        // Alternative implementations:
+        // - Could extend RowConsumer to have native scroll support
+        //   e.g. accept(bi, scrollMode, count)?
+        //
+        // - Could also have a "ScrollingBatchIterator"
+
+        BatchIterator<Row> batchIterator;
+        if (count <= Integer.MAX_VALUE) {
+            batchIterator = LimitingBatchIterator.newInstance(fullResult, (int) count);
+        } else {
+            batchIterator = fullResult;
+        }
+        var nonClosingBi = new ForwardingBatchIterator<Row>() {
+
+            @Override
+            protected BatchIterator<Row> delegate() {
+                return batchIterator;
+            }
+
+            @Override
+            public void close() {
+                // Close must be deferred to when the cursor gets closed
+            }
+        };
+        consumer.accept(nonClosingBi, null);
+    }
+
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public void close() {
+        if (queryIterator.isDone() && !queryIterator.isCompletedExceptionally()) {
+            queryIterator.join().close();
+        } else {
+            queryIterator.whenComplete((bi, err) -> {
+                if (bi != null) {
+                    bi.close();
+                }
+            });
+        }
+    }
+}

--- a/server/src/main/java/io/crate/action/sql/Cursors.java
+++ b/server/src/main/java/io/crate/action/sql/Cursors.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.action.sql;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+public final class Cursors {
+
+    public static final Cursors EMPTY = new Cursors(Map.of());
+
+    private final Map<String, Cursor> cursors;
+
+    private Cursors(Map<String, Cursor> cursors) {
+        this.cursors = cursors;
+    }
+
+    public Cursors() {
+        this.cursors = new HashMap<>();
+    }
+
+    public void add(String cursorName, Cursor cursor) {
+        Cursor previous = cursors.put(cursorName, cursor);
+        if (previous != null) {
+            throw new IllegalStateException("Cursor `" + cursorName + "` already exists");
+        }
+    }
+
+    public Cursor get(String cursorName) {
+        Cursor cursor = cursors.get(cursorName);
+        if (cursor == null) {
+            throw new IllegalArgumentException("No cursor named `" + cursorName + "` available");
+        }
+        return cursor;
+    }
+
+    public int size() {
+        return cursors.size();
+    }
+
+    /**
+     * Close and remove all cursors matching the predicate
+     */
+    public void close(Predicate<Cursor> predicate) {
+        Iterator<Entry<String, Cursor>> it = cursors.entrySet().iterator();
+        while (it.hasNext()) {
+            var cursor = it.next().getValue();
+            if (predicate.test(cursor)) {
+                cursor.close();
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * @param cursorName name of cursor to close, if null all cursors are closed
+     */
+    public void close(@Nullable String cursorName) {
+        if (cursorName == null) {
+            close(c -> true);
+        } else {
+            Cursor cursor = cursors.remove(cursorName);
+            if (cursor == null) {
+                throw new IllegalArgumentException("No cursor named `" + cursorName + "` available");
+            } else {
+                cursor.close();
+            }
+        }
+    }
+}

--- a/server/src/main/java/io/crate/analyze/AnalyzedClose.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedClose.java
@@ -21,38 +21,40 @@
 
 package io.crate.analyze;
 
-import io.crate.action.sql.Cursors;
-import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.settings.CoordinatorSessionSettings;
+import java.util.function.Consumer;
 
-public class Analysis {
+import javax.annotation.Nullable;
 
-    private final CoordinatorTxnCtx coordinatorTxnCtx;
-    private final ParamTypeHints paramTypeHints;
-    private final Cursors cursors;
+import io.crate.expression.symbol.Symbol;
+import io.crate.sql.tree.Close;
 
+public class AnalyzedClose implements AnalyzedStatement {
 
-    public Analysis(CoordinatorTxnCtx coordinatorTxnCtx,
-                    ParamTypeHints paramTypeHints,
-                    Cursors cursors) {
-        this.paramTypeHints = paramTypeHints;
-        this.coordinatorTxnCtx = coordinatorTxnCtx;
-        this.cursors = cursors;
+    private final Close close;
+
+    public AnalyzedClose(Close close) {
+        this.close = close;
     }
 
-    public Cursors cursors() {
-        return cursors;
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitClose(this, context);
     }
 
-    public CoordinatorTxnCtx transactionContext() {
-        return coordinatorTxnCtx;
+    @Override
+    public boolean isWriteOperation() {
+        return false;
     }
 
-    public CoordinatorSessionSettings sessionSettings() {
-        return coordinatorTxnCtx.sessionSettings();
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 
-    public ParamTypeHints paramTypeHints() {
-        return paramTypeHints;
+    /**
+     * Name of the cursor to close. If `null` all cursors should be closed
+     **/
+    @Nullable
+    public String cursorName() {
+        return close.cursorName();
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDeclare.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDeclare.java
@@ -21,38 +21,41 @@
 
 package io.crate.analyze;
 
-import io.crate.action.sql.Cursors;
-import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.settings.CoordinatorSessionSettings;
+import java.util.function.Consumer;
 
-public class Analysis {
+import io.crate.expression.symbol.Symbol;
+import io.crate.sql.tree.Declare;
 
-    private final CoordinatorTxnCtx coordinatorTxnCtx;
-    private final ParamTypeHints paramTypeHints;
-    private final Cursors cursors;
+public class AnalyzedDeclare implements AnalyzedStatement {
 
+    private final Declare declare;
+    private final AnalyzedStatement query;
 
-    public Analysis(CoordinatorTxnCtx coordinatorTxnCtx,
-                    ParamTypeHints paramTypeHints,
-                    Cursors cursors) {
-        this.paramTypeHints = paramTypeHints;
-        this.coordinatorTxnCtx = coordinatorTxnCtx;
-        this.cursors = cursors;
+    public AnalyzedDeclare(Declare declare, AnalyzedStatement query) {
+        this.declare = declare;
+        this.query = query;
     }
 
-    public Cursors cursors() {
-        return cursors;
+    public AnalyzedStatement query() {
+        return query;
     }
 
-    public CoordinatorTxnCtx transactionContext() {
-        return coordinatorTxnCtx;
+    public Declare declare() {
+        return declare;
     }
 
-    public CoordinatorSessionSettings sessionSettings() {
-        return coordinatorTxnCtx.sessionSettings();
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitDeclare(this, context);
     }
 
-    public ParamTypeHints paramTypeHints() {
-        return paramTypeHints;
+    @Override
+    public boolean isWriteOperation() {
+        return false;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        query.visitSymbols(consumer);
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -283,4 +283,16 @@ public class AnalyzedStatementVisitor<C, R> {
     public R visitAlterSubscription(AnalyzedAlterSubscription alterSubscription, C context) {
         return visitDDLStatement(alterSubscription, context);
     }
+
+    public R visitDeclare(AnalyzedDeclare declare, C context) {
+        return visitAnalyzedStatement(declare, context);
+    }
+
+    public R visitFetch(AnalyzedFetch fetch, C context) {
+        return visitAnalyzedStatement(fetch, context);
+    }
+
+    public R visitClose(AnalyzedClose close, C context) {
+        return visitAnalyzedStatement(close, context);
+    }
 }

--- a/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -201,7 +201,9 @@ class ShowStatementAnalyzer {
         return analyzer.analyze(
             query,
             analysis.sessionSettings(),
-            analysis.paramTypeHints());
+            analysis.paramTypeHints(),
+            analysis.cursors()
+        );
     }
 
     public Query rewriteShowTables(ShowTables node) {

--- a/server/src/main/java/io/crate/planner/DeclarePlan.java
+++ b/server/src/main/java/io/crate/planner/DeclarePlan.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.crate.action.sql.Cursor;
+import io.crate.action.sql.Cursors;
+import io.crate.analyze.AnalyzedDeclare;
+import io.crate.data.BatchIterator;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowConsumer;
+import io.crate.data.SentinelRow;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.protocols.postgres.TransactionState;
+import io.crate.sql.tree.Declare.Hold;
+
+public class DeclarePlan implements Plan {
+
+    private final AnalyzedDeclare declare;
+    private final Plan queryPlan;
+
+    public DeclarePlan(AnalyzedDeclare declare, Plan queryPlan) {
+        this.declare = declare;
+        this.queryPlan = queryPlan;
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.SELECT;
+    }
+
+    @Override
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
+        if (declare.declare().hold() == Hold.WITHOUT
+                && plannerContext.transactionState() != TransactionState.IN_TRANSACTION) {
+            throw new UnsupportedOperationException("DECLARE CURSOR can only be used in transaction blocks");
+        }
+        CursorRowConsumer cursorRowConsumer = new CursorRowConsumer(consumer);
+        Cursors cursors = plannerContext.cursors();
+        Cursor cursor = new Cursor(
+            declare.declare().hold(),
+            cursorRowConsumer.result,
+            declare.query().outputs()
+        );
+        cursors.add(declare.declare().cursorName(), cursor);
+        queryPlan.execute(dependencies, plannerContext, cursorRowConsumer, params, subQueryResults);
+    }
+
+    private static class CursorRowConsumer implements RowConsumer {
+
+        private final CompletableFuture<BatchIterator<Row>> result = new CompletableFuture<>();
+        private final RowConsumer consumer;
+
+        public CursorRowConsumer(RowConsumer consumer) {
+            this.consumer = consumer;
+        }
+
+        @Override
+        public void accept(BatchIterator<Row> iterator, Throwable failure) {
+            if (failure != null) {
+                result.completeExceptionally(failure);
+            } else {
+                // The result of DECLARE itself, not of the query
+                consumer.accept(InMemoryBatchIterator.empty(SentinelRow.SENTINEL), null);
+                result.complete(iterator);
+            }
+        }
+
+        @Override
+        public CompletableFuture<?> completionFuture() {
+            return result;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -30,6 +30,7 @@ import io.crate.analyze.AnalyzedAlterTableRename;
 import io.crate.analyze.AnalyzedAlterUser;
 import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
+import io.crate.analyze.AnalyzedClose;
 import io.crate.analyze.AnalyzedCommit;
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.AnalyzedCopyTo;
@@ -42,6 +43,7 @@ import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateTableAs;
 import io.crate.analyze.AnalyzedCreateUser;
 import io.crate.analyze.AnalyzedDeallocate;
+import io.crate.analyze.AnalyzedDeclare;
 import io.crate.analyze.AnalyzedDecommissionNode;
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedDiscard;
@@ -52,6 +54,7 @@ import io.crate.analyze.AnalyzedDropSnapshot;
 import io.crate.analyze.AnalyzedDropTable;
 import io.crate.analyze.AnalyzedDropUser;
 import io.crate.analyze.AnalyzedDropView;
+import io.crate.analyze.AnalyzedFetch;
 import io.crate.analyze.AnalyzedGCDanglingArtifacts;
 import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.AnalyzedKill;
@@ -577,6 +580,23 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     public Plan visitDropSubscription(AnalyzedDropSubscription dropSubscription,
                                       PlannerContext context) {
         return new DropSubscriptionPlan(dropSubscription);
+    }
+
+    @Override
+    public Plan visitDeclare(AnalyzedDeclare declare, PlannerContext context) {
+        AnalyzedStatement query = declare.query();
+        Plan queryPlan = query.accept(this, context);
+        return new DeclarePlan(declare, queryPlan);
+    }
+
+    @Override
+    public Plan visitFetch(AnalyzedFetch fetch, PlannerContext context) {
+        return new FetchPlan(fetch);
+    }
+
+    @Override
+    public Plan visitClose(AnalyzedClose close, PlannerContext context) {
+        return new ClosePlan(close);
     }
 }
 

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -239,8 +239,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement analyzedStatement = e.analyzer.analyze(
             SqlParser.createStatement("delete from users where name = ?"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
-        );
+            ParamTypeHints.EMPTY,
+            e.cursors);
         ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
         DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
 
@@ -253,8 +253,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement analyzedStatement = e.analyzer.analyze(
             SqlParser.createStatement("update users set name = ? || '_updated' where id = ?"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
-        );
+            ParamTypeHints.EMPTY,
+            e.cursors);
         ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
         DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
 
@@ -267,7 +267,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement analyzedStatement = e.analyzer.analyze(
             SqlParser.createStatement("INSERT INTO users (id, name) values (?, ?)"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
+            ParamTypeHints.EMPTY,
+            e.cursors
         );
         ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
         DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
@@ -284,7 +285,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             SqlParser.createStatement("INSERT INTO users (id, name) (SELECT id, name FROM users_clustered_by_only " +
                                       "WHERE name = ?)"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
+            ParamTypeHints.EMPTY,
+            e.cursors
         );
         ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
         DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
@@ -301,8 +303,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             SqlParser.createStatement("INSERT INTO users (id, name) values (?, ?) " +
                                       "ON CONFLICT (id) DO UPDATE SET name = ?"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
-        );
+            ParamTypeHints.EMPTY,
+            e.cursors);
         ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
         DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
 
@@ -312,8 +314,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             SqlParser.createStatement("INSERT INTO users (id, name) (SELECT id, name FROM users_clustered_by_only " +
                                       "WHERE name = ?) ON CONFLICT (id) DO UPDATE SET name = ?"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
-        );
+            ParamTypeHints.EMPTY,
+            e.cursors);
         typeExtractor = new ParameterTypeExtractor();
         parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
 
@@ -327,7 +329,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement stmt = e.analyzer.analyze(
             SqlParser.createStatement("select * from (select $1::int + $2) t"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
+            ParamTypeHints.EMPTY,
+            e.cursors
         );
         DataType[] parameterTypes = new ParameterTypeExtractor().getParameterTypes(
             consumer -> Relations.traverseDeepSymbols(stmt, consumer));
@@ -343,7 +346,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement stmt = e.analyzer.analyze(
             SqlParser.createStatement("insert into t (x) (select * from (select $1::int + $2) t)"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
+            ParamTypeHints.EMPTY,
+            e.cursors
         );
         DataType[] parameterTypes = new ParameterTypeExtractor().getParameterTypes(
             consumer -> Relations.traverseDeepSymbols(stmt, consumer));
@@ -359,7 +363,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement stmt = e.analyzer.analyze(
             SqlParser.createStatement("delete from t where x = (select $1::long)"),
             CoordinatorSessionSettings.systemDefaults(),
-            ParamTypeHints.EMPTY
+            ParamTypeHints.EMPTY,
+            e.cursors
         );
         DataType[] parameterTypes = new ParameterTypeExtractor().getParameterTypes(
             consumer -> Relations.traverseDeepSymbols(stmt, consumer));

--- a/server/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
@@ -79,7 +79,9 @@ public class CreateFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest
                 "CREATE FUNCTION bar(long, long)" +
                 " RETURNS long LANGUAGE dummy_lang AS 'function(a, b) { return a + b; }'"),
             new CoordinatorSessionSettings(User.CRATE_USER, "my_schema"),
-            ParamTypeHints.EMPTY);
+            ParamTypeHints.EMPTY,
+            e.cursors
+        );
 
         assertThat(analysis.schema(), is("my_schema"));
         assertThat(analysis.name(), is("bar"));
@@ -91,7 +93,9 @@ public class CreateFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest
             SqlParser.createStatement("CREATE FUNCTION my_other_schema.bar(long, long)" +
                 " RETURNS long LANGUAGE dummy_lang AS 'function(a, b) { return a + b; }'"),
             new CoordinatorSessionSettings(User.CRATE_USER, "my_schema"),
-            ParamTypeHints.EMPTY);
+            ParamTypeHints.EMPTY,
+            e.cursors
+        );
 
         assertThat(analysis.schema(), is("my_other_schema"));
         assertThat(analysis.name(), is("bar"));

--- a/server/src/test/java/io/crate/analyze/CursorTest.java
+++ b/server/src/test/java/io/crate/analyze/CursorTest.java
@@ -129,4 +129,24 @@ public class CursorTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> executePlan(executor, plan).getBucket())
             .hasMessage("DECLARE CURSOR can only be used in transaction blocks");
     }
+
+    @Test
+    public void test_fetch_backward_is_not_supported() {
+        Plan plan = executor.plan("declare c1 no scroll cursor for select 1");
+        executePlan(executor, plan);
+
+        Plan fetch = executor.plan("fetch backward from c1");
+        assertThatThrownBy(() -> executePlan(executor, fetch).getBucket())
+            .hasMessage("Cannot scroll backwards");
+    }
+
+    @Test
+    public void test_fetch_absolute_is_not_supported() {
+        Plan plan = executor.plan("declare c1 no scroll cursor for select 1");
+        executePlan(executor, plan);
+
+        Plan fetch = executor.plan("fetch absolute 3 from c1");
+        assertThatThrownBy(() -> executePlan(executor, fetch).getBucket())
+            .hasMessage("Scrolling to an absolute position is not supported");
+    }
 }

--- a/server/src/test/java/io/crate/analyze/CursorTest.java
+++ b/server/src/test/java/io/crate/analyze/CursorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.data.Row;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.protocols.postgres.TransactionState;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.TestingRowConsumer;
+
+public class CursorTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor executor;
+
+    private TestingRowConsumer executePlan(SQLExecutor executor, Plan plan) {
+        TestingRowConsumer consumer = new TestingRowConsumer(true);
+        plan.execute(
+            mock(DependencyCarrier.class),
+            executor.getPlannerContext(clusterService.state()),
+            consumer,
+            Row.EMPTY,
+            SubQueryResults.EMPTY
+        );
+        return consumer;
+    }
+
+    @Before
+    public void setup() {
+        executor = SQLExecutor.builder(clusterService).build();
+        executor.transactionState = TransactionState.IN_TRANSACTION;
+    }
+
+    @Test
+    public void test_explicit_binary_mode_is_not_supported() {
+        // binary mode from pg-wire is possible, but not via HTTP; so we forbid it on a statement level
+        assertThatThrownBy(() -> executor.analyze("declare c1 binary cursor for select 1"))
+            .hasMessage("BINARY mode in DECLARE is not supported");
+    }
+
+    @Test
+    public void test_scroll_mode_is_not_supported() {
+        assertThatThrownBy(() -> executor.analyze("declare c1 scroll cursor for select 1"))
+            .hasMessage("SCROLL mode in DECLARE is not supported");
+    }
+
+    @Test
+    public void test_declare_has_no_outputs() {
+        // message flow from postgresql:
+        // 84,24,4      Parse,Describe,Flush    declare c1 cursor for select * from generate_series(1, 10)
+        // 4,6,4        Parse completion,Parameter description,No data
+        // 34,9,4       Bind,Execute,Sync
+        //
+        // To get "No Data" message declare must not have any outputs
+
+        AnalyzedDeclare declare = executor.analyze("declare c1 no scroll cursor for select 1");
+        assertThat(declare.outputs()).isNull();
+    }
+
+    @Test
+    public void test_declare_fails_if_cursor_already_exists() throws Exception {
+        executePlan(executor, executor.plan("declare c1 no scroll cursor for select 1"));
+        Plan plan = executor.plan("declare c1 no scroll cursor for select 1");
+        assertThatThrownBy(() -> executePlan(executor, plan).getBucket())
+            .hasMessage("Cursor `c1` already exists");
+    }
+
+    @Test
+    public void test_fetch_has_query_outputs() throws Exception {
+        Plan plan = executor.plan("declare c1 no scroll cursor for select 1");
+        executePlan(executor, plan);
+        AnalyzedFetch fetch = executor.analyze("fetch from c1");
+        assertThat(fetch.outputs()).satisfiesExactly(
+            s -> assertThat(s.toString()).isEqualTo("1")
+        );
+    }
+
+    @Test
+    public void test_close_closes_and_removes_cursor() {
+        Plan plan = executor.plan("declare c1 no scroll cursor for select 1");
+        executePlan(executor, plan);
+
+        assertThat(executor.cursors.size()).isEqualTo(1);
+
+        executePlan(executor, executor.plan("CLOSE ALL"));
+
+        assertThat(executor.cursors.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_close_fails_if_cursor_does_not_exist() {
+        Plan plan = executor.plan("close c1");
+        assertThatThrownBy(() -> executePlan(executor, plan).getBucket())
+            .hasMessage("No cursor named `c1` available");
+    }
+
+    @Test
+    public void test_declare_fails_without_hold_if_not_in_transaction() {
+        executor.transactionState = TransactionState.IDLE;
+        Plan plan = executor.plan("declare c1 no scroll cursor for select 1");
+        assertThatThrownBy(() -> executePlan(executor, plan).getBucket())
+            .hasMessage("DECLARE CURSOR can only be used in transaction blocks");
+    }
+}

--- a/server/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
@@ -63,7 +63,9 @@ public class DropFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedDropFunction analysis = (AnalyzedDropFunction) e.analyzer.analyze(
             SqlParser.createStatement("DROP FUNCTION bar(long, object)"),
             new CoordinatorSessionSettings(User.CRATE_USER, "my_schema"),
-            ParamTypeHints.EMPTY);
+            ParamTypeHints.EMPTY,
+            e.cursors
+        );
 
         assertThat(analysis.schema(), is("my_schema"));
         assertThat(analysis.name(), is("bar"));
@@ -72,9 +74,7 @@ public class DropFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDropFunctionExplicitSchemaSupersedesSessionSchema() throws Exception {
         AnalyzedDropFunction analysis = (AnalyzedDropFunction) e.analyzer.analyze(
-            SqlParser.createStatement("DROP FUNCTION my_other_schema.bar(long, object)"),
-            new CoordinatorSessionSettings(User.CRATE_USER, "my_schema"),
-            ParamTypeHints.EMPTY);
+            SqlParser.createStatement("DROP FUNCTION my_other_schema.bar(long, object)"), new CoordinatorSessionSettings(User.CRATE_USER, "my_schema"), ParamTypeHints.EMPTY, e.cursors);
 
         assertThat(analysis.schema(), is("my_other_schema"));
         assertThat(analysis.name(), is("bar"));

--- a/server/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
@@ -271,7 +271,9 @@ public class PrivilegesDCLAnalyzerTest extends CrateDummyClusterServiceUnitTest 
         return (AnalyzedPrivileges) e.analyzer.analyze(
             SqlParser.createStatement(statement),
             new CoordinatorSessionSettings(GRANTOR_TEST_USER),
-            ParamTypeHints.EMPTY);
+            ParamTypeHints.EMPTY,
+            e.cursors
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -3042,25 +3042,4 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analyzed.outputs().size(), is(1));
         assertThat(analyzed.outputs().get(0), isFunction("subscript", isField("obj"), isLiteral("unknown")));
     }
-
-    @Test
-    public void test_declare_is_not_supported() {
-        var executor = SQLExecutor.builder(clusterService).build();
-        assertThatThrownBy(() -> executor.analyze("declare c1 cursor for select 1"))
-            .hasMessage("DECLARE is not supported");
-    }
-
-    @Test
-    public void test_fetch_is_not_supported() {
-        var executor = SQLExecutor.builder(clusterService).build();
-        assertThatThrownBy(() -> executor.analyze("fetch from c1"))
-            .hasMessage("FETCH is not supported");
-    }
-
-    @Test
-    public void test_close_is_not_supported() {
-        var executor = SQLExecutor.builder(clusterService).build();
-        assertThatThrownBy(() -> executor.analyze("CLOSE ALL"))
-            .hasMessage("CLOSE is not supported");
-    }
 }

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -142,9 +142,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     private void analyze(String stmt, User user) {
         e.analyzer.analyze(
-            SqlParser.createStatement(stmt),
-            new CoordinatorSessionSettings(user),
-            ParamTypeHints.EMPTY);
+            SqlParser.createStatement(stmt), new CoordinatorSessionSettings(user), ParamTypeHints.EMPTY, e.cursors);
     }
 
     @SuppressWarnings("unchecked")
@@ -581,7 +579,9 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         e.analyzer.analyze(
             SqlParser.createStatement("SET SESSION AUTHORIZATION " + superUser.name()),
             new CoordinatorSessionSettings(superUser, user),
-            ParamTypeHints.EMPTY);
+            ParamTypeHints.EMPTY,
+            e.cursors
+        );
         assertThat(validationCallArguments.size(), is(0));
     }
 
@@ -590,7 +590,8 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         e.analyzer.analyze(
             SqlParser.createStatement("SET SESSION AUTHORIZATION DEFAULT"),
             new CoordinatorSessionSettings(superUser, user),
-            ParamTypeHints.EMPTY);
+            ParamTypeHints.EMPTY,
+            e.cursors);
         assertThat(validationCallArguments.size(), is(0));
     }
 
@@ -599,7 +600,9 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         e.analyzer.analyze(
             SqlParser.createStatement("RESET SESSION AUTHORIZATION"),
             new CoordinatorSessionSettings(superUser, user),
-            ParamTypeHints.EMPTY);
+            ParamTypeHints.EMPTY,
+            e.cursors
+        );
         assertThat(validationCallArguments.size(), is(0));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/CursorITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CursorITest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.protocols.postgres.PostgresNetty;
+
+public class CursorITest extends IntegTestCase {
+
+    private Properties properties;
+
+    private String url() {
+        PostgresNetty postgresNetty = internalCluster().getInstance(PostgresNetty.class);
+        int port = postgresNetty.boundAddress().publishAddress().getPort();
+        return "jdbc:postgresql://127.0.0.1:" + port + '/';
+    }
+
+    @Before
+    public void setup() {
+        properties = new Properties();
+        properties.setProperty("user", "crate");
+    }
+
+    @Test
+    public void test_declare_fetch_and_close() throws Exception {
+        // Using JDBC to be able to re-use the same connection to the same node
+        try (var conn = DriverManager.getConnection(url(), properties)) {
+            Statement statement = conn.createStatement();
+            conn.setAutoCommit(false);
+            String declare = "declare c1 no scroll cursor for select * from generate_series(1, 10)";
+            statement.execute(declare);
+
+            ResultSet result = statement.executeQuery("fetch from c1");
+            assertThat(result.next()).isEqualTo(true);
+            assertThat(result.getInt(1)).isEqualTo(1);
+            assertThat(result.next()).isEqualTo(false);
+
+            result = statement.executeQuery("fetch forward 2 from c1");
+            assertThat(result.next()).isEqualTo(true);
+            assertThat(result.getInt(1)).isEqualTo(2);
+            assertThat(result.next()).isEqualTo(true);
+            assertThat(result.getInt(1)).isEqualTo(3);
+
+            statement.execute("close c1");
+
+            assertThatThrownBy(() -> statement.executeQuery("fetch forward 2 from c1"))
+                .hasMessageContaining("No cursor named `c1` available");
+        }
+    }
+
+    @Test
+    public void test_declare_with_hold_survives_transaction() throws Exception {
+        try (var conn = DriverManager.getConnection(url(), properties)) {
+            Statement statement = conn.createStatement();
+            conn.setAutoCommit(false);
+
+            String declare = "declare c1 no scroll cursor with hold for select * from generate_series(1, 10)";
+            statement.execute(declare);
+
+            conn.commit();
+
+            ResultSet result = statement.executeQuery("fetch from c1");
+            assertThat(result.next()).isEqualTo(true);
+            assertThat(result.getInt(1)).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void test_declare_without_hold_does_not_survive_transaction() throws Exception {
+        try (var conn = DriverManager.getConnection(url(), properties)) {
+            Statement statement = conn.createStatement();
+            conn.setAutoCommit(false);
+
+            String declare = "declare c1 no scroll cursor without hold for select * from generate_series(1, 10)";
+            statement.execute(declare);
+
+            conn.commit();
+
+            assertThatThrownBy(() -> statement.executeQuery("fetch from c1"))
+                .hasMessageContaining("No cursor named `c1` available");
+        }
+    }
+
+}

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,7 +34,6 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
@@ -65,6 +65,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.Constants;
+import io.crate.action.sql.Cursors;
 import io.crate.analyze.Analysis;
 import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.BoundCreateTable;
@@ -1166,7 +1167,11 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
 
         CreateTableStatementAnalyzer analyzer = new CreateTableStatementAnalyzer(nodeCtx);
 
-        Analysis analysis = new Analysis(new CoordinatorTxnCtx(CoordinatorSessionSettings.systemDefaults()), ParamTypeHints.EMPTY);
+        Analysis analysis = new Analysis(
+            new CoordinatorTxnCtx(CoordinatorSessionSettings.systemDefaults()),
+            ParamTypeHints.EMPTY,
+            Cursors.EMPTY
+        );
         CoordinatorTxnCtx txnCtx = new CoordinatorTxnCtx(CoordinatorSessionSettings.systemDefaults());
         AnalyzedCreateTable analyzedCreateTable = analyzer.analyze(
             (CreateTable<Expression>) statement,

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.Randomness;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.action.sql.Cursors;
 import io.crate.data.Row1;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
@@ -45,6 +46,7 @@ import io.crate.planner.node.ddl.UpdateSettingsPlan;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanner;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.tree.Assignment;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.Asserts;
@@ -93,7 +95,9 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(CoordinatorSessionSettings.systemDefaults()),
             e.nodeCtx,
             0,
-            null
+            null,
+            Cursors.EMPTY,
+            TransactionState.IDLE
         );
 
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));

--- a/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
@@ -137,7 +137,8 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             () -> e.analyzer.analyze(
                 SqlParser.createStatement("DROP PUBLICATION pub1"),
                 new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY
+                ParamTypeHints.EMPTY,
+                e.cursors
             ),
             UnauthorizedException.class,
             "A publication can only be dropped by the owner or a superuser"
@@ -188,7 +189,8 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             () -> e.analyzer.analyze(
                 SqlParser.createStatement("ALTER PUBLICATION pub1 ADD TABLE doc.t2"),
                 new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY
+                ParamTypeHints.EMPTY,
+                e.cursors
             ),
             UnauthorizedException.class,
             "A publication can only be altered by the owner or a superuser"
@@ -233,7 +235,8 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             () -> e.analyzer.analyze(
                 SqlParser.createStatement("DROP SUBSCRIPTION sub1"),
                 new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY
+                ParamTypeHints.EMPTY,
+                e.cursors
             ),
             UnauthorizedException.class,
             "A subscription can only be dropped by the owner or a superuser"
@@ -250,7 +253,8 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             () -> e.analyzer.analyze(
                 SqlParser.createStatement("ALTER SUBSCRIPTION sub1 DISABLE"),
                 new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY
+                ParamTypeHints.EMPTY,
+                e.cursors
             ),
             UnauthorizedException.class,
             "A subscription can only be altered by the owner or a superuser"

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -167,6 +167,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
 import io.crate.Constants;
+import io.crate.action.sql.Cursors;
 import io.crate.action.sql.SQLOperations;
 import io.crate.action.sql.Session;
 import io.crate.analyze.Analyzer;
@@ -208,6 +209,7 @@ import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.PostgresNetty;
+import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.SystemPropsTestLoggingListener;
@@ -1804,14 +1806,19 @@ public abstract class IntegTestCase extends ESTestCase {
             coordinatorTxnCtx,
             nodeCtx,
             0,
-            null
+            null,
+            Cursors.EMPTY,
+            TransactionState.IDLE
         );
         Plan plan = planner.plan(
             analyzer.analyze(
                 SqlParser.createStatement(stmt),
                 coordinatorTxnCtx.sessionSettings(),
-                ParamTypeHints.EMPTY),
-            plannerContext);
+                ParamTypeHints.EMPTY,
+                plannerContext.cursors()
+            ),
+            plannerContext
+        );
         return new PlanForNode(plan, nodeName, plannerContext);
     }
 


### PR DESCRIPTION
Implement cursor support (declare, fetch, close analyzer + execution)

Partially based on https://github.com/crate/crate/pull/12597, but made
some different decisions.

High level overview:

- Session now has cursors
- Analyzer and Planner get access to cursors
- There are Declare, Fetch and Close analyzed statements and plans
- DeclarePlan.execute adds the cursor and invokes the query; returns empty result itself
- FetchPlan.execute uses previously created cursor to access a BatchIterator and consume more rows
- ClosePlan.execute closes & removes cursors

Currently only forward movement is supported.

Not supported and out of scope of this PR:

- SCROLL
- BINARY (at statement level, it is supported on pg-wire level)
- Any backward movements
- Any absolute movements


TODO:

- [x] Write docs