### PR TITLE
Add `attributes` column to `sys.nodes` table

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -284,6 +284,19 @@ The table schema is as follows:
 |              | and port.                                           |             |
 +--------------+-----------------------------------------------------+-------------+
 
+``attributes``
+--------------
+
++----------------+-----------------------------------------------------+-------------+
+| Column Name    | Description                                         | Return Type |
++================+=====================================================+=============+
+| ``attributes`` | The :ref:`custom attributes <conf-node-attributes>` | ``OBJECT``  |
+|                | set for the node, e.g. if ``node.attr.color`` is    |             |
+|                | ``blue``, and ``node.attr.location`` is ``east`,    |             |
+|                | the value of this column would be:                  |             |
+|                | ``{color=blue, location=east}``                     |             |
++----------------+-----------------------------------------------------+-------------+
+
 ``port``
 --------
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -53,6 +53,9 @@ None
 Changes
 =======
 
+- Added ``attributes`` column to :ref:`sys.nodes <sys-nodes>` table to expose
+  :ref:`custom node settings <conf-node-attributes>`.
+
 - Added support for ``SCROLL`` and backward movement to cursors. See
   :ref:`DECLARE <sql-declare>` and :ref:`FETCH <sql-fetch>`.
 

--- a/server/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -21,25 +21,25 @@
 
 package io.crate.metadata.sys;
 
-import io.crate.expression.reference.sys.node.NodeStatsContext;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.SystemTable;
-import io.crate.monitor.FsInfoHelpers;
-import io.crate.types.DataTypes;
-
-import org.elasticsearch.Version;
-import org.elasticsearch.monitor.fs.FsInfo;
-import org.elasticsearch.monitor.jvm.JvmStats;
-import org.elasticsearch.threadpool.ThreadPoolStats;
-
-
 import static io.crate.types.DataTypes.DOUBLE;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.LONG;
 import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
+import static io.crate.types.DataTypes.UNTYPED_OBJECT;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.monitor.fs.FsInfo;
+import org.elasticsearch.monitor.jvm.JvmStats;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+
+import io.crate.expression.reference.sys.node.NodeStatsContext;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.monitor.FsInfoHelpers;
+import io.crate.types.DataTypes;
 
 public class SysNodesTableInfo {
 
@@ -49,6 +49,7 @@ public class SysNodesTableInfo {
     private static final String SYS_COL_NODE_NAME = "name";
     private static final String SYS_COL_HOSTNAME = "hostname";
     private static final String SYS_COL_REST_URL = "rest_url";
+    private static final String SYS_COL_ATTRIBUTES = "attributes";
     private static final String SYS_COL_PORT = "port";
     private static final String SYS_COL_CLUSTER_STATE_VERSION = "cluster_state_version";
     private static final String SYS_COL_LOAD = "load";
@@ -67,6 +68,7 @@ public class SysNodesTableInfo {
         public static final ColumnIdent NAME = new ColumnIdent(SYS_COL_NODE_NAME);
         public static final ColumnIdent HOSTNAME = new ColumnIdent(SYS_COL_HOSTNAME);
         public static final ColumnIdent REST_URL = new ColumnIdent(SYS_COL_REST_URL);
+        public static final ColumnIdent ATTRIBUTES = new ColumnIdent(SYS_COL_ATTRIBUTES);
 
         public static final ColumnIdent PORT = new ColumnIdent(SYS_COL_PORT);
         public static final ColumnIdent CLUSTER_STATE_VERSION = new ColumnIdent(SYS_COL_CLUSTER_STATE_VERSION);
@@ -101,6 +103,7 @@ public class SysNodesTableInfo {
             .add("name", STRING, NodeStatsContext::name)
             .add("hostname", STRING, NodeStatsContext::hostname)
             .add("rest_url", STRING, NodeStatsContext::restUrl)
+            .add("attributes", UNTYPED_OBJECT, NodeStatsContext::attributes)
             .startObject("port")
                 .add("http", INTEGER, NodeStatsContext::httpPort)
                 .add("transport", INTEGER, NodeStatsContext::transportPort)

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -196,6 +196,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         List<String> outputNames = outputNames(relation);
         assertThat(outputNames).containsExactly(
             "id",
+            "attributes",
             "cluster_state_version",
             "connections",
             "fs",

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -562,7 +562,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(936, response.rowCount());
+        assertEquals(937, response.rowCount());
     }
 
     @Test
@@ -813,7 +813,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("select max(ordinal_position) from information_schema.columns");
         assertEquals(1, response.rowCount());
 
-        assertEquals(119, response.rows()[0][0]);
+        assertEquals(120, response.rows()[0][0]);
 
         execute("create table t1 (id integer, col1 string)");
         execute("select max(ordinal_position) from information_schema.columns where table_schema = ?",

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -59,7 +59,7 @@ public class PgCatalogITest extends IntegTestCase {
     public void testPgClassTable() {
         execute("select * from pg_catalog.pg_class where relname in ('t1', 'v1', 'tables', 'nodes') order by relname");
         assertThat(printedTable(response.rows()), is(
-            "-1420189195| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| nodes| -458336339| 17| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
+            "-1420189195| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| nodes| -458336339| 18| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
             "728874843| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| t1| -2048275947| 3| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
             "-1689918046| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| tables| 204690627| 16| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n" +
             "845171032| NULL| 0| 0| 0| 0| false| 0| false| false| false| false| false| false| false| true| false| v| 0| v1| -2048275947| 1| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0\n"));

--- a/server/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
@@ -59,13 +59,13 @@ public class SysNodesTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCompatibilityVersion() {
-        RowCollectExpressionFactory<NodeStatsContext> sysNodeTableStatws = SysNodesTableInfo.create().expressions().get(
+        RowCollectExpressionFactory<NodeStatsContext> sysNodeTableStats = SysNodesTableInfo.create().expressions().get(
             SysNodesTableInfo.Columns.VERSION);
 
-        assertThat(sysNodeTableStatws.create().getChild("minimum_index_compatibility_version").value(),
+        assertThat(sysNodeTableStats.create().getChild("minimum_index_compatibility_version").value(),
                    is(Version.CURRENT.minimumIndexCompatibilityVersion().externalNumber()));
 
-        assertThat(sysNodeTableStatws.create().getChild("minimum_wire_compatibility_version").value(),
+        assertThat(sysNodeTableStats.create().getChild("minimum_wire_compatibility_version").value(),
                    is(Version.CURRENT.minimumCompatibilityVersion().externalNumber()));
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Expose custom attirbutes set to nodes via `node.attr.*` settings
in `sys.nodes` table.

Closes: #11800

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
