### PR TITLE
CI: Update to `errata-ai/vale-action@v2`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run vale
-        uses: errata-ai/vale-action@3160f4797e8eed7775c76cb2563bdee5455b6d21
+        uses: errata-ai/vale-action@v2
         with:
           files: docs/
         env:


### PR DESCRIPTION
The [_Vale_ job of the _CrateDB Docs_ workflow](https://github.com/crate/crate/blob/master/.github/workflows/docs.yml#L33-L44) emitted some deprecation warnings from https://github.com/errata-ai/vale-action observed at [^1].

[^1]: https://github.com/crate/crate/actions/runs/3732877981/jobs/6332913497#step:2:45
