### PR TITLE
Update bundled JDK to 19

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -47,7 +47,7 @@ jna=5.12.1
 
 # ES test
 assertj=3.23.1
-randomizedrunner=2.8.0
+randomizedrunner=2.8.1
 junit5=5.9.0
 junit=4.13.2
 httpclient=4.5.13
@@ -63,5 +63,5 @@ graalvm=22.2.0
 
 jmh=1.33
 
-bundled_jdk_version=18.0.2+9
+bundled_jdk_version=19+36
 bundled_jdk_vendor=adoptium


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`InetAddress` can no longer be mocked because it became sealed so tests
had to be adapted.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
