### PR TITLE
Add `FIRST` & `LAST` as aliases to `MAX_BY` & `MIN_BY`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,8 +53,9 @@ None
 Changes
 =======
 
-- Added the :ref:`MAX_BY <aggregation-max_by>` and :ref:`MIN_BY
-  <aggregation-min_by>` aggregation functions
+- Added the :ref:`MAX_BY <aggregation-max_by>` (alias
+  :ref:`FIRST <aggregation-first>`) and :ref:`MIN_BY <aggregation-min_by>`
+  (alias :ref:`LAST <aggregation-last>`) aggregation functions.
 
 Fixes
 =====

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,8 +54,8 @@ Changes
 =======
 
 - Added the :ref:`MAX_BY <aggregation-max_by>` (alias
-  :ref:`FIRST <aggregation-first>`) and :ref:`MIN_BY <aggregation-min_by>`
-  (alias :ref:`LAST <aggregation-last>`) aggregation functions.
+  :ref:`LAST <aggregation-last>`) and :ref:`MIN_BY <aggregation-min_by>`
+  (alias :ref:`FIRST <aggregation-first>`) aggregation functions.
 
 Fixes
 =====

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -340,7 +340,7 @@ The return value is always of type ``bigint``.
 ``first(returnField, searchField)``
 -------------------------------------
 
-An alias for :ref:`aggregation-max_by`.
+An alias for :ref:`aggregation-min_by`.
 
 .. _aggregation-geometric-mean:
 
@@ -580,7 +580,7 @@ An Example::
 ``last(returnField, searchField)``
 -------------------------------------
 
-An alias for :ref:`aggregation-last`.
+An alias for :ref:`aggregation-max_by`.
 
 .. _aggregation-stddev:
 

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -335,6 +335,13 @@ The return value is always of type ``bigint``.
     SELECT 3 rows in set (... sec)
 
 
+.. _aggregation-first:
+
+``first(returnField, searchField)``
+-------------------------------------
+
+An alias for :ref:`aggregation-max_by`.
+
 .. _aggregation-geometric-mean:
 
 ``geometric_mean(column)``
@@ -568,6 +575,12 @@ An Example::
     +--------------------------+
     SELECT 1 row in set (... sec)
 
+.. _aggregation-last:
+
+``last(returnField, searchField)``
+-------------------------------------
+
+An alias for :ref:`aggregation-last`.
 
 .. _aggregation-stddev:
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -23,6 +23,8 @@ package io.crate.execution.engine.aggregation.impl;
 
 import static io.crate.types.TypeSignature.parseTypeSignature;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import org.elasticsearch.Version;
@@ -42,7 +44,9 @@ import io.crate.types.TypeSignature;
 public final class CmpByAggregation extends AggregationFunction<CmpByAggregation.CompareBy, Object> {
 
     public static final String MAX_BY = "max_by";
+    public static final String FIRST = "first";
     public static final String MIN_BY = "min_by";
+    public static final String LAST = "last";
 
     static class CompareBy {
 
@@ -59,30 +63,34 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         TypeSignature cmpType = parseTypeSignature("B");
         var variableConstraintA = TypeVariableConstraint.typeVariableOfAnyType("A");
         var variableConstraintB = TypeVariableConstraint.typeVariableOfAnyType("B");
-        mod.register(
-            Signature.aggregate(
-                MAX_BY,
-                returnValueType,
-                cmpType,
-                returnValueType
-            ).withTypeVariableConstraints(
-                variableConstraintA,
-                variableConstraintB
-            ),
-            (signature, boundSignature) -> new CmpByAggregation(1, signature, boundSignature)
-        );
-        mod.register(
-            Signature.aggregate(
-                MIN_BY,
-                returnValueType,
-                cmpType,
-                returnValueType
-            ).withTypeVariableConstraints(
-                variableConstraintA,
-                variableConstraintB
-            ),
-            (signature, boundSignature) -> new CmpByAggregation(-1, signature, boundSignature)
-        );
+        for (String name : List.of(MAX_BY, FIRST)) {
+            mod.register(
+                Signature.aggregate(
+                    name,
+                    returnValueType,
+                    cmpType,
+                    returnValueType
+                ).withTypeVariableConstraints(
+                    variableConstraintA,
+                    variableConstraintB
+                ),
+                (signature, boundSignature) -> new CmpByAggregation(1, signature, boundSignature)
+            );
+        }
+        for (String name : List.of(MIN_BY, LAST)) {
+            mod.register(
+                Signature.aggregate(
+                    name,
+                    returnValueType,
+                    cmpType,
+                    returnValueType
+                ).withTypeVariableConstraints(
+                    variableConstraintA,
+                    variableConstraintB
+                ),
+                (signature, boundSignature) -> new CmpByAggregation(-1, signature, boundSignature)
+            );
+        }
     }
 
     private final Signature signature;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -44,9 +44,9 @@ import io.crate.types.TypeSignature;
 public final class CmpByAggregation extends AggregationFunction<CmpByAggregation.CompareBy, Object> {
 
     public static final String MAX_BY = "max_by";
-    public static final String FIRST = "first";
-    public static final String MIN_BY = "min_by";
     public static final String LAST = "last";
+    public static final String MIN_BY = "min_by";
+    public static final String FIRST = "first";
 
     static class CompareBy {
 
@@ -63,7 +63,7 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         TypeSignature cmpType = parseTypeSignature("B");
         var variableConstraintA = TypeVariableConstraint.typeVariableOfAnyType("A");
         var variableConstraintB = TypeVariableConstraint.typeVariableOfAnyType("B");
-        for (String name : List.of(MAX_BY, FIRST)) {
+        for (String name : List.of(MAX_BY, LAST)) {
             mod.register(
                 Signature.aggregate(
                     name,
@@ -77,7 +77,7 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
                 (signature, boundSignature) -> new CmpByAggregation(1, signature, boundSignature)
             );
         }
-        for (String name : List.of(MIN_BY, LAST)) {
+        for (String name : List.of(MIN_BY, FIRST)) {
             mod.register(
                 Signature.aggregate(
                     name,

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
@@ -38,7 +38,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
     @Test
     public void test_max_by() throws Exception {
         Signature signature = Signature.aggregate(
-            "max_by",
+            randomFrom("max_by", "last"),
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
@@ -57,7 +57,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_cmp_by_returns_null_if_all_search_fields_are_null() throws Exception {
-        for (String func : List.of("max_by", "min_by")) {
+        for (String func : List.of(randomFrom("max_by", "last"), randomFrom("min_by", "first"))) {
             Signature signature = Signature.aggregate(
                 func,
                 DataTypes.STRING.getTypeSignature(),
@@ -79,7 +79,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_cmp_by_returns_null_if_all_return_fields_are_null() throws Exception {
-        for (String func : List.of("max_by", "min_by")) {
+        for (String func : List.of(randomFrom("max_by", "last"), randomFrom("min_by", "first"))) {
             Signature signature = Signature.aggregate(
                 func,
                 DataTypes.STRING.getTypeSignature(),
@@ -102,7 +102,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
     @Test
     public void test_max_by_returns_null_if_return_field_of_max_search_field_is_null() throws Exception {
         Signature signature = Signature.aggregate(
-            "max_by",
+            randomFrom("max_by", "last"),
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
@@ -121,7 +121,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_cmp_by_result_is_nondeterministic_on_ties() throws Exception {
-        for (String func : List.of("max_by", "min_by")) {
+        for (String func : List.of(randomFrom("max_by", "last"), randomFrom("min_by", "first"))) {
             Signature signature = Signature.aggregate(
                 func,
                 DataTypes.STRING.getTypeSignature(),
@@ -144,7 +144,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
     @Test
     public void test_min_by() throws Exception {
         Signature signature = Signature.aggregate(
-            "min_by",
+            randomFrom("min_by", "first"),
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
@@ -163,9 +163,10 @@ public class CmpByAggregationTest extends AggregationTestCase {
     }
 
     @Test
-    public void test_cannot_use_max_by_on_non_comparable_types() throws Exception {
+    public void test_cannot_use_max_by_on_non_comparable_types() {
+        String functionName = randomFrom("max_by", "last", "min_by", "first");
         Signature signature = Signature.aggregate(
-            "max_by",
+            functionName,
             DataTypes.STRING.getTypeSignature(),
             DataTypes.UNTYPED_OBJECT.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
@@ -177,6 +178,6 @@ public class CmpByAggregationTest extends AggregationTestCase {
             },
             List.of()
         )).isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Cannot use `max_by` on values of type object");
+          .hasMessage("Cannot use `%s` on values of type object", functionName);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follows: https://github.com/crate/crate/pull/13127

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
