### PR TITLE
Add missing rst files to doc tests

### DIFF
--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -480,6 +480,7 @@ def load_tests(loader, suite, ignore):
                             'general/ddl/partitioned-tables.rst',
                             'general/builtins/arithmetic.rst',
                             'general/builtins/bit-operators.rst',
+                            'general/builtins/comparison-operators.rst',
                             'general/builtins/table-functions.rst',
                             'general/builtins/array-comparisons.rst',
                             'general/dql/selects.rst',

--- a/docs/general/builtins/comparison-operators.rst
+++ b/docs/general/builtins/comparison-operators.rst
@@ -77,12 +77,12 @@ When comparing dates, `ISO date formats`_ can be used::
     <sql-operator-invocation>` in any context. For example::
 
         cr> SELECT 1 < 10 as my_column;
-        +--------------+
-        | my_column    |
-        +--------------+
-        | true         |
-        +--------------+
-        SELECT 1 rows in set (... sec)
+        +-----------+
+        | my_column |
+        +-----------+
+        | TRUE      |
+        +-----------+
+        SELECT 1 row in set (... sec)
 
 .. _comparison-operators-where:
 


### PR DESCRIPTION
The following entries haven't been added as there are no queries or queries when output is not subject of "show-case" in those files:
```
'admin/ssl.rst',
'admin/udc.rst',
'admin/jobs-management.rst',
'admin/logical-replication.rst',
'admin/discovery.rst',
'admin/monitoring.rst'
```

I went through other files, it seems that only comparison-operators was skipped