### PR TITLE
  Adapt privileges for DECLARE

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -104,6 +104,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed privileges for :ref:`DECLARE <sql-declare>` for cursors to make it
+  accessible for non-super-users. All users can declare cursors as long as they
+  have the required permissions for the query used within ``DECLARE``.
+
 - Added dynamic bulk sizing for update by query or delete by query operations to
   reduce memory pressure and fix out of memory errors when running update
   statements with large assignment expressions.

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -34,6 +34,7 @@ import io.crate.analyze.AnalyzedAlterTableRename;
 import io.crate.analyze.AnalyzedAlterUser;
 import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
+import io.crate.analyze.AnalyzedClose;
 import io.crate.analyze.AnalyzedCommit;
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.AnalyzedCopyTo;
@@ -46,6 +47,7 @@ import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateTableAs;
 import io.crate.analyze.AnalyzedCreateUser;
 import io.crate.analyze.AnalyzedDeallocate;
+import io.crate.analyze.AnalyzedDeclare;
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedDiscard;
 import io.crate.analyze.AnalyzedDropFunction;
@@ -54,6 +56,7 @@ import io.crate.analyze.AnalyzedDropSnapshot;
 import io.crate.analyze.AnalyzedDropTable;
 import io.crate.analyze.AnalyzedDropUser;
 import io.crate.analyze.AnalyzedDropView;
+import io.crate.analyze.AnalyzedFetch;
 import io.crate.analyze.AnalyzedGCDanglingArtifacts;
 import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.AnalyzedKill;
@@ -261,6 +264,25 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         protected Void visitAnalyzedStatement(AnalyzedStatement analyzedStatement, User user) {
             throwRequiresSuperUserPermission(user.name());
+            return null;
+        }
+
+        @Override
+        public Void visitDeclare(AnalyzedDeclare declare, User user) {
+            declare.query().accept(this, user);
+            return null;
+        }
+
+        @Override
+        public Void visitFetch(AnalyzedFetch fetch, User user) {
+            // We always allow to fetch. The privileges are checked through `Declare` when the user creates the cursor.
+            return null;
+        }
+
+        @Override
+        public Void visitClose(AnalyzedClose close, User user) {
+            // We always allow to close a cursor. The privileges are checked through `Declare` when the user creates
+            // the cursor.
             return null;
         }
 


### PR DESCRIPTION
Privieges for DECLARE are adapted that they are depending on
the privileges of the user for the related query.  

Fixes https://github.com/crate/crate/issues/13306


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
