### PR TITLE
Clear unused values of upert items once source is generated

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -95,3 +95,6 @@ Fixes
 
 - Fixed an issue that could generate duplicate data on ``COPY FROM``  while
   some internal retries were happening due to I/O errors e.g. socket timeouts.
+
+- Fixed an issue which could lead to a replica shard being marked as failed due
+  to a upsert request containing large update assignment expressions.

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -199,6 +199,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                         (e instanceof VersionConflictEngineException)));
             }
         }
+        request.moveToReplicaStage();
         return new WritePrimaryResult<>(request, shardResponse, translogLocation, null, indexShard);
     }
 
@@ -212,6 +213,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
 
     @Override
     protected WriteReplicaResult<ShardUpsertRequest> processRequestItemsOnReplica(IndexShard indexShard, ShardUpsertRequest request) throws IOException {
+        assert request.stage() == ShardUpsertRequest.Stage.REPLICA : "Expecting request to be on REPLICA stage";
         Translog.Location location = null;
         for (ShardUpsertRequest.Item item : request.items()) {
             if (item.source() == null) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Once the source of a upsert item is generated on the primary shard, all values used for this generation aren't needed anymore. Clearing them will reduce the request size.

This fixes an issue where the replica upsert request runs into the 2GB limitation of the BytesStreamOutput implementation leading into a as failed marked replica.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
