### PR TITLE
Remove invalid deprecation note of `indices.breaker.query.limit`

### DIFF
--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1092,10 +1092,6 @@ keeps working.
   or percentage of the heap size (like ``12%``). A value of ``-1`` disables
   breaking the circuit while still accounting memory usage.
 
-  .. CAUTION::
-
-      This setting is deprecated and has no effect.
-
 .. _indices.breaker.query.overhead:
 
 **indices.breaker.query.overhead**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This setting isn't marked as deprecated.

Partly backport of https://github.com/crate/crate/commit/8a2b12e22e7.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
