### PR TITLE
Fix `./gradlew :app:run` and `./gradlew :app:runDebug`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,5 @@ out/
 
 # Misc
 sandbox/crate/data/
+sandbox/crate/repo/
 **/antlr/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
             "request": "launch",
             "name": "Debug CrateDB",
             "args": "-Cpath.home=${workspaceFolder}/sandbox/crate",
+            "cwd": "${workspaceFolder}/app",
             "vmArgs": "-Xms2G -Xmx2G",
             "mainClass": "io.crate.bootstrap.CrateDB",
             "projectName": "app",
@@ -17,7 +18,8 @@
             "name": "Attach to CrateDB",
             "hostName": "127.0.0.1",
             "port": 5005,
-            "projectName": "app"
+            "projectName": "app",
+            "cwd": "${workspaceFolder}/app"
         }
     ]
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -303,8 +303,7 @@ task(runDebug, dependsOn: 'classes', type: JavaExec) {
     debug = true
     enableAssertions = true
     classpath = sourceSets.main.runtimeClasspath
-    systemProperties += ['es.path.home': "${rootDir}/sandbox/crate"]
-    systemProperties System.getProperties()
+    args = ["-Cpath.home=${rootDir}/sandbox/crate"]
 }
 
 task(run, dependsOn: 'classes', type: JavaExec) {
@@ -312,8 +311,7 @@ task(run, dependsOn: 'classes', type: JavaExec) {
     debug = false
     enableAssertions = true
     classpath = sourceSets.main.runtimeClasspath
-    systemProperties += ['es.path.home': "${rootDir}/sandbox/crate"]
-    systemProperties System.getProperties()
+    args = ["-Cpath.home=${rootDir}/sandbox/crate"]
 }
 
 task createCrateNodeScripts(type: CreateStartScripts) {

--- a/idea/crateApp.xml
+++ b/idea/crateApp.xml
@@ -3,7 +3,7 @@
   <option name="MAIN_CLASS_NAME" value="io.crate.bootstrap.CrateDB" />
   <option name="VM_PARAMETERS" value="-Dlog4j.shutdownHookEnabled=false -Dlog4j.skipJansi=true" />
   <option name="PROGRAM_PARAMETERS" value="-Cpath.home=$PROJECT_DIR$/sandbox/crate" />
-  <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
+  <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/app" />
   <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
   <option name="ALTERNATIVE_JRE_PATH" value="" />
   <option name="ENABLE_SWING_INSPECTOR" value="false" />

--- a/sandbox/crate/config/crate.yml
+++ b/sandbox/crate/config/crate.yml
@@ -5,11 +5,11 @@ network.host: _local_
 
 ssl.psql.enabled: false
 ssl.http.enabled: false
-ssl.keystore_filepath: ./server/src/test/resources/keystore.pcks12
+ssl.keystore_filepath: ../server/src/test/resources/keystore.pcks12 # working dir is ${PROJEC_DIR}/app
 ssl.keystore_password: keystorePassword
 ssl.keystore_key_password: keystorePassword
 
-path.repo: ./sandbox/crate/repo
+path.repo: ../sandbox/crate/repo # working dir is ${PROJEC_DIR}/app
 
 http.cors.enabled: true
 http.cors.allow-origin: "*"


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Replace the old `es.path.home` with cmd line `-Cpath.home` which also seems to solve an issue on mac_aarch64:
```
[2022-11-07T15:16:11,483][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [Großer Möseler] fatal error in thread [main], exiting
java.lang.NoClassDefFoundError: Could not initialize class jdk.internal.icu.text.NormalizerBase$NFCModeImpl
        at jdk.internal.icu.text.NormalizerBase$NFCMode.getNormalizer2(NormalizerBase.java:313) ~[?:?]
        at jdk.internal.icu.text.NormalizerBase.normalize(NormalizerBase.java:457) ~[?:?]
        at jdk.internal.icu.text.NormalizerBase.normalize(NormalizerBase.java:461) ~[?:?]
        at java.text.Normalizer.normalize(Normalizer.java:159) ~[?:?]
        at java.util.regex.Pattern.normalizeClazz(Pattern.java:1556) ~[?:?]
        at java.util.regex.Pattern.normalize(Pattern.java:1487) ~[?:?]
        at java.util.regex.Pattern.compile(Pattern.java:1760) ~[?:?]
        at java.util.regex.Pattern.<init>(Pattern.java:1445) ~[?:?]
        at java.util.regex.Pattern.compile(Pattern.java:1110) ~[?:?]
        at sun.nio.fs.MacOSXFileSystem.compilePathMatchPattern(MacOSXFileSystem.java:44) ~[?:?]
        at sun.nio.fs.UnixFileSystem.getPathMatcher(UnixFileSystem.java:302) ~[?:?]
        at java.nio.file.Files.newDirectoryStream(Files.java:543) ~[?:?]
        at org.elasticsearch.gateway.MetadataStateFormat.findMaxGenerationId(MetadataStateFormat.java:357) ~[crate-server.jar:?]
	...
```
Moreover, fix the `keystore` and `repo` paths in `crate.yml` to be relative to `${PROJECT_DIR}/app`, the working dir when running `./gradlew :app:run`, and adjust the `crate` debuging configuration in IntelliJ to use the same working path.
