### PR TITLE
Set `--enable-preview` in jvmArgs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -312,6 +312,7 @@ task(run, dependsOn: 'classes', type: JavaExec) {
     enableAssertions = true
     classpath = sourceSets.main.runtimeClasspath
     args = ["-Cpath.home=${rootDir}/sandbox/crate"]
+    jvmArgs = ["--enable-preview"]
 }
 
 task createCrateNodeScripts(type: CreateStartScripts) {

--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -96,6 +96,9 @@ if NOT "%CRATE_HEAP_DUMP_PATH%" == "" (
     set JAVA_OPTS=%JAVA_OPTS% -XX:HeapDumpPath=%CRATE_HEAP_DUMP_PATH%
 )
 
+REM See https://github.com/elastic/elasticsearch/issues/90526
+set JAVA_OPTS=%JAVA_OPTS% --enable-preview
+
 if "%CRATE_CLASSPATH%" == "" (
     set CRATE_CLASSPATH=%CRATE_HOME%/lib/*
 ) else (

--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -164,6 +164,8 @@ if [ "x$CRATE_HEAP_DUMP_PATH" != "x" ]; then
     JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$CRATE_HEAP_DUMP_PATH"
 fi
 
+# See https://github.com/elastic/elasticsearch/issues/90526
+JAVA_OPTS="$JAVA_OPTS --enable-preview"
 
 if [ "$(uname -s)" = "Darwin" ]; then
     JAVA="$CRATE_HOME/jdk/Contents/Home/bin/java"

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -78,6 +78,7 @@ tasks.withType(JavaCompile) {
     sourceCompatibility = jdks.runtime.major()
     targetCompatibility = jdks.runtime.major()
 }
+
 tasks.withType(JavaExec) {
     if (System.getProperty('useSystemJdk') == null) {
         executable = jdks.runtime.getBinJavaPath()
@@ -130,6 +131,7 @@ tasks.withType(Test) {
         test.dependsOn jdks.runtime
         test.executable = jdks.runtime.getBinJavaPath()
     }
+    jvmArgs = ["--enable-preview"]
 
     // by default `-D` arguments are "caught" in the gradle process
     // and not passed-through to the test process.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://github.com/elastic/elasticsearch/issues/90526 for context

If it causes problems we can still remove it again before the release

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
