### PR TITLE
remove portals and cursors from Session.toString

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -862,8 +862,6 @@ public class Session implements AutoCloseable {
     @Override
     public String toString() {
         return "Session{" +
-            "portals=" + portals +
-            ", cursors=" + cursors +
             ", mostRecentJobID=" + mostRecentJobID +
             ", id=" + id +
             "}";


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/13069

As @matriv pointed out, `portals` is also a Map, so removing it. 
Removed `cursors` as well, as `cursors.toString` prints `Cursors.cursors` map.