### PR TITLE
Add optimizer rule to push down a Filter beneath a CorrelatedJoin

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -67,6 +67,9 @@ Changes
 
 - Allowed schema and table names to start with ``_``.
 
+- Improved the performance of queries using a correlated sub-query inside the
+  ``WHERE`` clause in conjunction with a non-correlated filter clause.
+
 Fixes
 =====
 

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -273,7 +273,7 @@ public class JoinPlanBuilder {
     /**
      * Splits the given Symbol tree into a list of correlated sub-queries and a list of remaining symbols.
      */
-    private static CorrelatedSubQueries extractCorrelatedSubQueries(@Nullable Symbol from) {
+    public static CorrelatedSubQueries extractCorrelatedSubQueries(@Nullable Symbol from) {
         if (from == null) {
             return new CorrelatedSubQueries(List.of(), List.of());
         }
@@ -290,5 +290,5 @@ public class JoinPlanBuilder {
         return new CorrelatedSubQueries(correlatedSubQueries, remainder);
     }
 
-    private record CorrelatedSubQueries(List<Symbol> correlatedSubQueries, List<Symbol> remainder) {}
+    public record CorrelatedSubQueries(List<Symbol> correlatedSubQueries, List<Symbol> remainder) {}
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -85,6 +85,7 @@ import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathNestedLoop;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathCorrelatedJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathJoin;
@@ -132,6 +133,7 @@ public class LogicalPlanner {
                 new MoveFilterBeneathOrder(),
                 new MoveFilterBeneathProjectSet(),
                 new MoveFilterBeneathJoin(),
+                new MoveFilterBeneathCorrelatedJoin(),
                 new MoveFilterBeneathUnion(),
                 new MoveFilterBeneathGroupBy(),
                 new MoveFilterBeneathWindowAgg(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.operators.JoinPlanBuilder.extractCorrelatedSubQueries;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.List;
+import java.util.function.Function;
+
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.expression.operator.AndOperator;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.CorrelatedJoin;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
+
+    private final Capture<CorrelatedJoin> joinCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathCorrelatedJoin() {
+        this.joinCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(CorrelatedJoin.class).capturedAs(joinCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+        var join = captures.get(joinCapture);
+        var splitQuery = QuerySplitter.split(filter.query());
+        assert join.sources().size() == 1 : "CorrelatedJoin operator must have 1 children, the input plan";
+        var inputPlan = join.sources().get(0);
+        var inputQuery = splitQuery.remove(inputPlan.getRelationNames());
+        if (inputQuery == null) {
+            return null;
+        }
+        // Only push down filters which are not part of the correlated sub-queries
+        var correlatedSubQueries = extractCorrelatedSubQueries(inputQuery);
+        if (correlatedSubQueries.remainder().isEmpty()) {
+            return null;
+        }
+
+        var newInputPlan = new Filter(inputPlan, AndOperator.join(correlatedSubQueries.remainder()));
+        var newJoin = join.replaceSources(List.of(newInputPlan));
+        return new Filter(newJoin, AndOperator.join(splitQuery.values()));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

A filter related to any source of a CorrelatedJoin can be pushed down to narrow down the result set used inside the CorrelatedJoin and such will improve performance.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
