### PR TITLE
bp: Fix node health-check-related test failures

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -278,7 +278,7 @@ should be crossed out as well.
 - [ ] c810a4a12e8 Continue to accept unused 'universal' params in <8.0 indexes (#59381)
 - [ ] 483386136d9 Move all Snapshot Master Node Steps to SnapshotsService (#56365) (#59373)
 - [x] f4caadd239f MappedFieldType no longer requires equals/hashCode/clone (#59212)
-- [ ] d56fc72ee5b Fix node health-check-related test failures (#59277)
+- [x] d56fc72ee5b Fix node health-check-related test failures (#59277)
 - [ ] 67a27e2b9d4 Add declarative parameters to FieldMappers (#58663)
 - [ ] 6a0f7411e25 Do not release safe commit with CancellableThreads (#59182)
 - [ ] 17bd5592537 Fix the timestamp field of a data stream to @timestamp (#59210)

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -329,16 +329,16 @@ public class FollowersChecker {
                         failureCountSinceLastSuccess++;
 
                         final String reason;
-                        if (failureCountSinceLastSuccess >= followerCheckRetryCount) {
-                            LOGGER.debug(() -> new ParameterizedMessage("{} failed too many times", FollowerChecker.this), exp);
-                            reason = "followers check retry count exceeded";
-                        } else if (exp instanceof ConnectTransportException
+                        if (exp instanceof ConnectTransportException
                             || exp.getCause() instanceof ConnectTransportException) {
                             LOGGER.debug(() -> new ParameterizedMessage("{} disconnected", FollowerChecker.this), exp);
                             reason = "disconnected";
                         } else if (exp.getCause() instanceof NodeHealthCheckFailureException) {
                             LOGGER.debug(() -> new ParameterizedMessage("{} health check failed", FollowerChecker.this), exp);
                             reason = "health check failed";
+                        } else if (failureCountSinceLastSuccess >= followerCheckRetryCount) {
+                            LOGGER.debug(() -> new ParameterizedMessage("{} failed too many times", FollowerChecker.this), exp);
+                            reason = "followers check retry count exceeded";
                         } else {
                             LOGGER.debug(() -> new ParameterizedMessage("{} failed, retrying", FollowerChecker.this), exp);
                             scheduleNextWakeUp();

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsHealthService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsHealthService.java
@@ -131,7 +131,7 @@ public class FsHealthService extends AbstractLifecycleComponent implements NodeH
 
     class FsHealthMonitor implements Runnable {
 
-        private static final String TEMP_FILE_NAME = ".es_temp_file";
+        static final String TEMP_FILE_NAME = ".es_temp_file";
         private byte[] byteToWrite;
 
         FsHealthMonitor() {

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
@@ -306,8 +306,7 @@ public class FsHealthServiceTests extends ESTestCase {
         AtomicBoolean injectIOException = new AtomicBoolean();
         AtomicInteger injectedPaths = new AtomicInteger();
 
-        private String pathPrefix = "/";
-        private long delay;
+        private final long delay;
         private final ThreadPool threadPool;
 
         FileSystemFsyncHungProvider(FileSystem inner, long delay, ThreadPool threadPool) {
@@ -326,7 +325,7 @@ public class FsHealthServiceTests extends ESTestCase {
                 @Override
                 public void force(boolean metaData) throws IOException {
                     if (injectIOException.get()) {
-                        if (path.toString().startsWith(pathPrefix) && path.toString().endsWith(".es_temp_file")) {
+                        if (path.getFileName().toString().equals(FsHealthService.FsHealthMonitor.TEMP_FILE_NAME)) {
                             injectedPaths.incrementAndGet();
                             final long startTimeMillis = threadPool.relativeTimeInMillis();
                             do {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Should fix flaky test failures:

    java.lang.AssertionError: 
    Expected: "health check failed"
         but: was "followers check retry count exceeded"
    	at __randomizedtesting.SeedInfo.seed([D5A376AC99151340:16FCD68AD43743BB]:0)
    	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
    	at org.junit.Assert.assertThat(Assert.java:964)
    	at org.junit.Assert.assertThat(Assert.java:930)
    	at org.elasticsearch.cluster.coordination.FollowersCheckerTests.lambda$testBehaviourOfFailingNode$19(FollowersCheckerTests.java:381)
    	at org.elasticsearch.cluster.coordination.FollowersChecker$FollowerChecker$2.run(FollowersChecker.java:372)
    	at org.elasticsearch.cluster.coordination.DeterministicTaskQueue.runTask(DeterministicTaskQueue.java:131)
    	at org.elasticsearch.cluster.coordination.DeterministicTaskQueue.runRandomTask(DeterministicTaskQueue.java:125)
    	at org.elasticsearch.cluster.coordination.DeterministicTaskQueue.runAllRunnableTasks(DeterministicTaskQueue.java:75)
    	at org.elasticsearch.cluster.coordination.FollowersCheckerTests.testBehaviourOfFailingNode(FollowersCheckerTests.java:390)
    	at org.elasticsearch.cluster.coordination.FollowersCheckerTests.testFailsNodeThatIsUnhealthy(FollowersCheckerTests.java:324)

https://github.com/elastic/elasticsearch/commit/d56fc72ee5bcfe6002a85a2370112703df8a19fb

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
