### PR TITLE
Change function resolve order to check built-in and udfs per schema in search path

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,12 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Changed the logic to resolve functions. Previously it would first look for
+  built-ins for all schemas within the search path before looking up user
+  defined functions. Now it will search for built-in and UDF per schema to
+  prioritize UDFs earlier in the search path over built-ins later in the search
+  path.
+
 - Fixed an issue that could lead to a encoded value getting returned for ``bit``
   columns that are part of an ``object`` column.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

So far function resolving iterated over the search path looking for
built-ins in a first step, and only if this search ended up empty did it
look for UDFs.

This changes the logic to look for built-in and UDF _per_ schema in the
search path.

Consider the setup:

```
Built-in Functions:
  pg_catalog.version()

UDFs:
  public.version()

search_path: [public, pg_catalog]
```

With the old logic it looked for built-in functions in public and then
pg_catalog and returned `pg_catalog.version()`

With the new logic it looks for built-in functions in public, then for
UDFs in public and returns `public.version()`.

Closes https://github.com/crate/crate/issues/13218


Not sure if this should be classified as fix and backported.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
