### PR TITLE
Do not check pause condition again after resume (fix infinite loop) (backport #13141)

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -64,6 +64,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could cause ``COPY FROM``, ``INSERT INTO``,
+  ``UPDATE`` and ``DELETE`` operations to get stuck if under memory pressure.
+
 - Fixed an issue that didn't allow queries with a greater than ``0`` ``OFFSET``
   but without ``LIMIT`` to be executed successfully, i.e.::
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutor.java
@@ -211,13 +211,6 @@ public class BatchIteratorBackpressureExecutor<T, R> {
 
     private void resumeConsumption() {
         T item = batchIterator.currentElement();
-        if (pauseConsumption.test(item)) {
-            long delayInMs = getDelayInMs.apply(item);
-            if (delayInMs > 0) {
-                scheduler.schedule(this::resumeConsumption, delayInMs, TimeUnit.MILLISECONDS);
-                return;
-            }
-        }
         try {
             executor.execute(() -> doResumeConsumption(item));
         } catch (RejectedExecutionException e) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`pauseConsumption` was both used in the consume loop to pause iteration and again on resume after a pause.

This could lead to a infinite pause-resume-pause-loop because there are cases where `pauseConsumption` would always return `true` again after the pause: If the current requests/item uses up enough memory to move `IsUsedBytesOverThreshold` over the threshold without there being any other activity on the cluster.

The requests are only freed up _after_ execution, if the execution is paused it would never get freed up.

Fixes https://github.com/crate/crate/issues/13123

(cherry picked from commit 78785b4a63bdd42b0ec0fe1d7e7cf14ac84141d5)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
