### PR TITLE
Replace deprecated API calls in GHA project workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -13,8 +13,8 @@ jobs:
         run: |-
           gh api graphql -F contentId=$PR_ID -f query='
             mutation($contentId: ID!) {
-              addProjectNextItem(input: {projectId: "PN_kwDOAD3FaM4ACoUS" contentId: $contentId}) {
-                projectNextItem {
+              addProjectV2ItemById(input: {projectId: "PN_kwDOAD3FaM4ACoUS" contentId: $contentId}) {
+                item {
                   id
                 }
               }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`addProjectNextItem` is deprecated

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
