### PR TITLE
Add object merge function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -148,6 +148,11 @@ Changes
   supported. Optionally provided pattern conventions for the order of date 
   parts (Day, Month, Year) are ignored.
 
+- Added the :ref:`concat(object, object) <scalar-concat-object>` scalar function 
+  which combines two objects into a new object containing the union of their 
+  first level properties, taking the second object's values for duplicate 
+  properties.
+
 Fixes
 =====
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -52,6 +52,11 @@ You can also use the ``||`` :ref:`operator <gloss-operator>`::
     +--------+
     SELECT 1 row in set (... sec)
 
+.. TIP::
+
+    The ``concat`` function can also be used for merging objects:
+    :ref:`concat(object, object) <scalar-concat-object>`
+
 
 .. _scalar-concat-ws:
 
@@ -3005,14 +3010,66 @@ Returns: ``array(text)``
 
 ::
 
-    cr> select
-    ...     object_keys({a = 1, b = { c = 2 }}) AS object_keys;
+    cr> SELECT
+    ...     object_keys({a = 1, b = {c = 2}}) AS object_keys;
     +-------------+
     | object_keys |
     +-------------+
     | ["a", "b"]  |
     +-------------+
     SELECT 1 row in set (... sec)
+
+
+.. _scalar-concat-object:
+
+``concat(object, object)``
+--------------------------
+
+The ``concat(object, object)`` function combines two objects into a new object 
+containing the union of their first level properties, taking the second 
+object's values for duplicate properties.  If one of the objects is ``NULL``, 
+the function returns the non-``NULL`` object. If both objects are ``NULL``, 
+the function returns ``NULL``.
+
+Returns: ``object``
+
+::
+
+    cr> SELECT
+    ...     concat({a = 1}, {a = 2, b = {c = 2}}) AS object_concat;
+    +-------------------------+
+    | object_concat           |
+    +-------------------------+
+    | {"a": 2, "b": {"c": 2}} |
+    +-------------------------+
+    SELECT 1 row in set (... sec)
+
+
+You can also use the concat :ref:`operator <gloss-operator>` ``||`` with
+objects::
+
+    cr> SELECT
+    ...     {a = 1} || {b = 2} || {c = 3} AS object_concat;
+    +--------------------------+
+    | object_concat            |
+    +--------------------------+
+    | {"a": 1, "b": 2, "c": 3} |
+    +--------------------------+
+    SELECT 1 row in set (... sec)
+
+.. NOTE::
+
+    ``concat(object, object)`` does not operate recursively: only the 
+    top-level object structure is merged::
+        
+        cr> SELECT
+        ...     concat({a = {b = 4}}, {a = {c = 2}}) as object_concat;                                                                                                                                                                                                                            
+        +-----------------+
+        | object_concat   |
+        +-----------------+
+        | {"a": {"c": 2}} |
+        +-----------------+
+        SELECT 1 row in set (... sec)
 
 
 .. _scalar-conditional-fn-exp:

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.expression.scalar.object.ObjectMergeFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -70,6 +71,16 @@ public abstract class ConcatFunction extends Scalar<String, String> {
             )
                 .withTypeVariableConstraints(typeVariable("E")),
             ArrayCatFunction::new
+        );
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                DataTypes.UNTYPED_OBJECT.getTypeSignature()
+            ),
+            ObjectMergeFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.object;
+
+import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ObjectMergeFunction extends Scalar<Map<String, Object>, Map<String, Object>> {
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    public ObjectMergeFunction(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @SafeVarargs
+    @Override
+    public final Map<String, Object> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Map<String, Object>>... args) {
+        var objectOne = args[0].value();
+        var objectTwo = args[1].value();
+        if (objectOne == null) {
+            return objectTwo;
+        }
+        if (objectTwo == null) {
+            return objectOne;
+        }
+        Map<String,Object> resultObject = new HashMap<>();
+        resultObject.putAll(objectOne);
+        resultObject.putAll(objectTwo);
+        return resultObject;
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -112,5 +113,10 @@ public class ConcatFunctionTest extends ScalarTestCase {
     public void test_two_string_arguments_result_in_special_scalar() {
         var func = getFunction(ConcatFunction.NAME, List.of(DataTypes.STRING, DataTypes.STRING));
         assertThat(func).isExactlyInstanceOf(ConcatFunction.StringConcatFunction.class);
+    }
+
+    @Test
+    public void test_two_objects() {
+        assertEvaluate("concat({a=1},{a=2,b=2})", Map.of("a",2,"b",2));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/object/ObjectMergeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/object/ObjectMergeFunctionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.object;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+
+public class ObjectMergeFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_input() {
+        assertEvaluateNull("concat(obj, obj)", Literal.NULL, Literal.NULL);
+        assertEvaluate("concat(null, {\"a\"=1})", Map.of("a",1));
+        assertEvaluate("concat({\"a\"=1}, null)", Map.of("a",1));
+    }
+
+    @Test
+    public void test_empty_object() {
+        assertEvaluate("concat({}, {\"a\"=1})", Map.of("a",1));
+        assertEvaluate("concat({\"a\"=1}, {})", Map.of("a",1));
+    }
+
+    @Test
+    public void test_seconds_overwrites_first_object() {
+        assertEvaluate("concat({a=1},{a=2,b=2})", Map.of("a",2,"b",2));
+    }
+
+    @Test
+    public void test_nested_object() {
+        assertEvaluate("concat({b=1},{a=1, b={c=2}})", Map.of("a",1,"b",Map.of("c",2)));
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Adding the `concat(object, object)` scalar function which combines two objects into a new object containing the union of their first level properties, taking the second object's values for duplicate properties.

closes: https://github.com/crate/crate/issues/12979

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
