### PR TITLE
Remove deferredExecutionsByStmt from Session.toString

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -864,7 +864,6 @@ public class Session implements AutoCloseable {
         return "Session{" +
             "portals=" + portals +
             ", cursors=" + cursors +
-            ", deferredExecutionsByStmt=" + deferredExecutionsByStmt.size() +
             ", mostRecentJobID=" + mostRecentJobID +
             ", id=" + id +
             "}";


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/13062
Having it included can lead to `ConcurrentModificationException`

There was no good reason to include it, other than "might be useful".

Fixes:

    java.util.ConcurrentModificationException
    	at __randomizedtesting.SeedInfo.seed([10B5036FFE4E8643:553829717697324E]:0)
    	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
    	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1630)
    	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1628)
    	at java.base/java.util.AbstractMap.toString(AbstractMap.java:550)
    	at java.base/java.lang.StringConcatHelper.stringOf(StringConcatHelper.java:453)
    	at io.crate.action.sql.Session.toString(Session.java:867)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
