### PR TITLE
bp: Add voting-only master node

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -641,6 +641,7 @@ should be crossed out as well.
 - [x] 433b3458522 Fix port range allocation with large worker IDs (#44213)
 - [x] c40b77b771b Simplify port usage in transport tests (#44157)
 - [x] 45b8aca6203 Some Cleanup in Test Framework (#44039)
+- [x] e689b20eba8 Add voting-only master node (#43410)
 - [x] 3166f7b836c Use unique ports per test worker (#43983)
 - [x] 25792d31321 Remove nodeId from BaseNodeRequest (#43658)
 - [x] aa12af8a3c4 Enable node roles to be pluggable (#43175)

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -125,14 +125,16 @@ public class ClusterFormationFailureHelper {
         private final List<TransportAddress> resolvedAddresses;
         private final List<DiscoveryNode> foundPeers;
         private final long currentTerm;
+        private final ElectionStrategy electionStrategy;
 
         ClusterFormationState(Settings settings, ClusterState clusterState, List<TransportAddress> resolvedAddresses,
-                              List<DiscoveryNode> foundPeers, long currentTerm) {
+                              List<DiscoveryNode> foundPeers, long currentTerm, ElectionStrategy electionStrategy) {
             this.settings = settings;
             this.clusterState = clusterState;
             this.resolvedAddresses = resolvedAddresses;
             this.foundPeers = foundPeers;
             this.currentTerm = currentTerm;
+            this.electionStrategy = electionStrategy;
         }
 
         String getDescription() {
@@ -188,7 +190,9 @@ public class ClusterFormationFailureHelper {
             final VoteCollection voteCollection = new VoteCollection();
             foundPeers.forEach(voteCollection::addVote);
             final String isQuorumOrNot
-                = CoordinationState.isElectionQuorum(voteCollection, clusterState) ? "is a quorum" : "is not a quorum";
+                = electionStrategy.isElectionQuorum(clusterState.nodes().getLocalNode(), currentTerm, clusterState.term(),
+                    clusterState.version(), clusterState.getLastCommittedConfiguration(), clusterState.getLastAcceptedConfiguration(),
+                    voteCollection) ? "is a quorum" : "is not a quorum";
 
             return String.format(Locale.ROOT,
                 "master not discovered or elected yet, an election requires %s, have discovered %s which %s; %s",

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -25,15 +25,16 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.settings.Settings;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The core class of the cluster state coordination algorithm, directly implementing the
@@ -44,6 +45,8 @@ public class CoordinationState {
     private static final Logger LOGGER = LogManager.getLogger(CoordinationState.class);
 
     private final DiscoveryNode localNode;
+
+    private final ElectionStrategy electionStrategy;
 
     // persisted state
     private final PersistedState persistedState;
@@ -56,11 +59,12 @@ public class CoordinationState {
     private VotingConfiguration lastPublishedConfiguration;
     private VoteCollection publishVotes;
 
-    public CoordinationState(Settings settings, DiscoveryNode localNode, PersistedState persistedState) {
+    public CoordinationState(DiscoveryNode localNode, PersistedState persistedState, ElectionStrategy electionStrategy) {
         this.localNode = localNode;
 
         // persisted state
         this.persistedState = persistedState;
+        this.electionStrategy = electionStrategy;
 
         // transient state
         this.joinVotes = new VoteCollection();
@@ -103,13 +107,9 @@ public class CoordinationState {
         return electionWon;
     }
 
-    public boolean isElectionQuorum(VoteCollection votes) {
-        return isElectionQuorum(votes, getLastAcceptedState());
-    }
-
-    static boolean isElectionQuorum(VoteCollection votes, ClusterState lastAcceptedState) {
-        return votes.isQuorum(lastAcceptedState.getLastCommittedConfiguration())
-            && votes.isQuorum(lastAcceptedState.getLastAcceptedConfiguration());
+    public boolean isElectionQuorum(VoteCollection joinVotes) {
+        return electionStrategy.isElectionQuorum(localNode, getCurrentTerm(), getLastAcceptedTerm(), getLastAcceptedVersion(),
+            getLastCommittedConfiguration(), getLastAcceptedConfiguration(), joinVotes);
     }
 
     public boolean isPublishQuorum(VoteCollection votes) {
@@ -118,6 +118,11 @@ public class CoordinationState {
 
     public boolean containsJoinVoteFor(DiscoveryNode node) {
         return joinVotes.containsVoteFor(node);
+    }
+
+    // used for tests
+    boolean containsJoin(Join join) {
+        return joinVotes.getJoins().contains(join);
     }
 
     public boolean joinVotesHaveQuorumFor(VotingConfiguration votingConfiguration) {
@@ -246,7 +251,7 @@ public class CoordinationState {
             throw new CoordinationStateRejectedException("rejecting join since this node has not received its initial configuration yet");
         }
 
-        final boolean added = joinVotes.addVote(join.getSourceNode());
+        final boolean added = joinVotes.addJoinVote(join);
         boolean prevElectionWon = electionWon;
         electionWon = isElectionQuorum(joinVotes);
         assert !prevElectionWon || electionWon; // we cannot go from won to not won
@@ -499,18 +504,28 @@ public class CoordinationState {
     }
 
     /**
-     * A collection of votes, used to calculate quorums.
+     * A collection of votes, used to calculate quorums. Optionally records the Joins as well.
      */
     public static class VoteCollection {
 
         private final Map<String, DiscoveryNode> nodes;
+        private final Set<Join> joins;
 
         public boolean addVote(DiscoveryNode sourceNode) {
             return sourceNode.isMasterEligibleNode() && nodes.put(sourceNode.getId(), sourceNode) == null;
         }
 
+        public boolean addJoinVote(Join join) {
+            final boolean added = addVote(join.getSourceNode());
+            if (added) {
+                joins.add(join);
+            }
+            return added;
+        }
+
         public VoteCollection() {
             nodes = new HashMap<>();
+            joins = new HashSet<>();
         }
 
         public boolean isQuorum(VotingConfiguration configuration) {
@@ -529,24 +544,31 @@ public class CoordinationState {
             return Collections.unmodifiableCollection(nodes.values());
         }
 
+        public Set<Join> getJoins() {
+            return Collections.unmodifiableSet(joins);
+        }
+
         @Override
         public String toString() {
-            return "VoteCollection{" + String.join(",", nodes.keySet()) + "}";
+            return "VoteCollection{votes=" + nodes.keySet() + ", joins=" + joins + "}";
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (!(o instanceof VoteCollection)) return false;
 
             VoteCollection that = (VoteCollection) o;
 
-            return nodes.equals(that.nodes);
+            if (!nodes.equals(that.nodes)) return false;
+            return joins.equals(that.joins);
         }
 
         @Override
         public int hashCode() {
-            return nodes.hashCode();
+            int result = nodes.hashCode();
+            result = 31 * result + joins.hashCode();
+            return result;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
+import org.elasticsearch.cluster.coordination.CoordinationState.VoteCollection;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+/**
+ * Allows plugging in a custom election strategy, restricting the notion of an election quorum.
+ * Custom additional quorum restrictions can be defined by implementing the {@link #satisfiesAdditionalQuorumConstraints} method.
+ */
+public abstract class ElectionStrategy {
+
+    public static final ElectionStrategy DEFAULT_INSTANCE = new ElectionStrategy() {
+        @Override
+        protected boolean satisfiesAdditionalQuorumConstraints(DiscoveryNode localNode, long localCurrentTerm, long localAcceptedTerm,
+                                                               long localAcceptedVersion, VotingConfiguration lastCommittedConfiguration,
+                                                               VotingConfiguration lastAcceptedConfiguration, VoteCollection joinVotes) {
+            return true;
+        }
+    };
+
+    protected ElectionStrategy() {
+
+    }
+
+    /**
+     * Whether there is an election quorum from the point of view of the given local node under the provided voting configurations
+     */
+    public final boolean isElectionQuorum(DiscoveryNode localNode, long localCurrentTerm, long localAcceptedTerm, long localAcceptedVersion,
+                                          VotingConfiguration lastCommittedConfiguration, VotingConfiguration lastAcceptedConfiguration,
+                                          VoteCollection joinVotes) {
+        return joinVotes.isQuorum(lastCommittedConfiguration) &&
+            joinVotes.isQuorum(lastAcceptedConfiguration) &&
+            satisfiesAdditionalQuorumConstraints(localNode, localCurrentTerm, localAcceptedTerm, localAcceptedVersion,
+                lastCommittedConfiguration, lastAcceptedConfiguration, joinVotes);
+    }
+
+    /**
+     * The extension point to be overridden by plugins. Defines additional constraints on the election quorum.
+     * @param localNode                  the local node for the election quorum
+     * @param localCurrentTerm           the current term of the local node
+     * @param localAcceptedTerm          the last accepted term of the local node
+     * @param localAcceptedVersion       the last accepted version of the local node
+     * @param lastCommittedConfiguration the last committed configuration for the election quorum
+     * @param lastAcceptedConfiguration  the last accepted configuration for the election quorum
+     * @param joinVotes                  the votes that were provided so far
+     * @return true iff the additional quorum constraints are satisfied
+     */
+    protected abstract boolean satisfiesAdditionalQuorumConstraints(DiscoveryNode localNode,
+                                                                    long localCurrentTerm,
+                                                                    long localAcceptedTerm,
+                                                                    long localAcceptedVersion,
+                                                                    VotingConfiguration lastCommittedConfiguration,
+                                                                    VotingConfiguration lastAcceptedConfiguration,
+                                                                    VoteCollection joinVotes);
+}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PreVoteCollector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PreVoteCollector.java
@@ -35,12 +35,11 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongConsumer;
 
-import static org.elasticsearch.cluster.coordination.CoordinationState.isElectionQuorum;
-import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentSet;
+import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 
 public class PreVoteCollector {
 
@@ -51,14 +50,17 @@ public class PreVoteCollector {
     private final TransportService transportService;
     private final Runnable startElection;
     private final LongConsumer updateMaxTermSeen;
+    private final ElectionStrategy electionStrategy;
 
     // Tuple for simple atomic updates. null until the first call to `update()`.
     private volatile Tuple<DiscoveryNode, PreVoteResponse> state; // DiscoveryNode component is null if there is currently no known leader.
 
-    PreVoteCollector(final TransportService transportService, final Runnable startElection, final LongConsumer updateMaxTermSeen) {
+    PreVoteCollector(final TransportService transportService, final Runnable startElection, final LongConsumer updateMaxTermSeen,
+                     final ElectionStrategy electionStrategy) {
         this.transportService = transportService;
         this.startElection = startElection;
         this.updateMaxTermSeen = updateMaxTermSeen;
+        this.electionStrategy = electionStrategy;
 
         transportService.registerRequestHandler(REQUEST_PRE_VOTE_ACTION_NAME, Names.GENERIC, false, false,
             PreVoteRequest::new,
@@ -127,7 +129,7 @@ public class PreVoteCollector {
     }
 
     private class PreVotingRound implements Releasable {
-        private final Set<DiscoveryNode> preVotesReceived = newConcurrentSet();
+        private final Map<DiscoveryNode, PreVoteResponse> preVotesReceived = newConcurrentMap();
         private final AtomicBoolean electionStarted = new AtomicBoolean();
         private final PreVoteRequest preVoteRequest;
         private final ClusterState clusterState;
@@ -184,11 +186,20 @@ public class PreVoteCollector {
                 return;
             }
 
-            preVotesReceived.add(sender);
-            final VoteCollection voteCollection = new VoteCollection();
-            preVotesReceived.forEach(voteCollection::addVote);
+            preVotesReceived.put(sender, response);
 
-            if (isElectionQuorum(voteCollection, clusterState) == false) {
+            // create a fake VoteCollection based on the pre-votes and check if there is an election quorum
+            final VoteCollection voteCollection = new VoteCollection();
+            final DiscoveryNode localNode = clusterState.nodes().getLocalNode();
+            final PreVoteResponse localPreVoteResponse = getPreVoteResponse();
+
+            preVotesReceived.forEach((node, preVoteResponse) -> voteCollection.addJoinVote(
+                new Join(node, localNode, preVoteResponse.getCurrentTerm(),
+                preVoteResponse.getLastAcceptedTerm(), preVoteResponse.getLastAcceptedVersion())));
+
+            if (electionStrategy.isElectionQuorum(clusterState.nodes().getLocalNode(), localPreVoteResponse.getCurrentTerm(),
+                localPreVoteResponse.getLastAcceptedTerm(), localPreVoteResponse.getLastAcceptedVersion(),
+                clusterState.getLastCommittedConfiguration(), clusterState.getLastAcceptedConfiguration(), voteCollection) == false) {
                 LOGGER.debug("{} added {} from {}, no quorum yet", this, response, sender);
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -396,6 +396,11 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         sb.append('{').append(ephemeralId).append('}');
         sb.append('{').append(hostName).append('}');
         sb.append('{').append(address).append('}');
+        if (roles.isEmpty() == false) {
+            sb.append('{');
+            roles.stream().map(DiscoveryNodeRole::roleNameAbbreviation).sorted().forEach(sb::append);
+            sb.append('}');
+        }
         if (!attributes.isEmpty()) {
             sb.append(attributes);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -26,6 +26,8 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import io.crate.common.Booleans;
+import io.crate.common.collections.Sets;
+
 import javax.annotation.Nullable;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -367,6 +369,17 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                                 resolvedNodesIds.removeAll(getCoordinatingOnlyNodes().keys());
                             }
                         } else {
+                            for (DiscoveryNode node : this) {
+                                for (DiscoveryNodeRole role : Sets.difference(node.getRoles(), DiscoveryNodeRole.BUILT_IN_ROLES)) {
+                                    if (role.roleName().equals(matchAttrName)) {
+                                        if (Booleans.parseBoolean(matchAttrValue, true)) {
+                                            resolvedNodesIds.add(node.getId());
+                                        } else {
+                                            resolvedNodesIds.remove(node.getId());
+                                        }
+                                    }
+                                }
+                            }
                             for (DiscoveryNode node : this) {
                                 for (Map.Entry<String, String> entry : node.getAttributes().entrySet()) {
                                     String attrName = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -352,6 +352,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         NodeEnvironment.NODE_ID_SEED_SETTING,
         DiscoveryModule.DISCOVERY_TYPE_SETTING,
         DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING,
+        DiscoveryModule.ELECTION_STRATEGY_SETTING,
         SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING,
         SeedHostsResolver.DISCOVERY_SEED_RESOLVER_MAX_CONCURRENT_RESOLVERS_SETTING,
         SeedHostsResolver.DISCOVERY_SEED_RESOLVER_TIMEOUT_SETTING,

--- a/server/src/main/java/org/elasticsearch/discovery/DiscoveryModule.java
+++ b/server/src/main/java/org/elasticsearch/discovery/DiscoveryModule.java
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.Coordinator;
+import org.elasticsearch.cluster.coordination.ElectionStrategy;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -76,6 +77,11 @@ public class DiscoveryModule {
         Setting.listSetting("discovery.seed_providers", Collections.emptyList(), Function.identity(), DataTypes.STRING_ARRAY,
             Property.NodeScope);
 
+    public static final String DEFAULT_ELECTION_STRATEGY = "default";
+
+    public static final Setting<String> ELECTION_STRATEGY_SETTING =
+        new Setting<>("cluster.election.strategy", DEFAULT_ELECTION_STRATEGY, Function.identity(), DataTypes.STRING, Property.NodeScope);
+
     private final Discovery discovery;
 
     public DiscoveryModule(Settings settings, TransportService transportService,
@@ -87,6 +93,8 @@ public class DiscoveryModule {
         final Map<String, Supplier<SeedHostsProvider>> hostProviders = new HashMap<>();
         hostProviders.put("settings", () -> new SettingsBasedSeedHostsProvider(settings, transportService));
         hostProviders.put("file", () -> new FileBasedSeedHostsProvider(configFile));
+        final Map<String, ElectionStrategy> electionStrategies = new HashMap<>();
+        electionStrategies.put(DEFAULT_ELECTION_STRATEGY, ElectionStrategy.DEFAULT_INSTANCE);
         for (DiscoveryPlugin plugin : plugins) {
             plugin.getSeedHostProviders(transportService, networkService).forEach((key, value) -> {
                 if (hostProviders.put(key, value) != null) {
@@ -97,6 +105,11 @@ public class DiscoveryModule {
             if (joinValidator != null) {
                 joinValidators.add(joinValidator);
             }
+            plugin.getElectionStrategies().forEach((key, value) -> {
+                if (electionStrategies.put(key, value) != null) {
+                    throw new IllegalArgumentException("Cannot register election strategy [" + key + "] twice");
+                }
+            });
         }
 
         List<String> seedProviderNames = DISCOVERY_SEED_PROVIDERS_SETTING.get(settings);
@@ -127,6 +140,11 @@ public class DiscoveryModule {
             return Collections.unmodifiableList(addresses);
         };
 
+        final ElectionStrategy electionStrategy = electionStrategies.get(ELECTION_STRATEGY_SETTING.get(settings));
+        if (electionStrategy == null) {
+            throw new IllegalArgumentException("Unknown election strategy " + ELECTION_STRATEGY_SETTING.get(settings));
+        }
+
         if (ZEN2_DISCOVERY_TYPE.equals(discoveryType) || SINGLE_NODE_DISCOVERY_TYPE.equals(discoveryType)) {
             discovery = new Coordinator(
                 NODE_NAME_SETTING.get(settings),
@@ -141,7 +159,8 @@ public class DiscoveryModule {
                 clusterApplier,
                 joinValidators,
                 new Random(Randomness.get().nextLong()),
-                rerouteService
+                rerouteService,
+                electionStrategy
             );
         } else {
             throw new IllegalArgumentException("Unknown discovery type [" + discoveryType + "]");

--- a/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.plugins;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.ElectionStrategy;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
@@ -86,5 +87,12 @@ public interface DiscoveryPlugin {
      */
     default BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
         return null;
+    }
+
+    /**
+     * Allows plugging in election strategies (see {@link ElectionStrategy}) that define a customized notion of an election quorum.
+     */
+    default Map<String, ElectionStrategy> getElectionStrategies() {
+        return Map.of();
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -27,7 +27,6 @@ import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INI
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -48,10 +47,13 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.test.ESTestCase;
+import static org.hamcrest.Matchers.oneOf;
 
 public class ClusterFormationFailureHelperTests extends ESTestCase {
+
+    private static final ElectionStrategy electionStrategy = ElectionStrategy.DEFAULT_INSTANCE;
+
     public void testScheduling() {
         final long expectedDelayMillis;
         final Settings.Builder settingsBuilder = Settings.builder();
@@ -77,7 +79,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final ClusterFormationFailureHelper clusterFormationFailureHelper = new ClusterFormationFailureHelper(settingsBuilder.build(),
             () -> {
                 warningCount.incrementAndGet();
-                return new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 0L);
+                return new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 0L, electionStrategy);
             },
             deterministicTaskQueue.getThreadPool(), logLastFailedJoinAttemptWarningCount::incrementAndGet);
 
@@ -145,17 +147,20 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .version(12L).nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId())).build();
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 15L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 15L, electionStrategy)
+                .getDescription(),
             is("master not discovered yet: have discovered []; discovery will continue using [] from hosts providers " +
                 "and [] from last-known cluster state; node term 15, last-accepted version 12 in term 0"));
 
         final TransportAddress otherAddress = buildNewFakeTransportAddress();
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 16L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 16L, electionStrategy)
+                .getDescription(),
             is("master not discovered yet: have discovered []; discovery will continue using [" + otherAddress +
                 "] from hosts providers and [] from last-known cluster state; node term 16, last-accepted version 12 in term 0"));
 
         final DiscoveryNode otherNode = new DiscoveryNode("other", buildNewFakeTransportAddress(), Version.CURRENT);
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 17L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 17L, electionStrategy)
+                .getDescription(),
             is("master not discovered yet: have discovered [" + otherNode + "]; discovery will continue using [] from hosts providers " +
                 "and [] from last-known cluster state; node term 17, last-accepted version 12 in term 0"));
     }
@@ -167,28 +172,36 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
             .metadata(Metadata.builder().coordinationMetadata(CoordinationMetadata.builder().term(4L).build()))
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId())).build();
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 1L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 1L, electionStrategy).getDescription(),
             is("master not discovered yet, this node has not previously joined a bootstrapped (v5+) cluster, and " +
                 "[cluster.initial_master_nodes] is empty on this node: have discovered []; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 1, last-accepted version 7 in term 4"));
 
+        // master not discovered yet, this node has not previously joined a bootstrapped (v5+) cluster, and
+        // [cluster.initial_master_nodes] is empty on this node: have discovered [];
+        // discovery will continue using [] from hosts providers and [{local}{f4kYBY8ORTaRLvQl3osaxA}{0.0.0.0}{0.0.0.0:1}{dm}]
+        // from last-known cluster state; node term 1, last-accepted version 7 in term 4
+
+
         final TransportAddress otherAddress = buildNewFakeTransportAddress();
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 2L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 2L, electionStrategy)
+                .getDescription(),
             is("master not discovered yet, this node has not previously joined a bootstrapped (v5+) cluster, and " +
                 "[cluster.initial_master_nodes] is empty on this node: have discovered []; " +
                 "discovery will continue using [" + otherAddress + "] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 2, last-accepted version 7 in term 4"));
 
         final DiscoveryNode otherNode = new DiscoveryNode("other", buildNewFakeTransportAddress(), Version.CURRENT);
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 3L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 3L, electionStrategy)
+                .getDescription(),
             is("master not discovered yet, this node has not previously joined a bootstrapped (v5+) cluster, and " +
                 "[cluster.initial_master_nodes] is empty on this node: have discovered [" + otherNode + "]; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 3, last-accepted version 7 in term 4"));
 
         assertThat(new ClusterFormationState(Settings.builder().putList(INITIAL_MASTER_NODES_SETTING.getKey(), "other").build(),
-                clusterState, emptyList(), emptyList(), 4L).getDescription(),
+                clusterState, emptyList(), emptyList(), 4L, electionStrategy).getDescription(),
             is("master not discovered yet, this node has not previously joined a bootstrapped (v5+) cluster, and " +
                 "this node must discover master-eligible nodes [other] to bootstrap a cluster: have discovered []; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
@@ -218,28 +231,31 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final ClusterState clusterState = state(localNode,
                 VotingConfiguration.MUST_JOIN_ELECTED_MASTER.getNodeIds().toArray(new String[0]));
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 0L, electionStrategy).getDescription(),
                 is("master not discovered yet and this node was detached from its previous cluster, " +
                         "have discovered []; " +
                         "discovery will continue using [] from hosts providers and [" + localNode +
                         "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         final TransportAddress otherAddress = buildNewFakeTransportAddress();
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 0L, electionStrategy)
+                .getDescription(),
                 is("master not discovered yet and this node was detached from its previous cluster, " +
                         "have discovered []; " +
                         "discovery will continue using [" + otherAddress + "] from hosts providers and [" + localNode +
                         "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         final DiscoveryNode otherNode = new DiscoveryNode("otherNode", buildNewFakeTransportAddress(), Version.CURRENT);
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 0L, electionStrategy)
+                .getDescription(),
                 is("master not discovered yet and this node was detached from its previous cluster, " +
                         "have discovered [" + otherNode + "]; " +
                         "discovery will continue using [] from hosts providers and [" + localNode +
                         "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         final DiscoveryNode yetAnotherNode = new DiscoveryNode("yetAnotherNode", buildNewFakeTransportAddress(), Version.CURRENT);
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(yetAnotherNode), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(yetAnotherNode), 0L, electionStrategy)
+                .getDescription(),
                 is("master not discovered yet and this node was detached from its previous cluster, " +
                         "have discovered [" + yetAnotherNode + "]; " +
                         "discovery will continue using [] from hosts providers and [" + localNode +
@@ -252,104 +268,109 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
 
         final ClusterState clusterState = state(localNode, "otherNode");
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 0L, electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         final TransportAddress otherAddress = buildNewFakeTransportAddress();
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 0L, electionStrategy)
+                .getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [" + otherAddress + "] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         final DiscoveryNode otherNode = new DiscoveryNode("otherNode", buildNewFakeTransportAddress(), Version.CURRENT);
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 0L, electionStrategy)
+                .getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
                 "have discovered [" + otherNode + "] which is a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         final DiscoveryNode yetAnotherNode = new DiscoveryNode("yetAnotherNode", buildNewFakeTransportAddress(), Version.CURRENT);
-        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(yetAnotherNode), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(yetAnotherNode), 0L, electionStrategy)
+                .getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
                 "have discovered [" + yetAnotherNode + "] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2"), emptyList(), emptyList(), 0L).getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2"), emptyList(), emptyList(), 0L, electionStrategy)
+                .getDescription(),
             is("master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3"), emptyList(), emptyList(), 0L)
-                .getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3"), emptyList(), emptyList(), 0L,
+                electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires at least 2 nodes with ids from [n1, n2, n3], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", BOOTSTRAP_PLACEHOLDER_PREFIX + "n3"),
-                emptyList(), emptyList(), 0L).getDescription(),
+                emptyList(), emptyList(), 0L, electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires 2 nodes with ids [n1, n2], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4"), emptyList(), emptyList(), 0L)
-                .getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4"), emptyList(), emptyList(), 0L,
+                electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires at least 3 nodes with ids from [n1, n2, n3, n4], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4", "n5"), emptyList(), emptyList(), 0L)
-                .getDescription(),
+        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4", "n5"), emptyList(), emptyList(), 0L,
+                electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires at least 3 nodes with ids from [n1, n2, n3, n4, n5], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4", BOOTSTRAP_PLACEHOLDER_PREFIX + "n5"),
-                emptyList(), emptyList(), 0L).getDescription(),
+                emptyList(), emptyList(), 0L, electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires at least 3 nodes with ids from [n1, n2, n3, n4], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3",
-            BOOTSTRAP_PLACEHOLDER_PREFIX + "n4", BOOTSTRAP_PLACEHOLDER_PREFIX + "n5"), emptyList(), emptyList(), 0L).getDescription(),
+            BOOTSTRAP_PLACEHOLDER_PREFIX + "n4", BOOTSTRAP_PLACEHOLDER_PREFIX + "n5"), emptyList(), emptyList(), 0L, electionStrategy)
+                .getDescription(),
             is("master not discovered or elected yet, an election requires 3 nodes with ids [n1, n2, n3], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, new String[]{"n1"}, new String[]{"n1"}), emptyList(),
-                emptyList(), 0L).getDescription(),
+                emptyList(), 0L, electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, new String[]{"n1"}, new String[]{"n2"}), emptyList(),
-                emptyList(), 0L).getDescription(),
+                emptyList(), 0L, electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1] and a node with id [n2], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, new String[]{"n1"}, new String[]{"n2", "n3"}), emptyList(),
-                emptyList(), 0L).getDescription(),
+                emptyList(), 0L, electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1] and two nodes with ids [n2, n3], " +
                 "have discovered [] which is not a quorum; " +
                 "discovery will continue using [] from hosts providers and [" + localNode +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, new String[]{"n1"}, new String[]{"n2", "n3", "n4"}),
-                emptyList(), emptyList(), 0L).getDescription(),
+                emptyList(), emptyList(), 0L, electionStrategy).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1] and " +
                 "at least 2 nodes with ids from [n2, n3, n4], " +
                 "have discovered [] which is not a quorum; " +
@@ -369,26 +390,19 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
                 .lastAcceptedConfiguration(config(configNodeIds))
                 .lastCommittedConfiguration(config(configNodeIds)).build())).build();
 
-        assertThat(new ClusterFormationState(Settings.EMPTY, stateWithOtherNodes, emptyList(), emptyList(), 0L).getDescription(), isOneOf(
+        assertThat(
+            new ClusterFormationState(Settings.EMPTY, stateWithOtherNodes, emptyList(), emptyList(), 0L, electionStrategy).getDescription(),
 
             // nodes from last-known cluster state could be in either order
+            is(oneOf(
+                "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
+                    "have discovered [] which is not a quorum; " +
+                    "discovery will continue using [] from hosts providers and [" + localNode + ", " + otherMasterNode +
+                    "] from last-known cluster state; node term 0, last-accepted version 0 in term 0",
 
-            "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
-                "have discovered [] which is not a quorum; " +
-                "discovery will continue using [] from hosts providers and [" + localNode + ", " + otherMasterNode +
-                "] from last-known cluster state; node term 0, last-accepted version 0 in term 0",
-
-            "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
-                "have discovered [] which is not a quorum; " +
-                "discovery will continue using [] from hosts providers and [" + otherMasterNode + ", " + localNode +
-                "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
-
-        assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, GatewayMetaState.STALE_STATE_CONFIG_NODE_ID), emptyList(),
-                emptyList(), 0L).getDescription(),
-            is("master not discovered or elected yet, an election requires one or more nodes that have already participated as " +
-                "master-eligible nodes in the cluster but this node was not master-eligible the last time it joined the cluster, " +
-                "have discovered [] which is not a quorum; " +
-                "discovery will continue using [] from hosts providers and [" + localNode +
-                "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
+                "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
+                    "have discovered [] which is not a quorum; " +
+                    "discovery will continue using [] from hosts providers and [" + otherMasterNode + ", " + localNode +
+                    "] from last-known cluster state; node term 0, last-accepted version 0 in term 0")));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import static org.apache.lucene.tests.util.CrateLuceneTestCase.random;
-
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -29,44 +27,238 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.rarely;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.lucene.tests.util.CrateLuceneTestCase.random;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.elasticsearch.test.ESTestCase.randomLong;
+import static org.elasticsearch.test.ESTestCase.randomLongBetween;
+import static org.elasticsearch.test.ESTestCase.randomSubsetOf;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
 public class CoordinationStateTestCluster {
 
     public static ClusterState clusterState(long term, long version, DiscoveryNode localNode,
                                             CoordinationMetadata.VotingConfiguration lastCommittedConfig,
                                             CoordinationMetadata.VotingConfiguration lastAcceptedConfig, long value) {
         return clusterState(term, version, DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).build(),
-            lastCommittedConfig, lastAcceptedConfig, value);
+                            lastCommittedConfig, lastAcceptedConfig, value);
     }
 
     public static ClusterState clusterState(long term, long version, DiscoveryNodes discoveryNodes,
                                             CoordinationMetadata.VotingConfiguration lastCommittedConfig,
                                             CoordinationMetadata.VotingConfiguration lastAcceptedConfig, long value) {
         return setValue(ClusterState.builder(ClusterName.DEFAULT)
-            .version(version)
-            .nodes(discoveryNodes)
-            .metadata(Metadata.builder()
-                .clusterUUID(UUIDs.randomBase64UUID(random())) // generate cluster UUID deterministically for repeatable tests
-                .coordinationMetadata(CoordinationMetadata.builder()
-                    .term(term)
-                    .lastCommittedConfiguration(lastCommittedConfig)
-                    .lastAcceptedConfiguration(lastAcceptedConfig)
-                    .build()))
-            .stateUUID(UUIDs.randomBase64UUID(random())) // generate cluster state UUID deterministically for repeatable tests
-            .build(), value);
+                            .version(version)
+                            .nodes(discoveryNodes)
+                            .metadata(Metadata.builder()
+                                          .clusterUUID(UUIDs.randomBase64UUID(random())) // generate cluster UUID deterministically for repeatable tests
+                                          .coordinationMetadata(CoordinationMetadata.builder()
+                                                                    .term(term)
+                                                                    .lastCommittedConfiguration(lastCommittedConfig)
+                                                                    .lastAcceptedConfiguration(lastAcceptedConfig)
+                                                                    .build()))
+                            .stateUUID(UUIDs.randomBase64UUID(random())) // generate cluster state UUID deterministically for repeatable tests
+                            .build(), value);
     }
 
     public static ClusterState setValue(ClusterState clusterState, long value) {
         return ClusterState.builder(clusterState).metadata(
-            Metadata.builder(clusterState.metadata())
-                .persistentSettings(Settings.builder()
-                    .put(clusterState.metadata().persistentSettings())
-                    .put("value", value)
+                Metadata.builder(clusterState.metadata())
+                    .persistentSettings(Settings.builder()
+                                            .put(clusterState.metadata().persistentSettings())
+                                            .put("value", value)
+                                            .build())
                     .build())
-                .build())
             .build();
     }
 
     public static long value(ClusterState clusterState) {
         return clusterState.metadata().persistentSettings().getAsLong("value", 0L);
+    }
+
+    static class ClusterNode {
+
+        final DiscoveryNode localNode;
+        final CoordinationState.PersistedState persistedState;
+        private final ElectionStrategy electionStrategy;
+        CoordinationState state;
+
+        ClusterNode(DiscoveryNode localNode, ElectionStrategy electionStrategy) {
+            this.localNode = localNode;
+            persistedState = new InMemoryPersistedState(0L,
+                                                        clusterState(0L, 0L, localNode, CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
+                                                                     CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG, 0L));
+            this.electionStrategy = electionStrategy;
+            state = new CoordinationState(localNode, persistedState, electionStrategy);
+        }
+
+        void reboot() {
+            state = new CoordinationState(localNode, persistedState, electionStrategy);
+        }
+
+        void setInitialState(CoordinationMetadata.VotingConfiguration initialConfig, long initialValue) {
+            final ClusterState.Builder builder = ClusterState.builder(state.getLastAcceptedState());
+            builder.metadata(Metadata.builder()
+                                 .coordinationMetadata(CoordinationMetadata.builder()
+                                                           .lastAcceptedConfiguration(initialConfig)
+                                                           .lastCommittedConfiguration(initialConfig)
+                                                           .build()));
+            state.setInitialState(setValue(builder.build(), initialValue));
+        }
+    }
+
+    final ElectionStrategy electionStrategy;
+    final List<Message> messages;
+    final List<ClusterNode> clusterNodes;
+    final CoordinationMetadata.VotingConfiguration initialConfiguration;
+    final long initialValue;
+
+    CoordinationStateTestCluster(List<DiscoveryNode> nodes, ElectionStrategy electionStrategy) {
+        this.electionStrategy = electionStrategy;
+        messages = new ArrayList<>();
+
+        clusterNodes = nodes.stream()
+            .map(node -> new ClusterNode(node, electionStrategy))
+            .collect(Collectors.toList());
+
+        initialConfiguration = randomVotingConfig();
+        initialValue = randomLong();
+    }
+
+    static class Message {
+        final DiscoveryNode sourceNode;
+        final DiscoveryNode targetNode;
+        final Object payload;
+
+        Message(DiscoveryNode sourceNode, DiscoveryNode targetNode, Object payload) {
+            this.sourceNode = sourceNode;
+            this.targetNode = targetNode;
+            this.payload = payload;
+        }
+    }
+
+    void reply(Message m, Object payload) {
+        messages.add(new Message(m.targetNode, m.sourceNode, payload));
+    }
+
+    void broadcast(DiscoveryNode sourceNode, Object payload) {
+        messages.addAll(clusterNodes.stream().map(cn -> new Message(sourceNode, cn.localNode, payload)).collect(Collectors.toList()));
+    }
+
+    Optional<ClusterNode> getNode(DiscoveryNode node) {
+        return clusterNodes.stream().filter(cn -> cn.localNode.equals(node)).findFirst();
+    }
+
+    CoordinationMetadata.VotingConfiguration randomVotingConfig() {
+        return new CoordinationMetadata.VotingConfiguration(
+            randomSubsetOf(randomIntBetween(1, clusterNodes.size()), clusterNodes).stream()
+                .map(cn -> cn.localNode.getId()).collect(toSet()));
+    }
+
+    void applyMessage(Message message) {
+        final Optional<ClusterNode> maybeNode = getNode(message.targetNode);
+        if (maybeNode.isPresent() == false) {
+            throw new CoordinationStateRejectedException("node not available");
+        } else {
+            final Object payload = message.payload;
+            if (payload instanceof StartJoinRequest) {
+                reply(message, maybeNode.get().state.handleStartJoin((StartJoinRequest) payload));
+            } else if (payload instanceof Join) {
+                maybeNode.get().state.handleJoin((Join) payload);
+            } else if (payload instanceof PublishRequest) {
+                reply(message, maybeNode.get().state.handlePublishRequest((PublishRequest) payload));
+            } else if (payload instanceof PublishResponse) {
+                maybeNode.get().state.handlePublishResponse(message.sourceNode, (PublishResponse) payload)
+                    .ifPresent(ac -> broadcast(message.targetNode, ac));
+            } else if (payload instanceof ApplyCommitRequest) {
+                maybeNode.get().state.handleCommit((ApplyCommitRequest) payload);
+            } else {
+                throw new AssertionError("unknown message type");
+            }
+        }
+    }
+
+    void runRandomly() {
+        final int iterations = 10000;
+        final long maxTerm = 4;
+        long nextTerm = 1;
+        for (int i = 0; i < iterations; i++) {
+            try {
+                if (rarely() && nextTerm < maxTerm) {
+                    final long term = rarely() ? randomLongBetween(0, maxTerm + 1) : nextTerm++;
+                    final StartJoinRequest startJoinRequest = new StartJoinRequest(randomFrom(clusterNodes).localNode, term);
+                    broadcast(startJoinRequest.getSourceNode(), startJoinRequest);
+                } else if (rarely()) {
+                    randomFrom(clusterNodes).setInitialState(initialConfiguration, initialValue);
+                } else if (rarely() && rarely()) {
+                    randomFrom(clusterNodes).reboot();
+                } else if (rarely()) {
+                    final List<ClusterNode> masterNodes = clusterNodes.stream().filter(cn -> cn.state.electionWon())
+                        .collect(Collectors.toList());
+                    if (masterNodes.isEmpty() == false) {
+                        final ClusterNode clusterNode = randomFrom(masterNodes);
+                        final long term = rarely() ? randomLongBetween(0, maxTerm + 1) : clusterNode.state.getCurrentTerm();
+                        final long version = rarely() ? randomIntBetween(0, 5) : clusterNode.state.getLastPublishedVersion() + 1;
+                        final CoordinationMetadata.VotingConfiguration acceptedConfig = rarely() ? randomVotingConfig() :
+                            clusterNode.state.getLastAcceptedConfiguration();
+                        final PublishRequest publishRequest = clusterNode.state.handleClientValue(
+                            clusterState(term, version, clusterNode.localNode, clusterNode.state.getLastCommittedConfiguration(),
+                                         acceptedConfig, randomLong()));
+                        broadcast(clusterNode.localNode, publishRequest);
+                    }
+                } else if (messages.isEmpty() == false) {
+                    applyMessage(randomFrom(messages));
+                }
+
+                // check node invariants after each iteration
+                clusterNodes.forEach(cn -> cn.state.invariant());
+            } catch (CoordinationStateRejectedException e) {
+                // ignore
+            }
+        }
+
+        // check system invariants. It's sufficient to do this at the end as these invariants are monotonic.
+        invariant();
+    }
+
+    void invariant() {
+        // one master per term
+        messages.stream().filter(m -> m.payload instanceof PublishRequest)
+            .collect(Collectors.groupingBy(m -> ((PublishRequest) m.payload).getAcceptedState().term()))
+            .forEach((term, publishMessages) -> {
+                Set<DiscoveryNode> mastersForTerm = publishMessages.stream().collect(Collectors.groupingBy(m -> m.sourceNode)).keySet();
+                assertThat("Multiple masters " + mastersForTerm + " for term " + term, mastersForTerm, hasSize(1));
+            });
+
+        // unique cluster state per (term, version) pair
+        messages.stream().filter(m -> m.payload instanceof PublishRequest)
+            .map(m -> ((PublishRequest) m.payload).getAcceptedState())
+            .collect(Collectors.groupingBy(ClusterState::term))
+            .forEach((term, clusterStates) -> {
+                clusterStates.stream().collect(Collectors.groupingBy(ClusterState::version))
+                    .forEach((version, clusterStates1) -> {
+                        Set<String> clusterStateUUIDsForTermAndVersion = clusterStates1.stream().collect(Collectors.groupingBy(
+                            ClusterState::stateUUID
+                        )).keySet();
+                        assertThat("Multiple cluster states " + clusterStates1 + " for term " + term + " and version " + version,
+                                   clusterStateUUIDsForTermAndVersion, hasSize(1));
+
+                        Set<Long> clusterStateValuesForTermAndVersion = clusterStates1.stream().collect(Collectors.groupingBy(
+                            CoordinationStateTestCluster::value
+                        )).keySet();
+
+                        assertThat("Multiple cluster states " + clusterStates1 + " for term " + term + " and version " + version,
+                                   clusterStateValuesForTermAndVersion, hasSize(1));
+                    });
+            });
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -192,7 +192,8 @@ public class NodeJoinTests extends ESTestCase {
             new NoOpClusterApplier(),
             Collections.emptyList(),
             random,
-            (s, p, r) -> {}
+            (s, p, r) -> {},
+            ElectionStrategy.DEFAULT_INSTANCE
         );
         transportService.start();
         transportService.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PreVoteCollectorTests.java
@@ -117,7 +117,7 @@ public class PreVoteCollectorTests extends ESTestCase {
             assert electionOccurred == false;
             electionOccurred = true;
         }, l -> {
-        });
+        }, ElectionStrategy.DEFAULT_INSTANCE); // TODO need tests that check that the max term seen is updated
         preVoteCollector.update(getLocalPreVoteResponse(), null);
     }
 
@@ -235,8 +235,8 @@ public class PreVoteCollectorTests extends ESTestCase {
         DiscoveryNode[] votingNodes = votingNodesSet.toArray(new DiscoveryNode[0]);
         startAndRunCollector(votingNodes);
 
-        final CoordinationState coordinationState = new CoordinationState(Settings.EMPTY, localNode,
-            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)));
+        final CoordinationState coordinationState = new CoordinationState(localNode,
+            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)), ElectionStrategy.DEFAULT_INSTANCE);
 
         final long newTerm = randomLongBetween(currentTerm + 1, Long.MAX_VALUE);
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
@@ -82,7 +82,8 @@ public class PublicationTests extends ESTestCase {
             this.localNode = localNode;
             ClusterState initialState = CoordinationStateTests.clusterState(0L, 0L, localNode,
                 CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG, CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG, 0L);
-            coordinationState = new CoordinationState(settings, localNode, new InMemoryPersistedState(0L, initialState));
+            coordinationState = new CoordinationState(localNode, new InMemoryPersistedState(0L, initialState),
+                ElectionStrategy.DEFAULT_INSTANCE);
         }
 
         final DiscoveryNode localNode;


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/commit/e689b20eba8a583c0a3a7783e06b00a97cbdee63

Note:
The `voting-only` plugin itself is skipped because it's part of x-pack. The rest of the changes are a pre-cursor for further backports e.g. https://github.com/elastic/elasticsearch/pull/59138 . We could consider to simplify this a little bit, remove the plugin part and only keep the `ElectionStrategy` interface and the related code.




## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
