### PR TITLE
Reduce number of shards in testHealthWithClosedIndices

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -33,8 +33,6 @@ import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.crate.common.unit.TimeValue;
-import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -44,10 +42,12 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.TestCluster;
 import org.junit.Test;
 
-import org.elasticsearch.test.IntegTestCase;
+import io.crate.common.unit.TimeValue;
+import io.crate.testing.UseRandomizedSchema;
 
 public class ClusterHealthIT extends IntegTestCase {
 
@@ -129,7 +129,7 @@ public class ClusterHealthIT extends IntegTestCase {
         execute("alter table t2 close");
 
         var table_3 = getFqn("t3");
-        execute("create table t3 (id int) with (number_of_replicas = 20)");
+        execute("create table t3 (id int) clustered into 1 shards with (number_of_replicas = 20)");
         waitNoPendingTasksOnAll();
         execute("alter table t3 close");
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


Depending on node randomization, the large amount of replicas in the
test case can lead to slow allocation or even errors (shard lock),
leading to a timeout on a `alter table ... close`, causing flaky test
failures:

    org.elasticsearch.ElasticsearchTimeoutException: Timeout while running `alter table t3 close`
    	at __randomizedtesting.SeedInfo.seed([967E12237D9C33DA:AC4F34795F25B86D]:0)
    	at app//io.crate.testing.SQLTransportExecutor.executeTransportOrJdbc(SQLTransportExecutor.java:197)
    	at app//io.crate.testing.SQLTransportExecutor.exec(SQLTransportExecutor.java:137)
    	at app//org.elasticsearch.test.IntegTestCase.execute(IntegTestCase.java:1698)
    	at app//org.elasticsearch.test.IntegTestCase.execute(IntegTestCase.java:1834)
    	at app//org.elasticsearch.cluster.ClusterHealthIT.testHealthWithClosedIndices(ClusterHealthIT.java:134)

This sets the number of shards for the table to 1 to mitigate the issue.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
