### PR TITLE
Explain how users are backed up and restored

### DIFF
--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -19,8 +19,9 @@ When CrateDB is started, the cluster contains one predefined superuser. This
 user is called ``crate``. It is not possible to create any other superusers
 
 The definition of all users, including hashes of their passwords, is backed up
-together with the cluster's metadata when a snapshot is created, and it can be
-restored with the ``USERS`` option of the :ref:`sql-restore-snapshot` command.
+together with the cluster's metadata when a snapshot is created, and is 
+restored when using the ``ALL`` or ``USERS`` clause of the 
+:ref:`sql-restore-snapshot` command.
 
 .. rubric:: Table of contents
 

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -19,8 +19,8 @@ When CrateDB is started, the cluster contains one predefined superuser. This
 user is called ``crate``. It is not possible to create any other superusers
 
 The definition of all users, including hashes of their passwords, is backed up
-together with the cluster's metadata when a snapshot is created, and is 
-restored when using the ``ALL`` or ``USERS`` clause of the 
+together with the cluster's metadata when a snapshot is created, and it is 
+restored when using the ``ALL``, ``METADATA``, or ``USERS`` clauses of the 
 :ref:`sql-restore-snapshot` command.
 
 .. rubric:: Table of contents

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -18,7 +18,9 @@ superusers that already exist in the CrateDB cluster. The `CREATE USER`_ and
 When CrateDB is started, the cluster contains one predefined superuser. This
 user is called ``crate``. It is not possible to create any other superusers
 
-Users cannot be backed up or restored.
+The definition of all users, including hashes of their passwords, is backed up
+together with the cluster's metadata when a snapshot is created, and it can be
+restored with the ``USERS`` option of the :ref:`sql-restore-snapshot` command.
 
 .. rubric:: Table of contents
 

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -20,7 +20,7 @@ user is called ``crate``. It is not possible to create any other superusers
 
 The definition of all users, including hashes of their passwords, is backed up
 together with the cluster's metadata when a snapshot is created, and it is 
-restored when using the ``ALL``, ``METADATA``, or ``USERS`` clauses of the 
+restored when using the ``ALL``, ``METADATA``, or ``USERS`` keywords with the 
 :ref:`sql-restore-snapshot` command.
 
 .. rubric:: Table of contents


### PR DESCRIPTION
Correction to the user management documentation removing a note that stated users' information could not be backed up and explaining this can be done with snapshots.