### PR TITLE
Remove deprecated allow_mmapfs setting

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,9 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Removed the ``node.store.allow_mmapfs`` setting. It was deprecated in 4.1.0
+  in favour of the ``node.store.allow_mmap`` setting.
+
 - Removed the ``indices.breaker.fielddata.limit`` setting and the ``*.overhead``
   settings for all circuit breakers. They were deprecated in 4.3.0 and had no
   effect since then.

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -283,7 +283,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
         HierarchyCircuitBreakerService.QUERY_CIRCUIT_BREAKER_LIMIT_SETTING,
         HierarchyCircuitBreakerService.JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING,
         HierarchyCircuitBreakerService.OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING,
-        IndexModule.NODE_STORE_ALLOW_MMAPFS,
         IndexModule.NODE_STORE_ALLOW_MMAP,
         ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
         ClusterService.USER_DEFINED_METADATA,

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index;
 
-import io.crate.common.Booleans;
 import io.crate.types.DataTypes;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.Constants;
@@ -73,15 +72,9 @@ import java.util.function.Function;
  */
 public final class IndexModule {
 
-    @Deprecated
-    public static final Setting<Boolean> NODE_STORE_ALLOW_MMAPFS = Setting.boolSetting(
-        "node.store.allow_mmapfs", true, Property.NodeScope, Property.Deprecated);
-
-    public static final Setting<Boolean> NODE_STORE_ALLOW_MMAP = new Setting<>(
-        new Setting.SimpleKey("node.store.allow_mmap"),
-        NODE_STORE_ALLOW_MMAPFS,
-        Booleans::parseBoolean,
-        DataTypes.BOOLEAN,
+    public static final Setting<Boolean> NODE_STORE_ALLOW_MMAP = Setting.boolSetting(
+        "node.store.allow_mmap",
+        true,
         Property.NodeScope
     );
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

🧹

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
