### PR TITLE
Fix function resolution for bit types with different lengths

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -205,3 +205,8 @@ Fixes
   consume invalid table names provided in a double-quoted string format
   containing ``.`` such as ``"table.t"`` by mis-interpreting it as
   ``"table"."t"``, which is a two double-quoted strings joined by a ``.``.
+
+- Fixed an issue that caused failure of the statements containing comparison of
+  :ref:`bit <data-type-bit>` strings with different length. An example::
+
+     SELECT B'01' = B'1'

--- a/server/src/main/java/io/crate/types/TypeCompatibility.java
+++ b/server/src/main/java/io/crate/types/TypeCompatibility.java
@@ -100,15 +100,13 @@ public final class TypeCompatibility {
                 }
             }
             return null;
-        } else {
-            if ((fromType.id() == StringType.ID && toType.id() == StringType.ID)
-                || (fromType.id() == CharacterType.ID && toType.id() == CharacterType.ID)) {
-                if (((StringType) fromType).lengthLimit() > ((StringType) toType).lengthLimit()) {
-                    return fromType;
-                } else {
-                    return toType;
-                }
+        } else if (fromType.id() == toType.id() 
+                   && fromType.characterMaximumLength() != null 
+                   && toType.characterMaximumLength() != null) {
+            if (fromType.characterMaximumLength() > toType.characterMaximumLength()) {
+                return fromType;
             }
+            return toType;
         }
 
         for (int i = 0; i < fromTypeParameters.size(); i++) {

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.crate.types.BitStringType;
 import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Test;
@@ -385,6 +386,17 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(eq.arguments()).satisfiesExactly(
             s -> assertThat(s).hasDataType(DataTypes.STRING),
             s -> assertThat(s).hasDataType(DataTypes.STRING));
+    }
+
+    @Test
+    public void test_resolve_eq_function_for_bit_types_with_different_length() throws IOException {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (b bit(3))")
+            .build();
+        var eq = (Function) e.asSymbol("tbl.b = B'1'");
+        assertThat(eq.arguments()).satisfiesExactly(
+            s -> assertThat(s).hasDataType(new BitStringType(3)),
+            s -> assertThat(s).hasDataType(new BitStringType(3)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -30,7 +30,6 @@ import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.types.BitStringType;
 import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -307,6 +308,20 @@ public class SignatureBinderTest extends ESTestCase {
             .boundTo(CharacterType.of(1), CharacterType.of(2))
             .produces(new BoundVariables(
                 Map.of("E", type(CharacterType.of(2).getTypeSignature().toString()))));
+    }
+
+    @Test
+    public void test_bind_type_bit_types_binds_type_with_highest_length() {
+        var signature = functionSignature()
+            .argumentTypes(parseTypeSignature("E"), parseTypeSignature("E"))
+            .returnType(DataTypes.BOOLEAN.getTypeSignature())
+            .typeVariableConstraints(List.of(typeVariable("E")))
+            .build();
+
+        assertThatSignature(signature)
+            .boundTo(new BitStringType(1), new BitStringType(2))
+            .produces(new BoundVariables(
+                Map.of("E", type(new BitStringType(2).getTypeSignature().toString()))));
     }
 
     @Test


### PR DESCRIPTION
Similar to `STRING` and `CHARACTER` types, need to resolve compatibility of `BIT` strings with different length.

See https://github.com/crate/crate/commit/0312972713071214ee27af408989a32f6cb58fe1#diff-2f38770d54ce83a675bffd39094bb90580effb7cc9e2213ded1237e90f4c0daaR104 and 

https://github.com/crate/crate/commit/1866a331f90aaaeabc6a789a2c11cee2aac5c611#diff-2f38770d54ce83a675bffd39094bb90580effb7cc9e2213ded1237e90f4c0daaR104


We compare BIT strings [lexicographically](https://github.com/crate/crate/blob/master/libs/sql-parser/src/main/java/io/crate/sql/tree/BitString.java#L137), so it's fine to compare bit strings with different length.

For operations requiring same length (bitwise functions), we have an explicit [check](https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java#L43).


Originally issue was spot on queries with bit operators of the same length:

```
CREATE TABLE tbl (b BIT(3));
SELECT * FROM tbl WHERE b & B'100' =  B'100'
```

We register bitwise functions with the default instance (len=1) and then [allow base name match](https://github.com/crate/crate/pull/13278/commits/abc3f7184080049960395960401cb7e93af02659#diff-65c7fdc8728440fe13f23f603e3fc16cf8fb14d32fb66ab3fdf00cc73c7fe9f0) for them. 

without this change, `b & B'100'` becames smth with return type of length 1 and then skips compatibility resolution (which is added now) and fails in 
https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/types/TypeCompatibility.java#L122 



