### PR TITLE
Reflect release 5.0.3

### DIFF
--- a/docs/appendices/release-notes/5.0.3.rst
+++ b/docs/appendices/release-notes/5.0.3.rst
@@ -1,0 +1,66 @@
+.. _version_5.0.3:
+
+=============
+Version 5.0.3
+=============
+
+Released on 2022-10-18.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher
+    before you upgrade to 5.0.3.
+
+    We recommend that you upgrade to the latest 4.8 release before moving to
+    5.0.3.
+
+    A rolling upgrade from 4.8.x to 5.0.3 is supported.
+    Before upgrading, you should `back up your data`_.
+
+.. WARNING::
+
+    Tables that were created before CrateDB 4.x will not function with 5.x
+    and must be recreated before moving to 5.x.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
+    `inserting the data into a new table`_.
+
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+See the :ref:`version_5.0.0` release notes for a full list of changes in the
+5.0 series.
+
+Fixes
+=====
+
+- Fixed an issue which caused ``PRIMARY KEY`` columns to be required on insert
+  even if they are generated and their source columns are default not-null,
+  i.e.::
+
+    CREATE TABLE test (
+      id INT NOT NULL PRIMARY KEY,
+      created TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp NOT NULL,
+      month TIMESTAMP GENERATED ALWAYS AS date_trunc('month', created) PRIMARY KEY
+    );
+
+    INSERT INTO test(id) VALUES(1);
+
+- Fixed an issue that could cause ``COPY FROM``, ``INSERT INTO``,
+  ``UPDATE`` and ``DELETE`` operations to get stuck if under memory pressure.
+
+- Fixed an issue that didn't allow queries with a greater than ``0`` ``OFFSET``
+  but without ``LIMIT`` to be executed successfully, i.e.::
+
+    SELECT * FROM test OFFSET 10
+    SELECT * FROM test LIMIT null OFFSET 10
+    SELECT * FROM test LIMIT ALL OFFSET 10
+
+- Fixed an issue that caused ``col IS NULL`` to match empty objects.

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -39,6 +39,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    5.0.3
     5.0.2
     5.0.1
     5.0.0

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -140,6 +140,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_5_0_0 = new Version(8_00_00_99, false, org.apache.lucene.util.Version.LUCENE_9_2_0);
     public static final Version V_5_0_1 = new Version(8_00_01_99, false, org.apache.lucene.util.Version.LUCENE_9_2_0);
     public static final Version V_5_0_2 = new Version(8_00_02_99, false, org.apache.lucene.util.Version.LUCENE_9_2_0);
+    public static final Version V_5_0_3 = new Version(8_00_03_99, false, org.apache.lucene.util.Version.LUCENE_9_2_0);
 
     public static final Version V_5_1_0 = new Version(8_01_00_99, false, org.apache.lucene.util.Version.LUCENE_9_3_0);
 


### PR DESCRIPTION
similar to https://github.com/crate/crate/pull/13044#discussion_r972070378, kept unreleased entries since we still have them on master https://github.com/crate/crate/blob/master/docs/appendices/release-notes/unreleased.rst#fixes
