### PR TITLE
Replace some tuples with records

### DIFF
--- a/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
@@ -94,7 +94,7 @@ public final class ViewAnalyzer {
         ArrayList<RelationName> missing = new ArrayList<>();
         for (QualifiedName qualifiedName : dropView.names()) {
             try {
-                views.add(schemas.resolveView(qualifiedName, txnCtx.sessionSettings().searchPath()).v2());
+                views.add(schemas.resolveView(qualifiedName, txnCtx.sessionSettings().searchPath()).name());
             } catch (RelationUnknown e) {
                 if (!dropView.ifExists()) {
                     missing.add(RelationName.of(qualifiedName, txnCtx.sessionSettings().searchPath().currentSchema()));

--- a/server/src/main/java/io/crate/metadata/view/View.java
+++ b/server/src/main/java/io/crate/metadata/view/View.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.view;
+
+import io.crate.metadata.RelationName;
+
+public record View(RelationName name, ViewMetadata metadata) {
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
@@ -49,18 +49,6 @@ public class CreateIndexResponse extends ShardsAcknowledgedResponse {
         out.writeString(index);
     }
 
-    /**
-     * Returns true if the requisite number of shards were started before
-     * returning from the index creation operation. If {@link #isAcknowledged()}
-     * is false, then this also returns false.
-     *
-     * @deprecated use {@link #isShardsAcknowledged()}
-     */
-    @Deprecated
-    public boolean isShardsAcked() {
-        return isShardsAcknowledged();
-    }
-
     public String index() {
         return index;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/ack/CreateIndexClusterStateUpdateResponse.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ack/CreateIndexClusterStateUpdateResponse.java
@@ -33,14 +33,7 @@ public class CreateIndexClusterStateUpdateResponse extends ClusterStateUpdateRes
 
     /**
      * Returns whether the requisite number of shard copies started before the completion of the operation.
-     * 
-     * @deprecated use {@link #isShardsAcknowledged()}
      */
-    @Deprecated
-    public boolean isShardsAcked() {
-        return shardsAcknowledged;
-    }
-    
     public boolean isShardsAcknowledged() {
         return shardsAcknowledged;
     }

--- a/server/src/main/java/org/elasticsearch/plugins/AnalysisPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/AnalysisPlugin.java
@@ -130,16 +130,6 @@ public interface AnalysisPlugin {
 
     /**
      * Mark an {@link AnalysisProvider} as requiring the index's settings.
-     *
-     * @deprecated use {@link #requiresAnalysisSettings(AnalysisProvider)}
-     */
-    @Deprecated
-    static <T> AnalysisProvider<T> requriesAnalysisSettings(AnalysisProvider<T> provider) {
-        return requiresAnalysisSettings(provider);
-    }
-
-    /**
-     * Mark an {@link AnalysisProvider} as requiring the index's settings.
      */
     static <T> AnalysisProvider<T> requiresAnalysisSettings(AnalysisProvider<T> provider) {
         return new AnalysisProvider<T>() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Replaces two usages of the deprecated Tuple.
Other places are not replaced yet because most of it is in the ES area where we
still may have outstanding patches.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
