### PR TITLE
Replace deprecated NO_MORE_ORDS checks with docValueCount

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -320,7 +320,7 @@ final class GroupByOptimizedIterator {
                         } else {
                             aggregateValues(aggregations, ramAccounting, memoryManager, states);
                         }
-                        if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
+                        if (values.docValueCount() > 1) {
                             throw new ArrayViaDocValuesUnsupportedException(keyColumnName);
                         }
                     } else {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/BitStringColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/BitStringColumnReference.java
@@ -50,7 +50,7 @@ public class BitStringColumnReference extends LuceneCollectorExpression<BitStrin
         try {
             if (values.advanceExact(docId)) {
                 long ord = values.nextOrd();
-                if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
+                if (values.docValueCount() > 1) {
                     throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
                 var bytesRef = values.lookupOrd(ord);

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
@@ -47,7 +47,7 @@ public class IpColumnReference extends LuceneCollectorExpression<String> {
         try {
             if (values.advanceExact(docId)) {
                 long ord = values.nextOrd();
-                if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
+                if (values.docValueCount() > 1) {
                     throw new ArrayViaDocValuesUnsupportedException(columnName);
                 }
                 BytesRef encoded = values.lookupOrd(ord);

--- a/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
@@ -40,8 +40,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
-import org.elasticsearch.index.fielddata.FieldData;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
 import io.crate.metadata.Reference;
 import io.crate.types.ArrayType;
@@ -118,11 +116,7 @@ public class NumTermsPerDocQuery extends Query {
         return doc -> {
             try {
                 if (docValues.advanceExact(doc)) {
-                    int c = 1;
-                    while (docValues.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
-                        c++;
-                    }
-                    return c;
+                    return docValues.docValueCount();
                 }
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -132,9 +126,9 @@ public class NumTermsPerDocQuery extends Query {
     }
 
     private static IntUnaryOperator numValuesPerDocForString(LeafReader reader, String fqColumn) {
-        SortedBinaryDocValues docValues;
+        SortedSetDocValues docValues;
         try {
-            docValues = FieldData.toString(DocValues.getSortedSet(reader, fqColumn));
+            docValues = DocValues.getSortedSet(reader, fqColumn);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -115,35 +115,21 @@ public enum FieldData {
      */
     public static SortedBinaryDocValues toString(final SortedSetDocValues values) {
         return new SortedBinaryDocValues() {
-            private int count = 0;
 
             @Override
             public boolean advanceExact(int doc) throws IOException {
-                if (values.advanceExact(doc) == false) {
-                    return false;
-                }
-                for (int i = 0; ; ++i) {
-                    if (values.nextOrd() == SortedSetDocValues.NO_MORE_ORDS) {
-                        count = i;
-                        break;
-                    }
-                }
-                // reset the iterator on the current doc
-                boolean advanced = values.advanceExact(doc);
-                assert advanced;
-                return true;
+                return values.advanceExact(doc);
             }
 
             @Override
             public int docValueCount() {
-                return count;
+                return values.docValueCount();
             }
 
             @Override
             public BytesRef nextValue() throws IOException {
                 return values.lookupOrd(values.nextOrd());
             }
-
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/search/MultiValueMode.java
+++ b/server/src/main/java/org/elasticsearch/search/MultiValueMode.java
@@ -408,8 +408,8 @@ public enum MultiValueMode {
         @Override
         protected int pick(SortedSetDocValues values) throws IOException {
             long maxOrd = -1;
-            for (long ord = values.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = values.nextOrd()) {
-                maxOrd = ord;
+            for (int i = 0; i < values.docValueCount(); i++) {
+                maxOrd = values.nextOrd();
             }
             return Math.toIntExact(maxOrd);
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

🧹

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
