### PR TITLE
Do not unwrap aliases in Eval.rewriteToFetch

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -210,3 +210,14 @@ Fixes
   :ref:`bit <data-type-bit>` strings with different length. An example::
 
      SELECT B'01' = B'1'
+
+- Fixed an issue that caused failures of queries joining a table to a virtual
+  table where virtual table is another ``JOIN`` on aliased column and having a
+  ``LIMIT`` clause. An example::
+
+     CREATE TABLE t1 (x INTEGER, i INTEGER);
+     CREATE TABLE t2 (y INTEGER);
+     SELECT * from GENERATE_SERIES(1, 2)
+     CROSS JOIN
+     (SELECT t1.i, t2.y AS aliased from t1 inner join t2 on t1.x = t2.y) v
+     LIMIT 10

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -126,7 +126,9 @@ public final class Eval extends ForwardingLogicalPlan {
         }
         for (Symbol output : outputs) {
             newReplacedOutputs.put(output, mapToFetchStubs.apply(output));
-            SymbolVisitors.intersection(output, newSource.outputs(), newOutputs::add);
+            if (SymbolVisitors.any(newSource.outputs()::contains, output)) {
+                newOutputs.add(output);
+            }
         }
         return new FetchRewrite(newReplacedOutputs, Eval.create(newSource, newOutputs));
     }


### PR DESCRIPTION

Supersedes https://github.com/crate/crate/pull/13416 and https://github.com/crate/crate/pull/13424/
Fixes https://github.com/crate/crate/issues/13414
