### PR TITLE
Avoid string conversion in bool doc-value lookup

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
@@ -21,21 +21,19 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
-import io.crate.execution.engine.fetch.ReaderContext;
-import org.apache.lucene.index.DocValues;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.fielddata.FieldData;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+
+import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
+import io.crate.execution.engine.fetch.ReaderContext;
+
 public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
 
-    private static final BytesRef TRUE_BYTESREF = new BytesRef("1");
     private final String columnName;
-    private SortedBinaryDocValues values;
+    private SortedNumericDocValues values;
     private int docId;
 
     public BooleanColumnReference(String columnName) {
@@ -48,7 +46,7 @@ public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
             if (values.advanceExact(docId)) {
                 switch (values.docValueCount()) {
                     case 1:
-                        return values.nextValue().compareTo(TRUE_BYTESREF) == 0;
+                        return values.nextValue() == 1;
 
                     default:
                         throw new ArrayViaDocValuesUnsupportedException(columnName);
@@ -69,6 +67,6 @@ public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
     @Override
     public void setNextReader(ReaderContext context) throws IOException {
         super.setNextReader(context);
-        values = FieldData.toString(DocValues.getSortedNumeric(context.reader(), columnName));
+        values = DocValues.getSortedNumeric(context.reader(), columnName);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -69,28 +69,6 @@ public enum FieldData {
      * typically used for scripts or for the `map` execution mode of terms aggs.
      * NOTE: this is very slow!
      */
-    public static SortedBinaryDocValues toString(final SortedNumericDocValues values) {
-        return toString(new ToStringValues() {
-
-            @Override
-            public boolean advanceExact(int doc) throws IOException {
-                return values.advanceExact(doc);
-            }
-
-            @Override
-            public void get(List<CharSequence> list) throws IOException {
-                for (int i = 0, count = values.docValueCount(); i < count; ++i) {
-                    list.add(Long.toString(values.nextValue()));
-                }
-            }
-        });
-    }
-
-    /**
-     * Return a {@link String} representation of the provided values. That is
-     * typically used for scripts or for the `map` execution mode of terms aggs.
-     * NOTE: this is very slow!
-     */
     public static SortedBinaryDocValues toString(final SortedNumericDoubleValues values) {
         return toString(new ToStringValues() {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

    Q: SELECT count(b) FROM tbl
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       24.881 ±   22.399 |     19.994 |     22.772 |     24.007 |    515.772 |
    |   V2    |       12.767 ±   21.075 |      9.551 |     11.116 |     12.327 |    479.364 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  64.36%                           -  68.79%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 64.36%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |   10     5.02     5.04 |    0     0.00     0.00 |      268     1571 |   945.10      11840
     V2 |    0     0.00     0.00 |    0     0.00     0.00 |      268        0 |    54.61        384

    Top frames (by count)
      V1
        Long.toString(long) total=11191287552, count=3715
        ArraysSupport.mismatch(...) total=582, count=582
        InputRow.get(int) total=542, count=542
        UnicodeUtil.UTF16toUTF8(...) total=482, count=482
        LuceneBatchIterator.onDoc(int) total=392, count=392
        AggregateCollector.iterate(...) total=380, count=380
        ArrayList.clear() total=344, count=344
        Objects.checkIndex(int, int) total=187, count=187
        String.charAt(int) total=164, count=164
        Long.getChars(...) total=157, count=157
      V2
        SingletonSortedNumericDocValues.nextValue() total=573, count=573
        LuceneBatchIterator.onDoc(int) total=379, count=379
        DirectReader$1.get(long) total=289, count=289
        AggregateCollector.iterate(...) total=230, count=230
        BatchIterators$BiCollector.collect() total=104, count=104
        600742078.accept(...) total=38, count=38
        LuceneBatchIterator.innerMoveNext() total=16, count=16
        LuceneBatchIterator.tryAdvanceDocIdSetIterator() total=15, count=15
        LuceneBatchIterator.moveNext() total=14, count=14
        ParserATNSimulator.getEpsilonTarget(...) total=16271706, count=12

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
