### PR TITLE
Allow COPY FROM to skip lines

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -82,6 +82,10 @@ Changes
 - Added support for :ref:`bit operators <bit-operators>` on integral and
   ``BIT`` types.
 
+- Added a :ref:`WITH clause <sql-copy-from-with>` option :ref:`SKIP
+  <sql-copy-from-skip>` for :ref:`COPY FROM <sql-copy-from>` which allows
+  skipping rows from the beginning while copying data.
+
 Fixes
 =====
 

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -582,6 +582,22 @@ If the table has generated columns or default expressions, validation
 will always take place and the parameter is ignored.
 
 
+.. _sql-copy-from-skip:
+
+``skip``
+''''''''
+
+Default: ``0``
+
+Setting this option to ``n`` skips the first ``n`` rows while copying.
+
+.. NOTE::
+
+    CrateDB by default expects a header in CSV files. If you're using the SKIP
+    option to skip the header, you have to set ``header = false`` as well. See
+    :ref:`header <sql-copy-from-header>`.
+
+
 .. _sql-copy-from-return-summary:
 
 ``RETURN SUMMARY``

--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -63,6 +63,8 @@ public final class CopyStatementSettings {
         true,
         Setting.Property.Dynamic);
 
+    public static final Setting<Long> SKIP_NUM_LINES = Setting.longSetting("skip", 0, 0, Setting.Property.Dynamic);
+
     public static final Setting<Character> CSV_COLUMN_SEPARATOR = new Setting<>(
         "delimiter",
         String.valueOf(CsvSchema.DEFAULT_COLUMN_SEPARATOR),

--- a/server/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
@@ -52,6 +52,9 @@ public class LineParser {
     public void readFirstLine(URI currentUri,
                               FileUriCollectPhase.InputFormat inputFormat,
                               BufferedReader currentReader) throws IOException {
+        for (long i = 0; i < parserProperties.skipNumLines(); i++) {
+            currentReader.readLine();
+        }
         if (isInputCsv(inputFormat, currentUri)) {
             csvLineParser = new CSVLineParser(parserProperties, targetColumns);
             if (parserProperties.fileHeader()) {

--- a/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/phases/FileUriCollectPhaseTest.java
@@ -57,7 +57,7 @@ public class FileUriCollectPhaseTest {
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, true, '|'),
+            new CopyFromParserProperties(true, true, '|', 0),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.EMPTY
         );
@@ -100,7 +100,7 @@ public class FileUriCollectPhaseTest {
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, true, '|'),
+            new CopyFromParserProperties(true, true, '|', 0),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.EMPTY
         );
@@ -131,7 +131,7 @@ public class FileUriCollectPhaseTest {
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, true, '|'),
+            new CopyFromParserProperties(true, true, '|', 0),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.EMPTY
         );
@@ -147,7 +147,7 @@ public class FileUriCollectPhaseTest {
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, true, '|'),
+            new CopyFromParserProperties(true, true, '|', 0),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.builder().put("protocol", "http").build()
         );
@@ -176,7 +176,7 @@ public class FileUriCollectPhaseTest {
             Collections.emptyList(),
             null,
             false,
-            new CopyFromParserProperties(true, true, '|'),
+            new CopyFromParserProperties(true, true, '|', 0),
             FileUriCollectPhase.InputFormat.CSV,
             Settings.builder().put("protocol", "http").build()
         );

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -39,7 +39,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.function.Supplier;
 
 import org.elasticsearch.common.settings.Settings;
@@ -282,11 +281,9 @@ public class FileReadingIteratorTest extends ESTestCase {
                         @Override
                         public String readLine() throws IOException {
                             var line = super.readLine();
-                            if (new Random().nextBoolean()) {
-                                // current implementation does not handle SocketTimeoutException thrown when parsing header so skip it here as well.
-                                if (currentLineNumber++ > 0 && retry++ < MAX_SOCKET_TIMEOUT_RETRIES) {
-                                    throw new SocketTimeoutException("dummy");
-                                }
+                            // current implementation does not handle SocketTimeoutException thrown when parsing header so skip it here as well.
+                            if (currentLineNumber++ > 0 && retry++ < MAX_SOCKET_TIMEOUT_RETRIES) {
+                                throw new SocketTimeoutException("dummy");
                             }
                             return line;
                         }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineParserTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineParserTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.collect.files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.crate.analyze.CopyFromParserProperties;
+import io.crate.execution.dsl.phases.FileUriCollectPhase;
+
+class LineParserTest {
+
+    @Test
+    void test_readFirstLine_can_skip_lines_without_header() throws IOException {
+        var bufferedReader = skipAndReadFirstLine(
+            new CopyFromParserProperties(false, false, ',', 1),
+            FileUriCollectPhase.InputFormat.CSV,
+            "1\n2\n3"
+        );
+        assertThat(bufferedReader.readLine()).isEqualTo("2"); // 1 is skipped
+    }
+
+    @Test
+    void test_readFirstLine_can_skip_lines_with_header() throws IOException {
+        var bufferedReader = skipAndReadFirstLine(
+            new CopyFromParserProperties(false, true, ',', 1),
+            FileUriCollectPhase.InputFormat.CSV,
+            "line_to_skip\nheader\n1\n2\n3"
+        );
+        assertThat(bufferedReader.readLine()).isEqualTo("1"); // 'line_to_skip' is skipped, 'header' is parsed
+    }
+
+    @Test
+    void test_readFirstLine_can_skip_all_lines_with_header() {
+        assertThatThrownBy(
+            () -> skipAndReadFirstLine(
+                new CopyFromParserProperties(false, true, ',', 10),
+                FileUriCollectPhase.InputFormat.CSV,
+                "line_to_skip\nheader\n1\n2\n3"
+            )).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void test_readFirstLine_can_skip_all_lines_without_header() throws IOException {
+        var bufferedReader = skipAndReadFirstLine(
+            new CopyFromParserProperties(false, false, ',', 10),
+            FileUriCollectPhase.InputFormat.CSV,
+            "1\n2\n3"
+        );
+        assertThat(bufferedReader.readLine()).isNull();
+    }
+
+    @Test
+    void test_readFirstLine_can_skip_no_lines_with_header() throws IOException {
+        var bufferedReader = skipAndReadFirstLine(
+            new CopyFromParserProperties(false, true, ',', -1), // skipNumLines <= 0 should have the same effect.
+            FileUriCollectPhase.InputFormat.CSV,
+            "header\n1\n2\n3"
+        );
+        assertThat(bufferedReader.readLine()).isEqualTo("1");
+    }
+
+    @Test
+    void test_readFirstLine_can_skip_lines_from_JSON_inputs() throws IOException {
+        var bufferedReader = skipAndReadFirstLine(
+            new CopyFromParserProperties(false, true, ',', 1),
+            FileUriCollectPhase.InputFormat.JSON,
+            "{\"x\":1}\n{\"x\":2}\n"
+        );
+        assertThat(bufferedReader.readLine()).isEqualTo("{\"x\":2}");
+    }
+
+    private BufferedReader skipAndReadFirstLine(CopyFromParserProperties properties, FileUriCollectPhase.InputFormat inputFormat, String lines) throws IOException {
+        LineParser lineParser = new LineParser(properties, List.of());
+        StringReader stringReader = new StringReader(lines);
+        BufferedReader bufferedReader = new BufferedReader(stringReader);
+        lineParser.readFirstLine(URI.create("dummy"), inputFormat, bufferedReader);
+        return bufferedReader;
+    }
+}

--- a/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
+++ b/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
@@ -113,7 +113,7 @@ public class CSVLineParserTest {
     public void parse_givenEscapedComma_thenParsesLineCorrectly() throws IOException {
         String header = "Code,\"Coun, try\"\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of("Code", "Coun, try", "City"));
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany\n", 0);
@@ -125,7 +125,7 @@ public class CSVLineParserTest {
     public void test_quoted_and_unquoted_empty_string_converted_to_null_empty_string_as_null_is_set() throws IOException {
         String header = "Code,Country,City\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
                                           List.of("Code", "Country", "City"));
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,,\"\"\n", 0);
@@ -140,7 +140,7 @@ public class CSVLineParserTest {
     public void test_parse_csv_with_configured_delimiter_parses_lines_correctly() throws IOException {
         String header = "Code|Country|City\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, true, '|'),
+            new CopyFromParserProperties(true, true, '|', 0),
                                           List.of("Code", "Country", "City"));
         csvParser.parseHeader(header);
         result = csvParser.parse("GER|Germany|Berlin\n", 0);
@@ -200,7 +200,7 @@ public class CSVLineParserTest {
     public void parse_targetColumnsMoreThanCsvHeader_thenKeepOnlyTargetValues() throws IOException {
         String header = "Code,Country\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, true,CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, true,CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of("Code", "Country", "City"));
 
         csvParser.parseHeader(header);
@@ -213,7 +213,7 @@ public class CSVLineParserTest {
     public void parse_targetColumnsLessThanCsvHeader_thenDropExtraCsvValues() throws IOException {
         String header = "Code,Country,City\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, true,CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, true,CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
                                           List.of("Code", "Country"));
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany,Berlin\n", 0);
@@ -224,7 +224,7 @@ public class CSVLineParserTest {
     @Test
     public void parse_targetColumnsSameCsvValuesNoHeader_thenParseAsIs() throws IOException {
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of("Code", "Country", "City"));
         csvParser.parseWithoutHeader("GER,Germany,Berlin\n", 0);
     }
@@ -232,7 +232,7 @@ public class CSVLineParserTest {
     @Test(expected = IllegalArgumentException.class)
     public void parse_targetColumnsMoreThanCsvValuesNoHeader_thenThrowException() throws IOException {
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of("Code", "Country", "City"));
         csvParser.parseWithoutHeader("GER,Germany\n", 0);
     }
@@ -240,7 +240,7 @@ public class CSVLineParserTest {
     @Test
     public void parse_targetColumnsLessThanCsvValuesNoHeader_thenDropExtraCsvValues() throws IOException {
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of("Code", "Country"));
         result = csvParser.parseWithoutHeader("GER,Germany,Berlin\n", 0);
         assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
@@ -250,7 +250,7 @@ public class CSVLineParserTest {
     public void parse_targetColumnsNotInOrder_thenParseWithOrder() throws IOException {
         String header = "Code,Country,City\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of("City", "Code"));
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany,Berlin\n", 0);
@@ -261,7 +261,7 @@ public class CSVLineParserTest {
     public void parse_targetColumnsEmpty_thenParseFromHeader() throws IOException {
         String header = "Code,Country,City\n";
         csvParser = new CSVLineParser(
-            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR),
+            new CopyFromParserProperties(true, true, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of());
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany,Berlin\n", 0);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Add a with clause option, `skip` for `COPY FROM` to be able to skip the specified number of lines.

resolves #12872

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
