### PR TITLE
bp: Optimize XContentParserUtils.ensureExpectedToken

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -119,7 +119,7 @@ should be crossed out as well.
 - [ ] 5c3a4c13ddd Clone Snapshot API (#61839) (#63291)
 - [ ] e91936512aa Refactor SnapshotsInProgress State Transitions (#60517) (#63266)
 - [ ] 860791260df Implement Shard Snapshot Clone Logic (#62771) (#63260)
-- [ ] cf75abb021f Optimize XContentParserUtils.ensureExpectedToken (#62691) (#63253)
+- [x] cf75abb021f Optimize XContentParserUtils.ensureExpectedToken (#62691) (#63253)
 - [ ] 51d0ed1bf30 Prepare Snapshot Shard State Update Logic For Clone Logic (#62617) (#63255)
 - [x] 89de9fdcf77 Cleanup Blobstore Repository Metadata Serialization (#62727) (#63249)
 - [x] d13c1f50581 Fix Overly Strict Assertion in BlobStoreRepository (#63061) (#63236)

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -389,13 +389,13 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      */
     public static ElasticsearchException fromXContent(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.nextToken();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
         return innerFromXContent(parser, false);
     }
 
     public static ElasticsearchException innerFromXContent(XContentParser parser, boolean parseRootCauses) throws IOException {
         XContentParser.Token token = parser.currentToken();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
 
         String type = null, reason = null, stack = null;
         ElasticsearchException cause = null;
@@ -582,7 +582,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             return new ElasticsearchException(buildMessage("exception", parser.text(), null));
         }
 
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
         token = parser.nextToken();
 
         // Root causes are parsed in the innerFromXContent() and are added as suppressed exceptions.

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -253,7 +253,7 @@ public class ReplicationResponse extends TransportResponse {
 
             public static Failure fromXContent(XContentParser parser) throws IOException {
                 XContentParser.Token token = parser.currentToken();
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
 
                 String shardIndex = null, nodeId = null;
                 int shardId = -1;

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -292,12 +292,12 @@ public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, W
     }
 
     public static ClusterIndexHealth fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         XContentParser.Token token = parser.nextToken();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
         String index = parser.currentName();
         ClusterIndexHealth parsed = innerFromXContent(parser, index);
-        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
         return parsed;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -238,12 +238,12 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
     }
 
     public static ClusterShardHealth fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         XContentParser.Token token = parser.nextToken();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
         String shardIdStr = parser.currentName();
         ClusterShardHealth parsed = innerFromXContent(parser, Integer.valueOf(shardIdStr));
-        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
         return parsed;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -623,7 +623,7 @@ public final class Settings implements ToXContentFragment {
         if (parser.currentToken() == null) {
             parser.nextToken();
         }
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         Builder innerBuilder = Settings.builder();
         StringBuilder currentKeyBuilder = new StringBuilder();
         fromXContent(parser, currentKeyBuilder, innerBuilder, allowNullValues);

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.xcontent.XContentParser.Token;
 
 import java.io.IOException;
 import java.util.Locale;
-import java.util.function.Supplier;
 
 /**
  * A set of static methods to get {@link Token} from {@link XContentParser}
@@ -40,7 +39,7 @@ public final class XContentParserUtils {
      * @throws ParsingException if the token is not of type {@link Token#FIELD_NAME} or is not equal to the given field name
      */
     public static void ensureFieldName(XContentParser parser, Token token, String fieldName) throws IOException {
-        ensureExpectedToken(Token.FIELD_NAME, token, parser::getTokenLocation);
+        ensureExpectedToken(Token.FIELD_NAME, token, parser);
         String currentName = parser.currentName();
         if (currentName.equals(fieldName) == false) {
             String message = "Failed to parse object: expecting field with name [%s] but found [%s]";
@@ -69,11 +68,15 @@ public final class XContentParserUtils {
      *
      * @throws ParsingException if the token is not equal to the expected type
      */
-    public static void ensureExpectedToken(Token expected, Token actual, Supplier<XContentLocation> location) {
+    public static void ensureExpectedToken(Token expected, Token actual, XContentParser parser) {
         if (actual != expected) {
-            String message = "Failed to parse object: expecting token of type [%s] but found [%s]";
-            throw new ParsingException(location.get(), String.format(Locale.ROOT, message, expected, actual));
+            throw parsingException(parser, expected, actual);
         }
+    }
+
+    private static ParsingException parsingException(XContentParser parser, Token expected, Token actual) {
+        return new ParsingException(parser.getTokenLocation(),
+                String.format(Locale.ROOT, "Failed to parse object: expecting token of type [%s] but found [%s]", expected, actual));
     }
 
 

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -508,7 +508,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
         XContentParser.Token token = parser.currentToken();
         if (token == XContentParser.Token.START_OBJECT) {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
                 final String currentFieldName = parser.currentName();
                 token = parser.nextToken();
                 if (token.isValue()) {

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -228,7 +228,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
         Map<String, FileInfo> files = new HashMap<>();
         if (token == XContentParser.Token.START_OBJECT) {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
                 String currentFieldName = parser.currentName();
                 token = parser.nextToken();
                 if (token == XContentParser.Token.START_ARRAY) {
@@ -244,10 +244,9 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                         throw new ElasticsearchParseException("unknown object [{}]", currentFieldName);
                     }
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
                         String snapshot = parser.currentName();
-                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(),
-                            parser::getTokenLocation);
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                             if (token == XContentParser.Token.FIELD_NAME) {
                                 currentFieldName = parser.currentName();

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -529,7 +529,7 @@ public final class RepositoryData {
      *                           from cached bytes that we trust to not contain broken generations.
      */
     public static RepositoryData snapshotsFromXContent(XContentParser parser, long genId, boolean fixBrokenShardGens) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 
         final Map<String, SnapshotId> snapshots = new HashMap<>();
         final Map<String, SnapshotState> snapshotStates = new HashMap<>();
@@ -550,13 +550,11 @@ public final class RepositoryData {
                     parseIndices(parser, fixBrokenShardGens, snapshots, indexSnapshots, indexLookup, shardGenerations);
                     break;
                 case INDEX_METADATA_IDENTIFIERS:
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(),
-                        parser::getTokenLocation);
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     indexMetaIdentifiers = parser.mapStrings();
                     break;
                 case MIN_VERSION:
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.nextToken(),
-                        parser::getTokenLocation);
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.nextToken(), parser);
                     final Version version = Version.fromString(parser.text());
                     assert SnapshotsService.useShardGenerations(version);
                     break;
@@ -611,7 +609,7 @@ public final class RepositoryData {
     private static void parseSnapshots(XContentParser parser, Map<String, SnapshotId> snapshots, Map<String, SnapshotState> snapshotStates,
                                        Map<String, Version> snapshotVersions,
                                        Map<SnapshotId, Map<String, String>> indexMetaLookup) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
             String name = null;
             String uuid = null;
@@ -669,14 +667,14 @@ public final class RepositoryData {
     private static void parseIndices(XContentParser parser, boolean fixBrokenShardGens, Map<String, SnapshotId> snapshots,
                                      Map<IndexId, List<SnapshotId>> indexSnapshots, Map<String, IndexId> indexLookup,
                                      ShardGenerations.Builder shardGenerations) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             final String indexName = parser.currentName();
             final List<SnapshotId> snapshotIds = new ArrayList<>();
             final List<String> gens = new ArrayList<>();
 
             IndexId indexId = null;
-            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                 final String indexMetaFieldName = parser.currentName();
                 final XContentParser.Token currentToken = parser.nextToken();
@@ -685,7 +683,7 @@ public final class RepositoryData {
                         indexId = new IndexId(indexName, parser.text());
                         break;
                     case SNAPSHOTS:
-                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, currentToken, parser::getTokenLocation);
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, currentToken, parser);
                         XContentParser.Token currToken;
                         while ((currToken = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             final String uuid;
@@ -710,8 +708,7 @@ public final class RepositoryData {
                         }
                         break;
                     case SHARD_GENERATIONS:
-                        XContentParserUtils.ensureExpectedToken(
-                            XContentParser.Token.START_ARRAY, currentToken, parser::getTokenLocation);
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, currentToken, parser);
                         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                             gens.add(parser.textOrNull());
                         }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -576,7 +576,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             parser.nextToken();
         }
         XContentParser.Token token;
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         String currentFieldName = parser.currentName();
         if (SNAPSHOT.equals(currentFieldName)) {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {


### PR DESCRIPTION
Minor change: https://github.com/elastic/elasticsearch/commit/cf75abb021f6b3635848452ae41f89dfdd1a53cc

aggregation, xpack, client-rest, rank-eval packages are ignored as we don't have them. In general, I ignored files which we don't have
