### PR TITLE
Add object deep merge function 

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -135,6 +135,11 @@ Changes
 - Added support for dollar quoted strings,
   see :ref:`String Literal <string_literal>` for further details.
 
+- Added the :ref:`object_deepmerge <scalar-object_deepmerge>` scalar function 
+  which combines two objects into a new object containing the deep union of 
+  their properties, taking the second object's values for duplicate properties 
+  for non-``OBJECT`` properties.
+
 - Added a :ref:`datestyle <conf-session-datestyle>` session setting that shows 
   the display format for date and time values. Only the ``ISO`` style is 
   supported. Optionally provided pattern conventions for the order of date 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3015,6 +3015,31 @@ Returns: ``array(text)``
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-object_deepmerge:
+
+``object_deepmerge(object, object)``
+------------------------------------
+
+The ``object_deepmerge`` function combines two objects into a new object 
+containing the deep union of their properties, taking the second 
+object's values for duplicate non-``OBJECT`` properties.  If one of the 
+objects is ``NULL``, the non-``NULL`` object is returned. If both objects 
+are ``NULL``, ``NULL`` is returned.
+
+Returns: ``object``
+
+::
+
+    cr> SELECT
+    ...     object_deepmerge({a = 1, b = {c = 2}}, {a = 3, b = {d = 4}}) AS object_deepmerge;
+    +---------------------------------+
+    | object_deepmerge                |
+    +---------------------------------+
+    | {"a": 3, "b": {"c": 2, "d": 4}} |
+    +---------------------------------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-conditional-fn-exp:
 
 Conditional functions and expressions

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -57,6 +57,7 @@ import io.crate.expression.scalar.geo.GeoHashFunction;
 import io.crate.expression.scalar.geo.IntersectsFunction;
 import io.crate.expression.scalar.geo.WithinFunction;
 import io.crate.expression.scalar.object.ObjectKeysFunction;
+import io.crate.expression.scalar.object.ObjectDeepMergeFunction;
 import io.crate.expression.scalar.postgres.CurrentSettingFunction;
 import io.crate.expression.scalar.postgres.PgBackendPidFunction;
 import io.crate.expression.scalar.postgres.PgEncodingToCharFunction;
@@ -223,6 +224,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         PgGetSerialSequenceFunction.register(this);
 
         ObjectKeysFunction.register(this);
+        ObjectDeepMergeFunction.register(this);
 
         HasSchemaPrivilegeFunction.register(this);
     }

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectDeepMergeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectDeepMergeFunction.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.object;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ObjectDeepMergeFunction extends Scalar<Map<String, Object>, Map<String, Object>> {
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                "object_deepmerge",
+                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                DataTypes.UNTYPED_OBJECT.getTypeSignature()
+            ),
+            ObjectDeepMergeFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    public ObjectDeepMergeFunction(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @SafeVarargs
+    @Override
+    public final Map<String, Object> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Map<String, Object>>... args) {
+        var objectOne = args[0].value();
+        var objectTwo = args[1].value();
+        if (objectOne == null) {
+            return objectTwo;
+        }
+        if (objectTwo == null) {
+            return objectOne;
+        }
+        Map<String,Object> resultObject = new HashMap<>();
+        resultObject.putAll(objectOne);
+        deepMerge(resultObject,objectTwo);
+        return resultObject;
+    }
+
+    private void deepMerge(Map<String, Object> objectOne, Map<String, Object> objectTwo) {
+        for (String key : objectTwo.keySet()) {
+            if (objectOne.get(key) instanceof Map && objectTwo.get(key) instanceof Map) {
+                deepMerge((Map)objectOne.get(key), (Map)objectTwo.get(key));
+            } else {
+                objectOne.put(key, objectTwo.get(key));
+            }
+        }
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/object/ObjectDeepMergeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/object/ObjectDeepMergeFunctionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.object;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+
+public class ObjectDeepMergeFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_input() {
+        assertEvaluateNull("object_deepmerge(null, null)");
+        assertEvaluate("object_deepmerge(null, {\"a\"=1})", Map.of("a",1));
+        assertEvaluate("object_deepmerge({\"a\"=1}, null)", Map.of("a",1));
+    }
+
+    @Test
+    public void test_empty_object() {
+        assertEvaluate("object_deepmerge({}, {\"a\"=1})", Map.of("a",1));
+        assertEvaluate("object_deepmerge({\"a\"=1}, {})", Map.of("a",1));
+    }
+
+    @Test
+    public void test_seconds_overwrites_first_object() {
+        assertEvaluate("object_deepmerge({a=1},{a=2,b=2})", Map.of("a",2,"b",2));
+    }
+
+    @Test
+    public void test_nested_object() {
+        assertEvaluate("object_deepmerge({b={a=1}},{a=1, b={c=2}})", Map.of("a",1,"b",Map.of("a",1,"c",2)));
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adding the `object_deepmerge(object, object)` scalar function which combines two objects into a new object containing the deep union of their properties, taking the second object's values for duplicate non-object properties.

```sql
SELECT object_deepmerge({a = {b = 1}}, {a = {c = 2}});                                                                                                                                         
+-------------------------+
| {"a"={"b"=1, "c"=2}}    |
+-------------------------+
| {"a": {"b": 1, "c": 2}} |
+-------------------------+
SELECT 1 row in set (0.008 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
