### PR TITLE
More backports

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -272,7 +272,7 @@ should be crossed out as well.
 - [ ] 31be3a36452 More Efficient Snapshot State Handling (#56669) (#59430)
 - [ ] b1b7bf39122 Make data streams a basic licensed feature. (#59392)
 - [ ] bd01fd107ce Revert "Migrate CompletionFieldMapper to parametrized format (#59291)"
-- [ ] 4e574a7136c Remove Dead Code from Closed Index Snapshot Logic (#56764) (#59398)
+- [x] 4e574a7136c Remove Dead Code from Closed Index Snapshot Logic (#56764) (#59398)
 - [ ] 19ba6c39d27 Migrate CompletionFieldMapper to parametrized format (#59291)
 - [x] 08b54feaaf2 Remove Snapshot INIT Step (#55918) (#59374)
 - [ ] c810a4a12e8 Continue to accept unused 'universal' params in <8.0 indexes (#59381)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -268,7 +268,7 @@ should be crossed out as well.
 - [ ] 68d56fa7dba Implement rejections in `WriteMemoryLimits` (#59451)
 - [ ] eb0b28dd1d6 Move getPointReaderOrNull into AggregatorBase (#58769) (#59455)
 - [ ] 64c5f70a2d4 Remove Needless Context Switches on Loading RepositoryData (#56935) (#59452)
-- [ ] bde92fc5fcc Remove Needless Context Switch From Snapshot Finalization (#56871) (#59443)
+- [x] bde92fc5fcc Remove Needless Context Switch From Snapshot Finalization (#56871) (#59443)
 - [x] 31be3a36452 More Efficient Snapshot State Handling (#56669) (#59430)
 - [ ] b1b7bf39122 Make data streams a basic licensed feature. (#59392)
 - [ ] bd01fd107ce Revert "Migrate CompletionFieldMapper to parametrized format (#59291)"

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -280,7 +280,7 @@ should be crossed out as well.
 - [x] f4caadd239f MappedFieldType no longer requires equals/hashCode/clone (#59212)
 - [x] d56fc72ee5b Fix node health-check-related test failures (#59277)
 - [ ] 67a27e2b9d4 Add declarative parameters to FieldMappers (#58663)
-- [ ] 6a0f7411e25 Do not release safe commit with CancellableThreads (#59182)
+- [x] 6a0f7411e25 Do not release safe commit with CancellableThreads (#59182)
 - [ ] 17bd5592537 Fix the timestamp field of a data stream to @timestamp (#59210)
 - [x] 9268b257895 Add Check for Metadata Existence in BlobStoreRepository (#59141) (#59216)
 - [x] ef5c397c0f6 Sending operations concurrently in peer recovery (#58018)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -274,7 +274,7 @@ should be crossed out as well.
 - [ ] bd01fd107ce Revert "Migrate CompletionFieldMapper to parametrized format (#59291)"
 - [ ] 4e574a7136c Remove Dead Code from Closed Index Snapshot Logic (#56764) (#59398)
 - [ ] 19ba6c39d27 Migrate CompletionFieldMapper to parametrized format (#59291)
-- [ ] 08b54feaaf2 Remove Snapshot INIT Step (#55918) (#59374)
+- [x] 08b54feaaf2 Remove Snapshot INIT Step (#55918) (#59374)
 - [ ] c810a4a12e8 Continue to accept unused 'universal' params in <8.0 indexes (#59381)
 - [x] 483386136d9 Move all Snapshot Master Node Steps to SnapshotsService (#56365) (#59373)
 - [x] f4caadd239f MappedFieldType no longer requires equals/hashCode/clone (#59212)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -276,7 +276,7 @@ should be crossed out as well.
 - [ ] 19ba6c39d27 Migrate CompletionFieldMapper to parametrized format (#59291)
 - [ ] 08b54feaaf2 Remove Snapshot INIT Step (#55918) (#59374)
 - [ ] c810a4a12e8 Continue to accept unused 'universal' params in <8.0 indexes (#59381)
-- [ ] 483386136d9 Move all Snapshot Master Node Steps to SnapshotsService (#56365) (#59373)
+- [x] 483386136d9 Move all Snapshot Master Node Steps to SnapshotsService (#56365) (#59373)
 - [x] f4caadd239f MappedFieldType no longer requires equals/hashCode/clone (#59212)
 - [x] d56fc72ee5b Fix node health-check-related test failures (#59277)
 - [ ] 67a27e2b9d4 Add declarative parameters to FieldMappers (#58663)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -267,7 +267,7 @@ should be crossed out as well.
 - [ ] 623df95a323 Adding indexing pressure stats to node stats API (#59467)
 - [ ] 68d56fa7dba Implement rejections in `WriteMemoryLimits` (#59451)
 - [ ] eb0b28dd1d6 Move getPointReaderOrNull into AggregatorBase (#58769) (#59455)
-- [ ] 64c5f70a2d4 Remove Needless Context Switches on Loading RepositoryData (#56935) (#59452)
+- [x] 64c5f70a2d4 Remove Needless Context Switches on Loading RepositoryData (#56935) (#59452)
 - [x] bde92fc5fcc Remove Needless Context Switch From Snapshot Finalization (#56871) (#59443)
 - [x] 31be3a36452 More Efficient Snapshot State Handling (#56669) (#59430)
 - [ ] b1b7bf39122 Make data streams a basic licensed feature. (#59392)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -269,7 +269,7 @@ should be crossed out as well.
 - [ ] eb0b28dd1d6 Move getPointReaderOrNull into AggregatorBase (#58769) (#59455)
 - [ ] 64c5f70a2d4 Remove Needless Context Switches on Loading RepositoryData (#56935) (#59452)
 - [ ] bde92fc5fcc Remove Needless Context Switch From Snapshot Finalization (#56871) (#59443)
-- [ ] 31be3a36452 More Efficient Snapshot State Handling (#56669) (#59430)
+- [x] 31be3a36452 More Efficient Snapshot State Handling (#56669) (#59430)
 - [ ] b1b7bf39122 Make data streams a basic licensed feature. (#59392)
 - [ ] bd01fd107ce Revert "Migrate CompletionFieldMapper to parametrized format (#59291)"
 - [x] 4e574a7136c Remove Dead Code from Closed Index Snapshot Logic (#56764) (#59398)

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -656,14 +656,13 @@ public class Node implements Closeable {
                 settings,
                 clusterService,
                 repositoryService,
-                threadPool
+                transportService
             );
 
             final SnapshotShardsService snapshotShardsService = new SnapshotShardsService(
                 settings,
                 clusterService,
                 repositoryService,
-                threadPool,
                 transportService,
                 indicesService
             );

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -369,62 +369,52 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     @Override
     public void executeConsistentStateUpdate(Function<RepositoryData, ClusterStateUpdateTask> createUpdateTask, String source,
                                              Consumer<Exception> onFailure) {
-        threadPool.generic().execute(new AbstractRunnable() {
-            @Override
-            protected void doRun() {
-                final RepositoryMetadata repositoryMetadataStart = metadata;
-                getRepositoryData(ActionListener.wrap(repositoryData -> {
-                    final ClusterStateUpdateTask updateTask = createUpdateTask.apply(repositoryData);
-                    clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask(updateTask.priority()) {
+        final RepositoryMetadata repositoryMetadataStart = metadata;
+        getRepositoryData(ActionListener.wrap(repositoryData -> {
+            final ClusterStateUpdateTask updateTask = createUpdateTask.apply(repositoryData);
+            clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask(updateTask.priority()) {
 
-                        private boolean executedTask = false;
+                private boolean executedTask = false;
 
-                        @Override
-                        public ClusterState execute(ClusterState currentState) throws Exception {
-                            // Comparing the full metadata here on purpose instead of simply comparing the safe generation.
-                            // If the safe generation has changed, then we have to reload repository data and start over.
-                            // If the pending generation has changed we are in the midst of a write operation and might pick up the
-                            // updated repository data and state on the retry. We don't want to wait for the write to finish though
-                            // because it could fail for any number of reasons so we just retry instead of waiting on the cluster state
-                            // to change in any form.
-                            if (repositoryMetadataStart.equals(getRepoMetadata(currentState))) {
-                                executedTask = true;
-                                return updateTask.execute(currentState);
-                            }
-                            return currentState;
-                        }
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    // Comparing the full metadata here on purpose instead of simply comparing the safe generation.
+                    // If the safe generation has changed, then we have to reload repository data and start over.
+                    // If the pending generation has changed we are in the midst of a write operation and might pick up the
+                    // updated repository data and state on the retry. We don't want to wait for the write to finish though
+                    // because it could fail for any number of reasons so we just retry instead of waiting on the cluster state
+                    // to change in any form.
+                    if (repositoryMetadataStart.equals(getRepoMetadata(currentState))) {
+                        executedTask = true;
+                        return updateTask.execute(currentState);
+                    }
+                    return currentState;
+                }
 
-                        @Override
-                        public void onFailure(String source, Exception e) {
-                            if (executedTask) {
-                                updateTask.onFailure(source, e);
-                            } else {
-                                onFailure.accept(e);
-                            }
-                        }
+                @Override
+                public void onFailure(String source, Exception e) {
+                    if (executedTask) {
+                        updateTask.onFailure(source, e);
+                    } else {
+                        onFailure.accept(e);
+                    }
+                }
 
-                        @Override
-                        public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                            if (executedTask) {
-                                updateTask.clusterStateProcessed(source, oldState, newState);
-                            } else {
-                                executeConsistentStateUpdate(createUpdateTask, source, onFailure);
-                            }
-                        }
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    if (executedTask) {
+                        updateTask.clusterStateProcessed(source, oldState, newState);
+                    } else {
+                        executeConsistentStateUpdate(createUpdateTask, source, onFailure);
+                    }
+                }
 
-                        @Override
-                        public TimeValue timeout() {
-                            return updateTask.timeout();
-                        }
-                    });
-                }, onFailure));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                onFailure.accept(e);
-            }
-        });
+                @Override
+                public TimeValue timeout() {
+                    return updateTask.timeout();
+                }
+            });
+        }, onFailure));
     }
 
     // Inspects all cluster state elements that contain a hint about what the current repository generation is and updates
@@ -573,17 +563,23 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         if (isReadOnly()) {
             listener.onFailure(new RepositoryException(metadata.name(), "cannot delete snapshot from a readonly repository"));
         } else {
-            try {
-                final Map<String, BlobMetadata> rootBlobs = blobContainer().listBlobs();
-                final RepositoryData repositoryData = safeRepositoryData(repositoryStateId, rootBlobs);
-                // Cache the indices that were found before writing out the new index-N blob so that a stuck master will never
-                // delete an index that was created by another master node after writing this index-N blob.
-                final Map<String, BlobContainer> foundIndices = blobStore().blobContainer(indicesPath()).children();
-                doDeleteShardSnapshots(snapshotIds, repositoryStateId, foundIndices, rootBlobs, repositoryData,
-                    SnapshotsService.useShardGenerations(repositoryMetaVersion), listener);
-            } catch (Exception ex) {
-                listener.onFailure(new RepositoryException(metadata.name(), "failed to delete snapshots " + snapshotIds, ex));
-            }
+            threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
+                @Override
+                protected void doRun() throws Exception {
+                    final Map<String, BlobMetadata> rootBlobs = blobContainer().listBlobs();
+                    final RepositoryData repositoryData = safeRepositoryData(repositoryStateId, rootBlobs);
+                    // Cache the indices that were found before writing out the new index-N blob so that a stuck master will never
+                    // delete an index that was created by another master node after writing this index-N blob.
+                    final Map<String, BlobContainer> foundIndices = blobStore().blobContainer(indicesPath()).children();
+                    doDeleteShardSnapshots(snapshotIds, repositoryStateId, foundIndices, rootBlobs, repositoryData,
+                            SnapshotsService.useShardGenerations(repositoryMetaVersion), listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(new RepositoryException(metadata.name(), "failed to delete snapshots " + snapshotIds, e));
+                }
+            });
         }
     }
 
@@ -1194,6 +1190,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             listener.onFailure(corruptedStateException(null));
             return;
         }
+        threadPool.generic().execute(ActionRunnable.wrap(listener, this::doGetRepositoryData));
+    }
+
+    private void doGetRepositoryData(ActionListener<RepositoryData> listener) {
         // Retry loading RepositoryData in a loop in case we run into concurrent modifications of the repository.
         // Keep track of the most recent generation we failed to load so we can break out of the loop if we fail to load the same
         // generation repeatedly.

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -454,7 +454,13 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         processStartedShards();
                     }
                     if (newMaster) {
-                        endCompletedSnapshots(event.state());
+                        // Cleanup all snapshots that have no more work left:
+                        // 1. Completed snapshots
+                        // 2. Snapshots in state INIT that the previous master failed to start
+                        // 3. Snapshots in any other state that have all their shard tasks completed
+                        snapshotsInProgress.entries().stream().filter(
+                                entry -> entry.state().completed() || entry.state() == State.INIT || completed(entry.shards().values())
+                        ).forEach(entry -> endSnapshot(entry, event.state().metadata()));
                     }
                 }
                 if (newMaster) {
@@ -534,7 +540,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     private void processSnapshotsOnRemovedNodes() {
         clusterService.submitStateUpdateTask("update snapshot state after node removal", new ClusterStateUpdateTask() {
 
-            private boolean changed = false;
+            private final Collection<SnapshotsInProgress.Entry> finishedSnapshots = new ArrayList<>();
 
             @Override
             public ClusterState execute(ClusterState currentState) {
@@ -543,6 +549,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 if (snapshots == null) {
                     return currentState;
                 }
+                boolean changed = false;
                 ArrayList<SnapshotsInProgress.Entry> entries = new ArrayList<>();
                 for (final SnapshotsInProgress.Entry snapshot : snapshots.entries()) {
                     SnapshotsInProgress.Entry updatedSnapshot = snapshot;
@@ -572,6 +579,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             ImmutableOpenMap<ShardId, ShardSnapshotStatus> shardsMap = shards.build();
                             if (!snapshot.state().completed() && completed(shardsMap.values())) {
                                 updatedSnapshot = new SnapshotsInProgress.Entry(snapshot, State.SUCCESS, shardsMap);
+                                finishedSnapshots.add(updatedSnapshot);
                             } else {
                                 updatedSnapshot = new SnapshotsInProgress.Entry(snapshot, snapshot.state(), shardsMap);
                             }
@@ -599,9 +607,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                if (changed) {
-                    endCompletedSnapshots(newState);
-                }
+                finishedSnapshots.forEach(entry -> endSnapshot(entry, newState.metadata()));
             }
         });
     }
@@ -609,12 +615,13 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     private void processStartedShards() {
         clusterService.submitStateUpdateTask("update snapshot state after shards started", new ClusterStateUpdateTask() {
 
-            private boolean changed = false;
+            private final Collection<SnapshotsInProgress.Entry> finishedSnapshots = new ArrayList<>();
 
             @Override
             public ClusterState execute(ClusterState currentState) {
                 RoutingTable routingTable = currentState.routingTable();
                 SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE);
+                boolean changed = false;
                 if (snapshots != null) {
                     ArrayList<SnapshotsInProgress.Entry> entries = new ArrayList<>();
                     for (final SnapshotsInProgress.Entry snapshot : snapshots.entries()) {
@@ -626,6 +633,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                 changed = true;
                                 if (!snapshot.state().completed() && completed(shards.values())) {
                                     updatedSnapshot = new SnapshotsInProgress.Entry(snapshot, State.SUCCESS, shards);
+                                    finishedSnapshots.add(updatedSnapshot);
                                 } else {
                                     updatedSnapshot = new SnapshotsInProgress.Entry(snapshot, shards);
                                 }
@@ -649,9 +657,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                if (changed) {
-                    endCompletedSnapshots(newState);
-                }
+                finishedSnapshots.forEach(entry -> endSnapshot(entry, newState.metadata()));
             }
         });
     }
@@ -1546,7 +1552,15 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         try {
                             listener.onResponse(new UpdateIndexShardSnapshotStatusResponse());
                         } finally {
-                            endCompletedSnapshots(newState);
+                            // Maybe this state update completed the snapshot. If we are not already ending it because of a concurrent
+                            // state update we check if its state is completed and end it if it is.
+                            if (endingSnapshots.contains(request.snapshot()) == false) {
+                                final SnapshotsInProgress snapshotsInProgress = newState.custom(SnapshotsInProgress.TYPE);
+                                final SnapshotsInProgress.Entry updatedEntry = snapshotsInProgress.snapshot(request.snapshot());
+                                if (updatedEntry.state().completed()) {
+                                    endSnapshot(updatedEntry, newState.metadata());
+                                }
+                            }
                         }
                     }
                 });

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -774,27 +774,24 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             removeSnapshotFromClusterState(entry.snapshot(), new SnapshotException(snapshot, "Aborted on initialization"), null);
             return;
         }
-        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
-            @Override
-            protected void doRun() {
-                final Repository repository = repositoriesService.repository(snapshot.getRepository());
-                final String failure = entry.failure();
-                LOGGER.trace("[{}] finalizing snapshot in repository, state: [{}], failure[{}]", snapshot, entry.state(), failure);
-                ArrayList<SnapshotShardFailure> shardFailures = new ArrayList<>();
-                for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shardStatus : entry.shards()) {
-                    ShardId shardId = shardStatus.key;
-                    ShardSnapshotStatus status = shardStatus.value;
-                    final ShardState state = status.state();
-                    if (state.failed()) {
-                        shardFailures.add(new SnapshotShardFailure(status.nodeId(), shardId, status.reason()));
-                    } else if (state.completed() == false) {
-                        shardFailures.add(new SnapshotShardFailure(status.nodeId(), shardId, "skipped"));
-                    } else {
-                        assert state == ShardState.SUCCESS;
-                    }
+        try {
+            final String failure = entry.failure();
+            LOGGER.trace("[{}] finalizing snapshot in repository, state: [{}], failure[{}]", snapshot, entry.state(), failure);
+            ArrayList<SnapshotShardFailure> shardFailures = new ArrayList<>();
+            for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shardStatus : entry.shards()) {
+                ShardId shardId = shardStatus.key;
+                ShardSnapshotStatus status = shardStatus.value;
+                final ShardState state = status.state();
+                if (state.failed()) {
+                    shardFailures.add(new SnapshotShardFailure(status.nodeId(), shardId, status.reason()));
+                } else if (state.completed() == false) {
+                    shardFailures.add(new SnapshotShardFailure(status.nodeId(), shardId, "skipped"));
+                } else {
+                    assert state == ShardState.SUCCESS;
                 }
-                final ShardGenerations shardGenerations = buildGenerations(entry, metadata);
-                repository.finalizeSnapshot(
+            }
+            final ShardGenerations shardGenerations = buildGenerations(entry, metadata);
+            repositoriesService.repository(snapshot.getRepository()).finalizeSnapshot(
                     snapshot.getSnapshotId(),
                     shardGenerations,
                     entry.startTime(),
@@ -818,25 +815,25 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         }
                         endingSnapshots.remove(snapshot);
                         LOGGER.info("snapshot [{}] completed with state [{}]", snapshot, result.v2().state());
-                    }, this::onFailure));
-            }
+                    }, e -> handleFinalizationFailure(e, entry)));
+        } catch (Exception e) {
+            handleFinalizationFailure(e, entry);
+        }
+    }
 
-            @Override
-            public void onFailure(final Exception e) {
-                Snapshot snapshot = entry.snapshot();
-                if (ExceptionsHelper.unwrap(e, NotMasterException.class, FailedToCommitClusterStateException.class) != null) {
-                    // Failure due to not being master any more, don't try to remove snapshot from cluster state the next master
-                    // will try ending this snapshot again
-                    LOGGER.debug(() -> new ParameterizedMessage(
-                        "[{}] failed to update cluster state during snapshot finalization", snapshot), e);
-                    failSnapshotCompletionListeners(snapshot,
-                        new SnapshotException(snapshot, "Failed to update cluster state during snapshot finalization", e));
-                } else {
-                    LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to finalize snapshot", snapshot), e);
-                    removeSnapshotFromClusterState(snapshot, e, null);
-                }
-            }
-        });
+    private void handleFinalizationFailure(Exception e, SnapshotsInProgress.Entry entry) {
+        Snapshot snapshot = entry.snapshot();
+        if (ExceptionsHelper.unwrap(e, NotMasterException.class, FailedToCommitClusterStateException.class) != null) {
+            // Failure due to not being master any more, don't try to remove snapshot from cluster state the next master
+            // will try ending this snapshot again
+            LOGGER.debug(() -> new ParameterizedMessage(
+                "[{}] failed to update cluster state during snapshot finalization", snapshot), e);
+            failSnapshotCompletionListeners(snapshot,
+                new SnapshotException(snapshot, "Failed to update cluster state during snapshot finalization", e));
+        } else {
+            LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to finalize snapshot", snapshot), e);
+            removeSnapshotFromClusterState(snapshot, e, null);
+        }
     }
 
     private static ClusterState stateWithoutSnapshot(ClusterState state, Snapshot snapshot) {

--- a/server/src/main/java/org/elasticsearch/snapshots/UpdateIndexShardSnapshotStatusRequest.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/UpdateIndexShardSnapshotStatusRequest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.cluster.SnapshotsInProgress;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import io.crate.common.unit.TimeValue;
+
+/**
+ * Internal request that is used to send changes in snapshot status to master
+ */
+public class UpdateIndexShardSnapshotStatusRequest extends MasterNodeRequest<UpdateIndexShardSnapshotStatusRequest> {
+    private final Snapshot snapshot;
+    private final ShardId shardId;
+    private final SnapshotsInProgress.ShardSnapshotStatus status;
+
+    public UpdateIndexShardSnapshotStatusRequest(StreamInput in) throws IOException {
+        super(in);
+        snapshot = new Snapshot(in);
+        shardId = new ShardId(in);
+        status = new SnapshotsInProgress.ShardSnapshotStatus(in);
+    }
+
+    public UpdateIndexShardSnapshotStatusRequest(Snapshot snapshot, ShardId shardId, SnapshotsInProgress.ShardSnapshotStatus status) {
+        this.snapshot = snapshot;
+        this.shardId = shardId;
+        this.status = status;
+        // By default, we keep trying to post snapshot status messages to avoid snapshot processes getting stuck.
+        this.masterNodeTimeout = TimeValue.timeValueNanos(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        snapshot.writeTo(out);
+        shardId.writeTo(out);
+        status.writeTo(out);
+    }
+
+    public Snapshot snapshot() {
+        return snapshot;
+    }
+
+    public ShardId shardId() {
+        return shardId;
+    }
+
+    public SnapshotsInProgress.ShardSnapshotStatus status() {
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return snapshot + ", shardId [" + shardId + "], status [" + status.state() + "]";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final UpdateIndexShardSnapshotStatusRequest that = (UpdateIndexShardSnapshotStatusRequest) o;
+        return snapshot.equals(that.snapshot) && shardId.equals(that.shardId) && status.equals(that.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(snapshot, shardId, status);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/snapshots/UpdateIndexShardSnapshotStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/UpdateIndexShardSnapshotStatusResponse.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.transport.TransportResponse;
+
+import java.io.IOException;
+
+class UpdateIndexShardSnapshotStatusResponse extends TransportResponse {
+
+    UpdateIndexShardSnapshotStatusResponse() {}
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {}
+}

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -59,7 +59,6 @@ import java.util.stream.StreamSupport;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
@@ -127,7 +126,6 @@ import org.elasticsearch.test.TestCluster;
 import org.elasticsearch.test.store.MockFSIndexStore;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.test.transport.StubbableTransport;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportChannel;
@@ -700,10 +698,8 @@ public class IndexRecoveryIT extends IntegTestCase {
         var indexName = IndexParts.toIndexName(sqlExecutor.getCurrentSchema(), INDEX_NAME, null);
         RecoveryResponse response = client().execute(RecoveryAction.INSTANCE, new RecoveryRequest(indexName)).get();
 
-        ThreadPool threadPool = internalCluster().getMasterNodeInstance(ThreadPool.class);
         Repository repository = internalCluster().getMasterNodeInstance(RepositoriesService.class).repository(REPO_NAME);
-        final RepositoryData repositoryData = PlainActionFuture.get(f ->
-            threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.wrap(f, repository::getRepositoryData)));
+        final RepositoryData repositoryData = PlainActionFuture.get(repository::getRepositoryData);
         for (Map.Entry<String, List<RecoveryState>> indexRecoveryStates : response.shardRecoveryStates().entrySet()) {
 
             assertThat(indexRecoveryStates.getKey(), equalTo(indexName));

--- a/server/src/test/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -247,7 +247,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         final ThreadPool threadPool = internalCluster().getCurrentMasterNodeInstance(ThreadPool.class);
         assertThat(
             FutureUtils.get(threadPool.generic().submit(() ->
-                snapshotsService.minCompatibleVersion(Version.CURRENT, repoName, getRepositoryData(repository), null)
+                snapshotsService.minCompatibleVersion(Version.CURRENT, getRepositoryData(repository), null)
             )),
             is(SnapshotsService.OLD_SNAPSHOT_FORMAT)
         );
@@ -258,7 +258,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         logger.info("--> verify that repository is assumed in new metadata format after removing corrupted snapshot");
         assertThat(
             FutureUtils.get(threadPool.generic().submit(() ->
-                snapshotsService.minCompatibleVersion(Version.CURRENT, repoName, getRepositoryData(repository), null)
+                snapshotsService.minCompatibleVersion(Version.CURRENT, getRepositoryData(repository), null)
             )),
             is(Version.CURRENT)
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See individual commits.

Note on https://github.com/crate/crate/pull/13189/commits/d36b2045e54592434da8177814046edbc5ba423b:
I decided to not support snapshots for mixed clusters and left out `createSnapshotLegacy` intentionally.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
