### PR TITLE
Make Symbol and DataType accountable

### DIFF
--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -322,6 +322,11 @@ public class EqualityExtractor {
             }
             return sb.toString();
         }
+
+        @Override
+        public long ramBytesUsed() {
+            return origin.ramBytesUsed();
+        }
     }
 
     static class ProxyInjectingVisitor extends SymbolVisitor<ProxyInjectingVisitor.Context, Symbol> {

--- a/server/src/main/java/io/crate/expression/symbol/Aggregation.java
+++ b/server/src/main/java/io/crate/expression/symbol/Aggregation.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -39,6 +40,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class Aggregation implements Symbol {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Aggregation.class);
 
     private final Signature signature;
     private final DataType<?> boundSignatureReturnType;
@@ -183,5 +186,15 @@ public class Aggregation implements Symbol {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + signature.ramBytesUsed()
+            + boundSignatureReturnType.ramBytesUsed()
+            + inputs.stream().mapToLong(Symbol::ramBytesUsed).sum()
+            + valueType.ramBytesUsed()
+            + filter.ramBytesUsed();
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/AliasSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/AliasSymbol.java
@@ -23,12 +23,16 @@ package io.crate.expression.symbol;
 
 import io.crate.expression.symbol.format.Style;
 import io.crate.types.DataType;
+
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
 public final class AliasSymbol implements Symbol {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(AliasSymbol.class);
 
     private final String alias;
     private final Symbol symbol;
@@ -80,6 +84,13 @@ public final class AliasSymbol implements Symbol {
     @Override
     public String toString(Style style) {
         return symbol.toString(style) + " AS " + alias;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + symbol.ramBytesUsed()
+            + RamUsageEstimator.sizeOf(alias);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/FetchMarker.java
+++ b/server/src/main/java/io/crate/expression/symbol/FetchMarker.java
@@ -24,6 +24,7 @@ package io.crate.expression.symbol;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.expression.symbol.format.Style;
@@ -95,5 +96,12 @@ public final class FetchMarker implements Symbol {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         fetchId.writeTo(out);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return fetchId.ramBytesUsed()
+            + RamUsageEstimator.sizeOf(relationName.schema())
+            + RamUsageEstimator.sizeOf(relationName.name());
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/FetchReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/FetchReference.java
@@ -85,4 +85,9 @@ public class FetchReference implements Symbol {
             + ref.toString(style)
             + ')';
     }
+
+    @Override
+    public long ramBytesUsed() {
+        return fetchId.ramBytesUsed() + ref.ramBytesUsed();
+    }
 }

--- a/server/src/main/java/io/crate/expression/symbol/FetchStub.java
+++ b/server/src/main/java/io/crate/expression/symbol/FetchStub.java
@@ -84,4 +84,9 @@ public final class FetchStub implements Symbol {
         throw new UnsupportedEncodingException(
             "Cannot stream FetchStub. This is a planning symbol and not suitable for the execution layer");
     }
+
+    @Override
+    public long ramBytesUsed() {
+        return ref.ramBytesUsed() + fetchMarker.ramBytesUsed();
+    }
 }

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -67,6 +68,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class Function implements Symbol, Cloneable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Function.class);
 
     private static final Map<String, String> ARITHMETIC_OPERATOR_MAPPING = Map.ofEntries(
         Map.entry(ArithmeticFunctions.Names.ADD, "+"),
@@ -173,6 +176,15 @@ public class Function implements Symbol, Cloneable {
             newDataType,
             null
         );
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + arguments.stream().mapToLong(Symbol::ramBytesUsed).sum()
+            + returnType.ramBytesUsed()
+            + (filter == null ? 0 : filter.ramBytesUsed())
+            + signature.ramBytesUsed();
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/InputColumn.java
+++ b/server/src/main/java/io/crate/expression/symbol/InputColumn.java
@@ -24,6 +24,8 @@ package io.crate.expression.symbol;
 import io.crate.expression.symbol.format.Style;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.IntegerType;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -136,4 +138,8 @@ public class InputColumn implements Symbol, Comparable<InputColumn> {
         return index;
     }
 
+    @Override
+    public long ramBytesUsed() {
+        return IntegerType.INTEGER_SIZE + dataType.ramBytesUsed();
+    }
 }

--- a/server/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/server/src/main/java/io/crate/expression/symbol/Literal.java
@@ -27,6 +27,8 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
+
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.joda.time.Period;
@@ -44,6 +46,8 @@ import java.util.Objects;
 
 
 public class Literal<T> implements Symbol, Input<T>, Comparable<Literal<T>> {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Literal.class);
 
     private final T value;
     private final DataType<T> type;
@@ -149,6 +153,11 @@ public class Literal<T> implements Symbol, Input<T>, Comparable<Literal<T>> {
     @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitLiteral(this, context);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + type.ramBytesUsed() + type.valueBytes(value);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/symbol/MatchPredicate.java
@@ -25,6 +25,8 @@ import io.crate.expression.symbol.format.Style;
 import io.crate.types.BooleanType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
+
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -88,6 +90,19 @@ public class MatchPredicate implements Symbol {
     @Override
     public String toString() {
         return toString(Style.UNQUALIFIED);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long bytes = 0L;
+        for (var entry : identBoostMap.entrySet()) {
+            bytes += entry.getKey().ramBytesUsed();
+            bytes += entry.getValue().ramBytesUsed();
+        }
+        return bytes
+            + queryTerm.ramBytesUsed()
+            + RamUsageEstimator.sizeOf(matchType)
+            + options.ramBytesUsed();
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/OuterColumn.java
+++ b/server/src/main/java/io/crate/expression/symbol/OuterColumn.java
@@ -93,4 +93,9 @@ public final class OuterColumn implements Symbol {
     public String toString(Style style) {
         return symbol.toString(style);
     }
+
+    @Override
+    public long ramBytesUsed() {
+        return symbol.ramBytesUsed();
+    }
 }

--- a/server/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
@@ -25,6 +25,7 @@ import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.symbol.format.Style;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.IntegerType;
 import io.crate.types.UndefinedType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -104,5 +105,10 @@ public class ParameterSymbol implements Symbol {
 
     public int index() {
         return index;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return IntegerType.INTEGER_SIZE + internalType.ramBytesUsed();
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/ScopedSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/ScopedSymbol.java
@@ -131,4 +131,9 @@ public final class ScopedSymbol implements Symbol {
         result = 31 * result + dataType.hashCode();
         return result;
     }
+
+    @Override
+    public long ramBytesUsed() {
+        return dataType.ramBytesUsed();
+    }
 }

--- a/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
@@ -23,6 +23,7 @@ package io.crate.expression.symbol;
 
 import java.io.IOException;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -34,6 +35,8 @@ import io.crate.types.DataType;
  * Symbol representing a sub-query
  */
 public class SelectSymbol implements Symbol {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(SelectSymbol.class);
 
     private final AnalyzedRelation relation;
     private final ArrayType<?> dataType;
@@ -111,5 +114,12 @@ public class SelectSymbol implements Symbol {
 
     public ResultType getResultType() {
         return resultType;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // Missing the size of the relation, but SelectSymbol isn't used inplaces
+        // where we batch a large amount of symbols, so this should be good enough.
+        return SHALLOW_SIZE + dataType.ramBytesUsed();
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -30,9 +30,10 @@ import io.crate.types.DataTypes;
 
 import java.util.Objects;
 
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.io.stream.Writeable;
 
-public interface Symbol extends Writeable {
+public interface Symbol extends Writeable, Accountable {
 
     public static boolean isLiteral(Symbol symbol, DataType<?> expectedType) {
         return symbol.symbolType() == SymbolType.LITERAL && symbol.valueType().equals(expectedType);

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -34,6 +34,8 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -44,8 +46,9 @@ import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.sql.Identifiers;
 import io.crate.sql.tree.QualifiedName;
 
-public class ColumnIdent implements Comparable<ColumnIdent> {
+public class ColumnIdent implements Comparable<ColumnIdent>, Accountable {
 
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ColumnIdent.class);
     private static final Pattern UNDERSCORE_PATTERN = Pattern.compile("^_([a-z][_a-z]*)*[a-z]$");
     private static final Pattern SUBSCRIPT_PATTERN = Pattern.compile("^\\w+(\\[[^\\]]+\\])+");
 
@@ -433,5 +436,12 @@ public class ColumnIdent implements Comparable<ColumnIdent> {
         } else {
             return new ColumnIdent(name, Lists2.concat(path, childName));
         }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + RamUsageEstimator.sizeOf(name)
+            + path.stream().mapToLong(RamUsageEstimator::sizeOf).sum();
     }
 }

--- a/server/src/main/java/io/crate/metadata/FunctionName.java
+++ b/server/src/main/java/io/crate/metadata/FunctionName.java
@@ -28,11 +28,14 @@ import javax.annotation.Nullable;
 
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-public final class FunctionName implements Writeable {
+public final class FunctionName implements Writeable, Accountable {
 
     @Nullable
     private final String schema;
@@ -50,6 +53,12 @@ public final class FunctionName implements Writeable {
     public FunctionName(StreamInput in) throws IOException {
         schema = in.readOptionalString();
         name = in.readString();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return (schema == null ? 0 : RamUsageEstimator.sizeOf(schema))
+            + RamUsageEstimator.sizeOf(name);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -43,8 +44,11 @@ import io.crate.types.DataType;
 
 public class GeneratedReference implements Reference {
 
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(GeneratedReference.class);
+
     private final Reference ref;
     private final String formattedGeneratedExpression;
+    @Nullable
     private Symbol generatedExpression;
     private List<Reference> referencedReferences = List.of();
 
@@ -226,5 +230,14 @@ public class GeneratedReference implements Reference {
             formattedGeneratedExpression,
             generatedExpression
         );
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + ref.ramBytesUsed()
+            + RamUsageEstimator.sizeOf(formattedGeneratedExpression)
+            + (generatedExpression == null ? 0 : generatedExpression.ramBytesUsed())
+            + referencedReferences.stream().mapToLong(Reference::ramBytesUsed).sum();
     }
 }

--- a/server/src/main/java/io/crate/metadata/ReferenceIdent.java
+++ b/server/src/main/java/io/crate/metadata/ReferenceIdent.java
@@ -21,6 +21,8 @@
 
 package io.crate.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -30,7 +32,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
-public class ReferenceIdent {
+public final class ReferenceIdent implements Accountable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ReferenceIdent.class);
 
     private final RelationName relationName;
     private final ColumnIdent columnIdent;
@@ -87,5 +91,12 @@ public class ReferenceIdent {
     public void writeTo(StreamOutput out) throws IOException {
         columnIdent.writeTo(out);
         relationName.writeTo(out);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + relationName.ramBytesUsed()
+            + columnIdent.ramBytesUsed();
     }
 }

--- a/server/src/main/java/io/crate/metadata/RelationName.java
+++ b/server/src/main/java/io/crate/metadata/RelationName.java
@@ -30,6 +30,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -44,9 +46,10 @@ import io.crate.sql.Identifiers;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
 
-public final class RelationName implements Writeable {
+public final class RelationName implements Writeable, Accountable {
 
     private static final Set<String> INVALID_NAME_CHARACTERS = Set.of(".");
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(RelationName.class);
 
     @Nullable
     private final String schema;
@@ -225,5 +228,12 @@ public final class RelationName implements Writeable {
         int result = schema != null ? schema.hashCode() : 0;
         result = 31 * result + name.hashCode();
         return result;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + RamUsageEstimator.sizeOf(schema)
+            + RamUsageEstimator.sizeOf(name);
     }
 }

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -40,6 +41,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class SimpleReference implements Reference {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(SimpleReference.class);
 
     protected DataType<?> type;
 
@@ -266,5 +269,13 @@ public class SimpleReference implements Reference {
         if (hasDefaultExpression) {
             Symbols.toStream(defaultExpression, out);
         }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE
+            + type.ramBytesUsed()
+            + ident.ramBytesUsed()
+            + (defaultExpression == null ? 0 : defaultExpression.ramBytesUsed());
     }
 }

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -44,8 +45,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.locationtech.spatial4j.shape.Point;
-
-import com.carrotsearch.hppc.RamUsageEstimator;
 
 import io.crate.Streamer;
 import io.crate.common.collections.Lists2;
@@ -63,6 +62,8 @@ import io.crate.sql.tree.Expression;
  * A type which contains a collection of elements of another type.
  */
 public class ArrayType<T> extends DataType<List<T>> {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ArrayType.class);
 
     public static final String NAME = "array";
     public static final int ID = 100;
@@ -337,8 +338,9 @@ public class ArrayType<T> extends DataType<List<T>> {
             }
             size--;
             ArrayList<T> values = new ArrayList<>(size);
+            Streamer<T> streamer = innerType.streamer();
             for (int i = 0; i < size; i++) {
-                values.add(innerType.streamer().readValueFrom(in));
+                values.add(streamer.readValueFrom(in));
             }
             return values;
         }
@@ -351,8 +353,9 @@ public class ArrayType<T> extends DataType<List<T>> {
                 return;
             }
             out.writeVInt(values.size() + 1);
+            Streamer<T> streamer = innerType.streamer();
             for (T value : values) {
-                innerType.streamer().writeValueTo(out, value);
+                streamer.writeValueTo(out, value);
             }
         }
     }
@@ -381,5 +384,10 @@ public class ArrayType<T> extends DataType<List<T>> {
             bytes += innerType.valueBytes(value);
         }
         return bytes;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + innerType.ramBytesUsed();
     }
 }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
@@ -40,7 +41,7 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
-public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable, Comparator<T> {
+public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable, Comparator<T>, Accountable {
 
     /**
      * Type precedence ids which help to decide when a type can be cast
@@ -239,4 +240,10 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      * Return the number of bytes used to represent the value
      */
     public abstract long valueBytes(@Nullable T value);
+
+    @Override
+    public long ramBytesUsed() {
+        // Most DataType's are singleton instances
+        return 0L;
+    }
 }

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -355,4 +355,16 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         }
         return RamUsageEstimator.sizeOfMap(value);
     }
+
+    @Override
+    public long ramBytesUsed() {
+        long bytes = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER; // innerTypes field
+        for (var entry : innerTypes.entrySet()) {
+            String childName = entry.getKey();
+            DataType<?> childType = entry.getValue();
+            bytes += RamUsageEstimator.sizeOf(childName);
+            bytes += childType.ramBytesUsed();
+        }
+        return bytes;
+    }
 }

--- a/server/src/main/java/io/crate/types/TypeSignature.java
+++ b/server/src/main/java/io/crate/types/TypeSignature.java
@@ -22,6 +22,8 @@
 package io.crate.types;
 
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -34,7 +36,7 @@ import java.util.Objects;
 
 import io.crate.signatures.TypeSignatureParser;
 
-public class TypeSignature implements Writeable {
+public class TypeSignature implements Writeable, Accountable {
 
     /**
      * Creates a type signature out of the given signature string.
@@ -91,6 +93,12 @@ public class TypeSignature implements Writeable {
         for (int i = 0; i < numParams; i++) {
             parameters.add(fromStream(in));
         }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.sizeOf(baseTypeName)
+            + parameters.stream().mapToLong(TypeSignature::ramBytesUsed).sum();
     }
 
     public String getBaseTypeName() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Symbol instances can grow large due to large function trees,
or due to ObjectType instances with many keys. Not accounting for them
can cause memory issues.

This adds `Accountable` implementations for both `DataType` and `Symbol`
to enable us to account for them in some places where we accumulate
large number of instances for batching

This is a pre-requisite for https://github.com/crate/crate/pull/13290

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
