### PR TITLE
Remove type property from MappingMetadata

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -168,7 +168,7 @@ public class DocTableInfoFactory {
         DocIndexMetadata docIndexMetadata;
         try {
             IndexMetadata.Builder builder = new IndexMetadata.Builder(relation.indexNameOrAlias());
-            builder.putMapping(Constants.DEFAULT_MAPPING_TYPE,
+            builder.putMapping(
                 indexTemplateMetadata.getMappings().get(Constants.DEFAULT_MAPPING_TYPE).toString());
 
             Settings.Builder settingsBuilder = Settings.builder()

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -26,17 +26,17 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import javax.annotation.Nullable;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.MetadataMappingService;
 
 import io.crate.Constants;
 import io.crate.common.annotations.VisibleForTesting;
-import org.elasticsearch.cluster.metadata.MetadataMappingService;
-
-import javax.annotation.Nullable;
 
 public class MetadataIndexUpgrader implements BiFunction<IndexMetadata, IndexTemplateMetadata, IndexMetadata> {
 
@@ -90,8 +90,7 @@ public class MetadataIndexUpgrader implements BiFunction<IndexMetadata, IndexTem
             }
         }
         try {
-            return new MappingMetadata(
-                Constants.DEFAULT_MAPPING_TYPE, Map.of(Constants.DEFAULT_MAPPING_TYPE, newMapping));
+            return new MappingMetadata(Map.of(Constants.DEFAULT_MAPPING_TYPE, newMapping));
         } catch (IOException e) {
             logger.error("Failed to upgrade mapping for index '" + indexName + "'", e);
             return mappingMetadata;

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -19,9 +19,13 @@
 
 package org.elasticsearch.cluster;
 
-import com.carrotsearch.hppc.cursors.IntObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
@@ -57,12 +61,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.discovery.Discovery;
 
-import java.io.IOException;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import com.carrotsearch.hppc.cursors.IntObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
+import io.crate.Constants;
 
 /**
  * Represents the current state of the cluster.
@@ -473,11 +476,11 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
                 if (mmd != null) {
                     Map<String, Object> mapping = XContentHelper
                             .convertToMap(mmd.source().uncompressed(), false).map();
-                    if (mapping.size() == 1 && mapping.containsKey(mmd.type())) {
+                    if (mapping.size() == 1 && mapping.containsKey(Constants.DEFAULT_MAPPING_TYPE)) {
                         // the type name is the root value, reduce it
-                        mapping = (Map<String, Object>) mapping.get(mmd.type());
+                        mapping = (Map<String, Object>) mapping.get(Constants.DEFAULT_MAPPING_TYPE);
                     }
-                    builder.field(mmd.type());
+                    builder.field(Constants.DEFAULT_MAPPING_TYPE);
                     builder.map(mapping);
                 }
                 builder.endObject();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -38,10 +38,6 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import com.carrotsearch.hppc.ObjectHashSet;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.CollectionUtil;
@@ -78,6 +74,12 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.rest.RestStatus;
+
+import com.carrotsearch.hppc.ObjectHashSet;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
+import io.crate.Constants;
 
 public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, ToXContentFragment {
 
@@ -414,8 +416,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         }
         Map<String, Object> sourceAsMap = XContentHelper.convertToMap(mappingMetadata.source().compressedReference(), true).map();
         Map<String, Object> mapping;
-        if (sourceAsMap.size() == 1 && sourceAsMap.containsKey(mappingMetadata.type())) {
-            mapping = (Map<String, Object>) sourceAsMap.get(mappingMetadata.type());
+        if (sourceAsMap.size() == 1 && sourceAsMap.containsKey(Constants.DEFAULT_MAPPING_TYPE)) {
+            mapping = (Map<String, Object>) sourceAsMap.get(Constants.DEFAULT_MAPPING_TYPE);
         } else {
             mapping = sourceAsMap;
         }
@@ -427,7 +429,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
         filterFields("", properties, fieldPredicate);
 
-        return new MappingMetadata(mappingMetadata.type(), sourceAsMap);
+        return new MappingMetadata(sourceAsMap);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -215,11 +215,11 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                     final CompressedXContent currentSource = currentIndexMetadata.mapping().source();
                     final CompressedXContent newSource = mapping.source();
                     assert currentSource.equals(newSource) :
-                        "expected current mapping [" + currentSource + "] for type [" + mapping.type() + "] "
+                        "expected current mapping [" + currentSource + "] for type [" + Constants.DEFAULT_MAPPING_TYPE + "] "
                             + "to be the same as new mapping [" + newSource + "]";
                     final CompressedXContent mapperSource = new CompressedXContent(Strings.toString(mapper));
                     assert currentSource.equals(mapperSource) :
-                        "expected current mapping [" + currentSource + "] for type [" + mapping.type() + "] "
+                        "expected current mapping [" + currentSource + "] for type [" + Constants.DEFAULT_MAPPING_TYPE + "] "
                             + "to be the same as new mapping [" + mapperSource + "]";
                 }
             } else {

--- a/server/src/test/java/io/crate/metadata/PartitionInfosTest.java
+++ b/server/src/test/java/io/crate/metadata/PartitionInfosTest.java
@@ -37,7 +37,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
-import io.crate.Constants;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
@@ -88,7 +87,7 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata.Builder indexMetadata = IndexMetadata
             .builder(partitionName.asIndexName())
             .settings(defaultSettings())
-            .putMapping(Constants.DEFAULT_MAPPING_TYPE, "{\"_meta\":{\"partitioned_by\":[[\"col\", \"string\"]]}}")
+            .putMapping("{\"_meta\":{\"partitioned_by\":[[\"col\", \"string\"]]}}")
             .numberOfShards(10)
             .numberOfReplicas(4);
         addIndexMetadataToClusterState(indexMetadata);
@@ -109,7 +108,7 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata.Builder indexMetadata = IndexMetadata
             .builder(partitionName.asIndexName())
             .settings(defaultSettings())
-            .putMapping(Constants.DEFAULT_MAPPING_TYPE, "{\"_meta\":{\"partitioned_by\":[[\"col\", \"string\"], [\"col2\", \"integer\"]]}}")
+            .putMapping("{\"_meta\":{\"partitioned_by\":[[\"col\", \"string\"], [\"col2\", \"integer\"]]}}")
             .numberOfShards(10)
             .numberOfReplicas(4);
         addIndexMetadataToClusterState(indexMetadata);

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -37,7 +38,6 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -120,7 +120,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
 
         IndexMetadata.Builder mdBuilder = IndexMetadata.builder(indexName)
             .settings(settingsBuilder)
-            .putMapping(new MappingMetadata(Constants.DEFAULT_MAPPING_TYPE, mappingSource));
+            .putMapping(new MappingMetadata(mappingSource));
         return mdBuilder.build();
     }
 
@@ -1197,7 +1197,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
 
         IndexMetadata indexMetadata = IndexMetadata.builder(analyzedStatement.tableIdent().name())
             .settings(settingsBuilder)
-            .putMapping(new MappingMetadata(Constants.DEFAULT_MAPPING_TYPE, analyzedStatement.mapping()))
+            .putMapping(new MappingMetadata(analyzedStatement.mapping()))
             .build();
 
         return newMeta(indexMetadata, analyzedStatement.tableIdent().name());

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
-import io.crate.Constants;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
@@ -64,7 +63,7 @@ public class DocTableInfoFactoryTest extends ESTestCase {
             .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
             .numberOfReplicas(0)
             .numberOfShards(5)
-            .putMapping(Constants.DEFAULT_MAPPING_TYPE,
+            .putMapping(
                 "{" +
                 "  \"default\": {" +
                 "    \"properties\":{" +

--- a/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
@@ -65,7 +65,6 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
             .numberOfShards(1)
             .numberOfReplicas(0)
             .putMapping(
-                Constants.DEFAULT_MAPPING_TYPE,
                 "{" +
                 "   \"_all\": {\"enabled\": false}," +
                 "   \"properties\": {" +
@@ -89,7 +88,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
             .settings(Settings.builder().put("index.version.created", Version.V_4_7_0))
             .numberOfShards(1)
             .numberOfReplicas(0)
-            .putMapping(null) // here
+            .putMapping((MappingMetadata) null) // here
             .build();
 
         MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -57,7 +57,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.crate.Constants;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.replication.logical.MetadataTracker.RestoreDiff;
@@ -92,7 +91,7 @@ public class MetadataTrackerTest extends ESTestCase {
 
         public Builder addTable(String name, Map<String, Object> mapping, Settings settings) throws IOException {
             var indexMetadata = IndexMetadata.builder(name)
-                .putMapping(new MappingMetadata(Constants.DEFAULT_MAPPING_TYPE, mapping))
+                .putMapping(new MappingMetadata(mapping))
                 .settings(settings(Version.CURRENT).put(settings))
                 .numberOfShards(1)
                 .numberOfReplicas(0)
@@ -114,7 +113,7 @@ public class MetadataTrackerTest extends ESTestCase {
             Map<String, Object> mapping = Map.of();
             Settings settings = Settings.EMPTY;
             var indexMetadata = IndexMetadata.builder(partition)
-                .putMapping(new MappingMetadata(Constants.DEFAULT_MAPPING_TYPE, mapping))
+                .putMapping(new MappingMetadata(mapping))
                 .settings(settings(Version.CURRENT).put(settings))
                 .numberOfShards(1)
                 .numberOfReplicas(0)
@@ -169,7 +168,7 @@ public class MetadataTrackerTest extends ESTestCase {
         public Builder updateTableMapping(String name, Map<String, Object> newMapping) throws IOException {
             var indexMetadata = clusterState.metadata().index(name);
             var newIndexMetadata = IndexMetadata.builder(indexMetadata)
-                .putMapping(new MappingMetadata(Constants.DEFAULT_MAPPING_TYPE, newMapping))
+                .putMapping(new MappingMetadata(newMapping))
                 .mappingVersion(2L)
                 .build();
             clusterState = ClusterState.builder(clusterState)

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -165,7 +165,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
         IndexMetadata indexMetadata = IndexMetadata.builder(shardId.getIndexName())
             .settings(indexSettings)
             .primaryTerm(shardId.id(), primary.getOperationPrimaryTerm())
-            .putMapping("default","{ \"properties\": { \"value\":  { \"type\": \"short\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"value\":  { \"type\": \"short\", \"position\": 1}}}")
             .build();
         state.metadata(Metadata.builder().put(indexMetadata, false).generateClusterUuidIfNeeded());
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -537,7 +537,7 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testIndexingOperationListenersIsInvokedOnRecovery() throws IOException {
         IndexShard shard = newStartedShard(true);
         updateMappings(shard, IndexMetadata.builder(shard.indexSettings.getIndexMetadata())
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
         indexDoc(shard, "0", "{\"foo\" : \"bar\"}");
         deleteDoc(shard, "0");
         indexDoc(shard, "1", "{\"foo\" : \"bar\"}");
@@ -588,7 +588,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metaData = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metaData.getIndex(), 0), true, "n1", metaData, null);
@@ -635,7 +635,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metaData = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, randomLongBetween(1, Long.MAX_VALUE)).build();
         IndexShard primary = newShard(new ShardId(metaData.getIndex(), 0), true, "n1", metaData, null);
@@ -719,7 +719,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metaData = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metaData.getIndex(), 0), true, "n1", metaData, null);
@@ -775,7 +775,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metaData = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metaData.getIndex(), 0), true, "n1", metaData, null);
@@ -863,7 +863,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metaData = IndexMetadata.builder("source")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
 
@@ -1065,7 +1065,6 @@ public class IndexShardTests extends IndexShardTestCase {
                 IndexMetadata
                     .builder(indexShard.indexSettings.getIndexMetadata())
                     .putMapping(
-                        "default",
                         "{ \"properties\": {" +
                             "\"count\": { \"type\": \"integer\", \"position\": 1}, " +
                             "\"point\": { \"type\": \"float\", \"position\": 2}, " +
@@ -1118,7 +1117,6 @@ public class IndexShardTests extends IndexShardTestCase {
                 IndexMetadata.builder(
                     indexShard.indexSettings.getIndexMetadata()
                 ).putMapping(
-                    "default",
                     "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}"
                 ).build());
             for (int i = 0; i < numDoc / 2; i++) {
@@ -1457,7 +1455,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metadata = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
@@ -1502,7 +1500,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metadata = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
@@ -1566,7 +1564,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metadata = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
@@ -2838,7 +2836,7 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testIndexingOperationsListeners() throws IOException {
         IndexShard shard = newStartedShard(true);
         updateMappings(shard, IndexMetadata.builder(shard.indexSettings.getIndexMetadata())
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
         indexDoc(shard, "0", "{\"foo\" : \"bar\"}");
         shard.updateLocalCheckpointForShard(shard.shardRouting.allocationId().getId(), 0);
         AtomicInteger preIndex = new AtomicInteger();
@@ -3540,7 +3538,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metaData = IndexMetadata.builder("test")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         ShardRouting shardRouting =
@@ -3618,7 +3616,7 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testOnCloseStats() throws IOException {
         IndexShard indexShard = newStartedShard(true);
         updateMappings(indexShard, IndexMetadata.builder(indexShard.indexSettings.getIndexMetadata())
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
         for (int i = 0; i < 3; i++) {
             indexDoc(indexShard, String.valueOf(i), "{\"foo\" : \"" + randomAlphaOfLength(10) + "\"}");
             indexShard.refresh("test"); // produce segments
@@ -3664,7 +3662,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertThat(deleteDoc.getField(DocSysColumns.Names.TOMBSTONE).numericValue().longValue(), equalTo(1L));
 
         updateMappings(shard, IndexMetadata.builder(shard.indexSettings.getIndexMetadata())
-            .putMapping("default", "{ \"properties\": {}}").build());
+            .putMapping("{ \"properties\": {}}").build());
         final String reason = randomUnicodeOfLength(200);
         ParsedDocument noopTombstone = shard.getEngine().config().getTombstoneDocSupplier().newNoopTombstoneDoc(reason);
         Document noopDoc = noopTombstone.doc();
@@ -3801,7 +3799,7 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testResetEngineWithBrokenTranslog() throws Exception {
         IndexShard shard = newStartedShard(false);
         updateMappings(shard, IndexMetadata.builder(shard.indexSettings.getIndexMetadata())
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}").build());
         final List<Translog.Operation> operations = Stream.concat(
             IntStream.range(0, randomIntBetween(0, 10)).mapToObj(n -> new Translog.Index(
                 "1",
@@ -4056,7 +4054,7 @@ public class IndexShardTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
         IndexMetadata metaData = IndexMetadata.builder("index")
-            .putMapping("default", "{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\", \"position\": 1}}}")
             .settings(settings)
             .primaryTerm(0, 1).build();
         IndexShard shard = newShard(new ShardId(metaData.getIndex(), 0), true, "n1", metaData, null);

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -87,7 +87,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import io.crate.Constants;
 import io.crate.analyze.WhereClause;
 import io.crate.breaker.RamAccounting;
 import io.crate.common.collections.Lists2;
@@ -100,8 +99,8 @@ import io.crate.execution.dsl.projection.AggregationProjection;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.collect.CollectTask;
 import io.crate.execution.engine.collect.DocValuesAggregates;
-import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.collect.MapSideDataCollectOperation;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.jobs.SharedShardContexts;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.AggregateMode;
@@ -495,7 +494,7 @@ public abstract class AggregationTestCase extends ESTestCase {
         var indexMetadata = IndexMetadata.builder(routing.getIndexName())
             .settings(indexSettings)
             .primaryTerm(0, 1)
-            .putMapping(Constants.DEFAULT_MAPPING_TYPE, Strings.toString(mapping))
+            .putMapping(Strings.toString(mapping))
             .build();
         var shardId = routing.shardId();
         var nodePath = new NodeEnvironment.NodePath(createTempDir());

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -100,8 +100,8 @@ import org.mockito.Answers;
 
 import io.crate.Constants;
 import io.crate.action.sql.Cursors;
-import io.crate.action.sql.Sessions;
 import io.crate.action.sql.Session;
+import io.crate.action.sql.Sessions;
 import io.crate.analyze.AnalyzedCreateBlobTable;
 import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedStatement;
@@ -581,9 +581,7 @@ public class SQLExecutor {
             IndexMetadata.Builder metaBuilder = IndexMetadata.builder(indexName)
                 .settings(indexSettings);
             if (mapping != null) {
-                metaBuilder.putMapping(new MappingMetadata(
-                    Constants.DEFAULT_MAPPING_TYPE,
-                    mapping));
+                metaBuilder.putMapping(new MappingMetadata(mapping));
             }
 
             return metaBuilder;

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1276,7 +1276,7 @@ public abstract class EngineTestCase extends ESTestCase {
             .settings(Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
-            .putMapping(type, "{\"properties\": {}}")
+            .putMapping("{\"properties\": {}}")
             .build();
         MapperService mapperService = MapperTestUtils.newMapperService(new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
             createTempDir(), Settings.EMPTY, "test");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The type was always "default" in CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
