### PR TITLE
bp: Handle IOException while checking translog corruption

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/index/translog/TestTranslog.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/translog/TestTranslog.java
@@ -248,7 +248,7 @@ public class TestTranslog {
         try {
             final int version = TranslogHeader.readHeaderVersion(corruptedFile, channel, in);
             return version == TranslogHeader.VERSION_CHECKPOINTS;
-        } catch (IllegalStateException | TranslogCorruptedException e) {
+        } catch (IllegalStateException | TranslogCorruptedException | IOException e) {
             return false;
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

https://github.com/elastic/elasticsearch/commit/65645217bc43a63013b5e00636a4815ffe42b57a

Should fix flaky `testCorruptTranslogHeader`

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
