### PR TITLE
Remove empty ShardRequest constructor

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ShardRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/ShardRequest.java
@@ -45,17 +45,14 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ShardRequest.class);
 
-    private UUID jobId;
+    private final UUID jobId;
     protected List<I> items;
-
-    public ShardRequest() {
-    }
 
     public ShardRequest(ShardId shardId, UUID jobId) {
         setShardId(shardId);
         this.jobId = jobId;
         this.index = shardId.getIndexName();
-        items = new ArrayList<>();
+        this.items = new ArrayList<>();
     }
 
     public void add(int location, I item) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The empty constructor should never be used

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
