### PR TITLE
Add teardown assertion to ensure sessions get closed

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Cursors.java
+++ b/server/src/main/java/io/crate/action/sql/Cursors.java
@@ -91,4 +91,9 @@ public final class Cursors {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "Cursors{" + cursors.keySet() + "}";
+    }
 }

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -858,4 +858,15 @@ public class Session implements AutoCloseable {
         executor.client().execute(KillJobsNodeAction.INSTANCE, request);
         resetDeferredExecutions();
     }
+
+    @Override
+    public String toString() {
+        return "Session{" +
+            "portals=" + portals +
+            ", cursors=" + cursors +
+            ", deferredExecutionsByStmt=" + deferredExecutionsByStmt.size() +
+            ", mostRecentJobID=" + mostRecentJobID +
+            ", id=" + id +
+            "}";
+    }
 }

--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -143,4 +143,8 @@ public class Sessions {
             session.cancelCurrentJob();
         }
     }
+
+    public Iterable<Session> getActive() {
+        return sessions.values();
+    }
 }

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -126,29 +126,31 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_out_of_bounds_getParamType_fails() throws Exception {
         SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
-        Session session = sqlExecutor.createSession();
-        session.parse("S_1", "Select 1 + ? + ?;", Collections.emptyList());
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> session.getParamType("S_1", 3),
-            "foo"
-        );
+        try (Session session = sqlExecutor.createSession()) {
+            session.parse("S_1", "Select 1 + ? + ?;", Collections.emptyList());
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> session.getParamType("S_1", 3),
+                "foo"
+            );
+        }
     }
 
     @Test
     public void test_getParamType_returns_types_infered_from_statement() {
         SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
-        Session session = sqlExecutor.createSession();
+        try (Session session = sqlExecutor.createSession()) {
 
-        session.parse("S_1", "Select 1 + ? + ?;", Collections.emptyList());
-        assertThat(session.getParamType("S_1", 0), is(DataTypes.INTEGER));
-        assertThat(session.getParamType("S_1", 1), is(DataTypes.INTEGER));
+            session.parse("S_1", "Select 1 + ? + ?;", Collections.emptyList());
+            assertThat(session.getParamType("S_1", 0), is(DataTypes.INTEGER));
+            assertThat(session.getParamType("S_1", 1), is(DataTypes.INTEGER));
 
-        DescribeResult describe = session.describe('S', "S_1");
-        assertThat(describe.getParameters(), equalTo(new DataType[] { DataTypes.INTEGER, DataTypes.INTEGER }));
+            DescribeResult describe = session.describe('S', "S_1");
+            assertThat(describe.getParameters(), equalTo(new DataType[] { DataTypes.INTEGER, DataTypes.INTEGER }));
 
-        assertThat(session.getParamType("S_1", 0), is(DataTypes.INTEGER));
-        assertThat(session.getParamType("S_1", 1), is(DataTypes.INTEGER));
+            assertThat(session.getParamType("S_1", 0), is(DataTypes.INTEGER));
+            assertThat(session.getParamType("S_1", 1), is(DataTypes.INTEGER));
+        }
     }
 
     @Test

--- a/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
@@ -109,7 +109,8 @@ public class AuthenticationIntegrationTest extends IntegTestCase {
     public void testValidCrateUser() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("user", "crate");
-        DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties);
+        Connection connection = DriverManager.getConnection(sqlExecutor.jdbcUrl(), properties);
+        connection.close();
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/DefaultSchemaIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DefaultSchemaIntegrationTest.java
@@ -32,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import io.crate.action.sql.Session;
 import io.crate.testing.SQLResponse;
 
 public class DefaultSchemaIntegrationTest extends IntegTestCase {
@@ -42,7 +43,9 @@ public class DefaultSchemaIntegrationTest extends IntegTestCase {
 
     @Override
     public SQLResponse execute(String stmt, Object[] args, String schema) {
-        return execute(stmt, args, createSession(schema));
+        try (Session session = createSession(schema)) {
+            return execute(stmt, args, session);
+        }
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -86,14 +86,16 @@ public class JobLogIntegrationTest extends IntegTestCase {
         // the jobs_log. We make sure that we hit both nodes with 2 queries each and then assert that
         // only the latest queries are found in the log.
         for (Sessions sqlOperations : internalCluster().getDataNodeInstances(Sessions.class)) {
-            Session session = sqlOperations.newSystemSession();
-            execute("select name from sys.cluster", null, session);
+            try (Session session = sqlOperations.newSystemSession()) {
+                execute("select name from sys.cluster", null, session);
+            }
         }
         assertJobLogOnNodesHaveOnlyStatement("select name from sys.cluster");
 
         for (Sessions sqlOperations : internalCluster().getDataNodeInstances(Sessions.class)) {
-            Session session = sqlOperations.newSystemSession();
-            execute("select id from sys.cluster", null, session);
+            try (Session session = sqlOperations.newSystemSession()) {
+                execute("select id from sys.cluster", null, session);
+            }
         }
         assertJobLogOnNodesHaveOnlyStatement("select id from sys.cluster");
 

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -340,10 +340,11 @@ public class ObjectColumnTest extends IntegTestCase {
 
     @Test
     public void testSelectUnknownObjectColumnPreservesTheUnknownName() throws Exception {
-        var session = sqlExecutor.newSession();
-        session.sessionSettings().setErrorOnUnknownObjectKey(false);
-        execute("create table t (a object)");
-        execute("explain select a['u'] = 123 from t", session);
+        try (var session = sqlExecutor.newSession()) {
+            session.sessionSettings().setErrorOnUnknownObjectKey(false);
+            execute("create table t (a object)");
+            execute("explain select a['u'] = 123 from t", session);
+        }
         // make sure that a['u'] is kept as requested.
         assertThat(printedTable(response.rows()), containsString("[(123 = _cast(a['u'], 'integer'))]"));
     }

--- a/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -42,6 +42,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.test.IntegTestCase;
+import org.junit.After;
 import org.junit.Before;
 
 import io.crate.common.Hex;
@@ -63,6 +64,11 @@ public abstract class SQLHttpIntegrationTest extends IntegTestCase {
         this.httpClient = HttpClients.custom()
             .setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
         this.usesSSL = useSSL;
+    }
+
+    @After
+    public void closeClient() throws Exception {
+        this.httpClient.close();
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -77,13 +77,21 @@ public class SQLTypeMappingTest extends IntegTestCase {
     public void testInsertAtNodeWithoutShard() throws Exception {
         setUpSimple(1);
 
-        execute("insert into t1 (id, string_field, timestamp_field, byte_field) values (?, ?, ?, ?)",
+        try (var session = createSessionOnNode(internalCluster().getNodeNames()[0])) {
+            execute(
+                "insert into t1 (id, string_field, timestamp_field, byte_field) values (?, ?, ?, ?)",
                 new Object[]{1, "With", "1970-01-01T00:00:00", 127},
-                createSessionOnNode(internalCluster().getNodeNames()[0]));
+                session
+            );
+        }
 
-        execute("insert into t1 (id, string_field, timestamp_field, byte_field) values (?, ?, ?, ?)",
-                new Object[]{2, "Without", "1970-01-01T01:00:00", Byte.MIN_VALUE},
-                createSessionOnNode(internalCluster().getNodeNames()[1]));
+        try (var session = createSessionOnNode(internalCluster().getNodeNames()[1])) {
+            execute(
+                "insert into t1 (id, string_field, timestamp_field, byte_field) values (?, ?, ?, ?)",
+                new Object[] {2, "Without", "1970-01-01T01:00:00", Byte.MIN_VALUE},
+                session
+            );
+        }
 
         refresh();
         SQLResponse response = execute("select id, string_field, timestamp_field, byte_field from t1 order by id");

--- a/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
@@ -47,27 +47,29 @@ public class ScalarIntegrationTest extends IntegTestCase {
 
     @Test
     public void testSubscriptFunctionFromUnnest() {
-        var session = sqlExecutor.newSession();
-        session.sessionSettings().setErrorOnUnknownObjectKey(true);
-        Asserts.assertThrowsMatches(
-            () -> sqlExecutor.exec(
-                "SELECT unnest['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
-                session),
-            ColumnUnknownException.class,
-            "The object `{y=2, z=3}` does not contain the key `x`"
-        );
-        // This is documenting a bug. If this fails, it is a breaking change.
-        var response = sqlExecutor.exec("SELECT [unnest]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
-                         session);
-        assertThat(TestingHelpers.printedTable(response.rows()), is("[1]\n[null]\n"));
+        try (var session = sqlExecutor.newSession()) {
+            session.sessionSettings().setErrorOnUnknownObjectKey(true);
+            Asserts.assertThrowsMatches(
+                () -> sqlExecutor.exec(
+                    "SELECT unnest['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
+                    session),
+                ColumnUnknownException.class,
+                "The object `{y=2, z=3}` does not contain the key `x`"
+            );
+            // This is documenting a bug. If this fails, it is a breaking change.
+            var response = sqlExecutor.exec("SELECT [unnest]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
+                            session);
+            assertThat(TestingHelpers.printedTable(response.rows()), is("[1]\n[null]\n"));
+        }
 
-        var session2 = sqlExecutor.newSession();
-        session2.sessionSettings().setErrorOnUnknownObjectKey(false);
-        response = sqlExecutor.exec("SELECT unnest['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
-                                 session2);
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1\nNULL\n"));
-        response = sqlExecutor.exec("SELECT [unnest]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
-                                        session2);
-        assertThat(TestingHelpers.printedTable(response.rows()), is("[1]\n[null]\n"));
+        try (var session2 = sqlExecutor.newSession()) {
+            session2.sessionSettings().setErrorOnUnknownObjectKey(false);
+            response = sqlExecutor.exec("SELECT unnest['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
+                                    session2);
+            assertThat(TestingHelpers.printedTable(response.rows()), is("1\nNULL\n"));
+            response = sqlExecutor.exec("SELECT [unnest]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
+                                            session2);
+            assertThat(TestingHelpers.printedTable(response.rows()), is("[1]\n[null]\n"));
+        }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
@@ -48,8 +48,6 @@ public class SysPrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Before
     public void setUpNodesUsersAndPrivileges() throws Exception {
-        super.createSessions();
-
         for (String userName : USERNAMES) {
             executeAsSuperuser("create user " + userName);
         }

--- a/server/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
@@ -59,19 +59,19 @@ public class UserSessionIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void test_set_session_user_from_auth_superuser_to_unprivileged_user_round_trip() {
-        var session = createSuperUserSession();
+        try (var session = createSuperUserSession()) {
+            execute("SELECT SESSION_USER", session);
+            assertThat(response.rows()[0][0], is("crate"));
 
-        execute("SELECT SESSION_USER", session);
-        assertThat(response.rows()[0][0], is("crate"));
+            execute("CREATE USER test", session);
+            execute("SET SESSION AUTHORIZATION test", session);
+            execute("SELECT SESSION_USER", session);
+            assertThat(response.rows()[0][0], is("test"));
 
-        execute("CREATE USER test", session);
-        execute("SET SESSION AUTHORIZATION test", session);
-        execute("SELECT SESSION_USER", session);
-        assertThat(response.rows()[0][0], is("test"));
-
-        execute("RESET SESSION AUTHORIZATION", session);
-        execute("SELECT SESSION_USER", session);
-        assertThat(response.rows()[0][0], is("crate"));
+            execute("RESET SESSION AUTHORIZATION", session);
+            execute("SELECT SESSION_USER", session);
+            assertThat(response.rows()[0][0], is("crate"));
+        }
     }
 
     private String getNodeByEnterpriseNode(boolean enterpriseEnabled) {

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -229,8 +229,9 @@ public class SQLTransportExecutor {
     }
 
     public SQLResponse executeAs(String stmt, User user) {
-        Session session = clientProvider.sqlOperations().createSession(null, user);
-        return FutureUtils.get(execute(stmt, null, session), SQLTransportExecutor.REQUEST_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        try (Session session = clientProvider.sqlOperations().createSession(null, user)) {
+            return FutureUtils.get(execute(stmt, null, session), SQLTransportExecutor.REQUEST_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        }
     }
 
     public SQLResponse exec(String statement, @Nullable Object[] args, Session session, TimeValue timeout) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Helps prevent leaks.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
