### PR TITLE
Fix handling of BitString in undefined type serialization

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,6 +67,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could lead to serialization errors when using the ``bit``
+  type in objects.
+
 - Fixed an issue that could lead to ``IllegalIndexShardStateException`` errors
   when running a ``SELECT count(*) FROM tbl`` on partitioned tables.
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -43,6 +43,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -81,6 +82,7 @@ import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.sql.tree.BitString;
 import io.crate.types.TimeTZ;
 
 /**
@@ -681,6 +683,8 @@ public abstract class StreamInput extends InputStream {
                 return readPeriod();
             case 27:
                 return new PointImpl(readDouble(), readDouble(), JtsSpatialContext.GEO);
+            case 28:
+                return new BitString(BitSet.valueOf(readByteArray()), readVInt());
             default:
                 throw new IOException("Can't read unknown type [" + type + "]");
         }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -70,6 +70,7 @@ import org.joda.time.ReadableInstant;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.sql.tree.BitString;
 import io.crate.types.TimeTZ;
 
 /**
@@ -707,6 +708,12 @@ public abstract class StreamOutput extends OutputStream {
             PointImpl value = (PointImpl) v;
             o.writeDouble(value.getX());
             o.writeDouble(value.getY());
+        }),
+        Map.entry(BitString.class, (o, v) -> {
+            o.writeByte((byte) 28);
+            BitString bs = (BitString) v;
+            o.writeByteArray(bs.bitSet().toByteArray());
+            o.writeVInt(bs.length());
         })
     );
 

--- a/server/src/test/java/io/crate/types/UndefinedTypeTest.java
+++ b/server/src/test/java/io/crate/types/UndefinedTypeTest.java
@@ -21,13 +21,18 @@
 
 package io.crate.types;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+
+import java.util.BitSet;
+import java.util.Map;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
+import io.crate.sql.tree.BitString;
 import io.crate.testing.DataTypeTesting;
 
 public class UndefinedTypeTest extends ESTestCase {
@@ -61,5 +66,21 @@ public class UndefinedTypeTest extends ESTestCase {
     @Test
     public void test_undefined_type_can_stream_geo_point_values() throws Exception {
         testRoundTrip(DataTypes.GEO_POINT);
+    }
+
+    @Test
+    public void test_can_stream_bitstring_values() throws Exception {
+        BitSet bits = new BitSet();
+        bits.set(0);
+        bits.set(1);
+        BitString bitString = new BitString(bits, 4);
+        var map = Map.of("foo", bitString);
+
+        var out = new BytesStreamOutput();
+        DataTypes.UNDEFINED.writeValueTo(out, map);
+
+        var in = out.bytes().streamInput();
+        var mapIn = DataTypes.UNDEFINED.readValueFrom(in);
+        assertThat(map).isEqualTo(mapIn);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Changes in https://github.com/crate/crate/pull/13181 to include the
``bit`` type in more random tests made the `TransportSQLActionTest`
flaky, failing with errors like:

    org.opentest4j.AssertionFailedError: [All incoming requests on node [node_sd5] should have finished]
    expected: 0L
     but was: 16440L

The root cause was a bug causing a streaming error:

    Cause 1: java.io.IOException: can not write type [class io.crate.sql.tree.BitString]
            at org.elasticsearch.common.io.stream.StreamOutput.writeGenericValue(StreamOutput.java:742)
            at io.crate.types.UndefinedType.writeValueTo(UndefinedType.java:85)
            at io.crate.types.ObjectType.writeValueTo(ObjectType.java:275)
            at io.crate.types.ObjectType.writeValueTo(ObjectType.java:59)
            at io.crate.execution.dml.upsert.ShardUpsertRequest$Item.writeTo(ShardUpsertRequest.java:434)
            at io.crate.execution.dml.upsert.ShardUpsertRequest.writeTo(ShardUpsertRequest.java:179)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
