### PR TITLE
tests: Try to fix flakiness for testInsertIntoClosedPartition

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -193,16 +193,17 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
     @Test
     public void testInsertIntoClosedPartition() throws Exception {
         execute("create table t (n integer) partitioned by (n)");
+        ensureYellow();
         execute("insert into t (n) values (1)");
         refresh();
-        ensureYellow();
 
         execute("alter table t partition (n = 1) close");
+        waitNoPendingTasksOnAll(); // ensure close got processed on all shard copies
 
         execute("insert into t (n) values (1)");
         assertThat(response.rowCount(), is(0L));
 
-        waitNoPendingTasksOnAll(); // ensure close got processed on all shard copies
+        refresh();
         execute("select count(*) from t");
         assertEquals(0L, response.rows()[0][0]);
     }

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -92,6 +92,8 @@ import io.crate.testing.UseRandomizedSchema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 @IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 2)
 public class PartitionedTableIntegrationTest extends IntegTestCase {
 
@@ -190,6 +192,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[0].length, is(3));
     }
 
+    @Repeat(iterations = 100)
     @Test
     public void testInsertIntoClosedPartition() throws Exception {
         execute("create table t (n integer) partitioned by (n)");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Final assertions `select count(*)` sometimes returns `1` instead of `0`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
