### PR TITLE
Align number_of_replicas preffix stripping with other settings

### DIFF
--- a/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
+++ b/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
@@ -278,7 +278,7 @@ public class MetadataToASTNodeResolver {
             // WITH ( key = value, ... )
             Map<String, Expression> properties = new HashMap<>();
             Expression numReplicas = new StringLiteral(tableInfo.numberOfReplicas());
-            properties.put(TableParameters.NUMBER_OF_REPLICAS.getKey(), numReplicas);
+            properties.put(TableParameters.stripIndexPrefix(TableParameters.NUMBER_OF_REPLICAS.getKey()), numReplicas);
             // we want a sorted map of table parameters
 
             TreeMap<String, Object> tableParameters = new TreeMap<>(

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -67,8 +67,7 @@ import io.crate.types.DataTypes;
 public class TableParameters {
 
     // all available table settings
-    static final Map.Entry<String, NumberOfReplicasSetting> NUMBER_OF_REPLICAS =
-        Map.entry(stripIndexPrefix(NumberOfReplicasSetting.NAME), new NumberOfReplicasSetting());
+    static final NumberOfReplicasSetting NUMBER_OF_REPLICAS = new NumberOfReplicasSetting();
     static final Setting<String> COLUMN_POLICY = new Setting<>(
         new Setting.SimpleKey(ColumnPolicies.ES_MAPPING_NAME),
         s -> ColumnPolicy.STRICT.lowerCaseName(),
@@ -86,7 +85,7 @@ public class TableParameters {
 
     private static final List<Setting<?>> SUPPORTED_SETTINGS =
         List.of(
-            NUMBER_OF_REPLICAS.getValue(),
+            NUMBER_OF_REPLICAS,
             IndexSettings.INDEX_REFRESH_INTERVAL_SETTING,
             IndexMetadata.INDEX_READ_ONLY_SETTING,
             INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
@@ -157,7 +156,7 @@ public class TableParameters {
             .filter(s -> s.isFinal() == false)
             .collect(Collectors.toMap((s) -> stripDotSuffix(stripIndexPrefix(s.getKey())), s -> s));
 
-    private static final Set<Setting<?>> EXCLUDED_SETTING_FOR_METADATA_IMPORT = Set.of(NUMBER_OF_REPLICAS.getValue());
+    private static final Set<Setting<?>> EXCLUDED_SETTING_FOR_METADATA_IMPORT = Set.of(NUMBER_OF_REPLICAS);
 
     private static final Map<String, Setting<?>> SUPPORTED_SETTINGS_INCL_SHARDS
         = MapBuilder.newMapBuilder(SUPPORTED_NON_FINAL_SETTINGS_DEFAULT)
@@ -191,7 +190,7 @@ public class TableParameters {
 
     public static final TableParameters CREATE_BLOB_TABLE_PARAMETERS = new TableParameters(
         Map.of(
-            NUMBER_OF_REPLICAS.getKey(), NUMBER_OF_REPLICAS.getValue(),
+            stripIndexPrefix(NUMBER_OF_REPLICAS.getKey()), NUMBER_OF_REPLICAS,
             "blobs_path", Setting.simpleString(
                 BlobIndicesService.SETTING_INDEX_BLOBS_PATH.getKey(), Validators.stringValidator("blobs_path"))
         ),
@@ -199,8 +198,8 @@ public class TableParameters {
     );
 
     public static final TableParameters ALTER_BLOB_TABLE_PARAMETERS = new TableParameters(
-        Map.of(NUMBER_OF_REPLICAS.getKey(),
-               NUMBER_OF_REPLICAS.getValue(),
+        Map.of(stripIndexPrefix(NUMBER_OF_REPLICAS.getKey()),
+               NUMBER_OF_REPLICAS,
                stripDotSuffix(stripIndexPrefix(SETTING_READ_ONLY_ALLOW_DELETE)),
                INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING
         ),

--- a/server/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
+++ b/server/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
@@ -23,15 +23,15 @@ package io.crate.metadata.settings;
 
 import static io.crate.analyze.TableParameters.stripIndexPrefix;
 
-import io.crate.analyze.NumberOfReplicas;
-import io.crate.types.DataTypes;
+import java.util.function.Function;
 
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.function.Function;
+import io.crate.analyze.NumberOfReplicas;
+import io.crate.types.DataTypes;
 
 public class NumberOfReplicasSetting extends Setting<Settings> {
 

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -33,6 +33,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.BAD_REQUEST;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
@@ -89,8 +90,6 @@ import io.crate.metadata.Schemas;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseRandomizedSchema;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 2)
 public class PartitionedTableIntegrationTest extends IntegTestCase {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We currently strip the `index.` prefix of all settings at:
 - TableParameters while defining a set of settings used for certain operations (e.g. SUPPORTED_SETTINGS)
 - MetadataToASTNodeResolver while building SQL expressions out of index settings

Instead of adding even more spezialized handling for `number_of_replicas` introduced by fa8fd6f2387, we should just fix the missing prefix strip where we explicitly add this setting.

Follow up of fa8fd6f2387.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
