### PR TITLE
Fix wrong ordering of results for `array(subquery)`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,12 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused incorrect results to be returned when using
+  :ref:`array(subquery) <scalar-array>` when the subquery is using ``ORDER BY``
+  on a different column than the one returned, i.e.::
+
+    SELECT array(SELECT country FROM sys.summits ORDER BY height DESC LIMIT 3)
+
 - Fixed an issue that prevented defining a ``bit`` column with the same name as
   the parent object within a table. An example::
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -162,22 +162,19 @@ public final class ExpressionFormatter {
 
         @Override
         public String visitArrayComparisonExpression(ArrayComparisonExpression node, @Nullable List<Expression> parameters) {
-            StringBuilder builder = new StringBuilder();
 
             String array = node.getRight().accept(this, parameters);
             String left = node.getLeft().accept(this, parameters);
             String type = node.getType().getValue();
 
-            builder.append("(" + left + " " + type + " ANY(" + array + "))");
-            return builder.toString();
+            return "(" + left + " " + type + " ANY(" + array + "))";
         }
 
         @Override
         protected String visitArraySubQueryExpression(ArraySubQueryExpression node, @Nullable List<Expression> parameters) {
-            StringBuilder builder = new StringBuilder();
             String subqueryExpression = node.subqueryExpression().accept(this, parameters);
             assert subqueryExpression.startsWith("(") : "subqueryExpression must be enclosed in parenthesis";
-            return builder.append("ARRAY").append(subqueryExpression).append("").toString();
+            return "ARRAY" + subqueryExpression;
         }
 
         @Override

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -41,6 +41,7 @@ public class ExpressionAnalysisContext {
 
     private boolean hasAggregates;
     private boolean allowEagerNormalize = true;
+    private boolean parentIsOrderSensitive = true;
     private final boolean errorOnUnknownObjectKey;
 
     private Map<String, Window> windows = Map.of();
@@ -63,6 +64,14 @@ public class ExpressionAnalysisContext {
 
     public void allowEagerNormalize(boolean value) {
         this.allowEagerNormalize = value;
+    }
+
+    public boolean parentIsOrderSensitive() {
+        return parentIsOrderSensitive;
+    }
+
+    public void parentIsOrderSensitive(boolean parentIsOrderSensitive) {
+        this.parentIsOrderSensitive = parentIsOrderSensitive;
     }
 
     public void windows(Map<String, Window> windows) {

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -675,7 +675,8 @@ public class ExpressionAnalyzer {
             SelectSymbol selectSymbol = new SelectSymbol(
                 relation,
                 new ArrayType<>(innerType),
-                SelectSymbol.ResultType.SINGLE_COLUMN_EXISTS
+                SelectSymbol.ResultType.SINGLE_COLUMN_EXISTS,
+                false
             );
             return allocateFunction(ExistsOperator.NAME, List.of(selectSymbol), context);
         }
@@ -796,8 +797,10 @@ public class ExpressionAnalyzer {
         @Override
         public Symbol visitArrayComparisonExpression(ArrayComparisonExpression node, ExpressionAnalysisContext context) {
             context.registerArrayChild(node.getRight());
+            context.parentIsOrderSensitive(false);
             Symbol leftSymbol = node.getLeft().accept(this, context);
             Symbol arraySymbol = node.getRight().accept(this, context);
+            context.parentIsOrderSensitive(true);
             ComparisonExpression.Type operationType = node.getType();
             final String operatorName;
             switch (node.quantifier()) {
@@ -1128,7 +1131,7 @@ public class ExpressionAnalyzer {
             } else {
                 resultType = SelectSymbol.ResultType.SINGLE_COLUMN_SINGLE_VALUE;
             }
-            return new SelectSymbol(relation, dataType, resultType);
+            return new SelectSymbol(relation, dataType, resultType, context.parentIsOrderSensitive());
         }
     }
 

--- a/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
@@ -39,6 +39,7 @@ public class SelectSymbol implements Symbol {
     private final ArrayType<?> dataType;
     private final ResultType resultType;
     private final boolean isCorrelated;
+    private final boolean parentIsOrderSensitive;
 
     public enum ResultType {
         SINGLE_COLUMN_SINGLE_VALUE,
@@ -46,7 +47,10 @@ public class SelectSymbol implements Symbol {
         SINGLE_COLUMN_EXISTS
     }
 
-    public SelectSymbol(AnalyzedRelation relation, ArrayType<?> dataType, ResultType resultType) {
+    public SelectSymbol(AnalyzedRelation relation, ArrayType<?> dataType,
+                        ResultType resultType,
+                        boolean parentIsOrderSensitive) {
+
         this.relation = relation;
         this.dataType = dataType;
         this.resultType = resultType;
@@ -57,6 +61,7 @@ public class SelectSymbol implements Symbol {
             }
         });
         this.isCorrelated = isCorrelatedArr[0];
+        this.parentIsOrderSensitive = parentIsOrderSensitive;
     }
 
     public AnalyzedRelation relation() {
@@ -65,6 +70,10 @@ public class SelectSymbol implements Symbol {
 
     public boolean isCorrelated() {
         return isCorrelated;
+    }
+
+    public boolean parentIsOrderSensitive() {
+        return parentIsOrderSensitive;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -218,8 +218,10 @@ public class LogicalPlanner {
             return planBuilder;
         }
 
-        if (selectSymbol.getResultType() == SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES && relation instanceof QueriedSelectRelation) {
-            QueriedSelectRelation queriedRelation = (QueriedSelectRelation) relation;
+        if (selectSymbol.parentIsOrderSensitive() == false
+            && selectSymbol.getResultType() == SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES
+            && relation instanceof QueriedSelectRelation queriedRelation) {
+
             OrderBy relationOrderBy = queriedRelation.orderBy();
             Symbol firstOutput = queriedRelation.outputs().get(0);
             if ((relationOrderBy == null || relationOrderBy.orderBySymbols().get(0).equals(firstOutput) == false)
@@ -573,14 +575,14 @@ public class LogicalPlanner {
 
         @Override
         public LogicalPlan visitSelectStatement(AnalyzedRelation relation, PlannerContext context) {
-            SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> planSubSelect(s, context));
+            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(s -> planSubSelect(s, context));
             LogicalPlan logicalPlan = plan(relation, context, subqueryPlanner, false);
             return new RootRelationBoundary(logicalPlan);
         }
 
         @Override
         protected LogicalPlan visitAnalyzedInsertStatement(AnalyzedInsertStatement statement, PlannerContext context) {
-            SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> planSubSelect(s, context));
+            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(s -> planSubSelect(s, context));
             return writeOptimizer.optimize(
                 InsertFromSubQueryPlanner.plan(
                     statement,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, when using the `array(subquery)` expression and the subquery
was ordering by the return column but in `DESC` order, or ordering by a
different column than the one returned, incorrect results where
returned, i.e.:
```
SELECT array(SELECT country FROM sys.summits ORDER BY country DESC LIMIT 5)
```
or
```
SELECT array(SELECT country FROM sys.summits ORDER BY height LIMIT 5)
```

There is an optimisation that replaces the `ORDER BY` of the subquery
which should only be applied when the subquery is part of an `IN/ANY`
operator, i.e.
```
SELECT * FROM t1 WHERE t1.a IN (SELECT a FROM t2 ORDER BY c DESC)
```

Introduce a boolean flag in the `ExpressionAnalysisContext` which is
passed to the `SelectSymbol` and can be used by `LogicalPlanner` to
decided if the optimisation can be applied or not.

Fixes: #13197

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
