### PR TITLE
Try to fix flaky testInsertIntoClosedPartition

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -192,9 +192,10 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
 
     @Test
     public void testInsertIntoClosedPartition() throws Exception {
-        execute("create table t (a integer, b string) partitioned by (a)");
+        int numberOfReplicas = numberOfReplicas();
+        execute("create table t (a integer, b string) partitioned by (a) with (number_of_replicas = ?)", $(numberOfReplicas));
         execute("insert into t (a, b) values (1, 'foo')");
-        refresh();
+        ensureGreen();
 
         execute("alter table t partition (a = 1) close");
         assertBusy(() -> {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to:

- https://github.com/crate/crate/commit/861b7a45a2cf584fab268f39ac51a698bcdd0774
- https://github.com/crate/crate/commit/3523509a171d69876afff6ebefe7f28cbb3848d7
- https://github.com/crate/crate/commit/ac9ec02eeee2f9b39bf71fd567b667e893da5dd4

The close-table transport uses the `lenientExpandOpen` option to resolve
indices. In case of partitioned tables, indices can still be unavailable
after a `INSERT` created a new partition.

Based on the test stdout of a failure this might sometimes be the case:

    [i.c.e.d.t.TransportCloseTable] [[cratedb[node_sm0][masterService#updateTask][T#1]]] completed closing of indices []


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
