### PR TITLE
Replace `indices.breaker.fielddata.limit` ref in 4.3 release notes

### DIFF
--- a/docs/appendices/release-notes/4.3.0.rst
+++ b/docs/appendices/release-notes/4.3.0.rst
@@ -48,10 +48,8 @@ Deprecations
 - Deprecated the ``*.overhead`` setting for all circuit breakers. It now
   defaults to 1.0 for all of them and changing it has no effect.
 
-- Deprecated the :ref:`indices.breaker.fielddata.limit
-  <indices.breaker.fielddata.limit>` and
-  :ref:`indices.breaker.fielddata.overhead
-  <indices.breaker.fielddata.overhead>` settings. These no longer have any
+- Deprecated the ``indices.breaker.fielddata.limit`` and
+  ``indices.breaker.fielddata.overhead`` settings. These no longer have any
   effect as there is no fielddata cache anymore.
 
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

With 5.1 being stable the reference is no longer working.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
