### PR TITLE
Add privileges for non-super users for DECLARE CURSOR

### DIFF
--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -46,6 +46,7 @@ import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateTableAs;
 import io.crate.analyze.AnalyzedCreateUser;
 import io.crate.analyze.AnalyzedDeallocate;
+import io.crate.analyze.AnalyzedDeclare;
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedDiscard;
 import io.crate.analyze.AnalyzedDropFunction;
@@ -261,6 +262,12 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         protected Void visitAnalyzedStatement(AnalyzedStatement analyzedStatement, User user) {
             throwRequiresSuperUserPermission(user.name());
+            return null;
+        }
+
+        @Override
+        public Void visitDeclare(AnalyzedDeclare declare, User user) {
+            declare.query().accept(this, user);
             return null;
         }
 

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -700,4 +700,10 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         analyze("ANALYZE", user);
         assertAskedForCluster(Privilege.Type.AL);
     }
+
+    @Test
+    public void test_declare_cursor_for_non_super_users() {
+        analyze("DECLARE this_cursor NO SCROLL CURSOR FOR SELECT * FROM sys.summits;", user);
+        assertAskedForTable(Privilege.Type.DQL, "sys.summits");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/13306

This leads to a follow-up, because `FETCH` is also just for super users available.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
