### PR TITLE
Remove stream usage from JoinPlanBuilder for correlated subqueries

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -177,11 +177,16 @@ public class JoinPlanBuilder {
     private static boolean containsOuterColumnInCorrelatedSelect(Symbol symbol, AnalyzedRelation relation) {
         return SymbolVisitors.any(x -> x instanceof SelectSymbol s &&
                                        s.isCorrelated() &&
-                                       s.relation().outputs().stream().anyMatch(o -> containsOuterColumn(o, relation)), symbol);
+                                       containsOuterColumn(s, relation), symbol);
     }
 
-    private static boolean containsOuterColumn(Symbol symbol, AnalyzedRelation relation) {
-        return SymbolVisitors.any(x -> x instanceof OuterColumn o && o.relation().equals(relation), symbol);
+    private static boolean containsOuterColumn(SelectSymbol select, AnalyzedRelation relation) {
+        for (var output : select.relation().outputs()) {
+            if (SymbolVisitors.any(x -> x instanceof OuterColumn o && o.relation().equals(relation), output)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static LogicalPlan createCorrelatedJoinWithFilter(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a follow up to https://github.com/crate/crate/commit/9981eba6df08fab8672ce6e60d7ab81223d93a5b removing the java stream usage.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
