### PR TITLE
Change mappings on IndexTemplateMetadata to mapping

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/Templates.java
+++ b/server/src/main/java/io/crate/execution/ddl/Templates.java
@@ -21,15 +21,13 @@
 
 package io.crate.execution.ddl;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
+import java.util.Collections;
+
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
-import org.elasticsearch.common.compress.CompressedXContent;
 
-import java.io.IOException;
-import java.util.Collections;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 
 public final class Templates {
 
@@ -41,16 +39,10 @@ public final class Templates {
             .patterns(Collections.singletonList(PartitionName.templatePrefix(newName.schema(), newName.name())))
             .settings(source.settings())
             .order(source.order())
+            .putMapping(source.mapping())
             .putAlias(AliasMetadata.builder(targetAlias).build())
             .version(source.version());
 
-        for (ObjectObjectCursor<String, CompressedXContent> mapping : source.mappings()) {
-            try {
-                templateBuilder.putMapping(mapping.key, mapping.value);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
         return templateBuilder;
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -21,10 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
-import io.crate.Constants;
-import io.crate.analyze.BoundCreateTable;
-import io.crate.exceptions.Exceptions;
-import io.crate.exceptions.SQLExceptions;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
@@ -34,9 +35,9 @@ import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateReque
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
-import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
+import io.crate.analyze.BoundCreateTable;
+import io.crate.exceptions.Exceptions;
+import io.crate.exceptions.SQLExceptions;
 
 @Singleton
 public class TableCreator {
@@ -62,7 +63,7 @@ public class TableCreator {
             )
             : new CreateTableRequest(
                 new PutIndexTemplateRequest(templateName)
-                    .mapping(Constants.DEFAULT_MAPPING_TYPE, createTable.mapping())
+                    .mapping(createTable.mapping())
                     .create(true)
                     .settings(createTable.tableParameter().settings())
                     .patterns(Collections.singletonList(createTable.templatePrefix()))

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 
-import io.crate.Constants;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.metadata.IndexParts;
@@ -168,8 +167,7 @@ public class DocTableInfoFactory {
         DocIndexMetadata docIndexMetadata;
         try {
             IndexMetadata.Builder builder = new IndexMetadata.Builder(relation.indexNameOrAlias());
-            builder.putMapping(
-                indexTemplateMetadata.getMappings().get(Constants.DEFAULT_MAPPING_TYPE).toString());
+            builder.putMapping(indexTemplateMetadata.mapping().toString());
 
             Settings.Builder settingsBuilder = Settings.builder()
                 .put(indexTemplateMetadata.settings());

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -104,7 +104,7 @@ public class MetadataIndexUpgrader implements BiFunction<IndexMetadata, IndexTem
      */
     private void upgradeColumnPositions(Map<String, Object> defaultMap, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
         if (indexTemplateMetadata != null) {
-            MetadataMappingService.populateColumnPositions(defaultMap, indexTemplateMetadata.getMappings().get("default"));
+            MetadataMappingService.populateColumnPositions(defaultMap, indexTemplateMetadata.mapping());
         } else {
             IndexTemplateUpgrader.populateColumnPositions(defaultMap);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -19,28 +19,9 @@
 
 package org.elasticsearch.action.admin.indices.template.put;
 
-import org.elasticsearch.ElasticsearchGenerationException;
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
-import io.crate.common.collections.MapBuilder;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
+import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
+import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -53,9 +34,30 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
-import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
-import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
+import org.elasticsearch.ElasticsearchGenerationException;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+
+import io.crate.Constants;
+import io.crate.common.collections.MapBuilder;
 
 /**
  * A request to create an index template.
@@ -266,8 +268,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         return this;
     }
 
-    public Map<String, String> mappings() {
-        return this.mappings;
+    public String mapping() {
+        return this.mappings.get(Constants.DEFAULT_MAPPING_TYPE);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -26,7 +26,6 @@ import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -36,9 +35,9 @@ import java.util.stream.Collectors;
 
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.Strings;
@@ -57,7 +56,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 
 import io.crate.Constants;
-import io.crate.common.collections.MapBuilder;
 
 /**
  * A request to create an index template.
@@ -76,7 +74,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
 
     private Settings settings = EMPTY_SETTINGS;
 
-    private Map<String, String> mappings = new HashMap<>();
+    private String mapping;
 
     private final Set<Alias> aliases = new HashSet<>();
 
@@ -190,17 +188,6 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
     }
 
     /**
-     * Adds mapping that will be added when the index gets created.
-     *
-     * @param type   The mapping type
-     * @param source The mapping source
-     * @param xContentType The type of content contained within the source
-     */
-    public PutIndexTemplateRequest mapping(String type, String source, XContentType xContentType) {
-        return mapping(type, new BytesArray(source), xContentType);
-    }
-
-    /**
      * The cause for this index template creation.
      */
     public PutIndexTemplateRequest cause(String cause) {
@@ -218,8 +205,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * @param type   The mapping type
      * @param source The mapping source
      */
-    public PutIndexTemplateRequest mapping(String type, XContentBuilder source) {
-        return mapping(type, BytesReference.bytes(source), source.contentType());
+    public PutIndexTemplateRequest mapping(XContentBuilder source) {
+        return mapping(BytesReference.bytes(source), source.contentType());
     }
 
     /**
@@ -229,10 +216,10 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * @param source The mapping source
      * @param xContentType the source content type
      */
-    public PutIndexTemplateRequest mapping(String type, BytesReference source, XContentType xContentType) {
+    public PutIndexTemplateRequest mapping(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         try {
-            mappings.put(type, XContentHelper.convertToJson(source, xContentType));
+            mapping = XContentHelper.convertToJson(source, xContentType);
             return this;
         } catch (IOException e) {
             throw new UncheckedIOException("failed to convert source to json", e);
@@ -245,42 +232,22 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * @param type   The mapping type
      * @param source The mapping source
      */
-    public PutIndexTemplateRequest mapping(String type, Map<String, Object> source) {
+    public PutIndexTemplateRequest mapping(Map<String, Object> source) {
         // wrap it in a type map if its not
-        if (source.size() != 1 || !source.containsKey(type)) {
-            source = MapBuilder.<String, Object>newMapBuilder().put(type, source).map();
+        if (source.size() != 1 || !source.containsKey(Constants.DEFAULT_MAPPING_TYPE)) {
+            source = Map.of(Constants.DEFAULT_MAPPING_TYPE, source);
         }
         try {
             XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
             builder.map(source);
-            return mapping(type, builder);
+            return mapping(builder);
         } catch (IOException e) {
             throw new ElasticsearchGenerationException("Failed to generate [" + source + "]", e);
         }
     }
 
-    /**
-     * A specialized simplified mapping source method, takes the form of simple properties definition:
-     * ("field1", "type=string,store=true").
-     */
-    public PutIndexTemplateRequest mapping(String type, Object... source) {
-        mapping(type, PutMappingRequest.buildFromSimplifiedDef(type, source));
-        return this;
-    }
-
     public String mapping() {
-        return this.mappings.get(Constants.DEFAULT_MAPPING_TYPE);
-    }
-
-    /**
-     * The template source definition.
-     */
-    public PutIndexTemplateRequest source(XContentBuilder templateBuilder) {
-        try {
-            return source(BytesReference.bytes(templateBuilder), templateBuilder.contentType());
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to build json for template request", e);
-        }
+        return this.mapping;
     }
 
     /**
@@ -320,7 +287,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
                             "Malformed [mappings] section for type [" + entry1.getKey() +
                                 "], should include an inner object describing the mapping");
                     }
-                    mapping(entry1.getKey(), (Map<String, Object>) entry1.getValue());
+                    mapping((Map<String, Object>) entry1.getValue());
                 }
             } else if (name.equals("aliases")) {
                 aliases((Map<String, Object>) entry.getValue());
@@ -329,27 +296,6 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
             }
         }
         return this;
-    }
-
-    /**
-     * The template source definition.
-     */
-    public PutIndexTemplateRequest source(String templateSource, XContentType xContentType) {
-        return source(XContentHelper.convertToMap(xContentType.xContent(), templateSource, true));
-    }
-
-    /**
-     * The template source definition.
-     */
-    public PutIndexTemplateRequest source(byte[] source, XContentType xContentType) {
-        return source(source, 0, source.length, xContentType);
-    }
-
-    /**
-     * The template source definition.
-     */
-    public PutIndexTemplateRequest source(byte[] source, int offset, int length, XContentType xContentType) {
-        return source(new BytesArray(source, offset, length), xContentType);
     }
 
     /**
@@ -439,11 +385,15 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         order = in.readInt();
         create = in.readBoolean();
         settings = readSettingsFromStream(in);
-        int size = in.readVInt();
-        for (int i = 0; i < size; i++) {
-            final String type = in.readString();
-            String mappingSource = in.readString();
-            mappings.put(type, mappingSource);
+        if (in.getVersion().onOrAfter(Version.V_5_2_0)) {
+            mapping = in.readString();
+        } else {
+            int size = in.readVInt();
+            for (int i = 0; i < size; i++) {
+                in.readString(); // always "default"
+                String mappingSource = in.readString();
+                mapping = mappingSource;
+            }
         }
         int aliasesSize = in.readVInt();
         for (int i = 0; i < aliasesSize; i++) {
@@ -461,10 +411,12 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         out.writeInt(order);
         out.writeBoolean(create);
         writeSettingsToStream(settings, out);
-        out.writeVInt(mappings.size());
-        for (Map.Entry<String, String> entry : mappings.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeString(entry.getValue());
+        if (out.getVersion().onOrAfter(Version.V_5_2_0)) {
+            out.writeString(mapping);
+        } else {
+            out.writeVInt(1);
+            out.writeString(Constants.DEFAULT_MAPPING_TYPE);
+            out.writeString(mapping);
         }
         out.writeVInt(aliases.size());
         for (Alias alias : aliases) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -77,14 +77,10 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeAction<P
     public void masterOperation(final PutIndexTemplateRequest request,
                                 final ClusterState state,
                                 final ActionListener<AcknowledgedResponse> listener) {
-        String cause = request.cause();
-        if (cause.length() == 0) {
-            cause = "api";
-        }
         final Settings.Builder templateSettingsBuilder = Settings.builder();
         templateSettingsBuilder.put(request.settings()).normalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX);
         indexScopedSettings.validate(templateSettingsBuilder.build(), true); // templates must be consistent with regards to dependencies
-        indexTemplateService.putTemplate(new MetadataIndexTemplateService.PutRequest(cause, request.name())
+        indexTemplateService.putTemplate(new MetadataIndexTemplateService.PutRequest("api", request.name())
                 .patterns(request.patterns())
                 .order(request.order())
                 .settings(templateSettingsBuilder.build())

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.template.put;
 
+import java.io.IOException;
+
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -35,8 +37,6 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-
-import java.io.IOException;
 
 /**
  * Put index template action.
@@ -88,7 +88,7 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeAction<P
                 .patterns(request.patterns())
                 .order(request.order())
                 .settings(templateSettingsBuilder.build())
-                .mappings(request.mappings())
+                .mapping(request.mapping())
                 .aliases(request.aliases())
                 .create(request.create())
                 .masterTimeout(request.masterNodeTimeout())

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -48,7 +48,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -444,15 +443,13 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
                 builder.endObject();
 
                 builder.startObject("mappings");
-                for (ObjectObjectCursor<String, CompressedXContent> cursor1 : templateMetadata.mappings()) {
-                    Map<String, Object> mapping = XContentHelper.convertToMap(cursor1.value.uncompressed(), false).map();
-                    if (mapping.size() == 1 && mapping.containsKey(cursor1.key)) {
-                        // the type name is the root value, reduce it
-                        mapping = (Map<String, Object>) mapping.get(cursor1.key);
-                    }
-                    builder.field(cursor1.key);
-                    builder.map(mapping);
+                Map<String, Object> mapping = XContentHelper.convertToMap(templateMetadata.mapping().uncompressed(), false).map();
+                if (mapping.size() == 1 && mapping.containsKey(Constants.DEFAULT_MAPPING_TYPE)) {
+                    // the type name is the root value, reduce it
+                    mapping = (Map<String, Object>) mapping.get(Constants.DEFAULT_MAPPING_TYPE);
                 }
+                builder.field(Constants.DEFAULT_MAPPING_TYPE);
+                builder.map(mapping);
                 builder.endObject();
 
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -70,7 +70,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.ValidationException;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -95,7 +94,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
-import io.crate.Constants;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
@@ -339,16 +337,9 @@ public class MetadataCreateIndexService {
                     // apply templates, merging the mappings into the request mapping if exists
                     for (IndexTemplateMetadata template : templates) {
                         templateNames.add(template.getName());
-                        for (ObjectObjectCursor<String, CompressedXContent> cursor : template.mappings()) {
-                            String mappingString = cursor.value.string();
-                            String mappingType = cursor.key;
-                            if (mappingType.equals(Constants.DEFAULT_MAPPING_TYPE)) {
-                                XContentHelper.mergeDefaults(mapping,
-                                    MapperService.parseMapping(xContentRegistry, mappingString));
-                            } else {
-                                throw new IllegalStateException("Unexpected mapping type: " + mappingType);
-                            }
-                        }
+                        String mappingString = template.mapping().string();
+                        XContentHelper.mergeDefaults(mapping,
+                            MapperService.parseMapping(xContentRegistry, mappingString));
                         //handle aliases
                         for (ObjectObjectCursor<String, AliasMetadata> cursor : template.aliases()) {
                             AliasMetadata aliasMetadata = cursor.value;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -19,7 +19,17 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import io.crate.common.annotations.VisibleForTesting;
+import static io.crate.metadata.doc.DocIndexMetadata.furtherColumnProperties;
+import static org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.NO_LONGER_ASSIGNED;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -32,18 +42,9 @@ import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
-import javax.annotation.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
-
-import io.crate.Constants;
-import io.crate.common.collections.Maps;
-import io.crate.common.unit.TimeValue;
-import io.crate.common.io.IOUtils;
-import io.crate.metadata.IndexParts;
-import io.crate.metadata.PartitionName;
-
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
@@ -52,14 +53,12 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.indices.IndicesService;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static io.crate.metadata.doc.DocIndexMetadata.furtherColumnProperties;
-import static org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.NO_LONGER_ASSIGNED;
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.common.collections.Maps;
+import io.crate.common.io.IOUtils;
+import io.crate.common.unit.TimeValue;
+import io.crate.metadata.IndexParts;
+import io.crate.metadata.PartitionName;
 
 /**
  * Service responsible for submitting mapping changes
@@ -281,10 +280,8 @@ public class MetadataMappingService {
                     String partitionName = PartitionName.templateName(index.getName());
                     IndexTemplateMetadata indexTemplateMetadata = currentState.metadata().templates().get(partitionName);
                     updatedSourceMap = XContentHelper.convertToMap(mappingUpdateSource.compressedReference(), true).map();
-                    populateColumnPositions(updatedSourceMap,
-                                            // if partitioned, template-mapping should contain the latest column positions
-                                            indexTemplateMetadata.mappings().get(Constants.DEFAULT_MAPPING_TYPE)
-                    );
+                    // if partitioned, template-mapping should contain the latest column positions
+                    populateColumnPositions(updatedSourceMap, indexTemplateMetadata.mapping());
                 }
 
 

--- a/server/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/TransportSchemaUpdateActionTest.java
@@ -27,8 +27,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
-import io.crate.Constants;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Test;
+
 import io.crate.analyze.BoundAddColumn;
 import io.crate.common.collections.Maps;
 import io.crate.data.Row;
@@ -38,15 +46,6 @@ import io.crate.planner.node.ddl.AlterTableAddColumnPlan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.junit.Test;
-
-import java.util.Map;
 
 public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUnitTest {
 
@@ -90,7 +89,6 @@ public class TransportSchemaUpdateActionTest extends CrateDummyClusterServiceUni
                 .put(IndexTemplateMetadata.builder(templateName)
                     .patterns(template.patterns())
                     .putMapping(
-                        Constants.DEFAULT_MAPPING_TYPE,
                         Strings.toString(JsonXContent.contentBuilder().map(addXLong.mapping()))))
                 .build()
             ).build();

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -388,7 +388,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
             .get();
         assertThat(response.getIndexTemplates().size(), is(1));
         IndexTemplateMetadata template = response.getIndexTemplates().get(0);
-        CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
+        CompressedXContent mappingStr = template.mapping();
         assertThat(mappingStr, is(notNullValue()));
         ParsedXContent typeAndMap =
             XContentHelper.convertToMap(mappingStr.compressedReference(), false, XContentType.JSON);
@@ -427,7 +427,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
             .get();
         assertThat(response.getIndexTemplates().size(), is(1));
         IndexTemplateMetadata template = response.getIndexTemplates().get(0);
-        CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
+        CompressedXContent mappingStr = template.mapping();
         assertThat(mappingStr, is(notNullValue()));
         ParsedXContent typeAndMap = XContentHelper.convertToMap(mappingStr.compressedReference(), false);
         @SuppressWarnings("unchecked")
@@ -464,7 +464,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
             .get();
         assertThat(templateResponse.getIndexTemplates().size(), is(1));
         IndexTemplateMetadata template = templateResponse.getIndexTemplates().get(0);
-        CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
+        CompressedXContent mappingStr = template.mapping();
         assertThat(mappingStr, is(notNullValue()));
         ParsedXContent typeAndMap = XContentHelper.convertToMap(mappingStr.compressedReference(), false);
         @SuppressWarnings("unchecked")
@@ -589,7 +589,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
             .get();
         assertThat(response.getIndexTemplates().size(), is(1));
         IndexTemplateMetadata template = response.getIndexTemplates().get(0);
-        CompressedXContent mappingStr = template.mappings().get(Constants.DEFAULT_MAPPING_TYPE);
+        CompressedXContent mappingStr = template.mapping();
         assertThat(mappingStr, is(notNullValue()));
         ParsedXContent typeAndMap =
             XContentHelper.convertToMap(mappingStr.compressedReference(), false, XContentType.JSON);

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1715,7 +1715,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
 
         GetIndexTemplatesResponse templatesResponse = client().admin().indices().getTemplates(new GetIndexTemplatesRequest(".partitioned.t.")).get();
         IndexTemplateMetadata metadata = templatesResponse.getIndexTemplates().get(0);
-        String mappingSource = metadata.mappings().get(DEFAULT_MAPPING_TYPE).toString();
+        String mappingSource = metadata.mapping().toString();
         Map mapping = (Map) XContentFactory.xContent(mappingSource)
             .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, mappingSource)
             .map()
@@ -1743,7 +1743,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
 
         GetIndexTemplatesResponse templatesResponse = client().admin().indices().getTemplates(new GetIndexTemplatesRequest(".partitioned.t.")).get();
         IndexTemplateMetadata metadata = templatesResponse.getIndexTemplates().get(0);
-        String mappingSource = metadata.mappings().get(DEFAULT_MAPPING_TYPE).toString();
+        String mappingSource = metadata.mapping().toString();
         Map mapping = (Map) XContentFactory.xContent(mappingSource)
             .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, mappingSource)
             .map().get(DEFAULT_MAPPING_TYPE);

--- a/server/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
+++ b/server/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
@@ -22,7 +22,6 @@
 package io.crate.metadata.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -43,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import io.crate.analyze.TableParameters;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -52,6 +50,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
+import io.crate.analyze.TableParameters;
 import io.crate.execution.ddl.tables.AlterTableRequest;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
@@ -74,6 +73,7 @@ public class AlterTableClusterStateExecutorTest {
         IndexTemplateMetadata indexTemplateMetadata = IndexTemplateMetadata.builder(templateName)
             .patterns(Collections.singletonList("*"))
             .settings(settings)
+            .putMapping("{\"default\": {}}")
             .build();
 
         ClusterState initialState = ClusterState.builder(ClusterState.EMPTY_STATE)

--- a/server/src/test/java/io/crate/metadata/cluster/DDLClusterStateHelpersTest.java
+++ b/server/src/test/java/io/crate/metadata/cluster/DDLClusterStateHelpersTest.java
@@ -22,8 +22,10 @@
 package io.crate.metadata.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import io.crate.Constants;
-import io.crate.common.collections.MapBuilder;
+
+import java.util.List;
+import java.util.Map;
+
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -33,8 +35,8 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.Map;
+import io.crate.Constants;
+import io.crate.common.collections.MapBuilder;
 
 public class DDLClusterStateHelpersTest {
 
@@ -86,8 +88,7 @@ public class DDLClusterStateHelpersTest {
         Map<String, Object> mapping = DDLClusterStateHelpers.mergeTemplateMapping(
             IndexTemplateMetadata.builder("foo")
                 .patterns(List.of("*"))
-                .putMapping(Constants.DEFAULT_MAPPING_TYPE,
-                            Strings.toString(XContentFactory.jsonBuilder().map(
+                .putMapping(Strings.toString(XContentFactory.jsonBuilder().map(
                             MapBuilder.<String, Object>newMapBuilder()
                                 .put(Constants.DEFAULT_MAPPING_TYPE, oldMapping)
                                 .map())))

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -150,6 +150,7 @@ public class MetadataTrackerTest extends ESTestCase {
                 .patterns(Collections.singletonList(PartitionName.templatePrefix(relation.schema(), relation.name())))
                 .order(100)
                 .putAlias(AliasMetadata.builder(relation.indexNameOrAlias()))
+                .putMapping("{\"default\": {}}")
                 .build();
 
             clusterState = ClusterState.builder(clusterState)

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +48,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
+import io.crate.Constants;
 import io.crate.exceptions.SQLExceptions;
 
 public class TransportCreatePartitionsActionTest extends IntegTestCase {
@@ -64,6 +66,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
 
         PutIndexTemplateRequest request = new PutIndexTemplateRequest("*")
             .patterns(List.of("*"))
+            .mapping(Constants.DEFAULT_MAPPING_TYPE, Map.of())
             .settings(Settings.builder()
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
@@ -85,6 +88,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
     public void testRoutingOfIndicesIsNotOverridden() throws Exception {
         PutIndexTemplateRequest templateRequest = new PutIndexTemplateRequest("*")
             .patterns(List.of("*"))
+            .mapping(Constants.DEFAULT_MAPPING_TYPE, Map.of())
             .settings(Settings.builder()
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
@@ -127,6 +131,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
     public void testCreateBulkIndicesIgnoreExistingSame() throws Exception {
         PutIndexTemplateRequest templateRequest = new PutIndexTemplateRequest("*")
             .patterns(List.of("*"))
+            .mapping(Constants.DEFAULT_MAPPING_TYPE, Map.of())
             .settings(Settings.builder()
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -48,7 +48,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
-import io.crate.Constants;
 import io.crate.exceptions.SQLExceptions;
 
 public class TransportCreatePartitionsActionTest extends IntegTestCase {
@@ -66,7 +65,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
 
         PutIndexTemplateRequest request = new PutIndexTemplateRequest("*")
             .patterns(List.of("*"))
-            .mapping(Constants.DEFAULT_MAPPING_TYPE, Map.of())
+            .mapping(Map.of())
             .settings(Settings.builder()
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
@@ -88,7 +87,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
     public void testRoutingOfIndicesIsNotOverridden() throws Exception {
         PutIndexTemplateRequest templateRequest = new PutIndexTemplateRequest("*")
             .patterns(List.of("*"))
-            .mapping(Constants.DEFAULT_MAPPING_TYPE, Map.of())
+            .mapping(Map.of())
             .settings(Settings.builder()
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
@@ -131,7 +130,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
     public void testCreateBulkIndicesIgnoreExistingSame() throws Exception {
         PutIndexTemplateRequest templateRequest = new PutIndexTemplateRequest("*")
             .patterns(List.of("*"))
-            .mapping(Constants.DEFAULT_MAPPING_TYPE, Map.of())
+            .mapping(Map.of())
             .settings(Settings.builder()
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -98,7 +98,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusters;
 import org.mockito.Answers;
 
-import io.crate.Constants;
 import io.crate.action.sql.Cursors;
 import io.crate.action.sql.Session;
 import io.crate.action.sql.Sessions;
@@ -473,7 +472,7 @@ public class SQLExecutor {
             IndexTemplateMetadata.Builder template = IndexTemplateMetadata.builder(analyzedStmt.templateName())
                 .patterns(singletonList(analyzedStmt.templatePrefix()))
                 .order(100)
-                .putMapping(Constants.DEFAULT_MAPPING_TYPE, mapping)
+                .putMapping(mapping)
                 .settings(buildSettings(false, combinedSettings, prevState.nodes().getSmallestNonClientNodeVersion()))
                 .putAlias(alias);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

CrateDB always had a single mapping type "default". No need to maintain a map


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
