### PR TITLE
Implement CAST(<INTERVAL> AS LONG)

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -87,6 +87,13 @@ None
 
 Changes
 =======
+- Added support for ``CAST(<INTERVAL> AS LONG)`` to get the total number of
+  milliseconds in an interval, e.g.::
+
+    SELECT (ts_end - ts_start)::long FROM test
+    SELECT (ts_end - ts_start)::long / (1000 * 60 * 60 * 24) FROM test
+
+
 - Added support for ``SUM()`` aggregations on ``INTERVAL`` type. e.g.::
 
     SELECT SUM(tsEnd - tsStart) FROM test

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -239,6 +239,7 @@ public final class DataTypes {
         entry(TIMESTAMPZ.id(), Set.of(DOUBLE.id(), LONG.id(), STRING.id(), TIMESTAMP.id(), CHARACTER.id(), DATE.id())),
         entry(TIMESTAMP.id(), Set.of(DOUBLE.id(), LONG.id(), STRING.id(), TIMESTAMPZ.id(), CHARACTER.id(), DATE.id())),
         entry(DATE.id(), Set.of(DOUBLE.id(), LONG.id(), STRING.id(), TIMESTAMP.id(), TIMESTAMPZ.id(), CHARACTER.id())),
+        entry(INTERVAL.id(), Set.of(LONG.id())),
         entry(UNDEFINED.id(), Set.of()), // actually convertible to every type, see NullType
         entry(GEO_POINT.id(), Set.of()),
         entry(GEO_SHAPE.id(), Set.of(ObjectType.ID)),

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -27,6 +27,7 @@ import org.hamcrest.Matchers;
 import org.joda.time.Period;
 import org.junit.Test;
 
+import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarTestCase;
 
 public class IntervalFunctionTest extends ScalarTestCase {
@@ -58,10 +59,9 @@ public class IntervalFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_unsupported_arithmetic_operator_on_interval_types() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unknown function: (NULL * cast('1 second' AS interval))," +
-                                        " no overload found for matching argument types: (undefined, interval).");
-        assertEvaluate("null * interval '1 second'", Matchers.nullValue());
+        assertThatThrownBy(() -> assertEvaluate("null * interval '1 second'", Matchers.nullValue()))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'PT1S'::interval` of type `interval` to type `bigint`");
     }
 
     @Test
@@ -78,7 +78,7 @@ public class IntervalFunctionTest extends ScalarTestCase {
     public void test_unallowed_operations() {
         assertThatThrownBy(
             () -> assertEvaluate("interval '1 second' - '86401000'::timestamptz", 86400000L))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessageStartingWith("Unknown function: (cast('1 second' AS interval) - cast('86401000' AS timestamp with time zone)), ");
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'PT1S'::interval` of type `interval` to type `bigint`");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

With #13345, subtraction of timestamps returns an `INTERVAL`, from which
a user cannot extract the total amount of a time unit (days, minutes,
seconds, millis, etc.) As an alternative to casting timestamps to long
before subtracting them, in order to get their difference in millis,
implement implicit `CAST(<INTERVAL> AS LONG)` to allow users to cast the
result of a timestamp subtraction (or any other given `INTERVAL` to
milliseconds and then further calculate the desired unit. e.g.:
```
SELECT (ts_end - ts_start)::long / (1000 * 60 * 60)
```

Closes: #13364

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
