### PR TITLE
Fix swapping parted tables with drop_source = true

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -163,6 +163,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that led to table not being dropped when
+  :ref:`swapping two tables <alter_cluster_swap_table>` with
+  ``drop_source = true``, when either or both source and target tables were
+  partitioned.
+
 - Fixed an issue that allowed users without the related privileges to check
   other users' privileges by calling
   :ref:`has_schema_privilege <scalar-has-schema-priv>` function.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, when one of the tables (either source or target) or both table where partitioned, the table was not dropped, so the `source` table was still available and could be queried, as if `drop_source=false`.

Issue was that we were trying to remove indices from the original cluster state and not the updated one (failure for parted<->non-parted), plus we failed to remove the templateName (failure for non-parted<->parted).

Fixes: #13384



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
