### PR TITLE
Fix inefficient table swap in joins when expected rows are unavailable

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -93,6 +93,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed inefficient join optimizations on hash and nested-loop joins when
+  table statistics aren't available.
+
 - Fixed a race condition that could lead to a ``NullPointerException`` when
   using ``IS NULL`` on an object that was just added to a table.
 

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -124,7 +124,8 @@ public class HashJoin implements LogicalPlan {
 
         // We move smaller table to the right side since benchmarking
         // revealed that this improves performance in most cases.
-        if (lhs.numExpectedRows() < rhs.numExpectedRows()) {
+        boolean expectedRowsAvailable = lhs.numExpectedRows() != -1 && rhs.numExpectedRows() != -1;
+        if (expectedRowsAvailable && lhs.numExpectedRows() < rhs.numExpectedRows()) {
             leftLogicalPlan = rhs;
             rightLogicalPlan = lhs;
 
@@ -311,6 +312,9 @@ public class HashJoin implements LogicalPlan {
 
     @Override
     public long numExpectedRows() {
+        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
+            return -1;
+        }
         // We don't have any cardinality estimates, so just take the bigger table
         return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
     }

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -239,6 +239,9 @@ public class Union implements LogicalPlan {
 
     @Override
     public long numExpectedRows() {
+        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
+            return -1;
+        }
         return lhs.numExpectedRows() + rhs.numExpectedRows();
     }
 

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -21,13 +21,17 @@
 
 package io.crate.planner;
 
+import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT;
+import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -38,8 +42,13 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.LimitAndOffsetProjection;
+import io.crate.metadata.RelationName;
 import io.crate.planner.node.dql.Collect;
+import io.crate.planner.operators.LogicalPlanner;
 import io.crate.planner.operators.LogicalPlannerTest;
+import io.crate.planner.operators.Union;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -192,6 +201,32 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
             instanceOf(EvalProjection.class), // returns NULL
             instanceOf(EvalProjection.class)  // casts NULL to long to match `id`
         ));
+    }
+
+    @Test
+    public void test_union_returns_unknown_expected_rows_unknown_on_one_source_plan() {
+        String stmt = "select id from users union all select id from locations";
+        TableStats tableStats = new TableStats();
+        Map<RelationName, Stats> rowCountByTable = new HashMap<>();
+        rowCountByTable.put(USER_TABLE_IDENT, new Stats(-1, 0, Map.of()));
+        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(1, 0, Map.of()));
+        tableStats.updateTableStats(rowCountByTable);
+
+        var context = e.getPlannerContext(clusterService.state());
+        var logicalPlanner = new LogicalPlanner(
+            e.nodeCtx,
+            tableStats,
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
+        var plan = logicalPlanner.plan(e.analyze(stmt), context);
+        var union = (Union) plan.sources().get(0);
+        assertThat(union.numExpectedRows(), is(-1L));
+        rowCountByTable.put(USER_TABLE_IDENT, new Stats(1, 0, Map.of()));
+        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(-1, 0, Map.of()));
+        tableStats.updateTableStats(rowCountByTable);
+        plan = logicalPlanner.plan(e.analyze(stmt), context);
+        union = (Union) plan.sources().get(0);
+        assertThat(union.numExpectedRows(), is(-1L));
     }
 
 }

--- a/server/src/testFixtures/java/io/crate/analyze/TableDefinitions.java
+++ b/server/src/testFixtures/java/io/crate/analyze/TableDefinitions.java
@@ -130,6 +130,8 @@ public final class TableDefinitions {
         "  ))" +
         ")";
 
+    public static final RelationName TEST_DOC_LOCATIONS_TABLE_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "locations");
+
     public static final String TEST_DOC_LOCATIONS_TABLE_DEFINITION =
         "create table doc.locations (" +
         "  id bigint," +


### PR DESCRIPTION
Table stats are initialized with expected rows = -1. This can lead to wrong optimizations when used in Joins. The tables will be switched based on the number of expected rows and -1 may lead to the wrong table swap.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
