### PR TITLE
Add assertBusy to testSelectFromClosedTableNotAllowed

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.crate.testing.TestingHelpers.resolveCanonicalString;
@@ -451,7 +452,9 @@ public class SysShardsTest extends IntegTestCase {
         execute("create table doc.tbl (x int)");
         execute("insert into doc.tbl values(1)");
         execute("alter table doc.tbl close");
-        waitNoPendingTasksOnAll(); // ensure close is processed
+        assertBusy(() ->
+            assertThat(execute("select closed from information_schema.tables where table_name = 'tbl'")).hasRows("true\n")
+        );
         assertThatThrownBy(() -> execute("select * from doc.tbl"))
             .satisfiesAnyOf(
                 e -> Asserts.assertThat(e)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Might fix flakyness:

    java.lang.AssertionError:
    Expecting code to raise a throwable.
    	at __randomizedtesting.SeedInfo.seed([B3B867EFFCABFB84:CAD9FCAE166A156C]:0)
    	at io.crate.integrationtests.SysShardsTest.testSelectFromClosedTableNotAllowed(SysShardsTest.java:455)

https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.SysShardsTest/testSelectFromClosedTableNotAllowed


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
