### PR TITLE
Fix source decoding of bit string values, add additional base64 decoding step

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -96,3 +96,7 @@ Fixes
 
 - Fixed an issue that caused ``ARRAY_COL = []`` to throw an exception on
   ``OBJECT``, ``GEO_SHAPE``, ``IP`` or ``BIT`` array element types.
+
+- Fixed an issue that caused queries reading values of type ``BIT`` to return a
+  wrong result if the query contains a ``WHERE`` clause ``pk_col = ?``
+  condition.

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -63,7 +63,6 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import io.crate.types.BitStringType;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -1975,7 +1974,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         // primary key lookup uses different execution path to decode the value
         execute("select xs from tbl where id = 6");
         assertThat(TestingHelpers.printedTable(response.rows()), is(
-            "B'1100'\n"
+            "B'1001'\n"
         ));
 
         var properties = new Properties();
@@ -2006,11 +2005,6 @@ public class TransportSQLActionTest extends IntegTestCase {
         for (var type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
             if (type.equals(DataTypes.GEO_POINT)) {
                 // source and doc-value values don't match exactly
-                continue;
-            }
-
-            if (type.equals(BitStringType.INSTANCE_ONE)) {
-                // TODO: remove this and investigate failure in case when bit string  = B'1'.
                 continue;
             }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/25a7c2a1faeca9d22a8d4834f4e6b4e1c82839bf (changes entry also derived from there, difference is that query don't fail now but can return non-matching BIT string).

`PK=?` matches a correct row, was just a bit value (source) rendering/resolving issue.

See also https://github.com/crate/crate/pull/13181#discussion_r1004254931

