### PR TITLE
Short-circuit objects with NULL values on source parsing

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -154,3 +154,18 @@ Fixes
 - Fixed an issue that allowed users without the related privileges to check
   other users' privileges by calling
   :ref:`has_schema_privilege <scalar-has-schema-priv>` function.
+
+- Fixed an issue that caused ``SELECT *`` statements to fail if a table has an
+  object with inner null object and a sibling column with the same name with
+  one of the sub-columns. An example::
+
+    CREATE TABLE IF NOT EXISTS "t" (
+      "obj1" OBJECT(DYNAMIC) AS (
+       "target" text,
+       "obj2" OBJECT(DYNAMIC) AS (
+          "target" REAL
+       )
+      )
+    );
+    INSERT INTO t VALUES ('{"obj2": null, "target": "Sensor"}');
+    SELECT * FROM t;


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/13372

It was a regression caused by https://github.com/crate/crate/commit/e3eec7a37c1c82b49c0da3a639c9bbc761e8b470

Initially was going to use FQN in `ObjectMapper` (Similar to https://github.com/crate/crate/pull/13212) but objects can have same column names in `ObjectMapper` (it uses simpleName <==> leafName by design).

Actual problem is combination of:
1. same name of a sub-column and a sibling column 
2. object has NULL value and it's innerTypes gets applied to the sibling (because of same name + we keep moving parser "pointer")

 
 