### PR TITLE
Do not skip nullable flag in GeoReference

### DIFF
--- a/buildSrc/src/main/java/io/crate/gradle/OS.java
+++ b/buildSrc/src/main/java/io/crate/gradle/OS.java
@@ -56,7 +56,7 @@ public final class OS {
     @SuppressWarnings("unused")
     public static OS current() {
         String arch = System.getProperty("os.arch", "");
-        if ("amd64".equals(arch)) {
+        if ("amd64".equals(arch) || "x86_64".equals(arch)) {
             arch = "x64";
         }
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -135,3 +135,6 @@ Fixes
 - Fixed an issue that caused queries reading values of type ``BIT`` to return a
   wrong result if the query contains a ``WHERE`` clause ``pk_col = ?``
   condition.
+
+- Fixed an issue that prevented ``NOT NULL`` constraints on ``GEO_SHAPE``
+  columns from showing up in ``SHOW CREATE TABLE`` statements.

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import io.crate.sql.tree.ColumnPolicy;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -49,11 +50,12 @@ public class GeoReference extends SimpleReference {
 
     public GeoReference(int position,
                         ReferenceIdent ident,
+                        boolean nullable,
                         @Nullable String tree,
                         @Nullable String precision,
                         @Nullable Integer treeLevels,
                         @Nullable Double distanceErrorPct) {
-        super(ident, RowGranularity.DOC, DataTypes.GEO_SHAPE, position, null);
+        super(ident, RowGranularity.DOC, DataTypes.GEO_SHAPE, ColumnPolicy.DYNAMIC, IndexType.PLAIN, nullable, false, position, null);
         this.geoTree = Objects.requireNonNullElse(tree, DEFAULT_TREE);
         this.precision = precision;
         this.treeLevels = treeLevels;

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -240,10 +240,12 @@ public class DocIndexMetadata {
                                  @Nullable String tree,
                                  @Nullable String precision,
                                  @Nullable Integer treeLevels,
-                                 @Nullable Double distanceErrorPct) {
+                                 @Nullable Double distanceErrorPct,
+                                 boolean nullable) {
         GeoReference info = new GeoReference(
             position,
             refIdent(column),
+            nullable,
             tree,
             precision,
             treeLevels,
@@ -452,7 +454,7 @@ public class DocIndexMetadata {
                 String precision = (String) columnProperties.get("precision");
                 Integer treeLevels = (Integer) columnProperties.get("tree_levels");
                 Double distanceErrorPct = (Double) columnProperties.get("distance_error_pct");
-                addGeoReference(position, newIdent, geoTree, precision, treeLevels, distanceErrorPct);
+                addGeoReference(position, newIdent, geoTree, precision, treeLevels, distanceErrorPct, nullable);
             } else if (columnDataType.id() == ObjectType.ID
                        || (columnDataType.id() == ArrayType.ID
                            && ((ArrayType) columnDataType).innerType().id() == ObjectType.ID)) {

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -961,4 +961,21 @@ public class DDLIntegrationTest extends IntegTestCase {
                 """.stripIndent()
         ));
     }
+
+    @Test
+    public void test_geo_shape_can_be_not_null() {
+        execute("create table t (col geo_shape INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25') NOT NULL)");
+        execute("show create table t");
+        assertThat((String) response.rows()[0][0], startsWith(
+            """
+                CREATE TABLE IF NOT EXISTS "doc"."t" (
+                   "col" GEO_SHAPE NOT NULL INDEX USING QUADTREE WITH (
+                      distance_error_pct = 0.25,
+                      precision = '1.0m'
+                   )
+                )
+                """.stripIndent()
+        ));
+
+    }
 }

--- a/server/src/test/java/io/crate/metadata/GeoReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeoReferenceTest.java
@@ -35,7 +35,7 @@ public class GeoReferenceTest extends ESTestCase {
     public void testStreaming() throws Exception {
         RelationName relationName = new RelationName("doc", "test");
         ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "geo_column");
-        GeoReference geoReferenceInfo = new GeoReference(1, referenceIdent, "some_tree", "1m", 3, 0.5d);
+        GeoReference geoReferenceInfo = new GeoReference(1, referenceIdent, true, "some_tree", "1m", 3, 0.5d);
 
         BytesStreamOutput out = new BytesStreamOutput();
         Reference.toStream(geoReferenceInfo, out);
@@ -44,7 +44,7 @@ public class GeoReferenceTest extends ESTestCase {
 
         assertThat(geoReferenceInfo2, is(geoReferenceInfo));
 
-        GeoReference geoReferenceInfo3 = new GeoReference(2, referenceIdent, "some_tree", null, null, null);
+        GeoReference geoReferenceInfo3 = new GeoReference(2, referenceIdent, false, "some_tree", null, null, null);
         out = new BytesStreamOutput();
         Reference.toStream(geoReferenceInfo3, out);
         in = out.bytes().streamInput();


### PR DESCRIPTION
 don't lose `nullable` and `hasDocValue` flags of the GeoReference