### PR TITLE
bp: Also abort ongoing file restores when snapshot restore is aborted

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -140,7 +140,7 @@ should be crossed out as well.
 - [s] 6a298970fdd [7.x] Allow metadata fields in the _source (#62616)
 - [s] 17aabaed155 Fix warning on boost docs and warning message on non-implementing fieldmappers
 - [s] 43ace5f80d7 Emit deprecation warnings when boosts are defined in mappings (#62623)
-- [ ] 9f5e95505bf Also abort ongoing file restores when snapshot restore is aborted (#62441) (#62607)
+- [x] 9f5e95505bf Also abort ongoing file restores when snapshot restore is aborted (#62441) (#62607)
 - [x] 06d5d360f92 Tidy up fillInStackTrace implementations (#62555)
 - [s] 9bb7ce0b229 [7.x] Allocate new indices on "hot" or "content" tier depending on data stream inclusion (#62338) (#62557)
 - [s] 91e23305295 Warn on badly-formed null values for date and IP field mappers (#62487)

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
@@ -51,6 +51,12 @@ public class RecoveryRequest extends BroadcastRequest<RecoveryRequest> {
         super(indices, IndicesOptions.STRICT_EXPAND_OPEN_CLOSED);
     }
 
+    public RecoveryRequest(IndicesOptions options, boolean activeOnly, String... indices) {
+        super(indices, options);
+        this.activeOnly = activeOnly;
+    }
+
+
     /**
      * True if detailed flag is set, false otherwise. This value if false by default.
      *

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -408,12 +408,20 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
     @Override
     public void close() {
-
         if (isClosed.compareAndSet(false, true)) {
             // only do this once!
             decRef();
             logger.debug("store reference count on close: {}", refCounter.refCount());
         }
+    }
+
+    /**
+     * @return true if the {@link Store#close()} method has been called. This indicates that the current
+     * store is either closed or being closed waiting for all references to it to be released.
+     * You might prefer to use {@link Store#ensureOpen()} instead.
+     */
+    public boolean isClosing() {
+        return isClosed.get();
     }
 
     private void closeInternal() {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -57,6 +57,7 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -2009,6 +2010,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
 
                 private void restoreFile(BlobStoreIndexShardSnapshot.FileInfo fileInfo, Store store) throws IOException {
+                    ensureNotClosing(store);
                     LOGGER.trace(() -> new ParameterizedMessage("[{}] restoring [{}] to [{}]", metadata.name(), fileInfo, store));
                     boolean success = false;
                     try (IndexOutput indexOutput =
@@ -2021,12 +2023,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             try (InputStream stream = maybeRateLimitRestores(new SlicedInputStream(fileInfo.numberOfParts()) {
                                 @Override
                                 protected InputStream openSlice(int slice) throws IOException {
+                                    ensureNotClosing(store);
                                     return container.readBlob(fileInfo.partName(slice));
                                 }
                             })) {
                                 final byte[] buffer = new byte[Math.toIntExact(Math.min(bufferSize, fileInfo.length()))];
                                 int length;
                                 while ((length = stream.read(buffer)) > 0) {
+                                    ensureNotClosing(store);
                                     indexOutput.writeBytes(buffer, 0, length);
                                     recoveryState.getIndex().addRecoveredBytesToFile(fileInfo.physicalName(), length);
                                 }
@@ -2049,6 +2053,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         }
                     }
                 }
+
+                void ensureNotClosing(final Store store) throws AlreadyClosedException {
+                    assert store.refCount() > 0;
+                    if (store.isClosing()) {
+                        throw new AlreadyClosedException("store is closing");
+                    }
+                }
+
             }.restore(snapshotFiles, store, l);
         }));
     }

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -215,6 +215,14 @@ public class ThreadPool implements Scheduler {
         return cachedTimeThread.absoluteTimeInMillis();
     }
 
+    public Info info(String name) {
+        ExecutorHolder holder = executors.get(name);
+        if (holder == null) {
+            return null;
+        }
+        return holder.info;
+    }
+
     public ThreadPoolStats stats() {
         ArrayList<ThreadPoolStats.Stats> stats = new ArrayList<>(executors.size() - 1); // "same" is excluded
         for (ExecutorHolder holder : executors.values()) {

--- a/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import io.crate.testing.UseRandomizedSchema;
+import org.assertj.core.api.Assertions;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryAction;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.hamcrest.Matcher;
+import org.junit.Assert;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST, numDataNodes = 0)
+@UseRandomizedSchema(random = false)
+public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
+
+    public void testAbortedRestoreAlsoAbortFileRestores() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+
+        String indexName = "testAbortRestore";
+        String tableName = "doc." + indexName;
+        execute("create table " + tableName + "(x text) " +
+            "clustered into 1 shards " +
+            "with (column_policy='strict', number_of_replicas = 0)");
+
+
+        int docs = scaledRandomIntBetween(10, 1_000);
+        for (int i =0 ; i < docs; i++) {
+            execute("insert into " + tableName + "(x) values (?)", new Object[]{randomAlphaOfLengthBetween(10, 20)});
+        }
+
+        ensureGreen();
+        execute("optimize table " + tableName + " with (max_num_segments=1)");
+
+        final String repositoryName = "repository";
+        createRepository(repositoryName, "mock");
+
+        final String snapshotName = "snapshot";
+        execute(String.format(Locale.ENGLISH, "create snapshot %s.%s ALL WITH (wait_for_completion=true)", repositoryName, snapshotName));
+        waitNoPendingTasksOnAll();
+        execute("drop table " + tableName);
+        waitNoPendingTasksOnAll();
+
+        logger.info("--> blocking all data nodes for repository [{}]", repositoryName);
+        blockAllDataNodes(repositoryName);
+        failReadsAllDataNodes(repositoryName);
+
+        logger.info("--> starting restore");
+        RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest(repositoryName, snapshotName).waitForCompletion(true).indices(indexName);
+        final CompletableFuture<RestoreSnapshotResponse> future = client().admin().cluster().execute(RestoreSnapshotAction.INSTANCE, restoreSnapshotRequest);
+        assertBusy(() -> {
+            final RecoveryResponse recoveries = client().execute(RecoveryAction.INSTANCE,
+                new RecoveryRequest(IndicesOptions.LENIENT_EXPAND_OPEN, true, indexName)).get();
+          //  RecoveryResponse response = client().execute(RecoveryAction.INSTANCE, new RecoveryRequest(indexName)).get();
+
+            assertThat(recoveries.hasRecoveries()).isTrue();
+            final List<RecoveryState> shardRecoveries = recoveries.shardRecoveryStates().get(indexName);
+            assertThat(shardRecoveries).hasSize(1);
+            assertThat(future.isDone()).isFalse();
+//            execute(String.format(Locale.ENGLISH,
+//                "select state from sys.snapshot_restore where repository = %s AND snapshot = %s", repositoryName, snapshotName));
+//            Assert.assertThat(response.rowCount(), is(1L));
+//            Assert.assertThat(response.rowCount(), is(1L));
+//            assertThat(response.rows()[0][0]).isEqualTo("STARTED"); // not yet done
+
+            for (RecoveryState shardRecovery : shardRecoveries) {
+                assertThat(shardRecovery.getRecoverySource().getType()).isEqualTo(RecoverySource.Type.SNAPSHOT);
+                assertThat(shardRecovery.getStage()).isEqualTo(RecoveryState.Stage.INDEX);
+            }
+        });
+
+        final ThreadPool.Info snapshotThreadPoolInfo = threadPool(dataNode).info(ThreadPool.Names.SNAPSHOT);
+        assertThat(snapshotThreadPoolInfo.getMax()).isGreaterThan(0);
+
+        logger.info("--> waiting for snapshot thread [max={}] pool to be full", snapshotThreadPoolInfo.getMax());
+        waitForMaxActiveSnapshotThreads(dataNode, snapshotThreadPoolInfo.getMax());
+
+        logger.info("--> aborting restore by deleting the index");
+        execute("drop table " + tableName);
+
+        logger.info("--> unblocking repository [{}]", repositoryName);
+        unblockAllDataNodes(repositoryName);
+
+        logger.info("--> restore should have failed");
+        final RestoreSnapshotResponse restoreSnapshotResponse = future.get();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards()).isEqualTo(1);
+        assertThat(restoreSnapshotResponse.getRestoreInfo().successfulShards()).isEqualTo(0);
+
+//        execute(String.format(Locale.ENGLISH,
+//            "select state from sys.snapshot_restore where repository = %s AND snapshot = %s", repositoryName, snapshotName));
+//        Assert.assertThat(response.rowCount(), is(1L));
+//        assertThat(response.rows()[0][0]).isEqualTo("FAILED");
+
+        logger.info("--> waiting for snapshot thread pool to be empty");
+        waitForMaxActiveSnapshotThreads(dataNode, 0);
+    }
+
+    private static void waitForMaxActiveSnapshotThreads(final String node, int maxActiveSnapshotThreads) throws Exception {
+        assertBusy(() -> assertThat(threadPoolStats(node, ThreadPool.Names.SNAPSHOT).getActive()).isEqualTo(maxActiveSnapshotThreads), 30L, TimeUnit.SECONDS);
+    }
+
+    private static ThreadPool threadPool(final String node) {
+        return internalCluster().getInstance(ClusterService.class, node).getClusterApplierService().threadPool();
+    }
+
+    private static ThreadPoolStats.Stats threadPoolStats(final String node, final String threadPoolName) {
+        return StreamSupport.stream(threadPool(node).stats().spliterator(), false)
+            .filter(threadPool -> threadPool.getName().equals(threadPoolName))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Failed to find thread pool " + threadPoolName));
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -127,6 +127,12 @@ public class MockRepository extends FsRepository {
     /** Allows blocking on writing the snapshot file at the end of snapshot creation to simulate a died master node */
     private volatile boolean blockAndFailOnWriteSnapFile;
 
+    /**
+     * Reading blobs will fail with an {@link AssertionError} once the repository has been blocked once.
+     */
+    private volatile boolean failReadsAfterUnblock;
+    private volatile boolean throwReadErrorAfterUnblock = false;
+
     private volatile boolean blocked = false;
 
     public MockRepository(RepositoryMetadata metadata, Environment environment,
@@ -210,6 +216,10 @@ public class MockRepository extends FsRepository {
         blockOnDeleteIndexN = true;
     }
 
+    public void setFailReadsAfterUnblock(boolean failReadsAfterUnblock) {
+        this.failReadsAfterUnblock = failReadsAfterUnblock;
+    }
+
     public boolean blocked() {
         return blocked;
     }
@@ -228,6 +238,10 @@ public class MockRepository extends FsRepository {
             Thread.currentThread().interrupt();
         }
         logger.debug("[{}] Unblocking execution", metadata.name());
+        if (wasBlocked && failReadsAfterUnblock) {
+            logger.debug("[{}] Next read operations will fail", metadata.name());
+            this.throwReadErrorAfterUnblock = true;
+        }
         return wasBlocked;
     }
 
@@ -255,7 +269,6 @@ public class MockRepository extends FsRepository {
         }
 
         private class MockBlobContainer extends BlobContainerWrapper {
-            private MessageDigest digest;
 
             private boolean shouldFail(String blobName, double probability) {
                 if (probability > 0.0) {
@@ -270,7 +283,7 @@ public class MockRepository extends FsRepository {
 
             private int hashCode(String path) {
                 try {
-                    digest = MessageDigest.getInstance("MD5");
+                    MessageDigest digest = MessageDigest.getInstance("MD5");
                     byte[] bytes = digest.digest(path.getBytes("UTF-8"));
                     int i = 0;
                     return ((bytes[i++] & 0xFF) << 24) | ((bytes[i++] & 0xFF) << 16)
@@ -326,14 +339,28 @@ public class MockRepository extends FsRepository {
                 throw new IOException("exception after block");
             }
 
+            private void maybeReadErrorAfterBlock(final String blobName) {
+                if (throwReadErrorAfterUnblock) {
+                    throw new AssertionError("Read operation are not allowed anymore at this point [blob=" + blobName + "]");
+                }
+            }
+
             MockBlobContainer(BlobContainer delegate) {
                 super(delegate);
             }
 
             @Override
             public InputStream readBlob(String name) throws IOException {
+                maybeReadErrorAfterBlock(name);
                 maybeIOExceptionOrBlock(name);
                 return super.readBlob(name);
+            }
+
+            @Override
+            public InputStream readBlob(String name, long position, long length) throws IOException {
+                maybeReadErrorAfterBlock(name);
+                maybeIOExceptionOrBlock(name);
+                return super.readBlob(name, position, length);
             }
 
             @Override


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/commit/9f5e95505bf4adb28517604a46c2a9a531c402fb

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
