### PR TITLE
Fix: also get from translog when query matching on `_id`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -119,6 +119,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue causing queries with matching on ``_id`` to not get rows
+  from :ref:`translog <concept-addressing-documents>`, and therefore only
+  rows that were visible from the latest manual or automatic
+  :ref:`REFRESH <sql-refresh>` were returned.
+
 - Fixed an issue causing an ``IllegalArgumentException`` to be thrown when the
   optimizer attempts to convert a ``LEFT JOIN`` to an ``INNER JOIN`` and there
   is also a subquery in the ``WHERE`` clause.

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -136,6 +136,17 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_filter_by_internal_id_result_in_get_plan() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
+
+        LogicalPlan plan = e.logicalPlan("select name from users where _id = 1");
+        assertThat(plan, isPlan(
+            "Get[doc.users | name | DocKeys{1} | (_cast(_id, 'integer') = 1)]"));
+    }
+
+    @Test
     public void testGetWithVersion() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, we were only searching if the symbols in the `WHERE` clause
were matching all the columns comprising the table's `PRIMARY KEY`, but
we didn't search if the query of the `WHERE` clause was trying on `_id`,
which if an explicit `PRIMARY KEY` is defined, is a concaneted string of
those pk column values.

Fixes: #13057

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
