### PR TITLE
Fix: has_database_privilege `CREATE` on superuser

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
@@ -78,6 +78,9 @@ public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
     }
 
     private static boolean hasCreatePrivilege(User user) {
+        if (user.isSuperUser()) {
+            return true;
+        }
         for (Privilege p : user.privileges()) {
             if (p.ident().type() == Privilege.Type.DDL &&
                 (p.ident().clazz() == Privilege.Clazz.SCHEMA || p.ident().clazz() == Privilege.Clazz.CLUSTER)) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, checking for `CREATE` privilege on `crate` superuser would always return `false` instead of `true.

Fixes: #13443

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
