### PR TITLE
Change subtraction of timestamps to return `INTERVAL`s

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -52,6 +52,33 @@ Breaking Changes
   Docker, or via a service manager like ``systemd`` where these options are not
   required.
 
+- Subtraction of timestamps was returning their difference in milliseconds, but
+  with result type ``TIMESTAMP`` which was wrong and led to issues with several
+  PostgreSQL compliant clients. Instead of just fixing the result type, and
+  change it to ``LONG``, the subtraction of timestamps was changed to return an
+  ``INTERVAL`` and be compliant with PostgreSQL behaviour.
+
+  Before::
+
+    SELECT '2022-12-05T11:22:33.123456789'::timestamp - '2022-11-21T10:11:22.0012334'::timestamp;
+    +-----------------------+
+    | 1213871122::timestamp |
+    +-----------------------+
+    |            1213871122 |
+    +-----------------------+
+
+
+  After::
+
+    SELECT '2022-12-05T11:22:33.123456789'::timestamp - '2022-11-21T10:11:22.0012334'::timestamp;
+    +------------------------------+
+    | 'PT337H11M11.122S'::interval |
+    +------------------------------+
+    | 337:11:11.122                |
+    +------------------------------+
+
+
+
 Deprecations
 ============
 

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -37,6 +37,7 @@ import io.crate.expression.scalar.arithmetic.RadiansDegreesFunctions;
 import io.crate.expression.scalar.arithmetic.RandomFunction;
 import io.crate.expression.scalar.arithmetic.RoundFunction;
 import io.crate.expression.scalar.arithmetic.SquareRootFunction;
+import io.crate.expression.scalar.arithmetic.SubtractTimestampScalar;
 import io.crate.expression.scalar.arithmetic.TrigonometricFunctions;
 import io.crate.expression.scalar.arithmetic.TruncFunction;
 import io.crate.expression.scalar.bitwise.BitwiseFunctions;
@@ -111,6 +112,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
 
         ArithmeticFunctions.register(this);
         BitwiseFunctions.register(this);
+        SubtractTimestampScalar.register(this);
         IntervalTimestampArithmeticScalar.register(this);
         IntervalArithmeticScalar.register(this);
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -135,17 +135,29 @@ public class ArithmeticFunctions {
                 (signature, boundSignature) ->
                     new BinaryScalar<>(op.integerFunction, signature, boundSignature, DataTypes.INTEGER)
             );
-            for (var type : List.of(DataTypes.LONG, DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
-                module.register(
-                    Signature.scalar(
-                        op.toString(),
-                        type.getTypeSignature(),
-                        type.getTypeSignature(),
-                        type.getTypeSignature()
-                    ).withFeatures(op.features),
-                    (signature, boundSignature) ->
-                        new BinaryScalar<>(op.longFunction, signature, boundSignature, type)
-                );
+            module.register(
+                Signature.scalar(
+                    op.toString(),
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                ).withFeatures(op.features),
+                (signature, boundSignature) ->
+                    new BinaryScalar<>(op.longFunction, signature, boundSignature, DataTypes.LONG)
+            );
+            if (op != Operations.SUBTRACT) {
+                for (var type : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
+                    module.register(
+                        Signature.scalar(
+                            op.toString(),
+                            type.getTypeSignature(),
+                            type.getTypeSignature(),
+                            type.getTypeSignature()
+                        ).withFeatures(op.features),
+                        (signature, boundSignature) ->
+                            new BinaryScalar<>(op.longFunction, signature, boundSignature, type)
+                    );
+                }
             }
             module.register(
                 Signature.scalar(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.arithmetic;
+
+import java.util.List;
+
+import org.joda.time.Period;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public class SubtractTimestampScalar extends Scalar<Period, Object> {
+
+    public static void register(ScalarFunctionModule module) {
+        for (var timestampType : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
+            module.register(
+                Signature.scalar(
+                    ArithmeticFunctions.Names.SUBTRACT,
+                    timestampType.getTypeSignature(),
+                    timestampType.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature()
+                ),
+                SubtractTimestampScalar::new
+            );
+        }
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    public SubtractTimestampScalar(Signature declaredSignature,
+                                     BoundSignature boundSignature) {
+        this.signature = declaredSignature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public Period evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
+        Long start = (Long) args[1].value();
+        Long end = (Long) args[0].value();
+        if (end == null || start == null) {
+            return null;
+        }
+        return new Period(end - start);
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/TypeInferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar;
 
+import org.joda.time.Period;
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
@@ -49,11 +50,6 @@ public class TypeInferenceTest extends ScalarTestCase {
         assertEvaluate("coalesce(null, 1::integer, '1')", 1);
         assertEvaluate("coalesce(null, 1::integer)", 1);
         assertEvaluateNull("coalesce(null)");
-    }
-
-    @Test
-    public void testTimestampCalculationsWithNumerics() throws Exception {
-        assertEvaluate("current_timestamp between current_timestamp - 10 and current_timestamp + 10", true);
     }
 
     @Test
@@ -96,7 +92,7 @@ public class TypeInferenceTest extends ScalarTestCase {
      */
     @Test
     public void testTimestampOperations() {
-        assertEvaluate("3::timestamp with time zone - 1", 2L);
+        assertEvaluate("3::timestamp with time zone - 1", Period.millis(2));
         assertEvaluate("3000::timestamp with time zone / 1000", 3L);
         assertEvaluate("3000::timestamp with time zone/ 1000.0", 3.0);
     }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TimestampArithmeticTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TimestampArithmeticTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.arithmetic;
+
+import org.joda.time.Period;
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+
+public class TimestampArithmeticTest extends ScalarTestCase {
+
+    @Test
+    public void test_timestamp_add() {
+        assertEvaluate("'2022-12-05T11:22:33.123456789'::timestamp + '-0022-12-03T11:22:33.123456789'::timestamp",
+                       -61162132493754L);
+        assertEvaluate("'2022-12-03T11:22:33.123456789'::timestamp + '-2022-12-05T11:22:33.123456789'::timestamp",
+                       -124276036493754L);
+    }
+
+    @Test
+    public void test_timestamp_subtract() {
+        assertEvaluate("'2000-03-21T23:33:44.999999999'::timestamp - '2022-12-05T11:22:33.123456789'::timestamp",
+                       Period.hours(-199043).withMinutes(-48).withSeconds(-48).withMillis(-124));
+        assertEvaluate("'2022-12-05T11:22:33.123456789'::timestamp - '-2000-03-21T23:33:44.999999999'::timestamp",
+                       Period.hours(35262323).withMinutes(48).withSeconds(48).withMillis(124));
+        assertEvaluate("'2022-12-05T11:22:33.123456789+05:30'::timestamptz - '2022-12-03T11:22:33.123456789-02:15'::timestamptz",
+                       Period.hours(40).withMinutes(15));
+    }
+
+    @Test
+    public void test_timestamp_subtract_with_nulls() {
+        assertEvaluateNull("'2000-03-21T23:33:44.999999999'::timestamp - null::timestamp");
+        assertEvaluateNull("null::timestamp - '-2000-03-21T23:33:44.999999999'::timestamp");
+        assertEvaluateNull("null::timestamp - null::timestamptz");
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -198,7 +198,7 @@ public class ViewsITest extends IntegTestCase {
     public void test_where_clause_on_view_normalized_on_coordinator_node() {
         execute("create table test (x timestamp, y int)");
         execute("create view v_test as select * from test");
-        execute("select * from v_test where x > current_timestamp - 1000 * 60 * 60 * 24");
+        execute("select * from v_test where x > current_timestamp - INTERVAL '24' HOUR");
     }
 
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously the subtraction of two timestamps resulted in a long value representing their diff in milliseconds.
To be combatible with PostgreSQL, change this behaviour by returning an `INTERVAL` value instead by registering a dedicated scalar function for this operation.

Closes #12479

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
