### PR TITLE
Document silent skipping of rows on failed type casting during INSERT

### DIFF
--- a/docs/general/dml.rst
+++ b/docs/general/dml.rst
@@ -50,8 +50,8 @@ Inserting a row::
 
 When inserting rows with the ``VALUES`` clause all data is validated in terms
 of data types compatibility and compliance with defined
-:ref:`_table_constraints`, and if there are any issues an error message is
-returned and no rows are inserted.
+:ref:`constraints <table_constraints>`, and if there are any issues an error
+message is returned and no rows are inserted.
 
 Inserting multiple rows at once (aka. bulk insert) can be done by defining
 multiple values for the ``INSERT`` statement::

--- a/docs/general/dml.rst
+++ b/docs/general/dml.rst
@@ -139,7 +139,7 @@ changing a field's data type or convert a normal table into a partitioned one.
 .. CAUTION::
 
     When inserting data from a query, there is no error message returned when
-    rows failed to be inserted, they are instead skipped, and the number of
+    rows fail to be inserted, they are instead skipped, and the number of
     rows affected is decreased to reflect the actual number of rows for which
     the operation succeeded. 
 

--- a/docs/general/dml.rst
+++ b/docs/general/dml.rst
@@ -48,8 +48,10 @@ Inserting a row::
     ... );
     INSERT OK, 1 row affected (... sec)
 
-When inserting a single row, if an error occurs an error is returned as a
-response.
+When inserting rows with the ``VALUES`` clause all data is validated in terms
+of data types compatibility and compliance with defined
+:ref:`_table_constraints`, and if there are any issues an error message is
+returned and no rows are inserted.
 
 Inserting multiple rows at once (aka. bulk insert) can be done by defining
 multiple values for the ``INSERT`` statement::
@@ -72,10 +74,6 @@ multiple values for the ``INSERT`` statement::
     ...   10
     ... );
     INSERT OK, 2 rows affected (... sec)
-
-When inserting multiple rows, if an error occurs for some of these rows there
-is no error returned but instead the number of rows affected would be decreased
-by the number of rows that failed to be inserted.
 
 When inserting into tables containing :ref:`sql-create-table-generated-columns`
 or :ref:`sql-create-table-base-columns` having the
@@ -137,6 +135,13 @@ It is possible to insert data using a query instead of values. Column data
 types of source and target table can differ as long as the values are castable.
 This gives the opportunity to restructure the tables data, renaming a field,
 changing a field's data type or convert a normal table into a partitioned one.
+
+.. CAUTION::
+
+    When inserting data from a query, there is no error message returned when
+    rows failed to be inserted, they are instead skipped, and the number of
+    rows affected is decreased to reflect the actual number of rows for which
+    the operation succeeded. 
 
 Example of changing a field's data type, in this case, changing the
 ``position`` data type from ``integer`` to ``smallint``::

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -90,7 +90,7 @@ will attempt automatic :ref:`type conversion <data-types-casting>`.
 .. NOTE::
 
     When inserting data from a query, the number of rows affected indicates
-    the number of rows for which the ``INSERT` succeeded.
+    the number of rows for which the ``INSERT`` succeeded.
     Please refer to :ref:`dml` for more details.
 
 The optional ``RETURNING`` clause causes the ``INSERT`` statement to compute

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -84,9 +84,12 @@ the explicit or implicit column list left-to-right.
 CrateDB will not fill any column not present in the explicit or implicit column
 list.
 
-If the :ref:`expression <gloss-expression>` for any column is not of the
-correct data type, CrateDB will attempt automatic :ref:`type conversion
-<data-types-casting>`.
+.. CAUTION::
+
+    If the values for any column are not of the correct data type, CrateDB
+    will attempt automatic :ref:`type conversion <data-types-casting>`,
+    but if the casting fails the row will be skipped and the ``INSERT``
+    will still proceed for the remaining rows.
 
 The optional ``RETURNING`` clause causes the ``INSERT`` statement to compute
 and return values from each row inserted (or updated, in the case of ``ON

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -84,12 +84,14 @@ the explicit or implicit column list left-to-right.
 CrateDB will not fill any column not present in the explicit or implicit column
 list.
 
-.. CAUTION::
+If the values for any column are not of the correct data type, CrateDB
+will attempt automatic :ref:`type conversion <data-types-casting>`.
 
-    If the values for any column are not of the correct data type, CrateDB
-    will attempt automatic :ref:`type conversion <data-types-casting>`,
-    but if the casting fails the row will be skipped and the ``INSERT``
-    will still proceed for the remaining rows.
+.. NOTE::
+
+    When inserting data from a query, the number of rows affected indicates
+    the number of rows for which the ``INSERT` succeeded.
+    Please refer to :ref:`dml` for more details.
 
 The optional ``RETURNING`` clause causes the ``INSERT`` statement to compute
 and return values from each row inserted (or updated, in the case of ``ON


### PR DESCRIPTION
I think it is important to document this as other systems would return a warning or error message and will fail the whole INSERT as an atomic operation.