### PR TITLE
bp: Fix PersistedClusterStateServiceTests.testSlowLogging

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -837,7 +837,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     "writing cluster state took [*] which is above the warn threshold of [*]; " +
                         "wrote global metadata [false] and metadata for [1] indices and skipped [0] unchanged indices"));
 
-                writeDurationMillis.set(randomLongBetween(1, writeDurationMillis.get() - 1));
+                writeDurationMillis.set(randomLongBetween(0, writeDurationMillis.get() - 1));
                 assertExpectedLogs(1L, clusterState, newClusterState, writer, new MockLogAppender.UnseenEventExpectation(
                     "should not see warning below threshold",
                     PersistedClusterStateService.class.getCanonicalName(),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/elastic/elasticsearch/commit/34fc52dbf35925a7b072d887ba283122dd3d9518

Failed with:

    java.lang.AssertionError: max must be >= min: 1, 0
    	at __randomizedtesting.SeedInfo.seed([A4C1A6C6699E9943:17EC0019C06CE531]:0)
    	at com.carrotsearch.randomizedtesting.generators.RandomNumbers.randomLongBetween(RandomNumbers.java:29)
    	at org.elasticsearch.test.ESTestCase.randomLongBetween(ESTestCase.java:506)
    	at org.elasticsearch.gateway.PersistedClusterStateServiceTests.testSlowLogging(PersistedClusterStateServiceTests.java:840)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
