### PR TITLE
tests: Fix an issue causing ClassCastException when planning

### DIFF
--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -656,5 +656,9 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "    └ Collect[doc.t2 | [b, y, i] | (y = ANY((SELECT z FROM (doc.t3))))]\n" +
             "  └ OrderBy[z ASC]\n" +
             "    └ Collect[doc.t3 | [z] | true]")));
+
+        Object plan = e.plan(statement);
+        assertThat(plan, instanceOf(Merge.class));
+        assertThat(((Merge) plan).subPlan(), instanceOf(Join.class));
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -132,7 +132,6 @@ import io.crate.data.Row;
 import io.crate.execution.ddl.RepositoryService;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.pipeline.TopN;
-import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.udf.UDFLanguage;
@@ -914,7 +913,7 @@ public class SQLExecutor {
                 new SubQueryResults(emptyMap()) {
                     @Override
                     public Object getSafe(SelectSymbol key) {
-                        return Literal.of(key.valueType(), null);
+                        return null;
                     }
                 }
             );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, a `ClassCastException` was thrown when attempting to plan a join query with an uncorrelated subquery:

```
class io.crate.expression.symbol.Literal cannot be cast to class [Ljava.lang.Object; (io.crate.expression.symbol.Literal is in unnamed module of loader 'app'; [Ljava.lang.Object; is in module java.base of loader 'bootstrap')
java.lang.ClassCastException: class io.crate.expression.symbol.Literal cannot be cast to class [Ljava.lang.Object; (io.crate.expression.symbol.Literal is in unnamed module of loader 'app'; [Ljava.lang.Object; is in module java.base of loader 'bootstrap')
	at __randomizedtesting.SeedInfo.seed([F78E2051B6B6F38A:A88EB4BCDEC1BB29]:0)
	at io.crate.types.ArrayType.convert(ArrayType.java:237)
	at io.crate.types.ArrayType.sanitizeValue(ArrayType.java:149)
	at io.crate.types.ArrayType.sanitizeValue(ArrayType.java:63)
	at io.crate.planner.operators.SubQueryAndParamBinder.visitSelectSymbol(SubQueryAndParamBinder.java:72)
	at io.crate.planner.operators.SubQueryAndParamBinder.visitSelectSymbol(SubQueryAndParamBinder.java:37)
	at io.crate.expression.symbol.SelectSymbol.accept(SelectSymbol.java:82)
	at io.crate.expression.symbol.FunctionCopyVisitor.twoArgs(FunctionCopyVisitor.java:97)
	at io.crate.expression.symbol.FunctionCopyVisitor.processAndMaybeCopy(FunctionCopyVisitor.java:57)
	at io.crate.expression.symbol.FunctionCopyVisitor.visitFunction(FunctionCopyVisitor.java:154)
	at io.crate.expression.symbol.FunctionCopyVisitor.visitFunction(FunctionCopyVisitor.java:40)
	at io.crate.expression.symbol.Function.accept(Function.java:185)
	at io.crate.planner.operators.SubQueryAndParamBinder.apply(SubQueryAndParamBinder.java:84)
	at io.crate.planner.operators.SubQueryAndParamBinder.apply(SubQueryAndParamBinder.java:37)
	at java.base/java.util.function.Function.lambda$andThen$1(Function.java:88)
	at io.crate.analyze.WhereClause.map(WhereClause.java:188)
	at io.crate.planner.operators.Collect.createPhase(Collect.java:266)
```

Follows: #13037


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
