### PR TITLE
Propagate assertion errors in DDLClusterStateTaskExecutor

### DIFF
--- a/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateTaskExecutor.java
@@ -21,26 +21,26 @@
 
 package io.crate.metadata.cluster;
 
+import java.util.List;
+
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 
-import java.util.List;
+import io.crate.exceptions.Exceptions;
 
 public abstract class DDLClusterStateTaskExecutor<Request> implements ClusterStateTaskExecutor<Request> {
 
     @Override
     public ClusterTasksResult<Request> execute(ClusterState currentState, List<Request> requests) throws Exception {
         ClusterTasksResult.Builder<Request> builder = ClusterTasksResult.builder();
-
         for (Request request : requests) {
             try {
                 currentState = execute(currentState, request);
                 builder.success(request);
-            } catch (Exception e) {
-                builder.failure(request, e);
+            } catch (Throwable e) {
+                builder.failure(request, Exceptions.toException(e));
             }
         }
-
         return builder.build(currentState);
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The DDLClusterStateTaskExecutor swallowed assertion errors, preventing
listeners from triggering and causing queries to get stuck.

This isn't an issue in production were we do not expect assertions to
trigger, but during development it's helpful to track down the
assertion error if the listeners do get triggered.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
