### PR TITLE
Set `isNullable` on Reference correctly in add-column logic

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -211,7 +211,7 @@ public class DocIndexMetadata {
                      @Nullable String defaultExpression,
                      ColumnPolicy columnPolicy,
                      IndexType indexType,
-                     boolean isNotNull,
+                     boolean nullable,
                      boolean hasDocValues) {
         Reference ref;
         boolean partitionByColumn = partitionedBy.contains(column);
@@ -219,7 +219,7 @@ public class DocIndexMetadata {
         if (partitionByColumn) {
             indexType = IndexType.PLAIN;
         }
-        Reference simpleRef = newInfo(position, column, type, defaultExpression, columnPolicy, indexType, isNotNull, hasDocValues);
+        Reference simpleRef = newInfo(position, column, type, defaultExpression, columnPolicy, indexType, nullable, hasDocValues);
         if (generatedExpression == null) {
             ref = simpleRef;
         } else {
@@ -440,7 +440,6 @@ public class DocIndexMetadata {
             Map<String, Object> columnProperties = (Map) columnEntry.getValue();
             final DataType columnDataType = getColumnDataType(columnProperties);
             ColumnIdent newIdent = childIdent(columnIdent, columnEntry.getKey());
-
 
             boolean nullable = !notNullColumns.contains(newIdent) && !primaryKey.contains(newIdent);
             columnProperties = furtherColumnProperties(columnProperties);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`NOT NULL` was used as `is nullable`.
The mistake was made twice, cancelling each other out.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
