### PR TITLE
Remove wrong Nullable annotations in BatchIteratorBackpressureExecutor

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutor.java
@@ -65,8 +65,8 @@ public class BatchIteratorBackpressureExecutor<T, R> {
     private final BinaryOperator<R> combiner;
     private final Predicate<T> pauseConsumption;
     private final BiConsumer<R, Throwable> continueConsumptionOrFinish;
-    @Nullable private final Predicate<R> earlyTerminationCondition;
-    @Nullable private final Function<R, Throwable> resultsToFailure;
+    private final Predicate<R> earlyTerminationCondition;
+    private final Function<R, Throwable> resultsToFailure;
     private final AtomicInteger inFlightExecutions = new AtomicInteger(0);
     private final CompletableFuture<R> resultFuture = new CompletableFuture<>();
     private final Semaphore semaphore = new Semaphore(1);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

These two properties cannot be null. There are guards in the
constructor:

    this.earlyTerminationCondition = earlyTerminationCondition == null ? (results) -> false : earlyTerminationCondition;
    this.resultsToFailure = resultsToFailure == null ? (result) -> JobKilledException.of(null) : resultsToFailure;

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
