### PR TITLE
Fix terms query generation for `_id` column

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,6 +70,8 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that prevented ``_id IN (SELECT ...)`` from matching records.
+
 - Fixed an issue that could lead to a ``class_cast_exception`` error when using
   ``ORDER BY`` on a column of type ``TEXT`` or ``VARCHAR``
 

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -168,6 +168,14 @@ public final class EqOperator extends Operator<Object> {
         if (nonNullValues.isEmpty()) {
             return null;
         }
+        if (column.equals(DocSysColumns.ID.name())) {
+            BytesRef[] bytesRefs = new BytesRef[nonNullValues.size()];
+            for (int i = 0; i < bytesRefs.length; i++) {
+                Object idObject = nonNullValues.get(i);
+                bytesRefs[i] = Uid.encodeId(idObject.toString());
+            }
+            return new TermInSetQuery(column, bytesRefs);
+        }
         return switch (type.id()) {
             case StringType.ID -> new TermInSetQuery(column, nonNullValues.stream().map(BytesRefs::toBytesRef).toList());
             case IntegerType.ID -> IntPoint.newSetQuery(column, (List<Integer>) nonNullValues);

--- a/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
@@ -68,7 +68,7 @@ public final class AnyEqOperator extends AnyOperator {
             return Queries.newMatchNoDocsQuery("column does not exist in this index");
         }
         DataType<?> innerType = ArrayType.unnest(probe.valueType());
-        return EqOperator.termsQuery(columnName, (DataType) innerType, (List) values);
+        return EqOperator.termsQuery(columnName, innerType, values);
     }
 
     @Override

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -23,15 +23,20 @@ package io.crate.expression.operator;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.crate.testing.Asserts;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.QueryTester;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.metadata.doc.DocSysColumns;
 
 import java.util.List;
 
@@ -125,5 +130,11 @@ public class EqOperatorTest extends ScalarTestCase {
                 Asserts.assertThat(result.get(0)).asList().isEmpty();
             }
         }
+    }
+
+    @Test
+    public void test_terms_query_on__id_encodes_ids() throws Exception {
+        Query query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"));
+        assertThat(query.toString()).isEqualTo("_id:([7e 8a] [ff 62 61 72])");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes a regression introduced in 4.7.0 with https://github.com/crate/crate/pull/11814
In some cases this error does't surface because `IN ('literal-value',
...)` gets optimized to `Get` or `*ById` query plans. There are cases
where this optimization doesn't work.

This fixes https://github.com/crate/crate/issues/13217

(An alternative solution for the specific case in the issue is to extend the
`EqualityExtractor` to extract doc-keys for `IN (sub-query)`, but that's more
work and we need to fix the query generation anyways. There are also other
scenarios where the optimization wouldn't work and we generally should not
depend on optimizations for correct semantics)

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
