### PR TITLE
Improve error message when fetching `ABSOLUTE` past last row

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,3 +74,6 @@ Fixes
 
 - Fixed an issue that caused wrong rows to be returned when scrolling backwards
   and then forwards through a :ref:`CURSOR <sql-fetch>`.
+
+- Improved error message when :ref:`fetching <sql-fetch>` using ``ABSOLUTE``,
+  past the last row returned by the cursor query.

--- a/server/src/test/java/io/crate/action/sql/CursorTest.java
+++ b/server/src/test/java/io/crate/action/sql/CursorTest.java
@@ -126,4 +126,22 @@ public class CursorTest {
                 """
         );
     }
+
+    @Test
+    public void test_fetching_absolute_exceeding_last_row() throws Exception {
+        BatchIterator<Row> rows = TestingBatchIterators.range(1, 6);
+        Cursor cursor = new Cursor(
+                new NoopCircuitBreaker("dummy"),
+                true,
+                Hold.WITHOUT,
+                CompletableFuture.completedFuture(rows),
+                List.of(new InputColumn(0, DataTypes.INTEGER))
+        );
+
+        final TestingRowConsumer consumer = new TestingRowConsumer();
+        cursor.fetch(consumer, ScrollMode.ABSOLUTE, 6);
+        assertThatThrownBy(consumer::getBucket)
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot return row: 6, total rows: 5");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB 
    
Throw a nice error message, instead of `IndexOutOfBoundsException` when
trying to fetch an `ABSOLUTE` row from a `CURSOR`, past the last
available row returned by the defined query.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
