### PR TITLE
Move nested-loop-join-to-hashjoin logic into a optimizer rule

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -57,7 +57,7 @@ public class EquiJoinDetector {
         return isEquiJoin(joinCondition);
     }
 
-    private static boolean isEquiJoin(Symbol joinCondition) {
+    public static boolean isEquiJoin(Symbol joinCondition) {
         assert joinCondition != null : "join condition must not be null on inner joins";
         Context context = new Context();
         joinCondition.accept(VISITOR, context);

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -80,6 +80,7 @@ public class NestedLoopJoin implements LogicalPlan {
     private boolean orderByWasPushedDown = false;
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
     private final boolean joinConditionOptimised;
+    private final boolean finalized;
 
     NestedLoopJoin(LogicalPlan lhs,
                    LogicalPlan rhs,
@@ -87,7 +88,8 @@ public class NestedLoopJoin implements LogicalPlan {
                    @Nullable Symbol joinCondition,
                    boolean isFiltered,
                    AnalyzedRelation topMostLeftRelation,
-                   boolean joinConditionOptimised) {
+                   boolean joinConditionOptimised,
+                   boolean finalized) {
         this.joinType = joinType;
         this.isFiltered = isFiltered || joinCondition != null;
         this.lhs = lhs;
@@ -102,6 +104,7 @@ public class NestedLoopJoin implements LogicalPlan {
         this.joinCondition = joinCondition;
         this.dependencies = Maps.concat(lhs.dependencies(), rhs.dependencies());
         this.joinConditionOptimised = joinConditionOptimised;
+        this.finalized = finalized;
     }
 
     public NestedLoopJoin(LogicalPlan lhs,
@@ -112,8 +115,9 @@ public class NestedLoopJoin implements LogicalPlan {
                           AnalyzedRelation topMostLeftRelation,
                           boolean orderByWasPushedDown,
                           boolean rewriteFilterOnOuterJoinToInnerJoinDone,
-                          boolean joinConditionOptimised) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation, joinConditionOptimised);
+                          boolean joinConditionOptimised,
+                          boolean processed) {
+        this(lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation, joinConditionOptimised, processed);
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
     }
@@ -141,6 +145,10 @@ public class NestedLoopJoin implements LogicalPlan {
 
     public boolean isFiltered() {
         return true;
+    }
+
+    public boolean isFinalized() {
+        return finalized;
     }
 
     public AnalyzedRelation topMostLeftRelation() {
@@ -281,7 +289,8 @@ public class NestedLoopJoin implements LogicalPlan {
             topMostLeftRelation,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            joinConditionOptimised
+            joinConditionOptimised,
+            finalized
         );
     }
 
@@ -311,7 +320,8 @@ public class NestedLoopJoin implements LogicalPlan {
             topMostLeftRelation,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            joinConditionOptimised
+            joinConditionOptimised,
+            finalized
         );
     }
 
@@ -347,7 +357,8 @@ public class NestedLoopJoin implements LogicalPlan {
                 topMostLeftRelation,
                 orderByWasPushedDown,
                 rewriteFilterOnOuterJoinToInnerJoinDone,
-                joinConditionOptimised
+                joinConditionOptimised,
+                finalized
             )
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -52,6 +52,7 @@ import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathRename;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathUnion;
 import io.crate.planner.optimizer.rule.OptimizeCollectWhereClauseAccess;
+import io.crate.planner.optimizer.rule.RewriteEquiJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToTopNDistinct;
@@ -87,7 +88,8 @@ public class LoadedRules implements SessionSettingProvider {
         OptimizeCollectWhereClauseAccess.class,
         RewriteGroupByKeysLimitToTopNDistinct.class,
         RewriteInsertFromSubQueryToInsertFromValues.class,
-        RewriteToQueryThenFetch.class
+        RewriteToQueryThenFetch.class,
+        RewriteEquiJoinToHashJoin.class
     );
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -88,7 +88,9 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 nl.topMostLeftRelation(),
                 nl.orderByWasPushedDown(),
                 nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                true // Mark joinConditionOptimised = true
+                true, // Mark joinConditionOptimised = true,
+                nl.isFinalized()
+
             );
         } else {
             // Push constant join condition down to source

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -67,7 +67,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
             .with(source(),
                 typeOf(NestedLoopJoin.class)
                     .capturedAs(nlCapture)
-                    .with(nl -> !nl.joinType().isOuter())
+                    .with(nl -> !nl.joinType().isOuter() && nl.isFinalized() == true)
             );
     }
 
@@ -106,7 +106,8 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.topMostLeftRelation(),
                     true,
                     nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                    false
+                    false,
+                    nestedLoop.isFinalized()
                 );
             }
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteEquiJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteEquiJoinToHashJoin.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.operators.EquiJoinDetector.isEquiJoin;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.node.dql.join.JoinType;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class RewriteEquiJoinToHashJoin implements Rule<NestedLoopJoin> {
+
+    private final Pattern<NestedLoopJoin> pattern;
+
+    public RewriteEquiJoinToHashJoin() {
+        this.pattern = typeOf(NestedLoopJoin.class)
+            .with(nestedLoopJoin -> !nestedLoopJoin.isFinalized() &&
+                                    nestedLoopJoin.joinType() == JoinType.INNER);
+    }
+
+    @Override
+    public Pattern<NestedLoopJoin> pattern() {
+        return this.pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(NestedLoopJoin nestedLoopJoin,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx) {
+        if (nestedLoopJoin.joinCondition() != null &&
+            txnCtx.sessionSettings().hashJoinsEnabled() &&
+            isEquiJoin(nestedLoopJoin.joinCondition())) {
+            return new HashJoin(
+                nestedLoopJoin.lhs(),
+                nestedLoopJoin.rhs(),
+                nestedLoopJoin.joinCondition()
+            );
+        } else {
+            return new NestedLoopJoin(
+                nestedLoopJoin.lhs(),
+                nestedLoopJoin.rhs(),
+                nestedLoopJoin.joinType(),
+                nestedLoopJoin.joinCondition(),
+                nestedLoopJoin.isFiltered(),
+                nestedLoopJoin.topMostLeftRelation(),
+                nestedLoopJoin.orderByWasPushedDown(),
+                nestedLoopJoin.isRewriteFilterOnOuterJoinToInnerJoinDone(),
+                nestedLoopJoin.isJoinConditionOptimised(),
+                true
+            );
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -256,6 +256,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             nl.topMostLeftRelation(),
             nl.orderByWasPushedDown(),
             true,
+            false,
             false
         );
         assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -135,12 +135,12 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("insert into t2 (num, value, qty) values (1, 'xxx', 12), (3, 'yyy', 7), (5, 'zzz', 0)");
         execute("refresh table t1, t2");
         ensureGreen();
-        execute("SELECT * FROM t1 AS rel1 INNER JOIN t2 USING (num, value) ORDER BY rel1.num");
+        execute("SELECT * FROM t1 AS rel1 INNER JOIN t2 USING (num, value) ORDER BY rel1.num asc");
         assertThat(printedTable(response.rows()), is(
             "1| xxx| 1| xxx| 12\n" +
             "3| yyy| 3| yyy| 7\n" +
             "5| zzz| 5| zzz| 0\n"));
-        execute("SELECT * FROM (SELECT * FROM t1) AS rel1 JOIN (SELECT * FROM t2) AS rel2 USING (num, value) ORDER BY rel1.num;");
+        execute("SELECT * FROM (SELECT * FROM t1) AS rel1 JOIN (SELECT * FROM t2) AS rel2 USING (num, value) ORDER BY rel1.num asc;");
         assertThat(printedTable(response.rows()), is(
             "1| xxx| 1| xxx| 12\n" +
             "3| yyy| 3| yyy| 7\n" +

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -174,6 +174,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.| NULL| NULL",
             "optimizer_move_order_beneath_union| true| Indicates if the optimizer rule MoveOrderBeneathUnion is activated.| NULL| NULL",
             "optimizer_optimize_collect_where_clause_access| true| Indicates if the optimizer rule OptimizeCollectWhereClauseAccess is activated.| NULL| NULL",
+            "optimizer_optimize_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule OptimizeNestedLoopJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_remove_redundant_fetch_or_eval| true| Indicates if the optimizer rule RemoveRedundantFetchOrEval is activated.| NULL| NULL",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.| NULL| NULL",
             "optimizer_rewrite_group_by_keys_limit_to_top_n_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToTopNDistinct is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -427,6 +427,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.\n" +
             "optimizer_move_order_beneath_union| true| Indicates if the optimizer rule MoveOrderBeneathUnion is activated.\n" +
             "optimizer_optimize_collect_where_clause_access| true| Indicates if the optimizer rule OptimizeCollectWhereClauseAccess is activated.\n" +
+            "optimizer_optimize_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule OptimizeNestedLoopJoinToHashJoin is activated.\n" +
             "optimizer_remove_redundant_fetch_or_eval| true| Indicates if the optimizer rule RemoveRedundantFetchOrEval is activated.\n" +
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.\n" +
             "optimizer_rewrite_group_by_keys_limit_to_top_n_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToTopNDistinct is activated.\n" +

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -51,7 +51,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE t2.x = '10'"
         );
         var expectedPlan =
-            "NestedLoopJoin[INNER | (x = x)]\n" +
+            "HashJoin[(x = x)]\n" +
             "  ├ Collect[doc.t1 | [x] | true]\n" +
             "  └ Collect[doc.t2 | [x] | (x = 10)]";
         assertThat(plan, isPlan(expectedPlan));

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -22,6 +22,8 @@
 package io.crate.planner.operators;
 
 import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static io.crate.planner.operators.LogicalPlannerTest.printPlan;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -107,7 +109,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                 "inner join t2 on t1.a = t2.b " +
                                 "inner join t1 as t3 on t3.a = t2.b " +
                                 "order by t2.b");
-        assertThat(plan, isPlan(
+        assertThat(printPlan(plan), is(
             "Eval[a, b, a]\n" +
             "  └ NestedLoopJoin[INNER | (a = b)]\n" +
             "    ├ NestedLoopJoin[INNER | (a = b)]\n" +

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -100,6 +100,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
                                                 e.asSymbol("x = y"),
                                                 false,
                                                 t1Relation,
+                                                false,
                                                 false);
         assertThat(nestedLoopJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -72,7 +72,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false);
+        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false, false);
         var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
         Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
