### PR TITLE
Implement `SUM()` on `INTERVAL`s

### DIFF
--- a/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.aggregation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.joda.time.Period;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.crate.breaker.RamAccounting;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.execution.engine.aggregation.AggregateCollector;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
+import io.crate.execution.engine.aggregation.impl.IntervalSumAggregation;
+import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Literal;
+import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.Functions;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2)
+@Fork(value = 2)
+@State(Scope.Benchmark)
+public class IntervalAggregationBenchmark {
+
+    private final List<Row> rows = IntStream.range(0, 10_000)
+        .mapToObj(i -> {
+            int mod = i % 3;
+            if (mod == 0) {
+                return new Row1(Period.minutes(i).withSeconds(i + 1));
+            } else if (mod == 1) {
+                return new Row1(Period.hours(i).withMinutes(i + 1).withSeconds(i + 2));
+            } else {
+                return new Row1(Period.days(i).withHours(i + 1).withMinutes(i + 2).withSeconds(i + 3));
+            }
+        }).collect(Collectors.toList());
+
+    private OnHeapMemoryManager onHeapMemoryManager;
+    private AggregateCollector onHeapCollector;
+
+    @Setup
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        final InputCollectExpression inExpr0 = new InputCollectExpression(0);
+        Functions functions = new ModulesBuilder()
+            .add(new AggregationImplModule())
+            .createInjector().getInstance(Functions.class);
+
+        final IntervalSumAggregation intervalSumAggregation = (IntervalSumAggregation) functions.getQualified(
+                Signature.aggregate(
+                    IntervalSumAggregation.NAME,
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature()),
+                List.of(DataTypes.INTERVAL),
+                DataTypes.INTERVAL
+            );
+
+        onHeapMemoryManager = new OnHeapMemoryManager(bytes -> {});
+        onHeapCollector = new AggregateCollector(
+            Collections.singletonList(inExpr0),
+            RamAccounting.NO_ACCOUNTING,
+            onHeapMemoryManager,
+            Version.CURRENT,
+            AggregateMode.ITER_FINAL,
+            new AggregationFunction[] { intervalSumAggregation },
+            Version.CURRENT,
+            new Input[][] { { inExpr0 } },
+            new Input[] { Literal.BOOLEAN_TRUE }
+        );
+    }
+
+    @TearDown
+    public void tearDown() {
+        onHeapMemoryManager.close();
+    }
+
+    @Benchmark
+    public Iterable<Row> benchmarkIntervalAggregation() {
+        Object[] state = onHeapCollector.supplier().get();
+        BiConsumer<Object[], Row> accumulator = onHeapCollector.accumulator();
+        Function<Object[], Iterable<Row>> finisher = onHeapCollector.finisher();
+        for (int i = 0; i < rows.size(); i++) {
+            accumulator.accept(state, rows.get(i));
+        }
+        return finisher.apply(state);
+    }
+}

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -60,6 +60,10 @@ None
 
 Changes
 =======
+- Added support for ``SUM()`` aggregations on ``INTERVAL`` type. e.g.::
+
+    SELECT SUM(tsEnd - tsStart) FROM test
+
 
 - Exposed the ``require``, ``include`` and ``exclude`` ``routing.allocation``
   settings per partition within ``information_schema.table_partitions``.

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -695,8 +695,9 @@ in this implementation:
 ---------------
 
 Returns the sum of a set of numeric input values that are not ``NULL``.
-Depending on the argument type a suitable return type is chosen. For ``real``
-and ``double precison`` argument types the return type is equal to the argument
+Depending on the argument type a suitable return type is chosen. For
+``interval`` argument types the return type is ``interval``. For ``real`` and
+``double precision`` argument types the return type is equal to the argument
 type. For ``byte``, ``smallint``, ``integer`` and ``bigint`` the return type
 changes to ``bigint``. If the range of ``bigint`` values (-2^64 to 2^64-1) gets
 exceeded an ``ArithmeticException`` will be raised.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -72,7 +72,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     public abstract TPartial iterate(RamAccounting ramAccounting,
                                      MemoryManager memoryManager,
                                      TPartial state,
-                                     Input... args)
+                                     Input<?>... args)
         throws CircuitBreakingException;
 
     /**
@@ -113,7 +113,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
 
     public TPartial removeFromAggregatedState(RamAccounting ramAccounting,
                                               TPartial previousAggState,
-                                              Input[] stateToRemove) {
+                                              Input<?>[] stateToRemove) {
         throw new UnsupportedOperationException("Cannot remove state from the aggregated state as the function is " +
                                                 "not removable cumulative");
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/AggregationImplModule.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/AggregationImplModule.java
@@ -37,6 +37,7 @@ public class AggregationImplModule extends AbstractFunctionModule<AggregationFun
         ArbitraryAggregation.register(this);
         CmpByAggregation.register(this);
 
+        IntervalSumAggregation.register(this);
         SumAggregation.register(this);
         NumericSumAggregation.register(this);
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -112,7 +112,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     public Object iterate(RamAccounting ramAccounting,
                           MemoryManager memoryManager,
                           Object state,
-                          Input... args) {
+                          Input<?>... args) {
         return reduce(ramAccounting, state, args[0].value());
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -86,7 +86,7 @@ public final class ArrayAgg extends AggregationFunction<List<Object>, List<Objec
     public List<Object> iterate(RamAccounting ramAccounting,
                                 MemoryManager memoryManager,
                                 List<Object> state,
-                                Input... args) throws CircuitBreakingException {
+                                Input<?>... args) throws CircuitBreakingException {
         var value = args[0].value();
         ramAccounting.addBytes(elementType.valueBytes(value));
         state.add(value);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -207,7 +207,7 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
     public CompareBy iterate(RamAccounting ramAccounting,
                              MemoryManager memoryManager,
                              CompareBy state,
-                             Input... args) throws CircuitBreakingException {
+                             Input<?>... args) throws CircuitBreakingException {
         Object cmpVal = args[1].value();
 
         if (cmpVal instanceof Comparable comparable) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -97,7 +97,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
     public Map<Object, Object> iterate(RamAccounting ramAccounting,
                                        MemoryManager memoryManager,
                                        Map<Object, Object> state,
-                                       Input... args) throws CircuitBreakingException {
+                                       Input<?>... args) throws CircuitBreakingException {
         Object value = args[0].value();
         if (value == null) {
             return state;
@@ -191,7 +191,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
         @Override
         public Map<Object, Long> iterate(RamAccounting ramAccounting,
                                          MemoryManager memoryManager, Map<Object, Long> state,
-                                         Input... args) throws CircuitBreakingException {
+                                         Input<?>... args) throws CircuitBreakingException {
             Object value = args[0].value();
             if (value == null) {
                 return state;
@@ -227,7 +227,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
         @Override
         public Map<Object, Long> removeFromAggregatedState(RamAccounting ramAccounting,
                                                            Map<Object, Long> previousAggState,
-                                                           Input[] stateToRemove) {
+                                                           Input<?>[]stateToRemove) {
             Object value = stateToRemove[0].value();
             if (value == null) {
                 return previousAggState;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -112,7 +112,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     public MutableLong iterate(RamAccounting ramAccounting,
                                MemoryManager memoryManager,
                                MutableLong state,
-                               Input... args) {
+                               Input<?>... args) {
         if (!hasArgs || args[0].value() != null) {
             return state.add(1L);
         }
@@ -242,7 +242,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     @Override
     public MutableLong removeFromAggregatedState(RamAccounting ramAccounting,
                                                  MutableLong previousAggState,
-                                                 Input[] stateToRemove) {
+                                                 Input<?>[]stateToRemove) {
         if (!hasArgs || stateToRemove[0].value() != null) {
             return previousAggState.sub(1L);
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -239,7 +239,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     public GeometricMeanState iterate(RamAccounting ramAccounting,
                                       MemoryManager memoryManager,
                                       GeometricMeanState state,
-                                      Input... args) throws CircuitBreakingException {
+                                      Input<?>... args) throws CircuitBreakingException {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -274,7 +274,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     @Override
     public GeometricMeanState removeFromAggregatedState(RamAccounting ramAccounting,
                                                         GeometricMeanState previousAggState,
-                                                        Input[] stateToRemove) {
+                                                        Input<?>[]stateToRemove) {
         if (previousAggState != null) {
             Number value = (Number) stateToRemove[0].value();
             if (value != null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.joda.time.Period;
+
+import io.crate.breaker.RamAccounting;
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.data.Input;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.symbol.Literal;
+import io.crate.memory.MemoryManager;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+public class IntervalSumAggregation extends AggregationFunction<Period, Period> {
+
+    public static final String NAME = "sum";
+
+    public static void register(AggregationImplModule mod) {
+        mod.register(
+            Signature.aggregate(
+                NAME,
+                DataTypes.INTERVAL.getTypeSignature(),
+                DataTypes.INTERVAL.getTypeSignature()),
+            IntervalSumAggregation::new
+        );
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+    private final int bytesSize;
+
+    @VisibleForTesting
+    private IntervalSumAggregation(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        this.bytesSize = DataTypes.INTERVAL.fixedSize();
+    }
+
+    @Nullable
+    @Override
+    public Period newState(RamAccounting ramAccounting,
+                      Version indexVersionCreated,
+                      Version minNodeInCluster,
+                      MemoryManager memoryManager) {
+        ramAccounting.addBytes(bytesSize);
+        return null;
+    }
+
+    @Override
+    public Period iterate(RamAccounting ramAccounting,
+                          MemoryManager memoryManager,
+                          Period state,
+                          Input<?>[] args) throws CircuitBreakingException {
+        return reduce(ramAccounting, state, DataTypes.INTERVAL.sanitizeValue(args[0].value()));
+    }
+
+    @Override
+    public Period reduce(RamAccounting ramAccounting, Period state1, Period state2) {
+        if (state1 == null) {
+            return state2;
+        }
+        if (state2 == null) {
+            return state1;
+        }
+        return state1.plus(state2);
+    }
+
+    @Override
+    public Period terminatePartial(RamAccounting ramAccounting, Period state) {
+        return state;
+    }
+
+    @Override
+    public DataType<?> partialType() {
+        return boundSignature.returnType();
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public boolean isRemovableCumulative() {
+        return true;
+    }
+
+    @Override
+    public Period removeFromAggregatedState(RamAccounting ramAccounting,
+                                            Period previousAggState,
+                                            Input<?>[] stateToRemove) {
+        return previousAggState.minus(DataTypes.INTERVAL.sanitizeValue(stateToRemove[0].value()));
+    }
+
+    @Nullable
+    @Override
+    public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
+                                                       List<Reference> aggregationReferences,
+                                                       DocTableInfo table,
+                                                       List<Literal<?>> optionalParams) {
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -332,7 +332,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
     public Comparable iterate(RamAccounting ramAccounting,
                               MemoryManager memoryManager,
                               Comparable state,
-                              Input... args) throws CircuitBreakingException {
+                              Input<?>... args) throws CircuitBreakingException {
         Object value = args[0].value();
         return reduce(ramAccounting, state, (Comparable) value);
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -337,7 +337,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
     public Comparable iterate(RamAccounting ramAccounting,
                               MemoryManager memoryManager,
                               Comparable state,
-                              Input... args) throws CircuitBreakingException {
+                              Input<?>... args) throws CircuitBreakingException {
         return reduce(ramAccounting, state, (Comparable) args[0].value());
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -106,7 +106,7 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
     public BigDecimal iterate(RamAccounting ramAccounting,
                               MemoryManager memoryManager,
                               BigDecimal state,
-                              Input[] args) throws CircuitBreakingException {
+                              Input<?>[]args) throws CircuitBreakingException {
         BigDecimal value = returnType.implicitCast(args[0].value());
         if (value != null) {
             if (state != null) {
@@ -164,7 +164,7 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
     @Override
     public BigDecimal removeFromAggregatedState(RamAccounting ramAccounting,
                                                 BigDecimal previousAggState,
-                                                Input[] stateToRemove) {
+                                                Input<?>[]stateToRemove) {
         BigDecimal value = returnType.implicitCast(stateToRemove[0].value());
         if (value != null) {
             if (previousAggState != null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -101,7 +101,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
     public TDigestState iterate(RamAccounting ramAccounting,
                                 MemoryManager memoryManager,
                                 TDigestState state,
-                                Input... args) throws CircuitBreakingException {
+                                Input<?>... args) throws CircuitBreakingException {
         if (state.isEmpty()) {
             Object fractionValue = args[1].value();
             initState(state, fractionValue, ramAccounting);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -170,7 +170,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     public StandardDeviation iterate(RamAccounting ramAccounting,
                                      MemoryManager memoryManager,
                                      StandardDeviation state,
-                                     Input... args) throws CircuitBreakingException {
+                                     Input<?>... args) throws CircuitBreakingException {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -200,7 +200,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     @Override
     public StandardDeviation removeFromAggregatedState(RamAccounting ramAccounting,
                                                        StandardDeviation previousAggState,
-                                                       Input[] stateToRemove) {
+                                                       Input<?>[]stateToRemove) {
         if (previousAggState != null) {
             Number value = (Number) stateToRemove[0].value();
             if (value != null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -162,7 +162,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     public StringAggState iterate(RamAccounting ramAccounting,
                                   MemoryManager memoryManager,
                                   StringAggState state,
-                                  Input... args) throws CircuitBreakingException {
+                                  Input<?>... args) throws CircuitBreakingException {
         String expression = (String) args[0].value();
         if (expression == null) {
             return state;
@@ -189,7 +189,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     @Override
     public StringAggState removeFromAggregatedState(RamAccounting ramAccounting,
                                                     StringAggState previousAggState,
-                                                    Input[] stateToRemove) {
+                                                    Input<?>[]stateToRemove) {
         String expression = (String) stateToRemove[0].value();
         if (expression == null) {
             return previousAggState;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -141,7 +141,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     public T iterate(RamAccounting ramAccounting,
                      MemoryManager memoryManager,
                      T state,
-                     Input[] args) throws CircuitBreakingException {
+                     Input<?>[] args) throws CircuitBreakingException {
         return reduce(ramAccounting, state, returnType.sanitizeValue(args[0].value()));
     }
 
@@ -182,7 +182,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     }
 
     @Override
-    public T removeFromAggregatedState(RamAccounting ramAccounting, T previousAggState, Input[] stateToRemove) {
+    public T removeFromAggregatedState(RamAccounting ramAccounting, T previousAggState, Input<?>[] stateToRemove) {
         return subtraction.apply(previousAggState, returnType.sanitizeValue(stateToRemove[0].value()));
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -160,7 +160,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     public Variance iterate(RamAccounting ramAccounting,
                             MemoryManager memoryManager,
                             Variance state,
-                            Input... args) throws CircuitBreakingException {
+                            Input<?>... args) throws CircuitBreakingException {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -190,7 +190,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     @Override
     public Variance removeFromAggregatedState(RamAccounting ramAccounting,
                                               Variance previousAggState,
-                                              Input[] stateToRemove) {
+                                              Input<?>[]stateToRemove) {
         if (previousAggState != null) {
             Number value = (Number) stateToRemove[0].value();
             if (value != null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -233,7 +233,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     public AverageState iterate(RamAccounting ramAccounting,
                                 MemoryManager memoryManager,
                                 AverageState state,
-                                Input... args) {
+                                Input<?>... args) {
         if (state != null) {
             Number value = (Number) args[0].value();
             if (value != null) {
@@ -251,7 +251,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     @Override
     public AverageState removeFromAggregatedState(RamAccounting ramAccounting,
                                                   AverageState previousAggState,
-                                                  Input[] stateToRemove) {
+                                                  Input<?>[]stateToRemove) {
         if (previousAggState != null) {
             Number value = (Number) stateToRemove[0].value();
             if (value != null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -116,7 +116,7 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
     public NumericAverageState iterate(RamAccounting ramAccounting,
                               MemoryManager memoryManager,
                               NumericAverageState state,
-                              Input[] args) throws CircuitBreakingException {
+                              Input<?>[]args) throws CircuitBreakingException {
         if (state != null) {
             BigDecimal value = returnType.implicitCast(args[0].value());
             if (value != null) {
@@ -175,7 +175,7 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
     @Override
     public NumericAverageState removeFromAggregatedState(RamAccounting ramAccounting,
                                                          NumericAverageState previousAggState,
-                                                         Input[] stateToRemove) {
+                                                         Input<?>[]stateToRemove) {
         if (previousAggState != null) {
             BigDecimal value = returnType.implicitCast(stateToRemove[0].value());
             if (value != null) {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.elasticsearch.Version;
+import org.joda.time.Period;
 import org.junit.Test;
 
 import io.crate.execution.engine.aggregation.AggregationFunction;
@@ -164,6 +165,29 @@ public class SumAggregationTest extends AggregationTestCase {
         Object result = executeAggregation(DataTypes.BYTE, DataTypes.LONG, new Object[][]{{(byte) 7}, {(byte) 3}});
 
         assertEquals(10L, result);
+    }
+
+    @Test
+    public void testInterval() {
+        assertEquals(
+            Period.days(8).withHours(19).withMinutes(22).withSeconds(13).withMillis(667),
+            execPartialAggregationWithoutDocValues(
+                (IntervalSumAggregation) nodeCtx.functions().getQualified(
+                    Signature.aggregate(
+                        IntervalSumAggregation.NAME,
+                        DataTypes.INTERVAL.getTypeSignature(),
+                        DataTypes.INTERVAL.getTypeSignature()),
+                    List.of(DataTypes.INTERVAL),
+                    DataTypes.INTERVAL
+                ),
+                new Object[][]{
+                    {Period.days(6).withHours(12).withSeconds(10)},
+                    {Period.hours(3).withMinutes(2).withMillis(123)},
+                    {Period.minutes(20).withSeconds(3).withMillis(321)},
+                    {Period.days(2).withHours(4).withMillis(223)}},
+                true,
+                Version.CURRENT
+            ));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 
 public class AggregateExpressionIntegrationTest extends IntegTestCase {
 
@@ -66,6 +67,24 @@ public class AggregateExpressionIntegrationTest extends IntegTestCase {
         execute("select min_by(name, x) from tbl");
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
             "foo\n"
+        );
+    }
+
+    @Test
+    @UseJdbc(0) // Deterministic output format of INTERVAL
+    public void test_sum_interval() {
+        execute(
+            """
+                SELECT SUM(col1) FROM (SELECT
+                unnest(
+                [
+                    INTERVAL '6 years 5 mons' YEAR TO MONTH,
+                    INTERVAL '4 days 3 hours' DAY TO HOUR,
+                    INTERVAL '45.123']) AS col1) AS t
+            """);
+        assertThat(
+            TestingHelpers.printedTable(response.rows()),
+            is("P6Y5M4DT3H45.123S\n")
         );
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Avoid warnings for raw types in aggregation functions
- Add support for `SUM()` aggragation on `INTERVAL` types

Closes: #12480

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
