### PR TITLE
Avoid stack trace generation in insert code paths

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -200,15 +200,4 @@ public class SQLExceptions {
         return e instanceof VersionConflictEngineException
                    && e.getMessage().contains("document already exists");
     }
-
-    /**
-     * Converts a possible ES exception to a Crate one and returns the message.
-     * The message will not contain any information about possible nested exceptions.
-     * If the message is null, the exceptions name is used.
-     */
-    public static String userFriendlyCrateExceptionTopOnly(Throwable e) {
-        var throwable = esToCrateException(e);
-        var message = throwable.getMessage();
-        return message != null ? message : throwable.getClass().getName();
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/VersionConflictEngineException.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/VersionConflictEngineException.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.engine;
 
+import org.elasticsearch.Assertions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
@@ -62,5 +63,13 @@ public class VersionConflictEngineException extends EngineException {
 
     public VersionConflictEngineException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        if (Assertions.ENABLED) {
+            return super.fillInStackTrace();
+        }
+        return this;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See commits. There were some unnecessary stack trace generations.

Mostly motivated by `Throwable.fillInStackTrace` showing up as top allocation frame:

    Top allocation frames
      V1
        BufferedChecksum.<init>(...) total=2698906760, count=1703
        BytesStore.writeByte(byte) total=2397735840, count=209
        Throwable.fillInStackTrace(int) total=1812102344, count=387
        ArrayList.<init>(int) total=1696371313, count=409
        DirectMethodHandle.allocateInstance(Object) total=1260578651, count=344
        Arrays.copyOf(...) total=1254494522, count=808


Looks like this also has quite an effect on some benchmark cases:

    Q: insert into id_int_value_str ("id", "value") values ($1, $2)
    C: 10
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       15.182 ±   11.689 |      8.535 |     12.360 |     14.611 |    111.225 |
    |   V2    |       10.120 ±    7.902 |      5.585 |      8.233 |      9.763 |     81.969 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  40.01%                           -  40.08%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 40.01%
    The test has statistical significance

On others, it doesn't:

    Q: insert into tbl ("id", "value") values ($1, $2)
    C: 10
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       19.441 ±   11.528 |      9.198 |     16.170 |     18.733 |     87.690 |
    |   V2    |       19.183 ±   11.833 |      7.458 |     15.826 |     19.630 |    101.876 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   1.33%                           -   2.15%
    There is a 37.79% probability that the observed difference is not random, and the best estimate of that difference is 1.33%
    The test has no statistical significance

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
