### PR TITLE
Add method to create IndexMetaData mapping to Reference

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/collections/Maps.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Maps.java
@@ -204,4 +204,14 @@ public final class Maps {
         }
         return Collections.unmodifiableMap(result);
     }
+
+    /**
+     * Adds the value under the given key to the given map unless the value is null.
+     */
+    public static <K, V> V putNonNull(Map<K, V> map, K key, @Nullable V value) {
+        if (value != null) {
+            return map.put(key, value);
+        }
+        return null;
+    }
 }

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -24,6 +24,7 @@ package io.crate.metadata;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
@@ -239,5 +240,10 @@ public class GeneratedReference implements Reference {
             + RamUsageEstimator.sizeOf(formattedGeneratedExpression)
             + (generatedExpression == null ? 0 : generatedExpression.ramBytesUsed())
             + referencedReferences.stream().mapToLong(Reference::ramBytesUsed).sum();
+    }
+
+    @Override
+    public Map<String, Object> toMapping() {
+        return ref.toMapping();
     }
 }

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -22,15 +22,17 @@
 package io.crate.metadata;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import io.crate.sql.tree.ColumnPolicy;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.SymbolType;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataTypes;
 
 public class GeoReference extends SimpleReference {
@@ -130,5 +132,17 @@ public class GeoReference extends SimpleReference {
         if (distanceErrorPct != null) {
             out.writeDouble(distanceErrorPct);
         }
+    }
+
+    @Override
+    public Map<String, Object> toMapping() {
+        Map<String, Object> mapping = super.toMapping();
+        Maps.putNonNull(mapping, "tree", geoTree);
+        Maps.putNonNull(mapping, "precision", precision);
+        Maps.putNonNull(mapping, "tree_levels", treeLevels);
+        if (distanceErrorPct != null) {
+            mapping.put("distance_error_pct", distanceErrorPct.floatValue());
+        }
+        return mapping;
     }
 }

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
@@ -156,5 +157,15 @@ public class IndexReference extends SimpleReference {
         for (Reference reference : columns) {
             Reference.toStream(reference, out);
         }
+    }
+
+    @Override
+    public Map<String, Object> toMapping() {
+        Map<String, Object> mapping = super.toMapping();
+        if (analyzer != null) {
+            mapping.put("analyzer", analyzer);
+            mapping.put("type", "text");
+        }
+        return mapping;
     }
 }

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -25,9 +25,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -57,6 +59,14 @@ public interface Reference extends Symbol {
     Symbol defaultExpression();
 
     Reference getRelocated(ReferenceIdent referenceIdent);
+
+    /**
+     * Creates the {@link IndexMetadata} mapping representation of the Column.
+     * <p>
+     * Note that for object types it does _NOT_ include the inner columns.
+     * </p>
+     */
+    Map<String, Object> toMapping();
 
     static void toStream(Reference ref, StreamOutput out) throws IOException {
         out.writeVInt(ref.symbolType().ordinal());

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -25,17 +25,19 @@ import java.io.IOException;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
-import com.fasterxml.jackson.core.Base64Variants;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+
+import com.fasterxml.jackson.core.Base64Variants;
 
 import io.crate.Streamer;
 import io.crate.metadata.settings.SessionSettings;
@@ -254,5 +256,10 @@ public final class BitStringType extends DataType<BitString> implements Streamer
     @Override
     public Integer characterMaximumLength() {
         return length();
+    }
+
+    @Override
+    public void addMappingOptions(Map<String, Object> mapping) {
+        mapping.put("length", length);
     }
 }

--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -26,6 +26,7 @@ import static io.crate.common.StringUtils.padEnd;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -176,5 +177,11 @@ public class CharacterType extends StringType {
     @Override
     public Precedence precedence() {
         return Precedence.CHARACTER;
+    }
+
+    @Override
+    public void addMappingOptions(Map<String, Object> mapping) {
+        mapping.put("length_limit", lengthLimit);
+        mapping.put("blank_padding", true);
     }
 }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -25,12 +25,14 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
@@ -245,5 +247,12 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
     public long ramBytesUsed() {
         // Most DataType's are singleton instances
         return 0L;
+    }
+
+    /**
+     * Adds type specific information to the provided mapping.
+     * The mapping is for the cluster state's {@link IndexMetadata}
+     */
+    public void addMappingOptions(Map<String, Object> mapping) {
     }
 }

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -486,7 +486,7 @@ public final class DataTypes {
     private static final Map<Integer, String> TYPE_IDS_TO_MAPPINGS = Map.ofEntries(
         entry(TIMESTAMPZ.id(), "date"),
         entry(TIMESTAMP.id(), "date"),
-        entry(STRING.id(), "text"),
+        entry(STRING.id(), "keyword"),
         entry(CHARACTER.id(), "keyword"),
         entry(BYTE.id(), "byte"),
         entry(BOOLEAN.id(), "boolean"),

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -352,4 +352,11 @@ public class StringType extends DataType<String> implements Streamer<String> {
     public long valueBytes(String value) {
         return RamUsageEstimator.sizeOf(value);
     }
+
+    @Override
+    public void addMappingOptions(Map<String, Object> mapping) {
+        if (!unbound()) {
+            mapping.put("length_limit", lengthLimit);
+        }
+    }
 }

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -35,6 +35,7 @@ import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -218,5 +219,13 @@ public final class TimestampType extends DataType<Long>
     @Override
     public long valueBytes(Long value) {
         return LongType.LONG_SIZE;
+    }
+
+    @Override
+    public void addMappingOptions(Map<String, Object> mapping) {
+        mapping.put("format", "epoch_millis||strict_date_optional_time");
+        if (id == ID_WITHOUT_TZ) {
+            mapping.put("ignore_timezone", true);
+        }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -32,6 +32,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
@@ -992,7 +993,7 @@ public class DDLIntegrationTest extends IntegTestCase {
             "INDEX USING FULLTEXT WITH (analyzer = 'simple')");
 
         execute("show create table tbl");
-        assertThat((String) response.rows()[0][0], startsWith(
+        assertThat((String) response.rows()[0][0]).startsWith(
             """
                 CREATE TABLE IF NOT EXISTS "doc"."tbl" (
                    "id" INTEGER NOT NULL,
@@ -1004,7 +1005,7 @@ public class DDLIntegrationTest extends IntegTestCase {
                    CONSTRAINT id_check CHECK("id" > 0),
                    CONSTRAINT test_check CHECK("col1" <> 'd')
                 )""".stripIndent()
-        ));
+        );
 
         // test other options, which couldn't be tested in the first scenario:
         // Primary key can be used here as we don't have not null


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Makes it easier to write unit tests and allows us to keep concrete
DataType and Reference classes an implementation detail.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
