### PR TITLE
Remove nullable annotation on primitive return types

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -820,7 +820,6 @@ public abstract class Engine implements Closeable {
      * Synchronously refreshes the engine for new search operations to reflect the latest
      * changes.
      */
-    @Nullable
     public abstract void refresh(String source) throws EngineException;
 
     /**
@@ -829,7 +828,6 @@ public abstract class Engine implements Closeable {
      *
      * @return <code>true</code> if the a refresh happened. Otherwise <code>false</code>
      */
-    @Nullable
     public abstract boolean maybeRefresh(String source) throws EngineException;
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Those two methods cannot return `null`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
