### PR TITLE
Relieve the pressure on the Netty Channel when returning data

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -847,6 +847,7 @@ public class Session implements AutoCloseable {
 
     public void cancelCurrentJob() {
         if (mostRecentJobID == null) {
+            LOGGER.info("cancelling but mostRecentJobID is null");
             return;
         }
         var request = new KillJobsNodeRequest(

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -131,6 +131,7 @@ public class Messages {
      * rejected until block is ended).
      */
     static ChannelFuture sendReadyForQuery(Channel channel, TransactionState transactionState) {
+        LOGGER.info("readyForQuery");
         ByteBuf buffer = channel.alloc().buffer(6);
         buffer.writeByte('Z');
         buffer.writeInt(5);
@@ -187,6 +188,7 @@ public class Messages {
     }
 
     static ChannelFuture sendErrorResponse(Channel channel, AccessControl accessControl, Throwable throwable) {
+        LOGGER.info("sendErrorResponse: " + throwable + "  | channel.bytesBeforeWritable: " + channel.bytesBeforeWritable());
         final var error = PGError.fromThrowable(SQLExceptions.prepareForClientTransmission(accessControl, throwable));
 
         ByteBuf buffer = channel.alloc().buffer();
@@ -238,6 +240,7 @@ public class Messages {
         if (LOGGER.isTraceEnabled()) {
             channelFuture.addListener(f -> LOGGER.trace("sentErrorResponse msg={}", error.message()));
         }
+        channelFuture.addListener(f -> LOGGER.info("sentErrorResponse msg={}", error.message()));
         return channelFuture;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
One or more `select` statements running concurrently that are expected to return a large amount of data can fill up the Netty channel and cause `cancel`/`kill` to be stuck behind the line, or cause `OutOfMemoryError`.

The main problem is with the `RowConsumer` consuming too quick, so I am trying to slow it down by occasionally waiting for the Netty channel to be empty.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
