### PR TITLE
Fix: Allow omitting pk column generated from a col with default

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -63,6 +63,18 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue which caused ``PRIMARY KEY`` columns to be required on insert
+  even if they are generated and their source columns are default not-null,
+  i.e.::
+
+    CREATE TABLE test (
+      id INT NOT NULL PRIMARY KEY,
+      created TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp NOT NULL,
+      month TIMESTAMP GENERATED ALWAYS AS date_trunc('month', created) PRIMARY KEY
+    );
+
+    INSERT INTO test(id) VALUES(1);
+
 - Fixed an issue that could cause ``COPY FROM``, ``INSERT INTO``,
   ``UPDATE`` and ``DELETE`` operations to get stuck if under memory pressure.
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -252,10 +252,13 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
         InputColumn inputColumn = sourceSymbols.inputs.get(ref);
         if (inputColumn == null) {
             Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(ref, ref.column(), sourceSymbols.inputs);
-            if (subscriptOnRoot == null) {
-                return ref;
+            if (subscriptOnRoot != null) {
+                return subscriptOnRoot;
             }
-            return subscriptOnRoot;
+            if (ref.defaultExpression() != null) {
+                return ref.defaultExpression();
+            }
+            return ref;
         }
         return inputColumn;
     }

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import static io.crate.testing.Asserts.isAlias;
 import static io.crate.testing.Asserts.isFunction;
+import static io.crate.testing.Asserts.isInputColumn;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
@@ -93,6 +94,15 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                 "create table doc.nested_clustered (" +
                 "   obj object(strict) as (id int, name text)" +
                 ") clustered by (obj['id'])"
+            )
+            .addTable(
+            """
+                create table doc.pk_generated_default (
+                  col1 int not null primary key,
+                  col2 int default 10 not null,
+                  col3 int default 20 not null,
+                  col4 int generated always as ((col2 + col3) * col1 - 2) primary key)
+                """
             )
             .build();
     }
@@ -469,5 +479,20 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .satisfiesExactly(
                 isReference("col1", DataTypes.LONG),
                 isReference("col2", DataTypes.STRING));
+    }
+
+    @Test
+    public void test_pk_col_generated_from_col_with_default() throws Exception {
+        AnalyzedInsertStatement stmt = e.analyze("insert into doc.pk_generated_default(col1) values (1)");
+        Asserts.assertThat(stmt.subQueryRelation().outputs())
+            .satisfiesExactly(
+                isReference("col1", DataTypes.INTEGER));
+        Asserts.assertThat(stmt.primaryKeySymbols()).satisfiesExactly(
+            isInputColumn(0),
+            isFunction("subtract",
+                       isFunction("multiply",
+                                  isFunction("add", isLiteral(10), isLiteral(20)),
+                                  isInputColumn(0)),
+                       isLiteral(2)));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Allow to omit a pk column if it's generated and its sources are columns
which are non-null and have default values, e.g.:

```
CREATE TABLE test (
  id INT NOT NULL PRIMARY KEY,
  created TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp NOT NULL,
  month TIMESTAMP GENERATED ALWAYSE AS date_trunc('month', created) PRIMARY KEY
);

INSERT INTO test(id) values(1);
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
