### PR TITLE
Fix incorrect reference to 5.3.0 in 5.2.0 release notes

### DIFF
--- a/docs/appendices/release-notes/5.2.0.rst
+++ b/docs/appendices/release-notes/5.2.0.rst
@@ -12,9 +12,9 @@ Released on 2023-01-12.
     before you upgrade to 5.2.0.
 
     We recommend that you upgrade to the latest 5.0 release before moving to
-    5.3.0.
+    5.2.0.
 
-    A rolling upgrade from 5.0.x to 5.3.0 is supported.
+    A rolling upgrade from 5.0.x to 5.2.0 is supported.
     Before upgrading, you should `back up your data`_.
 
 .. WARNING::


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
`5.3.0` -> `5.2.0`

## Checklist

 - [X] Added an entry in `CHANGES.txt` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
