### PR TITLE
bp: Remove sporadic min/max usage estimates from stats + watermark integration test

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -232,6 +232,7 @@ should be crossed out as well.
 - [x] cefaa17c52c Simplify CheckSumBlobStoreFormat and make it more Reusable (#59888) (#59950)
 - [x] 5b92596fad5 Cleanup and Optimize Multiple Serialization Spots (#59626) (#59936)
 - [s] 8647872a1e5 Simplify structure for parsing points. (#59938)
+- [x] b75207a09f1 Remove sporadic min/max usage estimates from stats (#59755)
 - [x] 65f6fb8e94f Shortcut mapping update if the incoming mapping version is the same as the current mapping version (#59517) (#59772)
 - [s] 343053c0a7f Fix compilation in Eclipse (backport #59675)
 - [s] 27067de6991 Make MappedFieldType#meta final (#59383)

--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -162,7 +162,7 @@ should be crossed out as well.
 - [x] 075271758e3 Keep checkpoint file channel open across fsyncs (#61744)
 - [s] 2bb5716b3dc Add repositories metering API (#62088)
 - [s] bb0a583990e Allow enabling soft-deletes on restore from snapshot (#62018)
-- [ ] 3389d5ccb25 Introduce integ tests for high disk watermark (#60460)
+- [x] 3389d5ccb25 Introduce integ tests for high disk watermark (#60460)
 - [x] 395538f5083 Improve Snapshot State Machine Performance (#62000) (#62049)
 - [s] a295b0aa86f Fix null_value parsing for data_nanos field mapper (#61994)
 - [s] 1799c0c5833 Convert completion, binary, boolean tests to MapperTestCase (#62004)

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -377,14 +377,11 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                 }
                 String nodeId = nodeStats.getNode().getId();
                 String nodeName = nodeStats.getNode().getName();
-                if (traceEnabled) {
-                    logger.trace(
-                        "node: [{}], most available: total disk: {}, available disk: {} / least available: total disk: {}, available disk: {}",
-                        nodeId,
-                        mostAvailablePath.getTotal(),
-                        leastAvailablePath.getAvailable(),
-                        leastAvailablePath.getTotal(),
-                        leastAvailablePath.getAvailable());
+                if (logger.isTraceEnabled()) {
+                    logger.trace("node: [{}], most available: total disk: {}," +
+                            " available disk: {} / least available: total disk: {}, available disk: {}",
+                            nodeId, mostAvailablePath.getTotal(), mostAvailablePath.getAvailable(),
+                            leastAvailablePath.getTotal(), leastAvailablePath.getAvailable());
                 }
                 if (leastAvailablePath.getTotal().getBytes() < 0) {
                     if (traceEnabled) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -272,8 +272,8 @@ public class DiskThresholdDecider extends AllocationDecider {
         double freeSpaceAfterShard = freeDiskPercentageAfterShardAssigned(usage, shardSize);
         long freeBytesAfterShard = freeBytes - shardSize;
         if (freeBytesAfterShard < diskThresholdSettings.getFreeBytesThresholdHigh().getBytes()) {
-            LOGGER.warn("after allocating, node [{}] would have less than the required threshold of " +
-                    "{} free (currently {} free, estimated shard size is {}), preventing allocation",
+            LOGGER.warn("after allocating [{}] node [{}] would have less than the required threshold of " +
+                    "{} free (currently {} free, estimated shard size is {}), preventing allocation", shardRouting,
                     node.nodeId(), diskThresholdSettings.getFreeBytesThresholdHigh(), freeBytesValue, new ByteSizeValue(shardSize));
             return allocation.decision(Decision.NO, NAME,
                 "allocating the shard to this node will bring the node above the high watermark cluster setting [%s=%s] " +
@@ -284,8 +284,8 @@ public class DiskThresholdDecider extends AllocationDecider {
                 freeBytesValue, new ByteSizeValue(shardSize));
         }
         if (freeSpaceAfterShard < diskThresholdSettings.getFreeDiskThresholdHigh()) {
-            LOGGER.warn("after allocating, node [{}] would have more than the allowed " +
-                            "{} free disk threshold ({} free), preventing allocation",
+            LOGGER.warn("after allocating [{}] node [{}] would have more than the allowed " +
+                            "{} free disk threshold ({} free), preventing allocation", shardRouting,
                     node.nodeId(), Strings.format1Decimals(diskThresholdSettings.getFreeDiskThresholdHigh(), "%"),
                                                            Strings.format1Decimals(freeSpaceAfterShard, "%"));
             return allocation.decision(Decision.NO, NAME,

--- a/server/src/main/java/org/elasticsearch/monitor/MonitorService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/MonitorService.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor;
 
-import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
@@ -30,6 +29,8 @@ import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.process.ProcessService;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.IOException;
+
 public class MonitorService extends AbstractLifecycleComponent {
 
     private final JvmGcMonitorService jvmGcMonitorService;
@@ -38,15 +39,12 @@ public class MonitorService extends AbstractLifecycleComponent {
     private final JvmService jvmService;
     private final FsService fsService;
 
-    public MonitorService(Settings settings,
-                          NodeEnvironment nodeEnvironment,
-                          ThreadPool threadPool,
-                          ClusterInfoService clusterInfoService) {
+    public MonitorService(Settings settings, NodeEnvironment nodeEnvironment, ThreadPool threadPool) throws IOException {
         this.jvmGcMonitorService = new JvmGcMonitorService(settings, threadPool);
         this.osService = new OsService(settings);
         this.processService = new ProcessService(settings);
         this.jvmService = new JvmService(settings);
-        this.fsService = new FsService(settings, nodeEnvironment, clusterInfoService);
+        this.fsService = new FsService(settings, nodeEnvironment);
     }
 
     public OsService osService() {

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
@@ -26,12 +26,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.cluster.ClusterInfo;
-import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.NodeEnvironment.NodePath;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -51,7 +48,7 @@ public class FsProbe {
         this.nodeEnv = nodeEnv;
     }
 
-    public FsInfo stats(FsInfo previous, @Nullable ClusterInfo clusterInfo) throws IOException {
+    public FsInfo stats(FsInfo previous) throws IOException {
         if (!nodeEnv.hasNodeFile()) {
             return new FsInfo(System.currentTimeMillis(), null, new FsInfo.Path[0]);
         }
@@ -70,16 +67,10 @@ public class FsProbe {
             }
             ioStats = ioStats(devicesNumbers, previous);
         }
-        DiskUsage leastDiskEstimate = null;
-        DiskUsage mostDiskEstimate = null;
-        if (clusterInfo != null) {
-            leastDiskEstimate = clusterInfo.getNodeLeastAvailableDiskUsages().get(nodeEnv.nodeId());
-            mostDiskEstimate = clusterInfo.getNodeMostAvailableDiskUsages().get(nodeEnv.nodeId());
-        }
-        return new FsInfo(System.currentTimeMillis(), ioStats, paths, leastDiskEstimate, mostDiskEstimate);
+        return new FsInfo(System.currentTimeMillis(), ioStats, paths);
     }
 
-    private final FsInfo.IoStats ioStats(final Set<Tuple<Integer, Integer>> devicesNumbers, final FsInfo previous) {
+    final FsInfo.IoStats ioStats(final Set<Tuple<Integer, Integer>> devicesNumbers, final FsInfo previous) {
         try {
             final Map<Tuple<Integer, Integer>, FsInfo.DeviceStats> deviceMap = new HashMap<>();
             if (previous != null && previous.getIoStats() != null && previous.getIoStats().devicesStats != null) {

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsService.java
@@ -29,13 +29,13 @@ import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.env.NodeEnvironment;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 public class FsService {
 
     private static final Logger LOGGER = LogManager.getLogger(FsService.class);
 
-    private final FsProbe probe;
-    private final SingleObjectCache<FsInfo> cache;
+    private final Supplier<FsInfo> fsInfoSupplier;
 
     public static final Setting<TimeValue> REFRESH_INTERVAL_SETTING =
         Setting.timeSetting(
@@ -44,33 +44,46 @@ public class FsService {
             TimeValue.timeValueSeconds(1),
             Property.NodeScope);
 
+    // permits tests to bypass the refresh interval on the cache; deliberately unregistered since it is only for use in tests
+    public static final Setting<Boolean> ALWAYS_REFRESH_SETTING =
+        Setting.boolSetting("monitor.fs.always_refresh", false, Property.NodeScope);
+
     public FsService(final Settings settings, final NodeEnvironment nodeEnvironment) {
-        this.probe = new FsProbe(nodeEnvironment);
-        final TimeValue refreshInterval = REFRESH_INTERVAL_SETTING.get(settings);
-        LOGGER.debug("using refresh_interval [{}]", refreshInterval);
-        cache = new FsInfoCache(refreshInterval, stats(probe, null));
+        final FsProbe probe = new FsProbe(nodeEnvironment);
+        final FsInfo initialValue = stats(probe, null);
+        if (ALWAYS_REFRESH_SETTING.get(settings)) {
+            assert REFRESH_INTERVAL_SETTING.exists(settings) == false;
+            LOGGER.debug("bypassing refresh_interval");
+            fsInfoSupplier = () -> stats(probe, initialValue);
+        } else {
+            final TimeValue refreshInterval = REFRESH_INTERVAL_SETTING.get(settings);
+            LOGGER.debug("using refresh_interval [{}]", refreshInterval);
+            fsInfoSupplier = new FsInfoCache(refreshInterval, initialValue, probe)::getOrRefresh;
+        }
     }
 
     public FsInfo stats() {
-        return cache.getOrRefresh();
+        return fsInfoSupplier.get();
     }
 
     private static FsInfo stats(FsProbe probe, FsInfo initialValue) {
         try {
             return probe.stats(initialValue);
         } catch (IOException e) {
-            FsService.LOGGER.debug("unexpected exception reading filesystem info", e);
+            LOGGER.debug("unexpected exception reading filesystem info", e);
             return null;
         }
     }
 
-    private class FsInfoCache extends SingleObjectCache<FsInfo> {
+    private static class FsInfoCache extends SingleObjectCache<FsInfo> {
 
         private final FsInfo initialValue;
+        private final FsProbe probe;
 
-        FsInfoCache(TimeValue interval, FsInfo initialValue) {
+        FsInfoCache(TimeValue interval, FsInfo initialValue, FsProbe probe) {
             super(interval, initialValue);
             this.initialValue = initialValue;
+            this.probe = probe;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -424,8 +424,7 @@ public class Node implements Closeable {
 
             final MonitorService monitorService = new MonitorService(settings,
                                                                      nodeEnvironment,
-                                                                     threadPool,
-                                                                     clusterInfoService);
+                                                                     threadPool);
             ClusterModule clusterModule = new ClusterModule(settings,
                                                             clusterService,
                                                             clusterPlugins,

--- a/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.testing.UseRandomizedSchema;
+import org.apache.lucene.tests.mockfile.FilterFileStore;
+import org.apache.lucene.tests.mockfile.FilterFileSystemProvider;
+import org.apache.lucene.tests.mockfile.FilterPath;
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteAction;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
+import org.elasticsearch.action.admin.indices.stats.ShardStats;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.InternalClusterInfoService;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.io.PathUtilsForTesting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.monitor.fs.FsService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static io.crate.testing.SQLTransportExecutor.REQUEST_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST, numDataNodes = 0)
+@UseRandomizedSchema(random = false)
+public class DiskThresholdDeciderIT extends IntegTestCase {
+
+    private static TestFileSystemProvider fileSystemProvider;
+
+    private FileSystem defaultFileSystem;
+
+    @Before
+    public void installFilesystemProvider() {
+        assertThat(defaultFileSystem).isNull();
+        defaultFileSystem = PathUtils.getDefaultFileSystem();
+        assertThat(fileSystemProvider).isNull();
+        fileSystemProvider = new TestFileSystemProvider(defaultFileSystem, createTempDir());
+        PathUtilsForTesting.installMock(fileSystemProvider.getFileSystem(null));
+    }
+
+    @After
+    public void removeFilesystemProvider() {
+        fileSystemProvider = null;
+        assertThat(defaultFileSystem).isNotNull();
+        PathUtilsForTesting.installMock(defaultFileSystem); // set the default filesystem back
+        defaultFileSystem = null;
+    }
+
+    private static final long WATERMARK_BYTES = new ByteSizeValue(10, ByteSizeUnit.KB).getBytes();
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        final Path dataPath = fileSystemProvider.getRootDir().resolve("node-" + nodeOrdinal);
+        try {
+            Files.createDirectories(dataPath);
+        } catch (IOException e) {
+            throw new AssertionError("unexpected", e);
+        }
+        fileSystemProvider.addTrackedPath(dataPath);
+        return Settings.builder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put(Environment.PATH_DATA_SETTING.getKey(), dataPath)
+                .put(FsService.ALWAYS_REFRESH_SETTING.getKey(), true)
+                .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), WATERMARK_BYTES + "b")
+                .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), WATERMARK_BYTES + "b")
+                .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "0b")
+                .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms")
+                .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(InternalSettingsPlugin.class);
+    }
+
+    public void testHighWatermarkNotExceeded() throws InterruptedException, ExecutionException {
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNode();
+        final String dataNodeName = internalCluster().startDataOnlyNode();
+
+        final InternalClusterInfoService clusterInfoService
+                = (InternalClusterInfoService) internalCluster().getMasterNodeInstance(ClusterInfoService.class);
+        internalCluster().getMasterNodeInstance(ClusterService.class).addListener(event -> clusterInfoService.refresh());
+
+        final String dataNode0Id = internalCluster().getInstance(NodeEnvironment.class, dataNodeName).nodeId();
+        final Path dataNode0Path = internalCluster().getInstance(Environment.class, dataNodeName).dataFiles()[0];
+
+        String indexName = "test";
+        execute("create table " + indexName + "(x text) " +
+            "clustered into 6 shards " +
+            "with (column_policy='strict', \"store.stats_refresh_interval\" = '0ms', number_of_replicas = 0)");
+
+        final long minShardSize = createReasonableSizedShards(indexName);
+
+        // reduce disk size of node 0 so that no shards fit below the high watermark, forcing all shards onto the other data node
+        // (subtract the translog size since the disk threshold decider ignores this and may therefore move the shard back again)
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES - 1L);
+        refreshDiskUsage();
+        assertThat(getShardRoutings(dataNode0Id, indexName)).isEmpty();
+
+        // increase disk size of node 0 to allow just enough room for one shard, and check that it's rebalanced back
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 1L);
+        refreshDiskUsage();
+        assertThat(getShardRoutings(dataNode0Id, indexName)).hasSize(1);
+    }
+
+    private Set<ShardRouting> getShardRoutings(String nodeId, String indexName) {
+        final Set<ShardRouting> shardRoutings = new HashSet<>();
+        ClusterStateResponse clusterStateResponse = FutureUtils.get(client().admin().cluster().state(new ClusterStateRequest().routingTable(true)));
+        for (IndexShardRoutingTable indexShardRoutingTable : clusterStateResponse.getState().getRoutingTable().index(indexName)) {
+            for (ShardRouting shard : indexShardRoutingTable.shards()) {
+                assertThat(shard.state()).isEqualTo(ShardRoutingState.STARTED);
+                if (shard.currentNodeId().equals(nodeId)) {
+                    shardRoutings.add(shard);
+                }
+            }
+        }
+        return shardRoutings;
+    }
+
+    /**
+     * Index documents until all the shards are at least WATERMARK_BYTES in size, and return the size of the smallest shard
+     * @param indexName
+     */
+    private long createReasonableSizedShards(String indexName) throws InterruptedException, ExecutionException {
+        String tableName = "doc." + indexName; // UseRandomizedSchema is set to false
+        while (true) {
+
+            execute("insert into " + tableName + "(x) values (?)", new Object[]{randomAlphaOfLengthBetween(1000, 2000)});
+
+            ensureGreen();
+            execute("optimize table " + tableName + " with (max_num_segments=1)");
+
+            refresh();
+
+            var indicesStats = client().admin().indices().stats(new IndicesStatsRequest().indices(indexName).store(true)).get();
+            final ShardStats[] shardStatses = indicesStats.getIndex(indexName).getShards();
+
+            final long[] shardSizes = new long[shardStatses.length];
+            for (ShardStats shardStats : shardStatses) {
+                shardSizes[shardStats.getShardRouting().id()] = shardStats.getStats().getStore().sizeInBytes();
+            }
+
+            final long minShardSize = Arrays.stream(shardSizes).min().orElseThrow(() -> new AssertionError("no shards"));
+            if (minShardSize > WATERMARK_BYTES) {
+                return minShardSize;
+            }
+        }
+    }
+
+    private void refreshDiskUsage() throws ExecutionException, InterruptedException {
+        ((InternalClusterInfoService) internalCluster().getMasterNodeInstance(ClusterInfoService.class)).refresh();
+        // if the nodes were all under the low watermark already (but unbalanced) then a change in the disk usage doesn't trigger a reroute
+        // even though it's now possible to achieve better balance, so we have to do an explicit reroute. TODO fix this?
+        final ClusterInfo clusterInfo = internalCluster().getMasterNodeInstance(ClusterInfoService.class).getClusterInfo();
+        if (StreamSupport.stream(clusterInfo.getNodeMostAvailableDiskUsages().values().spliterator(), false)
+            .allMatch(cur -> cur.value.getFreeBytes() > WATERMARK_BYTES)) {
+
+            var clusterRerouteResponse = client().admin().cluster()
+                .execute(ClusterRerouteAction.INSTANCE, new ClusterRerouteRequest()).get();
+            assertAcked(clusterRerouteResponse);
+        }
+
+        var clusterHealthRequest = new ClusterHealthRequest()
+            .waitForEvents(Priority.LANGUID)
+            .waitForNoRelocatingShards(true)
+            .waitForNoInitializingShards(true);
+        ClusterHealthResponse response = FutureUtils.get(client().admin().cluster().health(clusterHealthRequest), REQUEST_TIMEOUT);
+        assertThat(response.isTimedOut()).isFalse();
+    }
+
+    private static class TestFileStore extends FilterFileStore {
+
+        private final Path path;
+
+        private volatile long totalSpace = -1;
+
+        TestFileStore(FileStore delegate, String scheme, Path path) {
+            super(delegate, scheme);
+            this.path = path;
+        }
+
+        @Override
+        public String name() {
+            return "fake"; // Lucene's is-spinning-disk check expects the device name here
+        }
+
+        @Override
+        public long getTotalSpace() throws IOException {
+            final long totalSpace = this.totalSpace;
+            if (totalSpace == -1) {
+                return super.getTotalSpace();
+            } else {
+                return totalSpace;
+            }
+        }
+
+        public void setTotalSpace(long totalSpace) {
+            assertThat(totalSpace).satisfiesAnyOf(l -> assertThat(l).isEqualTo(-1L), l -> assertThat(l).isGreaterThan(0L));
+            this.totalSpace = totalSpace;
+        }
+
+        @Override
+        public long getUsableSpace() throws IOException {
+            final long totalSpace = this.totalSpace;
+            if (totalSpace == -1) {
+                return super.getUsableSpace();
+            } else {
+                return Math.max(0L, totalSpace - getTotalFileSize(path));
+            }
+        }
+
+        @Override
+        public long getUnallocatedSpace() throws IOException {
+            final long totalSpace = this.totalSpace;
+            if (totalSpace == -1) {
+                return super.getUnallocatedSpace();
+            } else {
+                return Math.max(0L, totalSpace - getTotalFileSize(path));
+            }
+        }
+
+        private static long getTotalFileSize(Path path) throws IOException {
+            if (Files.isRegularFile(path)) {
+                try {
+                    return Files.size(path);
+                } catch (NoSuchFileException | FileNotFoundException e) {
+                    // probably removed
+                    return 0L;
+                }
+            } else if (path.getFileName().toString().equals("_state") || path.getFileName().toString().equals("translog")) {
+                // ignore metadata and translog, since the disk threshold decider only cares about the store size
+                return 0L;
+            } else {
+                try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(path)) {
+                    long total = 0L;
+                    for (Path subpath : directoryStream) {
+                        total += getTotalFileSize(subpath);
+                    }
+                    return total;
+                } catch (NotDirectoryException | NoSuchFileException | FileNotFoundException e) {
+                    // probably removed
+                    return 0L;
+                }
+            }
+        }
+    }
+
+    private static class TestFileSystemProvider extends FilterFileSystemProvider {
+        private final Map<Path, TestFileStore> trackedPaths = newConcurrentMap();
+        private final Path rootDir;
+
+        TestFileSystemProvider(FileSystem delegateInstance, Path rootDir) {
+            super("diskthreshold://", delegateInstance);
+            this.rootDir = new FilterPath(rootDir, fileSystem);
+        }
+
+        Path getRootDir() {
+            return rootDir;
+        }
+
+        void addTrackedPath(Path path) {
+            assertThat(path.startsWith(rootDir)).withFailMessage("path + \" starts with \" + rootDir").isTrue();
+            final FileStore fileStore;
+            try {
+                fileStore = super.getFileStore(path);
+            } catch (IOException e) {
+                throw new AssertionError("unexpected", e);
+            }
+            assertThat(trackedPaths.put(path, new TestFileStore(fileStore, getScheme(), path))).isNull();
+        }
+
+        @Override
+        public FileStore getFileStore(Path path) {
+            return getTestFileStore(path);
+        }
+
+        TestFileStore getTestFileStore(Path path) {
+            if (path.endsWith(path.getFileSystem().getPath("nodes", "0"))) {
+                path = path.getParent().getParent();
+            }
+            final TestFileStore fileStore = trackedPaths.get(path);
+            if (fileStore != null) {
+                return fileStore;
+            }
+
+            // On Linux, and only Linux, Lucene obtains a filestore for the index in order to determine whether it's on a spinning disk or
+            // not so it can configure the merge scheduler accordingly
+            assertThat(Constants.LINUX).withFailMessage(path + " not tracked and not on Linux").isTrue();
+            final Set<Path> containingPaths = trackedPaths.keySet().stream().filter(path::startsWith).collect(Collectors.toSet());
+            assertThat(containingPaths).withFailMessage(path + " not contained in a unique tracked path").hasSize(1);
+            return trackedPaths.get(containingPaths.iterator().next());
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.monitor.fs;
+
+import io.crate.common.collections.Tuple;
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.NodeEnvironment.NodePath;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileStoreAttributeView;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class FsProbeTests extends ESTestCase {
+
+    public void testFsInfo() throws IOException {
+
+        try (NodeEnvironment env = newNodeEnvironment()) {
+            FsProbe probe = new FsProbe(env);
+
+            FsInfo stats = probe.stats(null);
+            assertThat(stats).isNotNull();
+            assertThat(stats.getTimestamp()).isGreaterThan(0L);
+
+            if (Constants.LINUX) {
+                assertThat(stats.getIoStats()).isNotNull();
+                assertThat(stats.getIoStats().devicesStats).isNotNull();
+                for (int i = 0; i < stats.getIoStats().devicesStats.length; i++) {
+                    final FsInfo.DeviceStats deviceStats = stats.getIoStats().devicesStats[i];
+                    assertThat(deviceStats).isNotNull();
+                    assertThat(deviceStats.currentReadsCompleted).isGreaterThanOrEqualTo(0L);
+                    assertThat(deviceStats.previousReadsCompleted).isEqualTo(-1L);
+                    assertThat(deviceStats.currentSectorsRead).isGreaterThanOrEqualTo(0L);
+                    assertThat(deviceStats.previousSectorsRead).isEqualTo(-1L);
+                    assertThat(deviceStats.currentWritesCompleted).isGreaterThanOrEqualTo(0L);
+                    assertThat(deviceStats.previousWritesCompleted).isEqualTo(-1L);
+                    assertThat(deviceStats.currentSectorsWritten).isGreaterThanOrEqualTo(0L);
+                    assertThat(deviceStats.previousSectorsWritten).isEqualTo(-1L);
+                }
+            } else {
+                assertThat(stats.getIoStats()).isNull();
+            }
+
+            FsInfo.Path total = stats.getTotal();
+            assertThat(total).isNotNull();
+            assertThat(total.total).isGreaterThan(0L);
+            assertThat(total.free).isGreaterThan(0L);
+            assertThat(total.available).isGreaterThan(0L);
+
+            for (FsInfo.Path path : stats) {
+                assertThat(path).isNotNull();
+                assertThat(path.getPath()).isNotEmpty();
+                assertThat(path.getMount()).isNotEmpty();
+                assertThat(path.getType()).isNotEmpty();
+                assertThat(path.total).isGreaterThan(0L);
+                assertThat(path.free).isGreaterThan(0L);
+                assertThat(path.available).isGreaterThan(0L);
+            }
+        }
+    }
+
+    public void testFsInfoOverflow() throws Exception {
+        final FsInfo.Path pathStats =
+            new FsInfo.Path(
+                "/foo/bar",
+                null,
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong());
+
+        addUntilOverflow(
+            pathStats,
+            p -> p.total,
+            "total",
+            () -> new FsInfo.Path("/foo/baz", null, randomNonNegativeLong(), 0, 0));
+
+        addUntilOverflow(
+            pathStats,
+            p -> p.free,
+            "free",
+            () -> new FsInfo.Path("/foo/baz", null, 0, randomNonNegativeLong(), 0));
+
+        addUntilOverflow(
+            pathStats,
+            p -> p.available,
+            "available",
+            () -> new FsInfo.Path("/foo/baz", null, 0, 0, randomNonNegativeLong()));
+
+        // even after overflowing these should not be negative
+        assertThat(pathStats.total).isGreaterThan(0L);
+        assertThat(pathStats.free).isGreaterThan(0L);
+        assertThat(pathStats.available).isGreaterThan(0L);
+    }
+
+    private void addUntilOverflow(
+        final FsInfo.Path pathStats,
+        final Function<FsInfo.Path, Long> getter,
+        final String field,
+        final Supplier<FsInfo.Path> supplier) {
+        FsInfo.Path pathToAdd = supplier.get();
+        while ((getter.apply(pathStats) + getter.apply(pathToAdd)) > 0) {
+            // add a path to increase the total bytes until it overflows
+            logger.info(
+                "--> adding {} bytes to {}, {} will be: {}",
+                getter.apply(pathToAdd),
+                getter.apply(pathStats),
+                field,
+                getter.apply(pathStats) + getter.apply(pathToAdd));
+            pathStats.add(pathToAdd);
+            pathToAdd = supplier.get();
+        }
+        // this overflows
+        logger.info(
+            "--> adding {} bytes to {}, {} will be: {}",
+            getter.apply(pathToAdd),
+            getter.apply(pathStats),
+            field,
+            getter.apply(pathStats) + getter.apply(pathToAdd));
+        assertThat(getter.apply(pathStats) + getter.apply(pathToAdd)).isLessThan(0L);
+        pathStats.add(pathToAdd);
+    }
+
+    public void testIoStats() {
+        final AtomicReference<List<String>> diskStats = new AtomicReference<>();
+        diskStats.set(Arrays.asList(
+            " 259       0 nvme0n1 336609 0 7923613 82813 10264051 0 182983933 52451441 0 2970886 52536260",
+            " 259       1 nvme0n1p1 602 0 9919 131 1 0 1 0 0 19 131",
+            " 259       2 nvme0n1p2 186 0 8626 18 24 0 60 20 0 34 38",
+            " 259       3 nvme0n1p3 335733 0 7901620 82658 9592875 0 182983872 50843431 0 1737726 50926087",
+            " 253       0 dm-0 287716 0 7184666 33457 8398869 0 118857776 18730966 0 1918440 18767169",
+            " 253       1 dm-1 112 0 4624 13 0 0 0 0 0 5 13",
+            " 253       2 dm-2 47802 0 710658 49312 1371977 0 64126096 33730596 0 1058193 33781827"));
+
+        final FsProbe probe = new FsProbe(null) {
+            @Override
+            List<String> readProcDiskStats() throws IOException {
+                return diskStats.get();
+            }
+        };
+
+        final Set<Tuple<Integer, Integer>> devicesNumbers = new HashSet<>();
+        devicesNumbers.add(Tuple.tuple(253, 0));
+        devicesNumbers.add(Tuple.tuple(253, 2));
+        final FsInfo.IoStats first = probe.ioStats(devicesNumbers, null);
+        assertThat(first).isNotNull();
+        assertThat(first.devicesStats[0].majorDeviceNumber).isEqualTo(253);
+        assertThat(first.devicesStats[0].minorDeviceNumber).isEqualTo(0);
+        assertThat(first.devicesStats[0].deviceName).isEqualTo("dm-0");
+        assertThat(first.devicesStats[0].currentReadsCompleted).isEqualTo(287716L);
+        assertThat(first.devicesStats[0].previousReadsCompleted).isEqualTo(-1L);
+        assertThat(first.devicesStats[0].currentSectorsRead).isEqualTo(7184666L);
+        assertThat(first.devicesStats[0].previousSectorsRead).isEqualTo(-1L);
+        assertThat(first.devicesStats[0].currentWritesCompleted).isEqualTo(8398869L);
+        assertThat(first.devicesStats[0].previousWritesCompleted).isEqualTo(-1L);
+        assertThat(first.devicesStats[0].currentSectorsWritten).isEqualTo(118857776L);
+        assertThat(first.devicesStats[0].previousSectorsWritten).isEqualTo(-1L);
+        assertThat(first.devicesStats[1].majorDeviceNumber).isEqualTo(253);
+        assertThat(first.devicesStats[1].minorDeviceNumber).isEqualTo(2);
+        assertThat(first.devicesStats[1].deviceName).isEqualTo("dm-2");
+        assertThat(first.devicesStats[1].currentReadsCompleted).isEqualTo(47802L);
+        assertThat(first.devicesStats[1].previousReadsCompleted).isEqualTo(-1L);
+        assertThat(first.devicesStats[1].currentSectorsRead).isEqualTo(710658L);
+        assertThat(first.devicesStats[1].previousSectorsRead).isEqualTo(-1L);
+        assertThat(first.devicesStats[1].currentWritesCompleted).isEqualTo(1371977L);
+        assertThat(first.devicesStats[1].previousWritesCompleted).isEqualTo(-1L);
+        assertThat(first.devicesStats[1].currentSectorsWritten).isEqualTo(64126096L);
+        assertThat(first.devicesStats[1].previousSectorsWritten).isEqualTo(-1L);
+
+        diskStats.set(Arrays.asList(
+            " 259       0 nvme0n1 336870 0 7928397 82876 10264393 0 182986405 52451610 0 2971042 52536492",
+            " 259       1 nvme0n1p1 602 0 9919 131 1 0 1 0 0 19 131",
+            " 259       2 nvme0n1p2 186 0 8626 18 24 0 60 20 0 34 38",
+            " 259       3 nvme0n1p3 335994 0 7906404 82721 9593184 0 182986344 50843529 0 1737840 50926248",
+            " 253       0 dm-0 287734 0 7185242 33464 8398869 0 118857776 18730966 0 1918444 18767176",
+            " 253       1 dm-1 112 0 4624 13 0 0 0 0 0 5 13",
+            " 253       2 dm-2 48045 0 714866 49369 1372291 0 64128568 33730766 0 1058347 33782056"));
+
+        final FsInfo previous = new FsInfo(System.currentTimeMillis(), first, new FsInfo.Path[0]);
+        final FsInfo.IoStats second = probe.ioStats(devicesNumbers, previous);
+        assertThat(second).isNotNull();
+        assertThat(second.devicesStats[0].majorDeviceNumber).isEqualTo(253);
+        assertThat(second.devicesStats[0].minorDeviceNumber).isEqualTo(0);
+        assertThat(second.devicesStats[0].deviceName).isEqualTo("dm-0");
+        assertThat(second.devicesStats[0].currentReadsCompleted).isEqualTo(287734L);
+        assertThat(second.devicesStats[0].previousReadsCompleted).isEqualTo(287716L);
+        assertThat(second.devicesStats[0].currentSectorsRead).isEqualTo(7185242L);
+        assertThat(second.devicesStats[0].previousSectorsRead).isEqualTo(7184666L);
+        assertThat(second.devicesStats[0].currentWritesCompleted).isEqualTo(8398869L);
+        assertThat(second.devicesStats[0].previousWritesCompleted).isEqualTo(8398869L);
+        assertThat(second.devicesStats[0].currentSectorsWritten).isEqualTo(118857776L);
+        assertThat(second.devicesStats[0].previousSectorsWritten).isEqualTo(118857776L);
+        assertThat(second.devicesStats[1].majorDeviceNumber).isEqualTo(253);
+        assertThat(second.devicesStats[1].minorDeviceNumber).isEqualTo(2);
+        assertThat(second.devicesStats[1].deviceName).isEqualTo("dm-2");
+        assertThat(second.devicesStats[1].currentReadsCompleted).isEqualTo(48045L);
+        assertThat(second.devicesStats[1].previousReadsCompleted).isEqualTo(47802L);
+        assertThat(second.devicesStats[1].currentSectorsRead).isEqualTo(714866L);
+        assertThat(second.devicesStats[1].previousSectorsRead).isEqualTo(710658L);
+        assertThat(second.devicesStats[1].currentWritesCompleted).isEqualTo(1372291L);
+        assertThat(second.devicesStats[1].previousWritesCompleted).isEqualTo(1371977L);
+        assertThat(second.devicesStats[1].currentSectorsWritten).isEqualTo(64128568L);
+        assertThat(second.devicesStats[1].previousSectorsWritten).isEqualTo(64126096L);
+
+        assertThat(second.totalOperations).isEqualTo(575L);
+        assertThat(second.totalReadOperations).isEqualTo(261L);
+        assertThat(second.totalWriteOperations).isEqualTo(314L);
+        assertThat(second.totalReadKilobytes).isEqualTo(2392L);
+        assertThat(second.totalWriteKilobytes).isEqualTo(1236L);
+    }
+
+    public void testAdjustForHugeFilesystems() throws Exception {
+        NodePath np = new FakeNodePath(createTempDir());
+        assertThat(FsProbe.getFSInfo(np).total).isGreaterThanOrEqualTo(0L);
+        assertThat(FsProbe.getFSInfo(np).free).isGreaterThanOrEqualTo(0L);
+        assertThat(FsProbe.getFSInfo(np).available).isGreaterThanOrEqualTo(0L);
+    }
+
+    static class FakeNodePath extends NodeEnvironment.NodePath {
+        public final FileStore fileStore;
+
+        FakeNodePath(Path path) throws IOException {
+            super(path);
+            this.fileStore = new HugeFileStore();
+        }
+    }
+
+    /**
+     * Randomly returns negative values for disk space to simulate https://bugs.openjdk.java.net/browse/JDK-8162520
+     */
+    static class HugeFileStore extends FileStore {
+
+        @Override
+        public String name() {
+            return "myHugeFS";
+        }
+
+        @Override
+        public String type() {
+            return "bigFS";
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return false;
+        }
+
+        @Override
+        public long getTotalSpace() throws IOException {
+            return randomIntBetween(-1000, 1000);
+        }
+
+        @Override
+        public long getUsableSpace() throws IOException {
+            return randomIntBetween(-1000, 1000);
+        }
+
+        @Override
+        public long getUnallocatedSpace() throws IOException {
+            return randomIntBetween(-1000, 1000);
+        }
+
+        @Override
+        public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
+            return false;
+        }
+
+        @Override
+        public boolean supportsFileAttributeView(String name) {
+            return false;
+        }
+
+        @Override
+        public <V extends FileStoreAttributeView> V getFileStoreAttributeView(Class<V> type) {
+            throw new UnsupportedOperationException("don't call me");
+        }
+
+        @Override
+        public Object getAttribute(String attribute) throws IOException {
+            throw new UnsupportedOperationException("don't call me");
+        }
+
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/test/InternalSettingsPlugin.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/InternalSettingsPlugin.java
@@ -25,6 +25,7 @@ import io.crate.common.unit.TimeValue;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.monitor.fs.FsService;
 import org.elasticsearch.plugins.Plugin;
 
 import java.util.Arrays;
@@ -56,7 +57,8 @@ public final class InternalSettingsPlugin extends Plugin {
                 IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING,
                 INDEX_UUID,
                 IndexSettings.INDEX_TRANSLOG_RETENTION_TOTAL_FILES_SETTING,
-                IndexSettings.FILE_BASED_RECOVERY_THRESHOLD_SETTING
+                IndexSettings.FILE_BASED_RECOVERY_THRESHOLD_SETTING,
+                FsService.ALWAYS_REFRESH_SETTING
             );
     }
 }


### PR DESCRIPTION
see commits

Reverted usage of the `getLeastDiskEstimate` as we ported removal of the `leastDiskEstimate` (since it can become stale and not reported to data nodes)