### PR TITLE
Change outputHandler.sendBytes to take byte[]

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 
 
@@ -60,13 +61,13 @@ public final class OutboundHandler {
         this.bigArrays = bigArrays;
     }
 
-    ChannelFuture sendBytes(CloseableChannel channel, BytesReference bytes) {
+    ChannelFuture sendBytes(CloseableChannel channel, byte[] bytes) {
         channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
         try {
-            ChannelFuture future = channel.writeAndFlush(Netty4Utils.toByteBuf(bytes));
+            ChannelFuture future = channel.writeAndFlush(Unpooled.wrappedBuffer(bytes));
             future.addListener(f -> {
                 if (f.isSuccess()) {
-                    statsTracker.markBytesWritten(bytes.length());
+                    statsTracker.markBytesWritten(bytes.length);
                 } else {
                     LOGGER.warn("send message failed [channel: {}]", channel, f.cause());
                 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -55,7 +55,6 @@ import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
@@ -607,8 +606,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         } else if (e instanceof TcpTransport.HttpRequestOnTransportException) {
             // in case we are able to return data, serialize the exception content and sent it back to the client
             if (channel.isOpen()) {
-                BytesArray message = new BytesArray(e.getMessage().getBytes(StandardCharsets.UTF_8));
-                var future = outboundHandler.sendBytes(channel, message);
+                var future = outboundHandler.sendBytes(channel, e.getMessage().getBytes(StandardCharsets.UTF_8));
                 future.addListener(f -> {
                     if (f.isSuccess()) {
                         channel.close();

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -58,6 +58,7 @@ import org.junit.Test;
 
 import io.crate.common.unit.TimeValue;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 
 public class InboundHandlerTests extends ESTestCase {
@@ -92,7 +93,7 @@ public class InboundHandlerTests extends ESTestCase {
         };
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         TransportHandshaker handshaker = new TransportHandshaker(version, threadPool, (n, c, r, v) -> {});
-        TransportKeepAlive keepAlive = new TransportKeepAlive(threadPool, (c, b) -> channel.writeAndFlush(Netty4Utils.toByteBuf(b)));
+        TransportKeepAlive keepAlive = new TransportKeepAlive(threadPool, (c, b) -> channel.writeAndFlush(Unpooled.wrappedBuffer(b)));
         OutboundHandler outboundHandler = new OutboundHandler("node", version, new StatsTracker(), threadPool,
             BigArrays.NON_RECYCLING_INSTANCE);
         requestHandlers = new Transport.RequestHandlers();

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -61,6 +60,7 @@ import io.crate.common.collections.Tuple;
 import io.crate.common.io.Streams;
 import io.crate.common.unit.TimeValue;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.embedded.EmbeddedChannel;
 
@@ -114,16 +114,15 @@ public class OutboundHandlerTests extends ESTestCase {
 
     @Test
     public void testSendRawBytes() throws Throwable {
-        BytesArray bytesArray = new BytesArray("message".getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = "message".getBytes(StandardCharsets.UTF_8);
 
-        ChannelFuture future1 = handler.sendBytes(channel, bytesArray);
+        ChannelFuture future1 = handler.sendBytes(channel, bytes);
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
-        BytesReference reference = Netty4Utils.toBytesReference(msg);
-        assertThat(bytesArray).isEqualTo(reference);
+        assertThat(Unpooled.wrappedBuffer(bytes)).isEqualTo(msg);
         assertThat(future1.get(5, TimeUnit.SECONDS));
 
         embeddedChannel.disconnect();
-        ChannelFuture future2 = handler.sendBytes(channel, bytesArray);
+        ChannelFuture future2 = handler.sendBytes(channel, bytes);
         assertThatThrownBy(() -> future2.get(5, TimeUnit.SECONDS))
             .hasCauseInstanceOf(ClosedChannelException.class);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Instead of going from `byte[] -> BytesReference -> ByteBuf` we can go
straight from `byte[]` to `ByteBuf`.

Probably no big impact as `sendBytes` is only used for pings and one
error handling scenario that should be rare.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
