### PR TITLE
tests: Remove deprecated enableDefaultTables

### DIFF
--- a/plugins/es-analysis-common/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
@@ -54,7 +54,6 @@ public class CreateAnalyzerAnalyzerTest extends CrateDummyClusterServiceUnitTest
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService, 1, Randomness.get(), List.of(new CommonAnalysisPlugin()))
-            .enableDefaultTables()
             .build();
         plannerContext = e.getPlannerContext(clusterService.state());
     }

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -249,7 +249,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExtractTypesFromInsertFromQuery() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION)
             .build();
         AnalyzedStatement analyzedStatement = e.analyzer.analyze(
             SqlParser.createStatement("INSERT INTO users (id, name) (SELECT id, name FROM users_clustered_by_only " +
@@ -267,7 +268,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExtractTypesFromInsertWithOnDuplicateKey() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION)
             .build();
         AnalyzedStatement analyzedStatement = e.analyzer.analyze(
             SqlParser.createStatement("INSERT INTO users (id, name) values (?, ?) " +

--- a/server/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
@@ -36,7 +36,7 @@ public class AlterTableOpenCloseAnalyzerTest extends CrateDummyClusterServiceUni
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService).build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -56,7 +56,11 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
             .addBlobTable("create blob table blobs;")
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS
+            )
             .build();
         plannerContext = e.getPlannerContext(clusterService.state());
     }

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -67,10 +67,17 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS
+            )
+            .build();
         plannerContext = e.getPlannerContext(clusterService.state());
     }
 
+    @SuppressWarnings("unchecked")
     private <S> S analyze(String stmt, Object... arguments) {
         AnalyzedStatement analyzedStatement = e.analyze(stmt);
         if (analyzedStatement instanceof AnalyzedCopyFrom) {

--- a/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +94,24 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
                 .metadata(metadata)
                 .build();
         ClusterServiceUtils.setState(clusterService, state);
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        RelationName multiPartName = new RelationName("doc", "multi_parted");
+        e = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
+            .addPartitionedTable(
+                "create table doc.multi_parted (" +
+                "   id int," +
+                "   date timestamp with time zone," +
+                "   num long," +
+                "   obj object as (name string)" +
+                ") partitioned by (date, obj['name'])",
+                new PartitionName(multiPartName, Arrays.asList("1395874800000", "0")).toString(),
+                new PartitionName(multiPartName, Arrays.asList("1395961200000", "-100")).toString(),
+                new PartitionName(multiPartName, Arrays.asList(null, "-100")).toString()
+            )
+            .build();
         plannerContext = e.getPlannerContext(clusterService.state());
     }
 

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -115,7 +115,11 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             .build();
         ClusterServiceUtils.setState(clusterService, state);
         e = SQLExecutor.builder(clusterService, 3, Randomness.get(), List.of())
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
+            .addTable(TableDefinitions.USER_TABLE_REFRESH_INTERVAL_BY_ONLY_DEFINITION)
             .build();
         plannerContext = e.getPlannerContext(clusterService.state());
     }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -119,7 +119,12 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             .addPartitionedTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
-            .addTable(TableDefinitions.USER_TABLE_REFRESH_INTERVAL_BY_ONLY_DEFINITION)
+            .addTable(
+                "create table doc.user_refresh_interval (" +
+                "  id bigint," +
+                "  content text" +
+                ")" +
+                " clustered by (id)")
             .build();
         plannerContext = e.getPlannerContext(clusterService.state());
     }

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -53,7 +53,12 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
@@ -46,7 +46,9 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
@@ -45,7 +45,9 @@ public class ExplainAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -60,7 +60,8 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         sqlExecutor = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(TableDefinitions.USER_TABLE_MULTI_PK_DEFINITION)
             .addTable("create table foo.users (" +
                       " id long primary key," +
                       " name string," +

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -66,7 +66,8 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION)
             .addTable(
                 "create table doc.users_generated (" +
                 "  id bigint primary key," +

--- a/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -52,7 +52,10 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addBlobTable("create blob table blobs")
             .build();
         plannerContext = e.getPlannerContext(clusterService.state());

--- a/server/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
@@ -47,6 +47,7 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 import io.crate.user.Privilege;
 import io.crate.user.StubUserManager;
 import io.crate.user.User;
@@ -62,7 +63,9 @@ public class PrivilegesDCLAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Before
     public void setUpSQLExecutor() throws Exception {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables()
+        e = SQLExecutor.builder(clusterService)
+            .addTable(T3.T2_DEFINITION)
+            .addTable(TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINITION)
             .addTable("create table my_schema.locations (id int)")
             .addView(new RelationName("my_schema", "locations_view"),
                      "select * from my_schema.locations limit 2")

--- a/server/src/test/java/io/crate/analyze/QuerySpecTest.java
+++ b/server/src/test/java/io/crate/analyze/QuerySpecTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 
 public class QuerySpecTest extends CrateDummyClusterServiceUnitTest {
 
@@ -40,7 +41,9 @@ public class QuerySpecTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(T3.T1_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -48,7 +48,9 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addBlobTable("create blob table blobs")
             .build();
     }

--- a/server/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
@@ -42,6 +42,7 @@ import io.crate.expression.symbol.MatchPredicate;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 
 public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -49,7 +50,12 @@ public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnit
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
+            .addTable(T3.T3_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -49,6 +49,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 
 public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -58,8 +59,9 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         executor = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
             .addTable("create table nested_obj (o object as (a object as (b object as (c int))))")
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
             .build();
         t1Info = executor.schemas().getTableInfo(new RelationName("doc", "t1"));
     }

--- a/server/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
@@ -50,7 +50,8 @@ public class UnionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         sqlExecutor = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(TableDefinitions.USER_TABLE_MULTI_PK_DEFINITION)
             .build();
     }
 

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -85,7 +85,11 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         SQLExecutor.Builder builder = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addTable(
                 "create table doc.nestedclustered (" +
                 "   obj object as (" +

--- a/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.TableDefinitions;
 import io.crate.expression.symbol.Symbols;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -40,7 +41,9 @@ public class GroupByScalarAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Before
     public void prepare() throws IOException {
-        executor = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        executor = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
@@ -42,6 +42,7 @@ import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SymbolMatchers;
+import io.crate.testing.T3;
 
 public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -49,7 +50,11 @@ public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        executor = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        executor = SQLExecutor.builder(clusterService)
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
+            .addTable(T3.T3_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -50,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.analyze.ParamTypeHints;
+import io.crate.analyze.TableDefinitions;
 import io.crate.exceptions.UnauthorizedException;
 import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.metadata.RelationName;
@@ -58,6 +59,7 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 import io.crate.user.Privilege;
 import io.crate.user.User;
 import io.crate.user.UserLookupService;
@@ -125,7 +127,12 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
         e = SQLExecutor.builder(clusterService)
             .addBlobTable("create blob table blobs")
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .setUser(superUser)
             .addView(new RelationName("doc", "v1"), "select * from users")
             .setUserManager(userManager)

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -61,7 +61,7 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addPartitionedTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),

--- a/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
@@ -31,6 +31,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.TableDefinitions;
 import io.crate.planner.node.ddl.DropTablePlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -42,7 +43,10 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addBlobTable("create blob table screenshots")
             .build();
     }

--- a/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -35,6 +35,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.TableDefinitions;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -61,7 +62,9 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 
+import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.EvalProjection;
@@ -56,7 +57,7 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
     }
 

--- a/server/src/test/java/io/crate/planner/PlanPrinterTest.java
+++ b/server/src/test/java/io/crate/planner/PlanPrinterTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 
 public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
 
@@ -40,7 +41,10 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void setUpExecutor() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
+            .build();
     }
 
     private Map<String, Object> printPlan(String stmt) {

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -149,7 +149,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGetPlanStringLiteral() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
-            .addTable(TableDefinitions.TEST_CLUSTER_BY_STRING_TABLE_DEFINITION)
+            .addTable(
+                "create table doc.bystring (" +
+                "  name text primary key," +
+                "  score double precision" +
+                ")")
             .build();
 
         LogicalPlan plan = e.logicalPlan("select name from bystring where name = 'one'");
@@ -476,7 +480,10 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testSortOnUnknownColumn() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
-            .addTable(TableDefinitions.IGNORED_NESTED_TABLE_DEFINITION)
+            .addTable(
+                "create table doc.ignored_nested (" +
+                "  details object(ignored)" +
+                ")")
             .build();
 
         expectedException.expect(UnsupportedOperationException.class);

--- a/server/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
@@ -30,10 +30,12 @@ import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.TableDefinitions;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.RootRelationBoundary;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 
 public class SingleRowSubselectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -41,7 +43,11 @@ public class SingleRowSubselectPlannerTest extends CrateDummyClusterServiceUnitT
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService)
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -83,7 +83,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private static SQLExecutor buildExecutor(ClusterService clusterService) throws IOException {
         return SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addPartitionedTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -88,7 +88,12 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395961200000")).asIndexName())
-            .addPartitionedTable(TableDefinitions.TEST_EMPTY_PARTITIONED_TABLE_DEFINITION)
+            .addPartitionedTable(
+                "create table doc.empty_parted (" +
+                "  name text," +
+                "  date timestamp with time zone" +
+                ")" +
+                " partitioned by (date)")
             .build();
     }
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -38,6 +38,7 @@ import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.TopNDistinctProjection;
 import io.crate.metadata.ColumnIdent;
@@ -50,6 +51,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 import io.crate.types.DataTypes;
 
 public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
@@ -61,7 +63,9 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() throws IOException {
         tableStats = new TableStats();
         sqlExecutor = SQLExecutor.builder(clusterService)
-            .enableDefaultTables()
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable(T3.T1_DEFINITION)
+            .addTable(T3.T2_DEFINITION)
             .setTableStats(tableStats)
             .addView(new RelationName("doc", "v2"), "select a, x from doc.t1")
             .addView(new RelationName("doc", "v3"), "select a, x from doc.t1")

--- a/server/src/testFixtures/java/io/crate/analyze/TableDefinitions.java
+++ b/server/src/testFixtures/java/io/crate/analyze/TableDefinitions.java
@@ -76,21 +76,6 @@ public final class TableDefinitions {
         "  friends array(object)" +
         ")" +
         " clustered by (id)";
-    public static final String USER_TABLE_REFRESH_INTERVAL_BY_ONLY_DEFINITION =
-        "create table doc.user_refresh_interval (" +
-        "  id bigint," +
-        "  content text" +
-        ")" +
-        " clustered by (id)";
-    public static final String NESTED_PK_TABLE_DEFINITION =
-        "create table doc.nested_pk (" +
-        "  id bigint," +
-        "  o object as (" +
-        "    b byte" +
-        "  )," +
-        "  primary key (id, o['b'])" +
-        ")" +
-        " clustered by (o['b'])";
     static final RelationName TEST_PARTITIONED_TABLE_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "parted");
 
     public static final String TEST_PARTITIONED_TABLE_DEFINITION =
@@ -107,12 +92,6 @@ public final class TableDefinitions {
         new PartitionName(new RelationName("doc", "parted"), singletonList(null)).asIndexName()
     };
 
-    public static final String TEST_EMPTY_PARTITIONED_TABLE_DEFINITION =
-        "create table doc.empty_parted (" +
-        "  name text," +
-        "  date timestamp with time zone" +
-        ")" +
-        " partitioned by (date)";
     public static final String PARTED_PKS_TABLE_DEFINITION =
         "create table doc.parted_pks (" +
         "  id integer," +
@@ -151,20 +130,9 @@ public final class TableDefinitions {
         "  ))" +
         ")";
 
-    public static final String IGNORED_NESTED_TABLE_DEFINITION =
-        "create table doc.ignored_nested (" +
-        "  details object(ignored)" +
-        ")";
-
     public static final String TEST_DOC_LOCATIONS_TABLE_DEFINITION =
         "create table doc.locations (" +
         "  id bigint," +
         "  loc geo_point" +
-        ")";
-
-    public static final String TEST_CLUSTER_BY_STRING_TABLE_DEFINITION =
-        "create table doc.bystring (" +
-        "  name text primary key," +
-        "  score double precision" +
         ")";
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -21,17 +21,6 @@
 
 package io.crate.testing;
 
-import static io.crate.analyze.TableDefinitions.DEEPLY_NESTED_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.NESTED_PK_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_CLUSTER_BY_STRING_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_DOC_TRANSACTIONS_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_MULTI_PK_DEFINITION;
-import static io.crate.analyze.TableDefinitions.USER_TABLE_REFRESH_INTERVAL_BY_ONLY_DEFINITION;
 import static io.crate.blob.v2.BlobIndex.fullIndexName;
 import static io.crate.testing.DiscoveryNodes.newFakeAddress;
 import static io.crate.testing.TestingHelpers.createNodeContext;
@@ -146,7 +135,6 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.Schemas;
@@ -390,50 +378,6 @@ public class SQLExecutor {
 
         public Builder setUser(User user) {
             this.user = user;
-            return this;
-        }
-
-        /**
-         * Adds a couple of tables which are defined in {@link T3} and {@link io.crate.analyze.TableDefinitions}.
-         * <p>
-         * Note that these tables do have a static routing which doesn't necessarily match the nodes that
-         * are part of the clusterState of the {@code clusterService} provided to the builder.
-         *
-         * Note that these tables are not part of the clusterState and rely on a stubbed getRouting
-         * Using {@link #addTable(String)} is preferred for this reason.
-         * </p>
-         *
-         * @deprecated Please only add the tables used by a test scenario
-         */
-        @Deprecated
-        public Builder enableDefaultTables() throws IOException {
-            // we should try to reduce the number of tables here eventually...
-            addTable(USER_TABLE_DEFINITION);
-            addTable(USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION);
-            addTable(USER_TABLE_MULTI_PK_DEFINITION);
-            addTable(DEEPLY_NESTED_TABLE_DEFINITION);
-            addTable(NESTED_PK_TABLE_DEFINITION);
-            addPartitionedTable(TEST_PARTITIONED_TABLE_DEFINITION, TEST_PARTITIONED_TABLE_PARTITIONS);
-            addTable(TEST_DOC_TRANSACTIONS_TABLE_DEFINITION);
-            addTable(TEST_DOC_LOCATIONS_TABLE_DEFINITION);
-            addTable(TEST_CLUSTER_BY_STRING_TABLE_DEFINITION);
-            addTable(USER_TABLE_REFRESH_INTERVAL_BY_ONLY_DEFINITION);
-            addTable(T3.T1_DEFINITION);
-            addTable(T3.T2_DEFINITION);
-            addTable(T3.T3_DEFINITION);
-
-            RelationName multiPartName = new RelationName("doc", "multi_parted");
-            addPartitionedTable(
-                "create table doc.multi_parted (" +
-                "   id int," +
-                "   date timestamp with time zone," +
-                "   num long," +
-                "   obj object as (name string)" +
-                ") partitioned by (date, obj['name'])",
-                new PartitionName(multiPartName, Arrays.asList("1395874800000", "0")).toString(),
-                new PartitionName(multiPartName, Arrays.asList("1395961200000", "-100")).toString(),
-                new PartitionName(multiPartName, Arrays.asList(null, "-100")).toString()
-            );
             return this;
         }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Avoids processing unused CREATE TABLE statements in unit tests

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
