### PR TITLE
Rename InputCollectExpression to RowCollectExpression

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -53,7 +53,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowN;
 import io.crate.data.SkippingBatchIterator;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
 import io.crate.execution.engine.window.WindowFunction;
 import io.crate.execution.engine.window.WindowFunctionBatchIterator;
@@ -193,7 +193,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeWindowBatchIterator(Blackhole blackhole) throws Exception {
-        InputCollectExpression input = new InputCollectExpression(0);
+        RowCollectExpression input = new RowCollectExpression(0);
         BatchIterator<Row> batchIterator = WindowFunctionBatchIterator.of(
             new InMemoryBatchIterator<>(rows, SENTINEL, false),
             new NoRowAccounting<>(),

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -45,7 +45,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
@@ -65,7 +65,7 @@ public class AggregateCollectorBenchmark {
 
     @Setup
     public void setup() {
-        InputCollectExpression inExpr0 = new InputCollectExpression(0);
+        RowCollectExpression inExpr0 = new RowCollectExpression(0);
         Functions functions = new ModulesBuilder()
             .add(new AggregationImplModule())
             .createInjector()

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -68,7 +68,7 @@ import io.crate.data.Row1;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
@@ -128,7 +128,7 @@ public class GroupingLongCollectorBenchmark {
     }
 
     private static GroupingCollector createGroupBySumCollector(AggregationFunction sumAgg, MemoryManager memoryManager) {
-        InputCollectExpression keyInput = new InputCollectExpression(0);
+        RowCollectExpression keyInput = new RowCollectExpression(0);
         List<Input<?>> keyInputs = Arrays.<Input<?>>asList(keyInput);
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -31,7 +31,7 @@ import io.crate.data.Row1;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.aggregation.impl.MinimumAggregation;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
@@ -86,7 +86,7 @@ public class GroupingStringCollectorBenchmark {
     }
 
     private GroupingCollector createGroupByMinBytesRefCollector(Functions functions) {
-        InputCollectExpression keyInput = new InputCollectExpression(0);
+        RowCollectExpression keyInput = new RowCollectExpression(0);
         List<Input<?>> keyInputs = Collections.singletonList(keyInput);
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 

--- a/benchmarks/src/main/java/io/crate/execution/engine/sort/SortingLimitAndOffsetCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/sort/SortingLimitAndOffsetCollectorBenchmark.java
@@ -47,7 +47,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -55,7 +55,7 @@ import io.crate.execution.engine.collect.InputCollectExpression;
 public class SortingLimitAndOffsetCollectorBenchmark {
 
     private static final Comparator<Object[]> COMPARATOR = (o1, o2) -> Integer.compare((int) o2[0], (int) o1[0]);
-    private static final InputCollectExpression INPUT = new InputCollectExpression(0);
+    private static final RowCollectExpression INPUT = new RowCollectExpression(0);
     private static final List<Input<?>> INPUTS = List.of(INPUT);
     private static final Iterable<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = List.of(INPUT);
 

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -28,7 +28,7 @@ import io.crate.data.Row1;
 import io.crate.execution.engine.aggregation.AggregateCollector;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OffHeapMemoryManager;
@@ -79,7 +79,7 @@ public class HyperLogLogDistinctAggregationBenchmark {
     @Setup
     public void setUp() throws Exception {
         hash = new MurmurHash3.Hash128();
-        final InputCollectExpression inExpr0 = new InputCollectExpression(0);
+        final RowCollectExpression inExpr0 = new RowCollectExpression(0);
         Functions functions = new ModulesBuilder()
             .add(new ExtraFunctionsModule())
             .createInjector().getInstance(Functions.class);

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
@@ -51,7 +51,7 @@ import io.crate.execution.engine.aggregation.AggregateCollector;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.aggregation.impl.IntervalSumAggregation;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
@@ -84,7 +84,7 @@ public class IntervalAggregationBenchmark {
     @Setup
     @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
-        final InputCollectExpression inExpr0 = new InputCollectExpression(0);
+        final RowCollectExpression inExpr0 = new RowCollectExpression(0);
         Functions functions = new ModulesBuilder()
             .add(new AggregationImplModule())
             .createInjector().getInstance(Functions.class);

--- a/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/InsertSourceFromCells.java
@@ -34,7 +34,7 @@ import io.crate.data.BiArrayRow;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.expression.InputFactory;
 import io.crate.expression.InputFactory.Context;
@@ -206,7 +206,7 @@ public final class InsertSourceFromCells implements InsertSourceGen {
         public CollectExpression<Row, ?> getImplementation(Reference ref) {
             int idx = targets.indexOf(ref);
             if (idx >= 0) {
-                return new InputCollectExpression(idx);
+                return new RowCollectExpression(idx);
             } else {
                 int rootIdx = columns.indexOf(ref.column().getRoot());
                 if (rootIdx < 0) {

--- a/server/src/main/java/io/crate/execution/engine/collect/CollectExpression.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectExpression.java
@@ -24,6 +24,9 @@ package io.crate.execution.engine.collect;
 
 import io.crate.data.Input;
 
+/**
+ * An {@link Input} where the result value is set as side effect of {@link #setNextRow(Object)}
+ **/
 public interface CollectExpression<TRow, TReturnValue> extends Input<TReturnValue> {
 
     void setNextRow(TRow row);

--- a/server/src/main/java/io/crate/execution/engine/collect/RowCollectExpression.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RowCollectExpression.java
@@ -23,20 +23,23 @@ package io.crate.execution.engine.collect;
 
 import io.crate.data.Row;
 
-public class InputCollectExpression implements CollectExpression<Row, Object> {
+/**
+ * CollectExpression to retrieve values from a {@link Row} at a given index
+ */
+public final class RowCollectExpression implements CollectExpression<Row, Object> {
 
-    private final int position;
+    private final int index;
     private Object value;
 
-    public InputCollectExpression(int position) {
-        this.position = position;
+    public RowCollectExpression(int index) {
+        this.index = index;
     }
 
     @Override
     public void setNextRow(Row row) {
-        assert row.numColumns() > position
-            : "Wanted to retrieve value for column at position=" + position + " from row=" + row + " but row has only " + row.numColumns() + " columns";
-        value = row.get(position);
+        assert row.numColumns() > index
+            : "Wanted to retrieve value for column at position=" + index + " from row=" + row + " but row has only " + row.numColumns() + " columns";
+        value = row.get(index);
     }
 
     @Override
@@ -49,9 +52,9 @@ public class InputCollectExpression implements CollectExpression<Row, Object> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        InputCollectExpression that = (InputCollectExpression) o;
+        RowCollectExpression that = (RowCollectExpression) o;
 
-        if (position != that.position) return false;
+        if (index != that.index) return false;
         if (value != null ? !value.equals(that.value) : that.value != null) return false;
 
         return true;
@@ -59,13 +62,13 @@ public class InputCollectExpression implements CollectExpression<Row, Object> {
 
     @Override
     public int hashCode() {
-        int result = position;
+        int result = index;
         result = 31 * result + (value != null ? value.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
-        return "Input{pos=" + position + '}';
+        return "RowCollectExpression{idx=" + index + '}';
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/TableFunctionCollectSource.java
@@ -37,7 +37,7 @@ import io.crate.data.SentinelRow;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.dsl.phases.TableFunctionCollectPhase;
 import io.crate.execution.engine.collect.CollectTask;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.collect.ValueAndInputRow;
 import io.crate.expression.InputCondition;
 import io.crate.expression.InputFactory;
@@ -74,13 +74,13 @@ public class TableFunctionCollectSource implements CollectSource {
 
         List<Input<?>> topLevelInputs = new ArrayList<>(phase.toCollect().size());
         List<String> columns = rowType.fieldNames();
-        InputFactory.Context<InputCollectExpression> ctx = inputFactory.ctxForRefs(
+        InputFactory.Context<RowCollectExpression> ctx = inputFactory.ctxForRefs(
             txnCtx,
             ref -> {
                 for (int i = 0; i < columns.size(); i++) {
                     String column = columns.get(i);
                     if (ref.column().isTopLevel() && ref.column().name().equals(column)) {
-                        return new InputCollectExpression(i);
+                        return new RowCollectExpression(i);
                     }
                 }
                 throw new IllegalStateException(

--- a/server/src/main/java/io/crate/expression/InputFactory.java
+++ b/server/src/main/java/io/crate/expression/InputFactory.java
@@ -35,7 +35,7 @@ import io.crate.data.Row;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.reference.GatheringRefResolver;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.symbol.Aggregation;
@@ -167,7 +167,7 @@ public class InputFactory {
     private static class InputColumnVisitor extends BaseImplementationSymbolVisitor<Void> {
 
         private final List<CollectExpression<Row, ?>> expressions;
-        private final IntObjectMap<InputCollectExpression> inputCollectExpressions = new IntObjectHashMap<>();
+        private final IntObjectMap<RowCollectExpression> inputCollectExpressions = new IntObjectHashMap<>();
 
         InputColumnVisitor(TransactionContext txnCtx, NodeContext nodeCtx, List<CollectExpression<Row, ?>> expressions) {
             super(txnCtx, nodeCtx);
@@ -177,9 +177,9 @@ public class InputFactory {
         @Override
         public Input<?> visitInputColumn(InputColumn inputColumn, Void context) {
             int index = inputColumn.index();
-            InputCollectExpression inputCollectExpression = inputCollectExpressions.get(index);
+            RowCollectExpression inputCollectExpression = inputCollectExpressions.get(index);
             if (inputCollectExpression == null) {
-                inputCollectExpression = new InputCollectExpression(index);
+                inputCollectExpression = new RowCollectExpression(index);
                 inputCollectExpressions.put(index, inputCollectExpression);
                 expressions.add(inputCollectExpression);
             }

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -73,7 +73,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
     private IndexSearcher indexSearcher;
     private ArrayList<Object[]> expectedResult;
     private String columnName;
-    private InputCollectExpression inExpr;
+    private RowCollectExpression inExpr;
     private List<AggregationContext> aggregationContexts;
 
     @Before
@@ -92,7 +92,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
         iw.commit();
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
 
-        inExpr = new InputCollectExpression(0);
+        inExpr = new RowCollectExpression(0);
         CountAggregation aggregation = (CountAggregation) nodeCtx.functions().getQualified(
             CountAggregation.COUNT_STAR_SIGNATURE,
             Collections.emptyList(),

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -49,7 +49,7 @@ import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.pipeline.TableSettingsResolver;
 import io.crate.execution.jobs.NodeLimits;
 import io.crate.expression.symbol.InputColumn;
@@ -77,7 +77,7 @@ public class IndexWriterProjectorTest extends IntegTestCase {
         execute("create table bulk_import (id int primary key, name string) with (number_of_replicas=0)");
         ensureGreen();
 
-        InputCollectExpression sourceInput = new InputCollectExpression(1);
+        RowCollectExpression sourceInput = new RowCollectExpression(1);
         List<CollectExpression<Row, ?>> collectExpressions = Collections.<CollectExpression<Row, ?>>singletonList(sourceInput);
 
         RelationName bulkImportIdent = new RelationName(sqlExecutor.getCurrentSchema(), "bulk_import");

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -50,7 +50,7 @@ import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.jobs.NodeLimits;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
@@ -95,7 +95,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
 
     @Test
     public void testNullPKValue() throws Throwable {
-        InputCollectExpression sourceInput = new InputCollectExpression(0);
+        RowCollectExpression sourceInput = new RowCollectExpression(0);
         List<CollectExpression<Row, ?>> collectExpressions = Collections.<CollectExpression<Row, ?>>singletonList(sourceInput);
 
         IndexWriterProjector indexWriter = new IndexWriterProjector(

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingLimitAndOffsetProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingLimitAndOffsetProjectorTest.java
@@ -45,7 +45,7 @@ import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.pipeline.LimitAndOffset;
 import io.crate.expression.symbol.Literal;
 import io.crate.testing.TestingBatchIterators;
@@ -54,7 +54,7 @@ import io.crate.types.DataTypes;
 
 public class SortingLimitAndOffsetProjectorTest extends ESTestCase {
 
-    private static final InputCollectExpression INPUT = new InputCollectExpression(0);
+    private static final RowCollectExpression INPUT = new RowCollectExpression(0);
     private static final Literal<Boolean> TRUE_LITERAL = Literal.of(true);
     private static final List<Input<?>> INPUT_LITERAL_LIST = List.of(INPUT, TRUE_LITERAL);
     private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = List.of(INPUT);

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
@@ -43,7 +43,7 @@ import io.crate.data.Bucket;
 import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.Literal;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
@@ -54,7 +54,7 @@ public class SortingProjectorTest extends ESTestCase {
     private TestingRowConsumer consumer = new TestingRowConsumer();
 
     private SortingProjector createProjector(RowAccounting<Object[]> rowAccounting, int numOutputs, int offset) {
-        InputCollectExpression input = new InputCollectExpression(0);
+        RowCollectExpression input = new RowCollectExpression(0);
         return new SortingProjector(
             rowAccounting,
             List.of(input, Literal.of(true)),

--- a/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -51,7 +51,7 @@ import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.engine.aggregation.AggregationFunction;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.ExpressionsInput;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.ReferenceResolver;
@@ -120,8 +120,8 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
         assertThat(normalizedFunctionSymbol).isExactlyInstanceOf(io.crate.expression.symbol.WindowFunction.class);
 
         var windowFunctionSymbol = (io.crate.expression.symbol.WindowFunction) normalizedFunctionSymbol;
-        ReferenceResolver<InputCollectExpression> referenceResolver =
-            r -> new InputCollectExpression(rowsColumnDescription.indexOf(r.column()));
+        ReferenceResolver<RowCollectExpression> referenceResolver =
+            r -> new RowCollectExpression(rowsColumnDescription.indexOf(r.column()));
 
         var sourceSymbols = Lists2.map(rowsColumnDescription, x -> sqlExpressions.normalize(sqlExpressions.asSymbol(x.sqlFqn())));
         ensureInputRowsHaveCorrectType(sourceSymbols, inputRows);

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -100,7 +100,7 @@ import io.crate.execution.dsl.projection.AggregationProjection;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.collect.CollectTask;
 import io.crate.execution.engine.collect.DocValuesAggregates;
-import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.collect.MapSideDataCollectOperation;
 import io.crate.execution.jobs.SharedShardContexts;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
@@ -260,15 +260,15 @@ public abstract class AggregationTestCase extends ESTestCase {
                                                             boolean randomExtraStates,
                                                             Version minNodeVersion) {
         var argumentsSize = function.signature().getArgumentTypes().size();
-        InputCollectExpression[] inputs = new InputCollectExpression[argumentsSize];
+        RowCollectExpression[] inputs = new RowCollectExpression[argumentsSize];
         for (int i = 0; i < argumentsSize; i++) {
-            inputs[i] = new InputCollectExpression(i);
+            inputs[i] = new RowCollectExpression(i);
         }
 
         ArrayList<Object> states = new ArrayList<>();
         states.add(function.newState(RAM_ACCOUNTING, Version.CURRENT, minNodeVersion, memoryManager));
         for (Row row : new ArrayBucket(data)) {
-            for (InputCollectExpression input : inputs) {
+            for (RowCollectExpression input : inputs) {
                 input.setNextRow(row);
             }
             if (randomExtraStates && randomIntBetween(1, 4) == 1) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The name `Input` was used because the class is often used for
`InputColumn` symbols, but `Input` doesn't convey any useful information
regarding the `CollectExpression`. The `CollectExpression` interface
extends `Input` so this instance wasn't special in that regard.

This instead adds `Row` to the name to highlight that it operates on
`Row` instances.

In https://github.com/crate/crate/pull/13280 there might be a similar
implementation, but with `Object[]` instead of `Row`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
