### PR TITLE
Fix name of BitStringFieldMapper to avoid clash in objects

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,12 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that prevented defining a ``bit`` column with the same name as
+  the parent object within a table. An example::
+
+    CREATE TABLE tbl (x OBJECT AS (x bit(1)))
+                      ^            ^
+
 - Fixed an issue that could lead to out of memory errors if using the
   ``percentile`` aggregation.
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
@@ -102,7 +102,7 @@ public class BitStringFieldMapper extends FieldMapper {
                 length,
                 defaultExpression,
                 fieldType,
-                new BitStringFieldType(name, true, true),
+                new BitStringFieldType(buildFullName(context), true, true),
                 copyTo);
             context.putPositionInfo(mapper, position);
             return mapper;
@@ -128,6 +128,11 @@ public class BitStringFieldMapper extends FieldMapper {
             builder.length((Integer) length);
             return builder;
         }
+    }
+
+    @Override
+    protected BitStringFieldMapper clone() {
+        return (BitStringFieldMapper) super.clone();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BitStringFieldMapperTest.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BitStringFieldMapperTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+public class BitStringFieldMapperTest {
+
+    @Test
+    public void test_name_returns_full_path() throws Exception {
+        BitStringFieldMapper.Builder builder = new BitStringFieldMapper.Builder("x");
+        ContentPath contentPath = new ContentPath();
+        contentPath.add("o");
+        var context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+        BitStringFieldMapper mapper = builder.build(context);
+        assertThat(mapper.name()).isEqualTo("o.x");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes

    cr> create table tbl (id int primary key, x object(strict) as (x bit(1)));
    SQLParseException[Field [x] is defined both as an object and a field.]


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
