### PR TITLE
Fix String/BytesRef cast in OptimizeQueryForSearchAfter

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could lead to a ``class_cast_exception`` error when using
+  ``ORDER BY`` on a column of type ``TEXT`` or ``VARCHAR``
+
 - Changed the logic to resolve functions. Previously it would first look for
   built-ins for all schemas within the search path before looking up user
   defined functions. Now it will search for built-in and UDF per schema to

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -240,11 +240,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
                 sharedShardContext.indexShard().shardId(),
                 batchSize);
         }
-        OptimizeQueryForSearchAfter optimizeQueryForSearchAfter = new OptimizeQueryForSearchAfter(
-            collectPhase.orderBy(),
-            queryContext.queryShardContext(),
-            fieldTypeLookup
-        );
+        var optimizeQueryForSearchAfter = new OptimizeQueryForSearchAfter(collectPhase.orderBy());
         return new LuceneOrderedDocCollector(
             indexShard.shardId(),
             searcher.item(),

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
@@ -28,12 +28,10 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.QueryShardContext;
 
 import io.crate.analyze.OrderBy;
 import io.crate.expression.reference.doc.lucene.NullSentinelValues;
 import io.crate.expression.symbol.Symbol;
-import io.crate.lucene.FieldTypeLookup;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.types.EqQuery;
@@ -43,16 +41,10 @@ public class OptimizeQueryForSearchAfter implements Function<FieldDoc, Query> {
 
     private final OrderBy orderBy;
     private final Object[] missingValues;
-    private final QueryShardContext queryShardContext;
-    private final FieldTypeLookup fieldTypeLookup;
 
-    public OptimizeQueryForSearchAfter(OrderBy orderBy,
-                                       QueryShardContext queryShardContext,
-                                       FieldTypeLookup fieldTypeLookup) {
+    public OptimizeQueryForSearchAfter(OrderBy orderBy) {
         this.orderBy = orderBy;
         missingValues = new Object[orderBy.orderBySymbols().size()];
-        this.queryShardContext = queryShardContext;
-        this.fieldTypeLookup = fieldTypeLookup;
         for (int i = 0; i < orderBy.orderBySymbols().size(); i++) {
             missingValues[i] = NullSentinelValues.nullSentinelForScoreDoc(orderBy, i);
         }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -62,20 +62,20 @@ public class StringType extends DataType<String> implements Streamer<String> {
     public static final String T = "t";
     public static final String F = "f";
 
-    private static final StorageSupport<String> STORAGE = new StorageSupport<>(
+    private static final StorageSupport<Object> STORAGE = new StorageSupport<>(
         true,
         true,
-        new EqQuery<String>() {
+        new EqQuery<Object>() {
 
             @Override
-            public Query termQuery(String field, String value) {
+            public Query termQuery(String field, Object value) {
                 return new TermQuery(new Term(field, BytesRefs.toBytesRef(value)));
             }
 
             @Override
             public Query rangeQuery(String field,
-                                    String lowerTerm,
-                                    String upperTerm,
+                                    Object lowerTerm,
+                                    Object upperTerm,
                                     boolean includeLower,
                                     boolean includeUpper) {
                 return new TermRangeQuery(
@@ -334,7 +334,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
-    public StorageSupport<String> storageSupport() {
+    public StorageSupport<Object> storageSupport() {
         return STORAGE;
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -24,7 +24,6 @@ package io.crate.execution.engine.collect.collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -66,7 +65,6 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -157,8 +155,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         sortField.setMissingValue(missingValue);
         Sort sort = new Sort(sortField);
 
-        OptimizeQueryForSearchAfter queryForSearchAfter =
-            new OptimizeQueryForSearchAfter(orderBy, mock(QueryShardContext.class), name -> valueFieldType);
+        OptimizeQueryForSearchAfter queryForSearchAfter = new OptimizeQueryForSearchAfter(orderBy);
         Query nextPageQuery = queryForSearchAfter.apply(lastCollected);
         TopFieldDocs result = search(reader, nextPageQuery, sort);
         Long[] results = new Long[result.scoreDocs.length];
@@ -179,8 +176,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         FieldDoc fieldDoc = new FieldDoc(1, 0, new Object[]{null});
         OrderBy orderBy = new OrderBy(Collections.singletonList(REFERENCE), new boolean[]{false}, new boolean[]{false});
 
-        OptimizeQueryForSearchAfter queryForSearchAfter = new OptimizeQueryForSearchAfter(
-            orderBy, mock(QueryShardContext.class), name -> valueFieldType);
+        OptimizeQueryForSearchAfter queryForSearchAfter = new OptimizeQueryForSearchAfter(orderBy);
 
         queryForSearchAfter.apply(fieldDoc);
     }
@@ -276,8 +272,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
 
         FieldDoc lastCollected = new FieldDoc(0, 0, new Object[]{2L});
 
-        OptimizeQueryForSearchAfter queryForSearchAfter = new OptimizeQueryForSearchAfter(
-            orderBy, mock(QueryShardContext.class), name -> valueFieldType);
+        OptimizeQueryForSearchAfter queryForSearchAfter = new OptimizeQueryForSearchAfter(orderBy);
         Query nextPageQuery = queryForSearchAfter.apply(lastCollected);
 
         // returns null which leads to reuse of old query without paging optimization

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+
+package io.crate.execution.engine.collect.collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Test;
+
+import io.crate.analyze.OrderBy;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.DataTypes;
+
+public class OptimizeQueryForSearchAfterTest {
+
+    @Test
+    public void test_string_range_query_can_handle_byte_ref_values() throws Exception {
+        ReferenceIdent referenceIdent = new ReferenceIdent(new RelationName("doc", "dummy"), "x");
+        OrderBy orderBy = new OrderBy(List.of(
+            new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.STRING, 1, null)
+        ));
+        var optimize = new OptimizeQueryForSearchAfter(orderBy);
+        FieldDoc lastCollected = new FieldDoc(1, 1.0f, new Object[] { new BytesRef("foobar") });
+        Query query = optimize.apply(lastCollected);
+        assertThat(query.toString()).isEqualTo("+x:{* TO foobar}");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For strings the `FieldDoc` contains `BytesRef` values. The `StringType`
query builder only accepted `String` values, leading to a class cast
exception.

Fixes https://github.com/crate/crate/issues/13166

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
