### PR TITLE
Fix: Allow omitting pk column generated from a col with default (backport #13144)

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -64,6 +64,18 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue which caused ``PRIMARY KEY`` columns to be required on insert
+  even if they are generated and their source columns are default not-null,
+  i.e.::
+
+    CREATE TABLE test (
+      id INT NOT NULL PRIMARY KEY,
+      created TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp NOT NULL,
+      month TIMESTAMP GENERATED ALWAYS AS date_trunc('month', created) PRIMARY KEY
+    );
+
+    INSERT INTO test(id) VALUES(1);
+
 - Fixed an issue that could cause ``COPY FROM``, ``INSERT INTO``,
   ``UPDATE`` and ``DELETE`` operations to get stuck if under memory pressure.
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -252,10 +252,13 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
         InputColumn inputColumn = sourceSymbols.inputs.get(ref);
         if (inputColumn == null) {
             Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(ref, ref.column(), sourceSymbols.inputs);
-            if (subscriptOnRoot == null) {
-                return ref;
+            if (subscriptOnRoot != null) {
+                return subscriptOnRoot;
             }
-            return subscriptOnRoot;
+            if (ref.defaultExpression() != null) {
+                return ref.defaultExpression();
+            }
+            return ref;
         }
         return inputColumn;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Allow to omit a pk column if it's generated and its sources are columns which are non-null and have default values, e.g.:

```
CREATE TABLE test (
  id INT NOT NULL PRIMARY KEY,
  created TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp NOT NULL,
  month TIMESTAMP GENERATED ALWAYSE AS date_trunc('month', created) PRIMARY KEY
);

INSERT INTO test(id) values(1);
```

(cherry picked from commit 8b327cc3994edbe2920bcf9b6e7dc519f2716f5b)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
