### PR TITLE
Documentation: Fix table of available data types for the HTTP interface

### DIFF
--- a/docs/interfaces/http.rst
+++ b/docs/interfaces/http.rst
@@ -234,6 +234,12 @@ Example of JSON representation of a column list of (String, Integer[])::
 
   "column_types": [ 4, [ 100, 9 ] ]
 
+
+.. _http-data-types-table:
+
+Available data types
+--------------------
+
 IDs of all currently available data types:
 
 .. list-table::

--- a/docs/interfaces/http.rst
+++ b/docs/interfaces/http.rst
@@ -265,7 +265,7 @@ IDs of all currently available data types:
    * - 10
      - :ref:`BIGINT <type-bigint>`
    * - 11
-     - :ref:`TIMESTAMP <type-timestamp>`
+     - :ref:`TIMESTAMP WITH TIME ZONE <type-timestamp-with-tz>`
    * - 12
      - :ref:`OBJECT <type-object>`
    * - 13
@@ -273,6 +273,8 @@ IDs of all currently available data types:
    * - 14
      - :ref:`GEO_SHAPE <type-geo_shape>`
    * - 15
+     - :ref:`TIMESTAMP WITHOUT TIME ZONE <type-timestamp-without-tz>`
+   * - 16
      - Unchecked object
    * - 19
      - :ref:`REGPROC <type-regproc>`


### PR DESCRIPTION
Hi,

while working on https://github.com/crate/crate-python/pull/442, we discovered that the table at [IDs of all currently available data types for the HTTP interface](https://crate.io/docs/crate/reference/en/5.0/interfaces/http.html#column-types) needed a fix.

- `Unchecked object` has ID 16 instead of 15
- `TIMESTAMP WITHOUT TIME ZONE` has ID 15

Other than this, the patch adds an anchor to be able to directly refer to the table of available data types from other sections of the documentation.

With kind regards,
Andreas.

P.S.: The corresponding fix for `crate-python` is https://github.com/crate/crate-python/commit/acdeb874.
