### PR TITLE
Replace `internalCluster` with `cluster` in IntegTestCase

### DIFF
--- a/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -30,6 +30,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.SQLErrorMatcher.isSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 
 import java.io.IOException;
@@ -63,7 +64,7 @@ public class FulltextAnalyzerResolverTest extends IntegTestCase {
 
     @Before
     public void AnalyzerServiceSetup() {
-        fulltextAnalyzerResolver = internalCluster().getInstance(FulltextAnalyzerResolver.class);
+        fulltextAnalyzerResolver = cluster().getInstance(FulltextAnalyzerResolver.class);
     }
 
     @Override

--- a/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
@@ -93,7 +93,7 @@ public class AuthenticationIntegrationTest extends IntegTestCase {
 
     @Test
     public void testOptionsRequestDoesNotRequireAuth() throws Exception {
-        HttpServerTransport httpTransport = internalCluster().getInstance(HttpServerTransport.class);
+        HttpServerTransport httpTransport = cluster().getInstance(HttpServerTransport.class);
         InetSocketAddress address = httpTransport.boundAddress().publishAddress().address();
         String uri = String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort());
         HttpOptions request = new HttpOptions(uri);

--- a/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
@@ -107,10 +107,10 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
         @Override
         public void run() {
             try {
-                ClusterService clusterService = internalCluster().getDataNodeInstance(ClusterService.class);
+                ClusterService clusterService = cluster().getDataNodeInstance(ClusterService.class);
                 Metadata metadata = clusterService.state().getMetadata();
                 String indexUUID = metadata.index(".blob_b1").getIndexUUID();
-                BlobIndicesService blobIndicesService = internalCluster().getDataNodeInstance(BlobIndicesService.class);
+                BlobIndicesService blobIndicesService = cluster().getDataNodeInstance(BlobIndicesService.class);
                 BlobShard blobShard = blobIndicesService.blobShard(new ShardId(".blob_b1", indexUUID, 0));
                 Schemas schemas = new Schemas(Collections.emptyMap(), clusterService, null);
                 assertNotNull(blobShard);

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -107,8 +107,8 @@ public class DocLevelCollectTest extends IntegTestCase {
 
     @Before
     public void prepare() {
-        functions = internalCluster().getDataNodeInstance(Functions.class);
-        schemas = internalCluster().getDataNodeInstance(Schemas.class);
+        functions = cluster().getDataNodeInstance(Functions.class);
+        schemas = cluster().getDataNodeInstance(Schemas.class);
 
         execute(String.format(Locale.ENGLISH, "create table %s (" +
                                               "  id integer," +
@@ -232,10 +232,10 @@ public class DocLevelCollectTest extends IntegTestCase {
     }
 
     private Bucket collect(RoutedCollectPhase collectNode) throws Throwable {
-        JobSetup jobSetup = internalCluster().getDataNodeInstance(JobSetup.class);
-        TasksService tasksService = internalCluster().getDataNodeInstance(TasksService.class);
+        JobSetup jobSetup = cluster().getDataNodeInstance(JobSetup.class);
+        TasksService tasksService = cluster().getDataNodeInstance(TasksService.class);
         SharedShardContexts sharedShardContexts = new SharedShardContexts(
-            internalCluster().getDataNodeInstance(IndicesService.class), UnaryOperator.identity());
+            cluster().getDataNodeInstance(IndicesService.class), UnaryOperator.identity());
         RootTask.Builder builder = tasksService.newBuilder(collectNode.jobId());
         NodeOperation nodeOperation = NodeOperation.withDirectResponse(collectNode, mock(ExecutionPhase.class), (byte) 0,
             "remoteNode");

--- a/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -85,8 +85,8 @@ public class HandlerSideLevelCollectTest extends IntegTestCase {
 
     @Before
     public void prepare() {
-        operation = internalCluster().getDataNodeInstance(MapSideDataCollectOperation.class);
-        functions = internalCluster().getInstance(Functions.class);
+        operation = cluster().getDataNodeInstance(MapSideDataCollectOperation.class);
+        functions = cluster().getInstance(Functions.class);
     }
 
     private RoutedCollectPhase collectNode(Routing routing,
@@ -112,7 +112,7 @@ public class HandlerSideLevelCollectTest extends IntegTestCase {
 
     @Test
     public void testClusterLevel() throws Exception {
-        Schemas schemas = internalCluster().getInstance(Schemas.class);
+        Schemas schemas = cluster().getInstance(Schemas.class);
         TableInfo tableInfo = schemas.getTableInfo(new RelationName("sys", "cluster"));
         Routing routing = tableInfo.getRouting(
             clusterService().state(),
@@ -142,7 +142,7 @@ public class HandlerSideLevelCollectTest extends IntegTestCase {
 
     @Test
     public void testInformationSchemaTables() throws Exception {
-        InformationSchemaInfo schemaInfo = internalCluster().getInstance(InformationSchemaInfo.class);
+        InformationSchemaInfo schemaInfo = cluster().getInstance(InformationSchemaInfo.class);
         TableInfo tablesTableInfo = schemaInfo.getTableInfo("tables");
         Routing routing = tablesTableInfo.getRouting(
             clusterService().state(),
@@ -167,7 +167,7 @@ public class HandlerSideLevelCollectTest extends IntegTestCase {
 
     @Test
     public void testInformationSchemaColumns() throws Exception {
-        InformationSchemaInfo schemaInfo = internalCluster().getInstance(InformationSchemaInfo.class);
+        InformationSchemaInfo schemaInfo = cluster().getInstance(InformationSchemaInfo.class);
         TableInfo tableInfo = schemaInfo.getTableInfo("columns");
         assert tableInfo != null;
         Routing routing = tableInfo.getRouting(

--- a/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
@@ -43,7 +43,7 @@ public class ShardCollectorProviderTest extends IntegTestCase {
         final Field shards = ShardCollectSource.class.getDeclaredField("shards");
         shards.setAccessible(true);
         final List<ShardCollectSource> shardCollectSources = StreamSupport.stream(
-            internalCluster().getInstances(ShardCollectSource.class).spliterator(), false)
+            cluster().getInstances(ShardCollectSource.class).spliterator(), false)
             .collect(Collectors.toList());
         for (ShardCollectSource shardCollectSource : shardCollectSources) {
             try {

--- a/server/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
@@ -68,8 +68,8 @@ public class InternalCountOperationTest extends IntegTestCase {
         execute("insert into t (name) values ('Marvin'), ('Arthur'), ('Trillian')");
         execute("refresh table t");
 
-        CountOperation countOperation = internalCluster().getDataNodeInstance(CountOperation.class);
-        ClusterService clusterService = internalCluster().getDataNodeInstance(ClusterService.class);
+        CountOperation countOperation = cluster().getDataNodeInstance(CountOperation.class);
+        ClusterService clusterService = cluster().getDataNodeInstance(ClusterService.class);
         CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         Metadata metadata = clusterService.state().getMetadata();
         Index index = metadata.index(getFqn("t")).getIndex();
@@ -83,7 +83,7 @@ public class InternalCountOperationTest extends IntegTestCase {
             assertThat(count.get(5, TimeUnit.SECONDS), is(3L));
         }
 
-        Schemas schemas = internalCluster().getInstance(Schemas.class);
+        Schemas schemas = cluster().getInstance(Schemas.class);
         TableInfo tableInfo = schemas.getTableInfo(new RelationName(sqlExecutor.getCurrentSchema(), "t"));
         TableRelation tableRelation = new TableRelation(tableInfo);
         Map<RelationName, AnalyzedRelation> tableSources = Map.of(tableInfo.ident(), tableRelation);
@@ -100,11 +100,11 @@ public class InternalCountOperationTest extends IntegTestCase {
     public void test_handles_recovering_shard_state_for_partitioned_tables() throws Exception {
         execute("create table doc.t (name string, p int) partitioned by (p) clustered into 1 shards with (number_of_replicas = 0)");
         execute("insert into doc.t (name, p) values ('Foo', 1)");
-        ClusterService clusterService = internalCluster().getDataNodeInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getDataNodeInstance(ClusterService.class);
         CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         Metadata metadata = clusterService.state().getMetadata();
         Index index = metadata.index(new PartitionName(new RelationName("doc", "t"), List.of("1")).asIndexName()).getIndex();
-        var countOperation = (InternalCountOperation) internalCluster().getDataNodeInstance(CountOperation.class);
+        var countOperation = (InternalCountOperation) cluster().getDataNodeInstance(CountOperation.class);
         IndexService indexService = mock(IndexService.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.acquireSearcher(Mockito.anyString())).thenThrow(new IllegalIndexShardStateException(

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
@@ -58,7 +58,7 @@ public class SystemCollectSourceTest extends IntegTestCase {
 
     @Test
     public void testOrderBySymbolsDoNotAppearTwiceInRows() throws Exception {
-        SystemCollectSource systemCollectSource = internalCluster().getDataNodeInstance(SystemCollectSource.class);
+        SystemCollectSource systemCollectSource = cluster().getDataNodeInstance(SystemCollectSource.class);
 
         SimpleReference shardId = new SimpleReference(
             new ReferenceIdent(new RelationName("sys", "shards"), "id"),
@@ -102,7 +102,7 @@ public class SystemCollectSourceTest extends IntegTestCase {
 
     @Test
     public void testReadIsolation() throws Exception {
-        SystemCollectSource systemCollectSource = internalCluster().getDataNodeInstance(SystemCollectSource.class);
+        SystemCollectSource systemCollectSource = cluster().getDataNodeInstance(SystemCollectSource.class);
         RoutedCollectPhase collectPhase = new RoutedCollectPhase(
             UUID.randomUUID(),
             1,

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
 
@@ -54,7 +55,6 @@ import io.crate.execution.engine.pipeline.TableSettingsResolver;
 import io.crate.execution.jobs.NodeLimits;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
-import org.elasticsearch.test.IntegTestCase;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
@@ -83,7 +83,7 @@ public class IndexWriterProjectorTest extends IntegTestCase {
         RelationName bulkImportIdent = new RelationName(sqlExecutor.getCurrentSchema(), "bulk_import");
         ClusterState state = clusterService().state();
         Settings tableSettings = TableSettingsResolver.get(state.getMetadata(), bulkImportIdent, false);
-        ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class);
+        ThreadPool threadPool = cluster().getInstance(ThreadPool.class);
         IndexWriterProjector writerProjector = new IndexWriterProjector(
             clusterService(),
             new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
@@ -92,11 +92,11 @@ public class IndexWriterProjectorTest extends IntegTestCase {
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
             CoordinatorTxnCtx.systemTransactionContext(),
-            new NodeContext(internalCluster().getInstance(Functions.class), null),
+            new NodeContext(cluster().getInstance(Functions.class), null),
             Settings.EMPTY,
             IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(tableSettings),
             NumberOfReplicas.fromSettings(tableSettings, state.getNodes().getSize()),
-            internalCluster().client(),
+            cluster().client(),
             IndexNameResolver.forTable(bulkImportIdent),
             new SimpleReference(new ReferenceIdent(bulkImportIdent, DocSysColumns.RAW),
                           RowGranularity.DOC,

--- a/server/src/test/java/io/crate/executor/transport/DependencyCarrierDDLTest.java
+++ b/server/src/test/java/io/crate/executor/transport/DependencyCarrierDDLTest.java
@@ -55,7 +55,7 @@ public class DependencyCarrierDDLTest extends IntegTestCase {
 
     @Before
     public void transportSetup() {
-        executor = internalCluster().getInstance(DependencyCarrier.class);
+        executor = cluster().getInstance(DependencyCarrier.class);
     }
 
     @After

--- a/server/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -27,8 +27,8 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Before;
 
-import io.crate.action.sql.Sessions;
 import io.crate.action.sql.Session;
+import io.crate.action.sql.Sessions;
 import io.crate.testing.SQLResponse;
 import io.crate.user.User;
 import io.crate.user.UserLookup;
@@ -39,12 +39,12 @@ public abstract class BaseUsersIntegrationTest extends IntegTestCase {
     private Session normalUserSession;
 
     protected Session createSuperUserSession() {
-        Sessions sqlOperations = internalCluster().getInstance(Sessions.class);
+        Sessions sqlOperations = cluster().getInstance(Sessions.class);
         return sqlOperations.createSession(null, User.CRATE_USER);
     }
 
     private Session createUserSession() {
-        Sessions sqlOperations = internalCluster().getInstance(Sessions.class);
+        Sessions sqlOperations = cluster().getInstance(Sessions.class);
         return sqlOperations.createSession(null, User.of("normal"));
     }
 
@@ -73,8 +73,8 @@ public abstract class BaseUsersIntegrationTest extends IntegTestCase {
     }
 
     public SQLResponse executeAs(String stmt, String userName) {
-        Sessions sqlOperations = internalCluster().getInstance(Sessions.class);
-        UserLookup userLookup = internalCluster().getInstance(UserLookup.class);
+        Sessions sqlOperations = cluster().getInstance(Sessions.class);
+        UserLookup userLookup = cluster().getInstance(UserLookup.class);
         User user = Objects.requireNonNull(userLookup.findUser(userName), "User " + userName + " must exist");
         try (Session session = sqlOperations.createSession(null, user)) {
             return execute(stmt, null, session);

--- a/server/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
@@ -82,13 +82,13 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
 
     @Before
     public void setup() throws ExecutionException, InterruptedException {
-        randomNode = internalCluster().getInstances(HttpServerTransport.class)
+        randomNode = cluster().getInstances(HttpServerTransport.class)
             .iterator().next().boundAddress().publishAddress().address();
-        Iterable<HttpServerTransport> transports = internalCluster().getDataNodeInstances(HttpServerTransport.class);
+        Iterable<HttpServerTransport> transports = cluster().getDataNodeInstances(HttpServerTransport.class);
         Iterator<HttpServerTransport> httpTransports = transports.iterator();
         dataNode1 = httpTransports.next().boundAddress().publishAddress().address();
         dataNode2 = httpTransports.next().boundAddress().publishAddress().address();
-        BlobAdminClient blobAdminClient = internalCluster().getInstance(BlobAdminClient.class);
+        BlobAdminClient blobAdminClient = cluster().getInstance(BlobAdminClient.class);
 
         Settings indexSettings = Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
@@ -110,7 +110,7 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
 
     @After
     public void assertNoActiveTransfersRemaining() throws Exception {
-        Iterable<BlobTransferTarget> transferTargets = internalCluster().getInstances(BlobTransferTarget.class);
+        Iterable<BlobTransferTarget> transferTargets = cluster().getInstances(BlobTransferTarget.class);
         final Field activeTransfersField = BlobTransferTarget.class.getDeclaredField("activeTransfers");
         activeTransfersField.setAccessible(true);
         assertBusy(() -> {

--- a/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
@@ -404,7 +404,7 @@ public class BlobIntegrationTest extends BlobHttpIntegrationTest {
 
     @Nullable
     private BlobShard getBlobShard(String digest) {
-        Iterable<BlobIndicesService> services = internalCluster().getInstances(BlobIndicesService.class);
+        Iterable<BlobIndicesService> services = cluster().getInstances(BlobIndicesService.class);
         Iterator<BlobIndicesService> it = services.iterator();
         BlobShard blobShard = null;
         while (it.hasNext()) {

--- a/server/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
@@ -89,12 +89,12 @@ public abstract class BlobIntegrationTestBase extends IntegTestCase {
             }
         }));
 
-        internalCluster().wipeIndices("_all");
+        cluster().wipeIndices("_all");
         assertBusy(() -> forEachIndicesMap(i -> assertThat(i.keySet()).isEmpty()));
     }
 
     private void forEachIndicesMap(Consumer<Map<String, BlobIndex>> consumer) {
-        Iterable<BlobIndicesService> blobIndicesServices = internalCluster().getInstances(BlobIndicesService.class);
+        Iterable<BlobIndicesService> blobIndicesServices = cluster().getInstances(BlobIndicesService.class);
         for (BlobIndicesService blobIndicesService : blobIndicesServices) {
             try {
                 Map<String, BlobIndex> indices = (Map<String, BlobIndex>) indicesField.get(blobIndicesService);

--- a/server/src/test/java/io/crate/integrationtests/BlobPathITest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobPathITest.java
@@ -74,10 +74,10 @@ public class BlobPathITest extends BlobIntegrationTestBase {
     private void launchNodeAndInitClient(Settings settings) throws Exception {
         // using numDataNodes = 1 to launch the node doesn't work:
         // if globalBlobPath is created within nodeSetting it is sometimes not available for the tests
-        internalCluster().startNode(settings);
-        blobAdminClient = internalCluster().getInstance(BlobAdminClient.class);
+        cluster().startNode(settings);
+        blobAdminClient = cluster().getInstance(BlobAdminClient.class);
 
-        HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
+        HttpServerTransport httpServerTransport = cluster().getInstance(HttpServerTransport.class);
         InetSocketAddress address = httpServerTransport.boundAddress().publishAddress().address();
         client = new BlobHttpClient(address);
     }
@@ -94,7 +94,7 @@ public class BlobPathITest extends BlobIntegrationTestBase {
 
         client.put("b1", "abcdefg");
         assertThat(gatherDigests(data1).size(), is(1));
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
         assertThat(gatherDigests(data1).size(), is(1));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
@@ -50,7 +50,7 @@ public class BulkInsertOnClientNodeTest extends IntegTestCase {
                 @Override
                 public Client client() {
                     // make sure we use a client node (started with client=true)
-                    Client client = internalCluster().client();
+                    Client client = cluster().client();
                     nodeName = client.settings().get("node.name");
                     return client;
                 }
@@ -62,7 +62,7 @@ public class BulkInsertOnClientNodeTest extends IntegTestCase {
 
                 @Override
                 public Sessions sqlOperations() {
-                    return internalCluster().getInstance(Sessions.class, nodeName());
+                    return cluster().getInstance(Sessions.class, nodeName());
                 }
 
                 private String nodeName() {

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -51,7 +51,7 @@ public class CircuitBreakerIntegrationTest extends IntegTestCase {
         execute("insert into t1 values ('this is some text'), ('other text')");
         refresh();
 
-        CircuitBreakerService circuitBreakerService = internalCluster().getInstance(CircuitBreakerService.class);
+        CircuitBreakerService circuitBreakerService = cluster().getInstance(CircuitBreakerService.class);
         CircuitBreaker queryBreaker = circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
         long breakerBytesUsedBeforeQuery = queryBreaker.getUsed();
 

--- a/server/src/test/java/io/crate/integrationtests/ClientNodeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ClientNodeIntegrationTest.java
@@ -40,7 +40,7 @@ public class ClientNodeIntegrationTest extends IntegTestCase {
                 @Override
                 public Client client() {
                     // make sure we use a client node (started with client=true)
-                    return internalCluster().coordOnlyNodeClient();
+                    return cluster().coordOnlyNodeClient();
                 }
 
                 @Override
@@ -50,7 +50,7 @@ public class ClientNodeIntegrationTest extends IntegTestCase {
 
                 @Override
                 public Sessions sqlOperations() {
-                    return internalCluster().getInstance(Sessions.class);
+                    return cluster().getInstance(Sessions.class);
                 }
             }
         ));

--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -74,8 +74,8 @@ public class CopyFromFailFastITest extends IntegTestCase {
     @UseJdbc(0)
     @Test
     public void test_copy_from_with_fail_fast_with_single_node() throws Exception {
-        internalCluster().startNode();
-        internalCluster().ensureAtLeastNumDataNodes(1);
+        cluster().startNode();
+        cluster().ensureAtLeastNumDataNodes(1);
 
         // a single uri with 'shared = true' implies that one node will be involved at all times.
         Path tmpDir = newTempDir(LifecycleScope.TEST);
@@ -99,9 +99,9 @@ public class CopyFromFailFastITest extends IntegTestCase {
     @TestLogging("io.crate.execution.dml.upsert:DEBUG")
     @Test
     public void test_copy_from_with_fail_fast_with_write_error_on_non_handler_node() throws Exception {
-        internalCluster().startNode();
-        internalCluster().startNode();
-        internalCluster().ensureAtLeastNumDataNodes(2);
+        cluster().startNode();
+        cluster().startNode();
+        cluster().ensureAtLeastNumDataNodes(2);
 
         execute("set global overload_protection.dml.initial_concurrency = 2");
         execute("set global overload_protection.dml.max_concurrency = 2");
@@ -117,7 +117,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
 
             @Override
             public Client client() {
-                return internalCluster().client(nodeNameOfShard0);
+                return cluster().client(nodeNameOfShard0);
             }
 
             @Override
@@ -127,7 +127,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
 
             @Override
             public Sessions sqlOperations() {
-                return internalCluster().getInstance(Sessions.class, nodeNameOfShard0);
+                return cluster().getInstance(Sessions.class, nodeNameOfShard0);
             }
         };
         var handlerNodeExecutor = new SQLTransportExecutor(clientProvider);
@@ -172,9 +172,9 @@ public class CopyFromFailFastITest extends IntegTestCase {
     @TestLogging("io.crate.execution.dml.upsert:DEBUG")
     @Test
     public void test_copy_from_with_fail_fast_with_write_error_on_handler_node() throws Exception {
-        internalCluster().startNode();
-        internalCluster().startNode();
-        internalCluster().ensureAtLeastNumDataNodes(2);
+        cluster().startNode();
+        cluster().startNode();
+        cluster().ensureAtLeastNumDataNodes(2);
 
         execute("set global overload_protection.dml.initial_concurrency = 2");
         execute("set global overload_protection.dml.max_concurrency = 2");
@@ -189,7 +189,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
 
             @Override
             public Client client() {
-                return internalCluster().client(nodeNameOfShard0);
+                return cluster().client(nodeNameOfShard0);
             }
 
             @Override
@@ -199,7 +199,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
 
             @Override
             public Sessions sqlOperations() {
-                return internalCluster().getInstance(Sessions.class, nodeNameOfShard0);
+                return cluster().getInstance(Sessions.class, nodeNameOfShard0);
             }
         };
         var handlerNodeExecutor = new SQLTransportExecutor(clientProvider);
@@ -246,7 +246,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
         // fail_fast = true and fail_fast = false that do not fail take different UpsertResultCollectors.
         // fail_fast = false uses RowCountCollector while fail_fast = true uses newSummaryOnFailOrRowCountOnSuccessCollector
         // and in the case that nothing fail, the collected summary will turn into rowCounts
-        internalCluster().startNode();
+        cluster().startNode();
 
         Path tmpDir = newTempDir(LifecycleScope.TEST);
         Path target = Files.createDirectories(tmpDir.resolve("target"));

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -42,13 +42,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import com.carrotsearch.randomizedtesting.LifecycleScope;
-import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
-import org.elasticsearch.test.IntegTestCase;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -68,6 +61,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.carrotsearch.randomizedtesting.LifecycleScope;
+
+import io.crate.testing.SQLResponse;
+import io.crate.testing.UseJdbc;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
 public class CopyIntegrationTest extends SQLHttpIntegrationTest {
@@ -796,7 +799,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         String filename = "nonexistingfile.json";
         execute("copy t1 from ? return summary", new Object[]{tmpDirStr + filename});
-        assertThat(response.rowCount(), is((long) internalCluster().numDataNodes()));
+        assertThat(response.rowCount(), is((long) cluster().numDataNodes()));
 
         boolean isRunningOnWindows = System.getProperty("os.name").startsWith("Windows");
         String expected = "(No such file or directory)";
@@ -824,7 +827,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         // with shared=true and wildcards all nodes will try to match a file
         filename = "*.json";
         execute("copy t1 from ? with (shared=true) return summary", new Object[] {tmpDirStr + filename});
-        assertThat(response.rowCount(), is((long) internalCluster().numDataNodes()));
+        assertThat(response.rowCount(), is((long) cluster().numDataNodes()));
 
         for (Object[] row : response.rows()) {
             assertThat((String) row[1], endsWith("*.json"));

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -73,7 +73,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
         client().admin().indices().putMapping(new PutMappingRequest("tbl").source(builder))
             .get(5, TimeUnit.SECONDS);
 
-        assertThat(internalCluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"))
+        assertThat(cluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"))
             .isTrue();
         assertThrowsMatches(
             () -> execute("select * from doc.tbl"),
@@ -84,7 +84,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
         execute("drop table doc.tbl");
         execute("select count(*) from information_schema.tables where table_name = 'tbl'");
         assertThat(response.rows()[0][0]).isEqualTo(0L);
-        assertThat(internalCluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"))
+        assertThat(cluster().getInstance(ClusterService.class).state().metadata().hasIndex("tbl"))
             .isFalse();
     }
 

--- a/server/src/test/java/io/crate/integrationtests/CursorITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CursorITest.java
@@ -41,7 +41,7 @@ public class CursorITest extends IntegTestCase {
 
     private String url() {
         // Tests use JDBC to be able to re-use the same connection to the same node
-        PostgresNetty postgresNetty = internalCluster().getInstance(PostgresNetty.class);
+        PostgresNetty postgresNetty = cluster().getInstance(PostgresNetty.class);
         int port = postgresNetty.boundAddress().publishAddress().getPort();
         return "jdbc:postgresql://127.0.0.1:" + port + '/';
     }

--- a/server/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -105,9 +105,9 @@ public class CustomSchemaIntegrationTest extends IntegTestCase {
         execute("create table custom.foo (id integer)");
         execute("create table custom.bar (id integer)");
 
-        assertThat(internalCluster().clusterService().state().metadata().hasIndex("custom.foo"), is(true));
+        assertThat(cluster().clusterService().state().metadata().hasIndex("custom.foo"), is(true));
         execute("drop table custom.foo");
-        assertThat(internalCluster().clusterService().state().metadata().hasIndex("custom.foo"), is(false));
+        assertThat(cluster().clusterService().state().metadata().hasIndex("custom.foo"), is(false));
 
         assertBusy(() -> {
             try {

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -707,12 +707,12 @@ public class DDLIntegrationTest extends IntegTestCase {
     public void testDropTable() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)");
 
-        assertThat(internalCluster().clusterService().state().metadata().hasIndex("test"), is(true));
+        assertThat(cluster().clusterService().state().metadata().hasIndex("test"), is(true));
 
         execute("drop table test");
         assertThat(response.rowCount(), is(1L));
 
-        assertThat(internalCluster().clusterService().state().metadata().hasIndex("test"), is(false));
+        assertThat(cluster().clusterService().state().metadata().hasIndex("test"), is(false));
     }
 
     @Test
@@ -733,10 +733,10 @@ public class DDLIntegrationTest extends IntegTestCase {
     public void testDropTableIfExists() {
         execute("create table test (col1 integer primary key, col2 string)");
 
-        assertThat(internalCluster().clusterService().state().metadata().hasIndex("test"), is(true));
+        assertThat(cluster().clusterService().state().metadata().hasIndex("test"), is(true));
         execute("drop table if exists test");
         assertThat(response.rowCount(), is(1L));
-        assertThat(internalCluster().clusterService().state().metadata().hasIndex("test"), is(false));
+        assertThat(cluster().clusterService().state().metadata().hasIndex("test"), is(false));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
@@ -46,7 +46,7 @@ public class DanglingIndicesIntegrationTest extends IntegTestCase {
 
         createIndex(dangling1, dangling2, dangling3);
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         assertThat(clusterService.state().metadata().hasIndex(dangling1), is(true));
         assertThat(clusterService.state().metadata().hasIndex(dangling2), is(true));
         assertThat(clusterService.state().metadata().hasIndex(dangling3), is(true));

--- a/server/src/test/java/io/crate/integrationtests/DefaultTransportITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DefaultTransportITest.java
@@ -73,7 +73,7 @@ public class DefaultTransportITest extends IntegTestCase {
         SslContextProvider sslContextProvider = new SslContextProvider(sslSettings);
         SSLContext sslContext = sslContextProvider.jdkSSLContext();
 
-        for (var transport : internalCluster().getInstances(Transport.class)) {
+        for (var transport : cluster().getInstances(Transport.class)) {
             var publishAddress = transport.boundAddress().publishAddress();
             var address = publishAddress.address();
             ProbeResult probeResult = ConnectionTest.probeSSL(sslContext, address);

--- a/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
@@ -85,7 +85,7 @@ public class DiskUsagesITest extends IntegTestCase {
     public void testRerouteOccursOnDiskPassingHighWatermark() throws Exception {
         for (int i = 0; i < 3; i++) {
             // ensure that each node has a single data path
-            internalCluster().startNode(
+            cluster().startNode(
                 Settings.builder()
                     .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir())
                     .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms"));
@@ -148,7 +148,7 @@ public class DiskUsagesITest extends IntegTestCase {
     public void testOnlyMovesEnoughShardsToDropBelowHighWatermark() throws Exception {
         for (int i = 0; i < 3; i++) {
             // ensure that each node has a single data path
-            internalCluster().startNode(
+            cluster().startNode(
                 Settings.builder()
                     .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir())
                     .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms"));
@@ -157,7 +157,7 @@ public class DiskUsagesITest extends IntegTestCase {
 
         var clusterInfoService = getMockInternalClusterInfoService();
         AtomicReference<ClusterState> masterAppliedClusterState = new AtomicReference<>();
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> {
+        cluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> {
             masterAppliedClusterState.set(event.state());
             clusterInfoService.refresh(); // so subsequent reroute sees disk usage according to the current state
         });
@@ -209,7 +209,7 @@ public class DiskUsagesITest extends IntegTestCase {
     public void testDoesNotExceedLowWatermarkWhenRebalancing() {
         for (int i = 0; i < 3; i++) {
             // ensure that each node has a single data path
-            internalCluster().startNode(
+            cluster().startNode(
                 Settings.builder()
                     .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir())
                     .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "1ms"));
@@ -219,7 +219,7 @@ public class DiskUsagesITest extends IntegTestCase {
         var clusterInfoService = getMockInternalClusterInfoService();
 
         AtomicReference<ClusterState> masterAppliedClusterState = new AtomicReference<>();
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> {
+        cluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> {
             assertThat(event.state().getRoutingNodes().node(nodeIds.get(2)).size(), lessThanOrEqualTo(1));
             masterAppliedClusterState.set(event.state());
             clusterInfoService.refresh(); // so a subsequent reroute sees disk usage according to the current state
@@ -276,18 +276,18 @@ public class DiskUsagesITest extends IntegTestCase {
                 pathOverWatermark,
                 createTempDir().toString());
         }
-        internalCluster().startNode(twoPathSettings);
+        cluster().startNode(twoPathSettings);
 
         execute("SELECT id FROM sys.nodes");
         assertThat(response.rows().length, is(1));
         String nodeIdWithTwoPaths = (String) response.rows()[0][0];
 
         // other two nodes have one data path each
-        internalCluster().startNode(
+        cluster().startNode(
             Settings.builder()
                 .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir())
                 .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "1ms"));
-        internalCluster().startNode(
+        cluster().startNode(
             Settings.builder()
                 .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir())
                 .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "1ms"));
@@ -361,7 +361,7 @@ public class DiskUsagesITest extends IntegTestCase {
     public void testAutomaticReleaseOfIndexBlock() throws Exception {
         for (int i = 0; i < 3; i++) {
             // ensure that each node has a single data path
-            internalCluster().startNode(Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), createTempDir()));
+            cluster().startNode(Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), createTempDir()));
         }
 
         ClusterStateResponse clusterStateResponse = client().admin().cluster().state(new ClusterStateRequest()).get();
@@ -370,7 +370,7 @@ public class DiskUsagesITest extends IntegTestCase {
 
         // Start with all nodes at 50% usage
         final MockInternalClusterInfoService cis = (MockInternalClusterInfoService)
-            internalCluster().getInstance(ClusterInfoService.class, internalCluster().getMasterName());
+            cluster().getInstance(ClusterInfoService.class, cluster().getMasterName());
         cis.setUpdateFrequency(TimeValue.timeValueMillis(100));
 
         // prevent any effects from in-flight recoveries, since we are only simulating a 100-byte disk
@@ -487,7 +487,7 @@ public class DiskUsagesITest extends IntegTestCase {
     }
 
     private MockInternalClusterInfoService getMockInternalClusterInfoService() {
-        return (MockInternalClusterInfoService) internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
+        return (MockInternalClusterInfoService) cluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
     }
 
     private HashMap<String, Integer> getShardCountByNodeId() {

--- a/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsITest.java
@@ -36,7 +36,7 @@ public class GCDanglingArtifactsITest extends IntegTestCase {
         execute("create table doc.t1 (x int)");
         createIndex(".resized.foobar");
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         assertThat(clusterService.state().metadata().hasIndex(".resized.foobar"), is(true));
 
         execute("alter cluster gc dangling artifacts");

--- a/server/src/test/java/io/crate/integrationtests/IndexUpgraderTest.java
+++ b/server/src/test/java/io/crate/integrationtests/IndexUpgraderTest.java
@@ -21,18 +21,18 @@
 
 package io.crate.integrationtests;
 
-import org.apache.lucene.tests.util.TestUtil;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.test.IntegTestCase;
-import org.junit.Test;
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Test;
 
 @IntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
 public class IndexUpgraderTest extends IntegTestCase {
@@ -46,7 +46,7 @@ public class IndexUpgraderTest extends IntegTestCase {
             TestUtil.unzip(stream, indexDir);
         }
         Settings.Builder builder = Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), indexDir.toAbsolutePath());
-        internalCluster().startNode(builder.build());
+        cluster().startNode(builder.build());
         ensureGreen();
     }
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
@@ -85,7 +85,7 @@ public class InformationSchemaQueryTest extends IntegTestCase {
 
     @Test
     public void testConcurrentUnassignedShardsReferenceResolver() throws Exception {
-        internalCluster().ensureAtMostNumDataNodes(1);
+        cluster().ensureAtMostNumDataNodes(1);
         execute("create table t1 (col1 integer) " +
                 "clustered into 1 shards ");
         execute("create table t2 (col1 integer) " +

--- a/server/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
@@ -54,7 +54,7 @@ public class JobIntegrationTest extends IntegTestCase {
             new SQLTransportExecutor.ClientProvider() {
                 @Override
                 public Client client() {
-                    return internalCluster().coordOnlyNodeClient();
+                    return cluster().coordOnlyNodeClient();
                 }
 
                 @Nullable
@@ -65,7 +65,7 @@ public class JobIntegrationTest extends IntegTestCase {
 
                 @Override
                 public Sessions sqlOperations() {
-                    return internalCluster().getInstance(Sessions.class);
+                    return cluster().getInstance(Sessions.class);
                 }
             }
         ));

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -899,7 +899,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         long memoryLimit = 6 * 1024 * 1024;
         execute("set global \"indices.breaker.query.limit\" = '" + memoryLimit + "b'");
-        CircuitBreaker queryCircuitBreaker = internalCluster().getInstance(CircuitBreakerService.class).getBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker queryCircuitBreaker = cluster().getInstance(CircuitBreakerService.class).getBreaker(HierarchyCircuitBreakerService.QUERY);
         randomiseAndConfigureJoinBlockSize("t1", 5L, queryCircuitBreaker);
         randomiseAndConfigureJoinBlockSize("t2", 5L, queryCircuitBreaker);
 
@@ -912,7 +912,7 @@ public class JoinIntegrationTest extends IntegTestCase {
     }
 
     private void resetTableStats() {
-        for (TableStats tableStats : internalCluster().getInstances(TableStats.class)) {
+        for (TableStats tableStats : cluster().getInstances(TableStats.class)) {
             tableStats.updateTableStats(new HashMap<>());
         }
     }
@@ -926,7 +926,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("insert into t2 (x) values (1), (3), (4), (4), (5), (6)");
         execute("refresh table t1, t2");
 
-        Iterable<TableStats> tableStatsOnAllNodes = internalCluster().getInstances(TableStats.class);
+        Iterable<TableStats> tableStatsOnAllNodes = cluster().getInstances(TableStats.class);
         for (TableStats tableStats : tableStatsOnAllNodes) {
             Map<RelationName, Stats> newStats = new HashMap<>();
             newStats.put(new RelationName(sqlExecutor.getCurrentSchema(), "t1"), new Stats(4L, 16L, Map.of()));
@@ -955,7 +955,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("insert into t3 (y) values (0), (1), (2), (3), (4), (5), (6), (7), (8), (9)");
         execute("refresh table t1, t2, t3");
 
-        Iterable<TableStats> tableStatsOnAllNodes = internalCluster().getInstances(TableStats.class);
+        Iterable<TableStats> tableStatsOnAllNodes = cluster().getInstances(TableStats.class);
         for (TableStats tableStats : tableStatsOnAllNodes) {
             Map<RelationName, Stats> newStats = new HashMap<>();
             newStats.put(new RelationName(sqlExecutor.getCurrentSchema(), "t1"), new Stats(2L, 8L, Map.of()));
@@ -979,7 +979,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         long memoryLimit = 6 * 1024 * 1024;
         execute("set global \"indices.breaker.query.limit\" = '" + memoryLimit + "b'");
-        CircuitBreaker queryCircuitBreaker = internalCluster().getInstance(CircuitBreakerService.class).getBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker queryCircuitBreaker = cluster().getInstance(CircuitBreakerService.class).getBreaker(HierarchyCircuitBreakerService.QUERY);
         randomiseAndConfigureJoinBlockSize("t1", 10L, queryCircuitBreaker);
 
         execute("select x from t1 left_rel JOIN (select x x2, count(x) from t1 group by x2) right_rel " +
@@ -1006,7 +1006,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         long tableSizeInBytes = new Random().nextInt(3 * (int) availableMemory);
         long rowSizeBytes = tableSizeInBytes / rowsCount;
 
-        for (TableStats tableStats : internalCluster().getInstances(TableStats.class)) {
+        for (TableStats tableStats : cluster().getInstances(TableStats.class)) {
             Map<RelationName, Stats> newStats = new HashMap<>();
             newStats.put(new RelationName(sqlExecutor.getCurrentSchema(), relationName), new Stats(rowsCount, tableSizeInBytes, Map.of()));
             tableStats.updateTableStats(newStats);

--- a/server/src/test/java/io/crate/integrationtests/MetricsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetricsITest.java
@@ -91,7 +91,7 @@ public class MetricsITest extends IntegTestCase {
         // AFTER its execution has returned to this test (because async programming is evil like that).
         assertBusy(() -> {
             long cnt = 0;
-            for (JobsLogService jobsLogService : internalCluster().getInstances(JobsLogService.class)) {
+            for (JobsLogService jobsLogService : cluster().getInstances(JobsLogService.class)) {
                 for (MetricsView metrics: jobsLogService.get().metrics()) {
                     if (metrics.classification().type() == Plan.StatementType.SELECT) {
                         cnt += metrics.totalCount();

--- a/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -301,7 +301,7 @@ public class NodeStatsTest extends IntegTestCase {
         List data = (List) fs.get("data");
         if (data.size() > 0) {
             // without sigar, no data definition returned
-            int numDataPaths = internalCluster().getInstance(NodeEnvironment.class).nodeDataPaths().length;
+            int numDataPaths = cluster().getInstance(NodeEnvironment.class).nodeDataPaths().length;
             assertThat(data.size(), is(numDataPaths));
             Map<String, Object> someData = (Map<String, Object>) data.get(0);
             assertThat(someData.keySet().size(), is(2));

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -122,7 +122,7 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
             Collections.singletonList("a"));
         final String indexName = partitionName.asIndexName();
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         DiscoveryNodes nodes = clusterService.state().nodes();
         List<String> nodeIds = new ArrayList<>(2);
         for (DiscoveryNode node : nodes) {
@@ -237,7 +237,7 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
     @Test
     public void testTableUnknownExceptionIsNotRaisedIfPartitionsAreDeletedAfterPlanSingleNode() throws Exception {
         // with a sinlge node, this test leads to empty shard collectors
-        internalCluster().ensureAtMostNumDataNodes(1);
+        cluster().ensureAtMostNumDataNodes(1);
         Bucket bucket = deletePartitionsAndExecutePlan("select * from t");
         assertThat(bucket.size(), is(0));
     }

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1077,7 +1077,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             .getTemplates(new GetIndexTemplatesRequest(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes"))).get();
         assertThat(getIndexTemplatesResponse.getIndexTemplates().size(), is(0));
 
-        ClusterState state = internalCluster().clusterService().state();
+        ClusterState state = cluster().clusterService().state();
         assertThat(state.metadata().indices().size(), is(0));
         assertThat(state.metadata().hasAlias("quotes"), is(false));
     }

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -96,7 +96,7 @@ public class PostgresITest extends IntegTestCase {
     }
 
     private String url(String nodeName) {
-        PostgresNetty postgresNetty = internalCluster().getInstance(PostgresNetty.class, nodeName);
+        PostgresNetty postgresNetty = cluster().getInstance(PostgresNetty.class, nodeName);
         int port = postgresNetty.boundAddress().publishAddress().getPort();
         if (useIPv6) {
             return "jdbc:postgresql://::1:" + port + '/';
@@ -834,7 +834,7 @@ public class PostgresITest extends IntegTestCase {
             Integer port = resultSet.getInt(1);
 
             ArrayList<Integer> actualPorts = new ArrayList<>();
-            for (PostgresNetty postgresNetty : internalCluster().getInstances(PostgresNetty.class)) {
+            for (PostgresNetty postgresNetty : cluster().getInstances(PostgresNetty.class)) {
                 actualPorts.add(postgresNetty.boundAddress().publishAddress().getPort());
             }
             assertThat(port, Matchers.isOneOf(actualPorts.toArray(new Integer[0])));
@@ -928,7 +928,7 @@ public class PostgresITest extends IntegTestCase {
                 }
             }
         }
-        for (JobsLogService jobsLogService : internalCluster().getDataNodeInstances(JobsLogService.class)) {
+        for (JobsLogService jobsLogService : cluster().getDataNodeInstances(JobsLogService.class)) {
             assertBusy(() -> assertThat(jobsLogService.get().activeJobs(), emptyIterable()));
         }
     }
@@ -1129,7 +1129,7 @@ public class PostgresITest extends IntegTestCase {
 
     private long getNumQueriesFromJobsLogs() {
         long result = 0;
-        Iterable<JobsLogs> jobLogs = internalCluster().getInstances(JobsLogs.class);
+        Iterable<JobsLogs> jobLogs = cluster().getInstances(JobsLogs.class);
         for (JobsLogs jobsLogs : jobLogs) {
             for (var metrics : jobsLogs.metrics()) {
                 result += metrics.totalCount();

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -38,8 +38,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.crate.action.sql.Sessions;
 import io.crate.action.sql.Session;
+import io.crate.action.sql.Sessions;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.testing.SQLResponse;
 import io.crate.user.User;
@@ -79,12 +79,12 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        Iterable<UserDefinedFunctionService> udfServices = internalCluster().getInstances(UserDefinedFunctionService.class);
+        Iterable<UserDefinedFunctionService> udfServices = cluster().getInstances(UserDefinedFunctionService.class);
         for (UserDefinedFunctionService udfService : udfServices) {
             udfService.registerLanguage(dummyLang);
         }
-        userLookup = internalCluster().getInstance(UserLookup.class);
-        sqlOperations = internalCluster().getInstance(Sessions.class, null);
+        userLookup = cluster().getInstance(UserLookup.class);
+        sqlOperations = cluster().getInstance(Sessions.class, null);
         executeAsSuperuser("create user " + TEST_USERNAME);
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PromoteStaleReplicaITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PromoteStaleReplicaITest.java
@@ -37,7 +37,7 @@ public class PromoteStaleReplicaITest extends IntegTestCase {
 
     @Test
     public void test_stale_replica_can_manually_be_promoted() throws Exception {
-        internalCluster().startMasterOnlyNode();
+        cluster().startMasterOnlyNode();
         Settings s1 = Settings.builder()
             .put(Node.NODE_MASTER_SETTING.getKey(), false)
             .put(PATH_DATA_SETTING.getKey(), createTempDir())
@@ -47,17 +47,17 @@ public class PromoteStaleReplicaITest extends IntegTestCase {
             .put(PATH_DATA_SETTING.getKey(), createTempDir())
             .build();
 
-        String n1 = internalCluster().startNode(s1);
-        String n2 = internalCluster().startNode(s2);
+        String n1 = cluster().startNode(s1);
+        String n2 = cluster().startNode(s2);
         execute("create table t1 (x int) " +
                 "clustered into 1 shards with (number_of_replicas = 1, \"write.wait_for_active_shards\" = 1)");
 
         execute("insert into t1 (x) values (1)");
         ensureGreen();
-        internalCluster().stopRandomNode(s -> Node.NODE_NAME_SETTING.get(s).equals(n1));
+        cluster().stopRandomNode(s -> Node.NODE_NAME_SETTING.get(s).equals(n1));
         execute("insert into t1 (x) values (2)");
-        internalCluster().stopRandomNode(s -> Node.NODE_NAME_SETTING.get(s).equals(n2));
-        String newN1 = internalCluster().startNode(s1);
+        cluster().stopRandomNode(s -> Node.NODE_NAME_SETTING.get(s).equals(n2));
+        String newN1 = cluster().startNode(s1);
 
         execute("select shard_id, primary, current_state from sys.allocations order by 1, 2");
         assertThat(

--- a/server/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -58,7 +58,7 @@ public class ReadOnlyNodeIntegrationTest extends IntegTestCase {
                 @Override
                 public Client client() {
                     // make sure we use the read-only client
-                    return internalCluster().client(internalCluster().getNodeNames()[1]);
+                    return cluster().client(cluster().getNodeNames()[1]);
                 }
 
                 @Override
@@ -68,7 +68,7 @@ public class ReadOnlyNodeIntegrationTest extends IntegTestCase {
 
                 @Override
                 public Sessions sqlOperations() {
-                    return internalCluster().getInstance(Sessions.class, internalCluster().getNodeNames()[1]);
+                    return cluster().getInstance(Sessions.class, cluster().getNodeNames()[1]);
                 }
             }
         ));
@@ -100,7 +100,7 @@ public class ReadOnlyNodeIntegrationTest extends IntegTestCase {
                     @Override
                     public Client client() {
                         // make sure we use NOT the read-only client
-                        return internalCluster().client(internalCluster().getNodeNames()[0]);
+                        return cluster().client(cluster().getNodeNames()[0]);
                     }
 
                     @Nullable
@@ -112,7 +112,7 @@ public class ReadOnlyNodeIntegrationTest extends IntegTestCase {
                     @Override
                     public Sessions sqlOperations() {
                         // make sure we use NOT the read-only operations
-                        return internalCluster().getInstance(Sessions.class, internalCluster().getNodeNames()[0]);
+                        return cluster().getInstance(Sessions.class, cluster().getNodeNames()[0]);
                     }
                 }
             );

--- a/server/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -53,7 +53,7 @@ public class RemoteCollectorIntegrationTest extends IntegTestCase {
 
         PlanForNode plan = plan("update t set x = x * 2");
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         IndexShardRoutingTable t = clusterService.state().routingTable().shardRoutingTable(getFqn("t"), 0);
 
         String sourceNodeId = t.primaryShard().currentNodeId();

--- a/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
@@ -55,7 +55,7 @@ public class ResizeShardsITest extends IntegTestCase {
 
         execute("refresh table quotes");
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         final String resizeNodeName = getADataNodeName(clusterService.state());
 
         execute("alter table quotes set (\"routing.allocation.require._name\"=?, \"blocks.write\"=?)",
@@ -92,7 +92,7 @@ public class ResizeShardsITest extends IntegTestCase {
         final String resizeIndex = ".resized." + getFqn("quotes");
         createIndex(resizeIndex);
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         assertThat(clusterService.state().metadata().hasIndex(resizeIndex), is(true));
 
         final String resizeNodeName = getADataNodeName(clusterService.state());
@@ -129,7 +129,7 @@ public class ResizeShardsITest extends IntegTestCase {
         );
         execute("refresh table quotes");
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         final String resizeNodeName = getADataNodeName(clusterService.state());
 
         execute("alter table quotes partition (date=1395874800000) " +

--- a/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -86,7 +86,7 @@ public abstract class SQLHttpIntegrationTest extends IntegTestCase {
 
     @Before
     public void setup() {
-        HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
+        HttpServerTransport httpServerTransport = cluster().getInstance(HttpServerTransport.class);
         address = httpServerTransport.boundAddress().publishAddress().address();
         httpPost = new HttpPost(String.format(Locale.ENGLISH,
             "%s://%s:%s/_sql?error_trace",

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -77,7 +77,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
     public void testInsertAtNodeWithoutShard() throws Exception {
         setUpSimple(1);
 
-        try (var session = createSessionOnNode(internalCluster().getNodeNames()[0])) {
+        try (var session = createSessionOnNode(cluster().getNodeNames()[0])) {
             execute(
                 "insert into t1 (id, string_field, timestamp_field, byte_field) values (?, ?, ?, ?)",
                 new Object[]{1, "With", "1970-01-01T00:00:00", 127},
@@ -85,7 +85,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
             );
         }
 
-        try (var session = createSessionOnNode(internalCluster().getNodeNames()[1])) {
+        try (var session = createSessionOnNode(cluster().getNodeNames()[1])) {
             execute(
                 "insert into t1 (id, string_field, timestamp_field, byte_field) values (?, ?, ?, ?)",
                 new Object[] {2, "Without", "1970-01-01T01:00:00", Byte.MIN_VALUE},

--- a/server/src/test/java/io/crate/integrationtests/SSLTransportITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SSLTransportITest.java
@@ -80,7 +80,7 @@ public class SSLTransportITest extends IntegTestCase {
         SslContextProvider sslContextProvider = new SslContextProvider(sslSettings);
         SSLContext sslContext = sslContextProvider.jdkSSLContext();
 
-        for (var transport : internalCluster().getInstances(Transport.class)) {
+        for (var transport : cluster().getInstances(Transport.class)) {
             var publishAddress = transport.boundAddress().publishAddress();
             var address = publishAddress.address();
             ProbeResult probeResult = ConnectionTest.probeSSL(sslContext, address);

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -115,7 +115,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         );
 
         var dummyLang = new UserDefinedFunctionsIntegrationTest.DummyLang();
-        Iterable<UserDefinedFunctionService> udfServices = internalCluster().getInstances(UserDefinedFunctionService.class);
+        Iterable<UserDefinedFunctionService> udfServices = cluster().getInstances(UserDefinedFunctionService.class);
         for (UserDefinedFunctionService udfService : udfServices) {
             udfService.registerLanguage(dummyLang);
         }
@@ -820,9 +820,9 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
     }
 
     private RepositoryData getRepositoryData() throws Exception {
-        RepositoriesService service = internalCluster().getInstance(RepositoriesService.class, internalCluster().getMasterName());
+        RepositoriesService service = cluster().getInstance(RepositoriesService.class, cluster().getMasterName());
         Repository repository = service.repository(REPOSITORY_NAME);
-        ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class, internalCluster().getMasterName());
+        ThreadPool threadPool = cluster().getInstance(ThreadPool.class, cluster().getMasterName());
         final SetOnce<RepositoryData> repositoryData = new SetOnce<>();
         final CountDownLatch latch = new CountDownLatch(1);
         threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(() -> {

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -368,7 +368,7 @@ public class SubSelectIntegrationTest extends IntegTestCase {
         execute("insert into t (x) values (1), (2)");
         execute("refresh table t");
 
-        for (TableStats tableStats : internalCluster().getInstances(TableStats.class)) {
+        for (TableStats tableStats : cluster().getInstances(TableStats.class)) {
             Map<RelationName, Stats> newStats = new HashMap<>();
             newStats.put(
                 new RelationName(sqlExecutor.getCurrentSchema(), "t"),

--- a/server/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -43,8 +43,8 @@ public class SysCheckerIntegrationTest extends IntegTestCase {
 
     @Test
     public void testChecksPresenceAndSeverityLevels() throws Exception {
-        internalCluster().startNode(internalCluster().getDefaultSettings());
-        internalCluster().ensureAtLeastNumDataNodes(1);
+        cluster().startNode(cluster().getDefaultSettings());
+        cluster().ensureAtLeastNumDataNodes(1);
 
         SQLResponse response = execute("select severity, passed from sys.checks order by id asc");
         assertThat(response.rowCount(), equalTo(2L));
@@ -54,8 +54,8 @@ public class SysCheckerIntegrationTest extends IntegTestCase {
 
     @Test
     public void testNumberOfPartitionCheckPassedForDocTablesCustomAndDefaultSchemas() {
-        internalCluster().startNode();
-        internalCluster().ensureAtLeastNumDataNodes(1);
+        cluster().startNode();
+        cluster().ensureAtLeastNumDataNodes(1);
         execute("create table foo.bar (id int) partitioned by (id)");
         execute("create table bar (id int) partitioned by (id)");
         execute("insert into foo.bar (id) values (?)", new Object[]{1});
@@ -66,9 +66,9 @@ public class SysCheckerIntegrationTest extends IntegTestCase {
 
     @Test
     public void testSelectingConcurrentlyFromSysCheckPassesWithoutExceptions() throws Exception {
-        internalCluster().startNode();
-        internalCluster().startNode();
-        internalCluster().ensureAtLeastNumDataNodes(2);
+        cluster().startNode();
+        cluster().startNode();
+        cluster().ensureAtLeastNumDataNodes(2);
 
         List<CompletableFuture<SQLResponse>> responses = new ArrayList<>();
         for (int i = 0; i < 20; i++) {

--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -113,7 +113,7 @@ public class SysClusterSettingsTest extends IntegTestCase {
         assertSettingsValue(JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING.getKey(), 2);
         assertSettingsValue(JobsLogService.STATS_ENABLED_SETTING.getKey(), false);
 
-        internalCluster().fullRestart();
+        cluster().fullRestart();
 
         execute("select settings from sys.cluster");
         assertSettingsDefault(JobsLogService.STATS_JOBS_LOG_SIZE_SETTING);
@@ -128,7 +128,7 @@ public class SysClusterSettingsTest extends IntegTestCase {
         execute("select settings from sys.cluster");
         assertSettingsValue(JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING.getKey(), 100);
 
-        internalCluster().fullRestart();
+        cluster().fullRestart();
         // the gateway recovery is async and
         // it might take a bit until it reads the persisted cluster state and updates the settings expression
         assertBusy(() -> {
@@ -190,7 +190,7 @@ public class SysClusterSettingsTest extends IntegTestCase {
     @Test
     public void test_set_cluster_info_update_interval() throws Exception {
         execute("set global transient \"cluster.info.update.interval\" = '45s'");
-        var clusterService = internalCluster().getInstance(ClusterInfoService.class);
+        var clusterService = cluster().getInstance(ClusterInfoService.class);
         Field f1 = clusterService.getClass().getDeclaredField("updateFrequency");
         f1.setAccessible(true);
         assertThat(f1.get(clusterService), is(TimeValue.timeValueSeconds(45)));

--- a/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
@@ -37,7 +37,7 @@ public class SysHealthITest extends IntegTestCase {
     public void testTablesHealth() throws IOException {
         execute("create table doc.t1 (id int) with(number_of_replicas=0)");
         // stopping 1 node so t1 is red (missing primaries)
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
         // yellow cause missing replicas
         execute("create table doc.t2 (id int) with(number_of_replicas=1, \"write.wait_for_active_shards\"=1)");
         // green, all fine

--- a/server/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
@@ -56,7 +56,7 @@ public class SysNodeResiliencyIntegrationTest extends IntegTestCase {
         // wait until no master cluster state tasks are pending, otherwise this test may fail due to master task timeouts
         waitNoPendingTasksOnAll();
 
-        String[] nodeNames = internalCluster().getNodeNames();
+        String[] nodeNames = cluster().getNodeNames();
         String n1 = nodeNames[0];
         String n2 = nodeNames[1];
 
@@ -80,7 +80,7 @@ public class SysNodeResiliencyIntegrationTest extends IntegTestCase {
             assertThat(response.rows()[0][3], is(n2));
         } finally {
             partition.stopDisrupting();
-            internalCluster().clearDisruptionScheme(true);
+            cluster().clearDisruptionScheme(true);
             waitNoPendingTasksOnAll();
         }
     }

--- a/server/src/test/java/io/crate/integrationtests/SysOperationsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysOperationsTest.java
@@ -53,7 +53,7 @@ public class SysOperationsTest extends IntegTestCase {
         // but it could be that the collect is finished before the localMerge task is started in which
         // case it is missing.
 
-        assertThat(resp.rowCount(), Matchers.greaterThanOrEqualTo((long) internalCluster().numDataNodes()));
+        assertThat(resp.rowCount(), Matchers.greaterThanOrEqualTo((long) cluster().numDataNodes()));
         List<String> names = new ArrayList<>();
         for (Object[] objects : resp.rows()) {
             names.add((String) objects[0]);

--- a/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
@@ -52,7 +52,7 @@ public class SysPrivilegesIntegrationTest extends BaseUsersIntegrationTest {
             executeAsSuperuser("create user " + userName);
         }
 
-        UserManager userManager = internalCluster().getInstance(UserManager.class);
+        UserManager userManager = cluster().getInstance(UserManager.class);
         Long rowCount = userManager.applyPrivileges(USERNAMES, PRIVILEGES).get(5, TimeUnit.SECONDS);
         assertThat(rowCount, is(6L));
     }

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -94,7 +94,7 @@ public class SysShardsTest extends IntegTestCase {
         // path + /blobs == blob_path without custom blob path
         assertThat(response.rows()[0][0] + resolveCanonicalString("/blobs"), is(response.rows()[0][1]));
 
-        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
         Metadata metadata = clusterService.state().getMetadata();
         IndexMetadata index = metadata.index(".blob_b2");
         String indexUUID = index.getIndexUUID();

--- a/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -73,7 +73,7 @@ public class SysSnapshotsTest extends IntegTestCase {
         execute("insert into tbl (id) values (?)", bulkArgs);
         execute("refresh table tbl");
 
-        ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class);
+        ThreadPool threadPool = cluster().getInstance(ThreadPool.class);
         execute(
             "CREATE REPOSITORY r1 TYPE fs WITH (location = ?, compress = true)",
             new Object[] { TEMP_FOLDER.newFolder("backup_s1").getAbsolutePath() });

--- a/server/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
@@ -55,7 +55,7 @@ public class TableStatsServiceIntegrationTest extends IntegTestCase {
         execute("insert into t1(a) values(1), (2), (3), (4), (5)");
         execute("refresh table t1");
         assertBusy(() -> {
-            TableStats tableStats = internalCluster().getDataNodeInstance(TableStats.class);
+            TableStats tableStats = cluster().getDataNodeInstance(TableStats.class);
             assertThat(tableStats.numDocs(new RelationName(sqlExecutor.getCurrentSchema(), "t1")), is(5L));
             // tableStats.tableStats.estimatedSizePerRow() is not tested because it's based on sys.shards size
             // column which is is cached for 10 secs in ShardSizeExpression which will increase the time needed

--- a/server/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
@@ -43,7 +43,7 @@ public class TablesNeedUpgradeSysCheckTest extends IntegTestCase {
             TestUtil.unzip(stream, indexDir);
         }
         Settings.Builder builder = Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), indexDir.toAbsolutePath());
-        internalCluster().startNode(builder.build());
+        cluster().startNode(builder.build());
         ensureGreen();
     }
 

--- a/server/src/test/java/io/crate/integrationtests/TasksServiceIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TasksServiceIntegrationTest.java
@@ -78,7 +78,7 @@ public class TasksServiceIntegrationTest extends IntegTestCase {
 
         assertBusy(() -> {
             //noinspection resource
-            for (TasksService tasksService : internalCluster().getInstances(TasksService.class)) {
+            for (TasksService tasksService : cluster().getInstances(TasksService.class)) {
                 Map<UUID, RootTask> tasksByJobId;
                 try {
                     //noinspection unchecked

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -129,7 +129,7 @@ public class UserDefinedFunctionsIntegrationTest extends IntegTestCase {
         // records reside on two different nodes configured in the test setup.
         // So then it would be possible to test that a function is created and
         // applied on all of nodes.
-        Iterable<UserDefinedFunctionService> udfServices = internalCluster().getInstances(UserDefinedFunctionService.class);
+        Iterable<UserDefinedFunctionService> udfServices = cluster().getInstances(UserDefinedFunctionService.class);
         for (UserDefinedFunctionService udfService : udfServices) {
             udfService.registerLanguage(dummyLang);
         }

--- a/server/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
@@ -76,8 +76,8 @@ public class UserSessionIntegrationTest extends BaseUsersIntegrationTest {
 
     private String getNodeByEnterpriseNode(boolean enterpriseEnabled) {
         if (enterpriseEnabled) {
-            return internalCluster().getNodeNames()[0];
+            return cluster().getNodeNames()[0];
         }
-        return internalCluster().getNodeNames()[1];
+        return cluster().getNodeNames()[1];
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -67,7 +67,7 @@ public class ViewsITest extends IntegTestCase {
         execute("insert into t1 (x) values (1)");
         execute("refresh table t1");
         execute("create view v1 as select * from t1 where x > ?", $(0));
-        for (ClusterService clusterService : internalCluster().getInstances(ClusterService.class)) {
+        for (ClusterService clusterService : cluster().getInstances(ClusterService.class)) {
             ViewsMetadata views = clusterService.state().metadata().custom(ViewsMetadata.TYPE);
             assertThat(views, Matchers.notNullValue());
             assertThat(views.contains(RelationName.fromIndexName(sqlExecutor.getCurrentSchema() + ".v1")), is(true));
@@ -78,7 +78,7 @@ public class ViewsITest extends IntegTestCase {
             is("SELECT *\nFROM \"t1\"\nWHERE \"x\" > 0\n\n")
         );
         execute("drop view v1");
-        for (ClusterService clusterService : internalCluster().getInstances(ClusterService.class)) {
+        for (ClusterService clusterService : cluster().getInstances(ClusterService.class)) {
             ViewsMetadata views = clusterService.state().metadata().custom(ViewsMetadata.TYPE);
             assertThat(views.contains(RelationName.fromIndexName(sqlExecutor.getCurrentSchema() + ".v1")), is(false));
         }
@@ -100,7 +100,7 @@ public class ViewsITest extends IntegTestCase {
         assertThat(printedTable(execute("select * from v2").rows()), is("1\n"));
         execute("create or replace view v2 as select 2 from sys.cluster");
         assertThat(printedTable(execute("select * from v2").rows()), is("2\n"));
-        for (ClusterService clusterService : internalCluster().getInstances(ClusterService.class)) {
+        for (ClusterService clusterService : cluster().getInstances(ClusterService.class)) {
             ViewsMetadata views = clusterService.state().metadata().custom(ViewsMetadata.TYPE);
             assertThat(views, Matchers.notNullValue());
             assertThat(views.contains(RelationName.fromIndexName(sqlExecutor.getCurrentSchema() + ".v2")), is(true));

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.TestCluster;
 import org.elasticsearch.test.disruption.NetworkDisruption;
@@ -64,7 +65,6 @@ import org.elasticsearch.transport.TransportSettings;
 import org.junit.Before;
 
 import io.crate.common.unit.TimeValue;
-import org.elasticsearch.test.IntegTestCase;
 
 public abstract class AbstractDisruptionTestCase extends IntegTestCase {
 
@@ -130,14 +130,14 @@ public abstract class AbstractDisruptionTestCase extends IntegTestCase {
     protected void beforeIndexDeletion() throws Exception {
         if (disableBeforeIndexDeletion == false) {
             super.beforeIndexDeletion();
-            internalCluster().assertConsistentHistoryBetweenTranslogAndLuceneIndex();
-            internalCluster().assertSeqNos();
-            internalCluster().assertSameDocIdsOnShards();
+            cluster().assertConsistentHistoryBetweenTranslogAndLuceneIndex();
+            cluster().assertSeqNos();
+            cluster().assertSameDocIdsOnShards();
         }
     }
 
     List<String> startCluster(int numberOfNodes) {
-        TestCluster internalCluster = internalCluster();
+        TestCluster internalCluster = cluster();
         List<String> nodes = internalCluster.startNodes(numberOfNodes);
         ensureStableCluster(numberOfNodes);
         return nodes;
@@ -210,9 +210,9 @@ public abstract class AbstractDisruptionTestCase extends IntegTestCase {
     public ServiceDisruptionScheme addRandomDisruptionScheme() {
         final DisruptedLinks disruptedLinks;
         if (randomBoolean()) {
-            disruptedLinks = TwoPartitions.random(random(), internalCluster().getNodeNames());
+            disruptedLinks = TwoPartitions.random(random(), cluster().getNodeNames());
         } else {
-            disruptedLinks = Bridge.random(random(), internalCluster().getNodeNames());
+            disruptedLinks = Bridge.random(random(), cluster().getNodeNames());
         }
         final NetworkLinkDisruptionType disruptionType;
         switch (randomInt(2)) {
@@ -253,7 +253,7 @@ public abstract class AbstractDisruptionTestCase extends IntegTestCase {
     }
 
     TwoPartitions isolateNode(String isolatedNode) {
-        return isolateNode(internalCluster(), isolatedNode);
+        return isolateNode(cluster(), isolatedNode);
     }
 
     public static TwoPartitions isolateNode(TestCluster cluster, String isolatedNode) {

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiskDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/DiskDisruptionIT.java
@@ -167,7 +167,7 @@ public class DiskDisruptionIT extends AbstractDisruptionTestCase {
         }
 
         logger.info("full cluster restart");
-        internalCluster().fullRestart(new TestCluster.RestartCallback() {
+        cluster().fullRestart(new TestCluster.RestartCallback() {
 
             @Override
             public void onAllNodesStopped() {

--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
@@ -202,7 +202,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
                 } catch (TimeoutException e) {
                     roundBarrier.reset();
                 }
-                internalCluster().clearDisruptionScheme(false);
+                cluster().clearDisruptionScheme(false);
                 // heal cluster faster to reduce test time.
                 ensureFullyConnectedCluster();
             }

--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/SequenceConsistencyIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/SequenceConsistencyIT.java
@@ -49,9 +49,9 @@ public class SequenceConsistencyIT extends AbstractDisruptionTestCase {
     @Test
     public void testPrimaryTermIsIncreasedOnReplicaPromotion() throws Throwable {
         logger.info("starting 3 nodes");
-        String masterNodeName = internalCluster().startMasterOnlyNode(DEFAULT_SETTINGS);
-        String firstDataNodeName = internalCluster().startDataOnlyNode(DEFAULT_SETTINGS);
-        String secondDataNodeName = internalCluster().startDataOnlyNode(DEFAULT_SETTINGS);
+        String masterNodeName = cluster().startMasterOnlyNode(DEFAULT_SETTINGS);
+        String firstDataNodeName = cluster().startDataOnlyNode(DEFAULT_SETTINGS);
+        String secondDataNodeName = cluster().startDataOnlyNode(DEFAULT_SETTINGS);
 
         logger.info("wait for all nodes to join the cluster");
         ensureGreen();
@@ -90,7 +90,7 @@ public class SequenceConsistencyIT extends AbstractDisruptionTestCase {
             new NetworkDisruption.TwoPartitions(otherNodes, Set.of(isolatedNode)),
             new NetworkDisruption.NetworkDisconnect()
         );
-        internalCluster().setDisruptionScheme(partition);
+        cluster().setDisruptionScheme(partition);
 
         logger.info("start disrupting network");
         partition.startDisrupting();

--- a/server/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasITest.java
@@ -57,7 +57,7 @@ public class SchemasITest extends IntegTestCase {
 
     @Before
     public void setUpService() {
-        schemas = internalCluster().getInstance(Schemas.class);
+        schemas = cluster().getInstance(Schemas.class);
     }
 
     @Test

--- a/server/src/test/java/io/crate/rest/AdminUIHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/rest/AdminUIHttpIntegrationTest.java
@@ -81,11 +81,11 @@ public abstract class AdminUIHttpIntegrationTest extends IntegTestCase {
 
     @Before
     public void setup() throws IOException {
-        Iterable<HttpServerTransport> transports = internalCluster().getInstances(HttpServerTransport.class);
+        Iterable<HttpServerTransport> transports = cluster().getInstances(HttpServerTransport.class);
         Iterator<HttpServerTransport> httpTransports = transports.iterator();
         address = httpTransports.next().boundAddress().publishAddress().address();
         // place index file
-        final Path indexDirectory = internalCluster().getInstance(Environment.class).libFile().resolve("site");
+        final Path indexDirectory = cluster().getInstance(Environment.class).libFile().resolve("site");
         Files.createDirectories(indexDirectory);
         final Path indexFile = indexDirectory.resolve("index.html");
         Files.write(indexFile, Collections.singletonList("<h1>Crate Admin</h1>"), Charset.forName("UTF-8"));

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -56,7 +56,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
 
     @Before
     public void prepare() {
-        action = internalCluster().getInstance(TransportCreatePartitionsAction.class, internalCluster().getMasterName());
+        action = cluster().getInstance(TransportCreatePartitionsAction.class, cluster().getMasterName());
     }
 
     @Test
@@ -70,14 +70,14 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
             );
-        internalCluster().client().execute(PutIndexTemplateAction.INSTANCE, request).get();
+        cluster().client().execute(PutIndexTemplateAction.INSTANCE, request).get();
 
         AcknowledgedResponse response = action.execute(
             new CreatePartitionsRequest(indices, UUID.randomUUID())
         ).get();
         assertThat(response.isAcknowledged(), is(true));
 
-        Metadata indexMetadata = internalCluster().clusterService().state().metadata();
+        Metadata indexMetadata = cluster().clusterService().state().metadata();
         for (String index : indices) {
             assertThat(indexMetadata.hasIndex(index), is(true));
         }
@@ -92,7 +92,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
             );
-        internalCluster().client().execute(PutIndexTemplateAction.INSTANCE, templateRequest).get();
+        cluster().client().execute(PutIndexTemplateAction.INSTANCE, templateRequest).get();
 
         cluster().client().admin().indices()
             .create(new CreateIndexRequest("index_0")
@@ -121,7 +121,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
         assertThat("Create indices action did not lead to a new cluster state",
             response.get(5, TimeUnit.SECONDS).isAcknowledged(), is(true));
 
-        ClusterState currentState = internalCluster().clusterService().state();
+        ClusterState currentState = cluster().clusterService().state();
         ImmutableOpenIntMap<IndexShardRoutingTable> newRouting = currentState.routingTable().indicesRouting().get("index_0").getShards();
         assertTrue("[index_0][0] must be started already", newRouting.get(0).primaryShard().started());
     }
@@ -135,13 +135,13 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
             );
-        internalCluster().client().execute(PutIndexTemplateAction.INSTANCE, templateRequest).get();
+        cluster().client().execute(PutIndexTemplateAction.INSTANCE, templateRequest).get();
         List<String> indices = Arrays.asList("index1", "index2", "index3", "index1");
         AcknowledgedResponse response = action.execute(
             new CreatePartitionsRequest(indices, UUID.randomUUID())
         ).get();
         assertThat(response.isAcknowledged(), is(true));
-        Metadata indexMetadata = internalCluster().clusterService().state().metadata();
+        Metadata indexMetadata = cluster().clusterService().state().metadata();
         for (String index : indices) {
             assertThat(indexMetadata.hasIndex(index), is(true));
         }
@@ -172,6 +172,6 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
             },
             "Invalid index name [invalid/#haha], must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?]");
         // if one name is invalid no index is created
-        assertThat(internalCluster().clusterService().state().metadata().hasIndex("valid"), is(false));
+        assertThat(cluster().clusterService().state().metadata().hasIndex("valid"), is(false));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -56,7 +56,7 @@ public class ClusterHealthIT extends IntegTestCase {
         execute("create table test (id int) with (number_of_replicas = 0)");
         ensureGreen(); // master should think it's green now.
 
-        for (final String node : internalCluster().getNodeNames()) {
+        for (final String node : cluster().getNodeNames()) {
             // a very high time out, which should never fire due to the local flag
             logger.info("--> getting cluster health on [{}]", node);
             final ClusterHealthResponse health = FutureUtils.get(client(node).admin().cluster().health(
@@ -224,7 +224,7 @@ public class ClusterHealthIT extends IntegTestCase {
             );
 
         final AtomicBoolean keepSubmittingTasks = new AtomicBoolean(true);
-        final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
+        final ClusterService clusterService = cluster().getInstance(ClusterService.class, cluster().getMasterName());
         clusterService.submitStateUpdateTask("looping task", new ClusterStateUpdateTask(Priority.LOW) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
@@ -259,7 +259,7 @@ public class ClusterHealthIT extends IntegTestCase {
     @Test
     @UseRandomizedSchema(random = false)
     public void testHealthOnMasterFailover() throws Exception {
-        final String node = internalCluster().startDataOnlyNode();
+        final String node = cluster().startDataOnlyNode();
         boolean withIndex = randomBoolean();
         String indexName = null;
         if (withIndex) {
@@ -280,7 +280,7 @@ public class ClusterHealthIT extends IntegTestCase {
         for (int i = 0; i < iterations; ++i) {
             responseFutures.add(client(node).admin().cluster().health(new ClusterHealthRequest().waitForEvents(Priority.LANGUID)
                 .waitForGreenStatus().masterNodeTimeout(TimeValue.timeValueMinutes(1))));
-            internalCluster().restartNode(internalCluster().getMasterName(), TestCluster.EMPTY_CALLBACK);
+            cluster().restartNode(cluster().getMasterName(), TestCluster.EMPTY_CALLBACK);
         }
         if (withIndex) {
             assertAcked(client().admin().indices().updateSettings(

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -57,7 +57,7 @@ public class ClusterInfoServiceIT extends IntegTestCase {
     @Test
     @UseRandomizedSchema(random = false)
     public void testClusterInfoServiceCollectsInformation() throws Exception {
-        internalCluster().startNodes(2);
+        cluster().startNodes(2);
         assertAcked(client().admin().indices().create(
             new CreateIndexRequest("test", Settings.builder()
                 .put(Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), 0)
@@ -70,7 +70,7 @@ public class ClusterInfoServiceIT extends IntegTestCase {
             execute("alter table test close");
         }
         ensureGreen("test");
-        TestCluster internalTestCluster = internalCluster();
+        TestCluster internalTestCluster = cluster();
         // Get the cluster info service on the master node
         final InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster
             .getInstance(ClusterInfoService.class, internalTestCluster.getMasterName());

--- a/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -66,7 +66,7 @@ public class FilteringAllocationIT extends IntegTestCase {
 
     public void testDecommissionNodeNoReplicas() throws Exception {
         logger.info("--> starting 2 nodes");
-        List<String> nodesIds = internalCluster().startNodes(2);
+        List<String> nodesIds = cluster().startNodes(2);
         final String node_0 = nodesIds.get(0);
         final String node_1 = nodesIds.get(1);
         assertThat(cluster().size(), equalTo(2));
@@ -118,7 +118,7 @@ public class FilteringAllocationIT extends IntegTestCase {
     @Test
     public void testAutoExpandReplicasToFilteredNodes() throws Exception {
         logger.info("--> starting 2 nodes");
-        List<String> nodesIds = internalCluster().startNodes(2);
+        List<String> nodesIds = cluster().startNodes(2);
         final String node_0 = nodesIds.get(0);
         final String node_1 = nodesIds.get(1);
         assertThat(cluster().size(), equalTo(2));
@@ -156,7 +156,7 @@ public class FilteringAllocationIT extends IntegTestCase {
     @Test
     public void testDisablingAllocationFiltering() throws Exception {
         logger.info("--> starting 2 nodes");
-        List<String> nodesIds = internalCluster().startNodes(2);
+        List<String> nodesIds = cluster().startNodes(2);
         final String node_0 = nodesIds.get(0);
         final String node_1 = nodesIds.get(1);
         assertThat(cluster().size(), equalTo(2));
@@ -241,7 +241,7 @@ public class FilteringAllocationIT extends IntegTestCase {
     }
 
     public void testTransientSettingsStillApplied() throws Exception {
-        List<String> nodes = internalCluster().startNodes(6);
+        List<String> nodes = cluster().startNodes(6);
         Set<String> excludeNodes = new HashSet<>(nodes.subList(0, 3));
         Set<String> includeNodes = new HashSet<>(nodes.subList(3, 6));
         String excludeNodeIdsAsString = Strings.collectionToCommaDelimitedString(excludeNodes);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/RemoveCustomsCommandIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/RemoveCustomsCommandIT.java
@@ -40,31 +40,31 @@ public class RemoveCustomsCommandIT extends IntegTestCase {
 
     @Test
     public void testRemoveCustomsAbortedByUser() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         expectThrows(() -> removeCustoms(environment, true, new String[]{ "index-graveyard" }),
             ElasticsearchNodeCommand.ABORTED_BY_USER_MSG);
     }
 
     @Test
     public void testRemoveCustomsSuccessful() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
         createIndex("test");
         client().admin().indices().delete(new DeleteIndexRequest("test")).get();
         assertEquals(1, client().admin().cluster().state(new ClusterStateRequest()).get().getState().metadata().indexGraveyard().getTombstones().size());
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         MockTerminal terminal = removeCustoms(environment, false,
             randomBoolean() ?
                 new String[]{ "index-graveyard" } :
@@ -74,23 +74,23 @@ public class RemoveCustomsCommandIT extends IntegTestCase {
         assertThat(terminal.getOutput(), containsString("The following customs will be removed:"));
         assertThat(terminal.getOutput(), containsString("index-graveyard"));
 
-        internalCluster().startNode(dataPathSettings);
+        cluster().startNode(dataPathSettings);
         assertEquals(0, client().admin().cluster().state(new ClusterStateRequest()).get().getState().metadata().indexGraveyard().getTombstones().size());
     }
 
     @Test
     public void testCustomDoesNotMatch() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
         createIndex("test");
         client().admin().indices().delete(new DeleteIndexRequest("test")).get();
         assertEquals(1, client().admin().cluster().state(new ClusterStateRequest()).get().getState().metadata().indexGraveyard().getTombstones().size());
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         UserException ex = expectThrows(UserException.class, () -> removeCustoms(environment, false,
             new String[]{ "index-greveyard-with-typos" }));
         assertThat(ex.getMessage(), containsString("No custom metadata matching [index-greveyard-with-typos] were " +

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/RemoveSettingsCommandIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/RemoveSettingsCommandIT.java
@@ -44,15 +44,15 @@ public class RemoveSettingsCommandIT extends IntegTestCase {
 
     @Test
     public void testRemoveSettingsAbortedByUser() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
         execute("set global persistent cluster.routing.allocation.disk.threshold_enabled = false");
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         expectThrows(() -> removeSettings(environment, true,
                                           new String[]{ DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey() }),
                      ElasticsearchNodeCommand.ABORTED_BY_USER_MSG);
@@ -60,17 +60,17 @@ public class RemoveSettingsCommandIT extends IntegTestCase {
 
     @Test
     public void testRemoveSettingsSuccessful() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
         execute("set global persistent cluster.routing.allocation.disk.threshold_enabled = false");
         assertThat(client().admin().cluster().state(new ClusterStateRequest()).get().getState().metadata().persistentSettings().keySet(),
                    contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey()));
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         MockTerminal terminal = removeSettings(environment, false,
                                                randomBoolean() ?
                                                    new String[]{ DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey() } :
@@ -81,24 +81,24 @@ public class RemoveSettingsCommandIT extends IntegTestCase {
         assertThat(terminal.getOutput(), containsString(
             DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey() + ": "  + false));
 
-        internalCluster().startNode(dataPathSettings);
+        cluster().startNode(dataPathSettings);
         assertThat(client().admin().cluster().state(new ClusterStateRequest()).get().getState().metadata().persistentSettings().keySet(),
                    not(contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey())));
     }
 
     @Test
     public void testSettingDoesNotMatch() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
         execute("set global persistent cluster.routing.allocation.disk.threshold_enabled = false");
         assertThat(client().admin().cluster().state(new ClusterStateRequest()).get().getState().metadata().persistentSettings().keySet(),
                    contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey()));
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         UserException ex = expectThrows(UserException.class, () -> removeSettings(environment, false,
                                                                                   new String[]{ "cluster.routing.allocation.disk.bla.*" }));
         assertThat(ex.getMessage(), containsString("No persistent cluster settings matching [cluster.routing.allocation.disk.bla.*] were " +

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -116,19 +116,19 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
 
     public void testBootstrapNotMasterEligible() {
         final Environment environment = TestEnvironment.newEnvironment(Settings.builder()
-                                                                           .put(internalCluster().getDefaultSettings())
+                                                                           .put(cluster().getDefaultSettings())
                                                                            .put(Node.NODE_MASTER_SETTING.getKey(), false)
                                                                            .build());
         expectThrows(() -> unsafeBootstrap(environment), UnsafeBootstrapMasterCommand.NOT_MASTER_NODE_MSG);
     }
 
     public void testBootstrapNoDataFolder() {
-        final Environment environment = TestEnvironment.newEnvironment(internalCluster().getDefaultSettings());
+        final Environment environment = TestEnvironment.newEnvironment(cluster().getDefaultSettings());
         expectThrows(() -> unsafeBootstrap(environment), ElasticsearchNodeCommand.NO_NODE_FOLDER_FOUND_MSG);
     }
 
     public void testDetachNoDataFolder() {
-        final Environment environment = TestEnvironment.newEnvironment(internalCluster().getDefaultSettings());
+        final Environment environment = TestEnvironment.newEnvironment(cluster().getDefaultSettings());
         expectThrows(() -> detachCluster(environment), ElasticsearchNodeCommand.NO_NODE_FOLDER_FOUND_MSG);
     }
 
@@ -159,7 +159,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
     }
 
     public void testBootstrapNotBootstrappedCluster() throws Exception {
-        String node = internalCluster().startNode(
+        String node = cluster().startNode(
             Settings.builder()
                 .put(Node.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s") // to ensure quick node startup
                 .build());
@@ -169,85 +169,85 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        Settings dataPathSettings = cluster().dataPathSettings(node);
 
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         expectThrows(() -> unsafeBootstrap(environment), UnsafeBootstrapMasterCommand.EMPTY_LAST_COMMITTED_VOTING_CONFIG_MSG);
     }
 
     public void testBootstrapNoClusterState() throws IOException {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        NodeEnvironment nodeEnvironment = internalCluster().getMasterNodeInstance(NodeEnvironment.class);
-        internalCluster().stopRandomDataNode();
+        NodeEnvironment nodeEnvironment = cluster().getMasterNodeInstance(NodeEnvironment.class);
+        cluster().stopRandomDataNode();
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         PersistedClusterStateService.deleteAll(nodeEnvironment.nodeDataPaths());
 
         expectThrows(() -> unsafeBootstrap(environment), ElasticsearchNodeCommand.NO_NODE_METADATA_FOUND_MSG);
     }
 
     public void testDetachNoClusterState() throws IOException {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        NodeEnvironment nodeEnvironment = internalCluster().getMasterNodeInstance(NodeEnvironment.class);
-        internalCluster().stopRandomDataNode();
+        NodeEnvironment nodeEnvironment = cluster().getMasterNodeInstance(NodeEnvironment.class);
+        cluster().stopRandomDataNode();
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         PersistedClusterStateService.deleteAll(nodeEnvironment.nodeDataPaths());
 
         expectThrows(() -> detachCluster(environment), ElasticsearchNodeCommand.NO_NODE_METADATA_FOUND_MSG);
     }
 
     public void testBootstrapAbortedByUser() throws IOException {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         expectThrows(() -> unsafeBootstrap(environment, true), ElasticsearchNodeCommand.ABORTED_BY_USER_MSG);
     }
 
     public void testDetachAbortedByUser() throws IOException {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String node = internalCluster().startNode();
-        Settings dataPathSettings = internalCluster().dataPathSettings(node);
+        cluster().setBootstrapMasterNodeIndex(0);
+        String node = cluster().startNode();
+        Settings dataPathSettings = cluster().dataPathSettings(node);
         ensureStableCluster(1);
-        internalCluster().stopRandomDataNode();
+        cluster().stopRandomDataNode();
 
         Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataPathSettings).build());
         expectThrows(() -> detachCluster(environment, true), ElasticsearchNodeCommand.ABORTED_BY_USER_MSG);
     }
 
     @Test
     @UseJdbc(0)
     public void test3MasterNodes2Failed() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(2);
+        cluster().setBootstrapMasterNodeIndex(2);
         List<String> masterNodes = new ArrayList<>();
 
         logger.info("--> start 1st master-eligible node");
-        masterNodes.add(internalCluster().startMasterOnlyNode(Settings.builder()
+        masterNodes.add(cluster().startMasterOnlyNode(Settings.builder()
                 .put(Node.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
                 .build())); // node ordinal 0
 
         logger.info("--> start one data-only node");
-        String dataNode = internalCluster().startDataOnlyNode(Settings.builder()
+        String dataNode = cluster().startDataOnlyNode(Settings.builder()
                 .put(Node.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
                 .build()); // node ordinal 1
 
         logger.info("--> start 2nd and 3rd master-eligible nodes and bootstrap");
-        masterNodes.addAll(internalCluster().startMasterOnlyNodes(2)); // node ordinals 2 and 3
+        masterNodes.addAll(cluster().startMasterOnlyNodes(2)); // node ordinals 2 and 3
 
         logger.info("--> wait for all nodes to join the cluster");
         ensureStableCluster(4);
@@ -256,31 +256,31 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
         execute("create table doc.test (x int)");
         ensureGreen("test");
 
-        Settings master1DataPathSettings = internalCluster().dataPathSettings(masterNodes.get(0));
-        Settings master2DataPathSettings = internalCluster().dataPathSettings(masterNodes.get(1));
-        Settings master3DataPathSettings = internalCluster().dataPathSettings(masterNodes.get(2));
-        Settings dataNodeDataPathSettings = internalCluster().dataPathSettings(dataNode);
+        Settings master1DataPathSettings = cluster().dataPathSettings(masterNodes.get(0));
+        Settings master2DataPathSettings = cluster().dataPathSettings(masterNodes.get(1));
+        Settings master3DataPathSettings = cluster().dataPathSettings(masterNodes.get(2));
+        Settings dataNodeDataPathSettings = cluster().dataPathSettings(dataNode);
 
         logger.info("--> stop 2nd and 3d master eligible node");
-        internalCluster().stopRandomNode(TestCluster.nameFilter(masterNodes.get(1)));
-        internalCluster().stopRandomNode(TestCluster.nameFilter(masterNodes.get(2)));
+        cluster().stopRandomNode(TestCluster.nameFilter(masterNodes.get(1)));
+        cluster().stopRandomNode(TestCluster.nameFilter(masterNodes.get(2)));
 
         logger.info("--> ensure NO_MASTER_BLOCK on data-only node");
         assertBusy(() -> {
-            ClusterState state = internalCluster().client(dataNode).admin().cluster().state(new ClusterStateRequest().local(true))
+            ClusterState state = cluster().client(dataNode).admin().cluster().state(new ClusterStateRequest().local(true))
                     .get().getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
         logger.info("--> try to unsafely bootstrap 1st master-eligible node, while node lock is held");
         Environment environmentMaster1 = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(master1DataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(master1DataPathSettings).build());
         expectThrows(() -> unsafeBootstrap(environmentMaster1), UnsafeBootstrapMasterCommand.FAILED_TO_OBTAIN_NODE_LOCK_MSG);
 
         logger.info("--> stop 1st master-eligible node and data-only node");
-        NodeEnvironment nodeEnvironment = internalCluster().getMasterNodeInstance(NodeEnvironment.class);
-        internalCluster().stopRandomNode(TestCluster.nameFilter(masterNodes.get(0)));
-        internalCluster().stopRandomDataNode();
+        NodeEnvironment nodeEnvironment = cluster().getMasterNodeInstance(NodeEnvironment.class);
+        cluster().stopRandomNode(TestCluster.nameFilter(masterNodes.get(0)));
+        cluster().stopRandomDataNode();
 
         logger.info("--> unsafely-bootstrap 1st master-eligible node");
         MockTerminal terminal = unsafeBootstrap(environmentMaster1);
@@ -291,19 +291,19 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
                           metadata.coordinationMetadata().term(), metadata.version())));
 
         logger.info("--> start 1st master-eligible node");
-        internalCluster().startMasterOnlyNode(master1DataPathSettings);
+        cluster().startMasterOnlyNode(master1DataPathSettings);
 
         logger.info("--> detach-cluster on data-only node");
         Environment environmentData = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(dataNodeDataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(dataNodeDataPathSettings).build());
         detachCluster(environmentData, false);
 
         logger.info("--> start data-only node");
-        String dataNode2 = internalCluster().startDataOnlyNode(dataNodeDataPathSettings);
+        String dataNode2 = cluster().startDataOnlyNode(dataNodeDataPathSettings);
 
         logger.info("--> ensure there is no NO_MASTER_BLOCK and unsafe-bootstrap is reflected in cluster state");
         assertBusy(() -> {
-            ClusterState state = internalCluster().client(dataNode2).admin().cluster().state(new ClusterStateRequest().local(true))
+            ClusterState state = cluster().client(dataNode2).admin().cluster().state(new ClusterStateRequest().local(true))
                     .get().getState();
             assertFalse(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
             assertTrue(state.metadata().persistentSettings().getAsBoolean(UnsafeBootstrapMasterCommand.UNSAFE_BOOTSTRAP.getKey(), false));
@@ -316,30 +316,30 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
 
         logger.info("--> detach-cluster on 2nd and 3rd master-eligible nodes");
         Environment environmentMaster2 = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(master2DataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(master2DataPathSettings).build());
         detachCluster(environmentMaster2, false);
         Environment environmentMaster3 = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(master3DataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(master3DataPathSettings).build());
         detachCluster(environmentMaster3, false);
 
         logger.info("--> start 2nd and 3rd master-eligible nodes and ensure 4 nodes stable cluster");
-        internalCluster().startMasterOnlyNode(master2DataPathSettings);
-        internalCluster().startMasterOnlyNode(master3DataPathSettings);
+        cluster().startMasterOnlyNode(master2DataPathSettings);
+        cluster().startMasterOnlyNode(master3DataPathSettings);
         ensureStableCluster(4);
     }
 
     public void testAllMasterEligibleNodesFailedDanglingIndexImport() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
+        cluster().setBootstrapMasterNodeIndex(0);
 
         Settings settings = Settings.builder()
             .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
             .build();
 
         logger.info("--> start mixed data and master-eligible node and bootstrap cluster");
-        String masterNode = internalCluster().startNode(settings); // node ordinal 0
+        String masterNode = cluster().startNode(settings); // node ordinal 0
 
         logger.info("--> start data-only node and ensure 2 nodes stable cluster");
-        String dataNode = internalCluster().startDataOnlyNode(settings); // node ordinal 1
+        String dataNode = cluster().startDataOnlyNode(settings); // node ordinal 1
         ensureStableCluster(2);
 
         execute("create table doc.test(x int)");
@@ -350,7 +350,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
         execute("refresh table doc.test");
         ensureGreen("test");
 
-        assertBusy(() -> internalCluster().getInstances(IndicesService.class).forEach(
+        assertBusy(() -> cluster().getInstances(IndicesService.class).forEach(
             indicesService -> assertTrue(indicesService.allPendingDanglingIndicesWritten())));
 
         logger.info("--> verify 1 doc in the index");
@@ -360,21 +360,21 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
 
         logger.info("--> stop data-only node and detach it from the old cluster");
         Settings dataNodeDataPathSettings = Settings.builder()
-            .put(internalCluster().dataPathSettings(dataNode))
+            .put(cluster().dataPathSettings(dataNode))
             .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
             .build();
-        assertBusy(() -> internalCluster().getInstance(GatewayMetaState.class, dataNode).allPendingAsyncStatesWritten());
-        internalCluster().stopRandomNode(TestCluster.nameFilter(dataNode));
+        assertBusy(() -> cluster().getInstance(GatewayMetaState.class, dataNode).allPendingAsyncStatesWritten());
+        cluster().stopRandomNode(TestCluster.nameFilter(dataNode));
         final Environment environment = TestEnvironment.newEnvironment(
             Settings.builder()
-                .put(internalCluster().getDefaultSettings())
+                .put(cluster().getDefaultSettings())
                 .put(dataNodeDataPathSettings)
                 .put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true)
                 .build());
         detachCluster(environment, false);
 
         logger.info("--> stop master-eligible node, clear its data and start it again - new cluster should form");
-        internalCluster().restartNode(masterNode, new TestCluster.RestartCallback(){
+        cluster().restartNode(masterNode, new TestCluster.RestartCallback(){
             @Override
             public boolean clearData(String nodeName) {
                 return true;
@@ -382,7 +382,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
         });
 
         logger.info("--> start data-only only node and ensure 2 nodes stable cluster");
-        internalCluster().startDataOnlyNode(dataNodeDataPathSettings);
+        cluster().startDataOnlyNode(dataNodeDataPathSettings);
         ensureStableCluster(2);
 
         logger.info("--> verify that the dangling index exists and has green status");
@@ -402,51 +402,51 @@ public class UnsafeBootstrapAndDetachCommandIT extends IntegTestCase {
     }
 
     public void testNoInitialBootstrapAfterDetach() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String masterNode = internalCluster().startMasterOnlyNode();
-        Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
-        internalCluster().stopCurrentMasterNode();
+        cluster().setBootstrapMasterNodeIndex(0);
+        String masterNode = cluster().startMasterOnlyNode();
+        Settings masterNodeDataPathSettings = cluster().dataPathSettings(masterNode);
+        cluster().stopCurrentMasterNode();
 
         final Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(masterNodeDataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(masterNodeDataPathSettings).build());
         detachCluster(environment);
 
-        String node = internalCluster().startMasterOnlyNode(Settings.builder()
+        String node = cluster().startMasterOnlyNode(Settings.builder()
                                                                 // give the cluster 2 seconds to elect the master (it should not)
                                                                 .put(Node.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "2s")
                                                                 .put(masterNodeDataPathSettings)
                                                                 .build());
 
-        ClusterState state = internalCluster().client().admin().cluster().state(new ClusterStateRequest().local(true))
+        ClusterState state = cluster().client().admin().cluster().state(new ClusterStateRequest().local(true))
             .get().getState();
         assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
 
-        internalCluster().stopRandomNode(TestCluster.nameFilter(node));
+        cluster().stopRandomNode(TestCluster.nameFilter(node));
     }
 
     @Test
     public void testCanRunUnsafeBootstrapAfterErroneousDetachWithoutLoosingMetadata() throws Exception {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        String masterNode = internalCluster().startMasterOnlyNode();
-        Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
+        cluster().setBootstrapMasterNodeIndex(0);
+        String masterNode = cluster().startMasterOnlyNode();
+        Settings masterNodeDataPathSettings = cluster().dataPathSettings(masterNode);
 
         execute("SET GLOBAL PERSISTENT indices.recovery.max_bytes_per_sec = '1234kb'");
 
-        ClusterState state = internalCluster().client().admin().cluster().state(new ClusterStateRequest()).get().getState();
+        ClusterState state = cluster().client().admin().cluster().state(new ClusterStateRequest()).get().getState();
         assertThat(state.metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),
                    equalTo("1234kb"));
 
-        internalCluster().stopCurrentMasterNode();
+        cluster().stopCurrentMasterNode();
 
         final Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(internalCluster().getDefaultSettings()).put(masterNodeDataPathSettings).build());
+            Settings.builder().put(cluster().getDefaultSettings()).put(masterNodeDataPathSettings).build());
         detachCluster(environment);
         unsafeBootstrap(environment);
 
-        internalCluster().startMasterOnlyNode(masterNodeDataPathSettings);
+        cluster().startMasterOnlyNode(masterNodeDataPathSettings);
         ensureGreen();
 
-        state = internalCluster().client().admin().cluster().state(new ClusterStateRequest()).get().getState();
+        state = cluster().client().admin().cluster().state(new ClusterStateRequest()).get().getState();
         assertThat(state.metadata().settings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),
                    equalTo("1234kb"));
     }

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -39,10 +39,10 @@ import org.junit.Test;
 public class NodeEnvironmentIT extends IntegTestCase {
 
     private IllegalStateException expectThrowsOnRestart(CheckedConsumer<Path[], Exception> onNodeStopped) {
-        internalCluster().startNode();
-        final Path[] dataPaths = internalCluster().getInstance(NodeEnvironment.class).nodeDataPaths();
+        cluster().startNode();
+        final Path[] dataPaths = cluster().getInstance(NodeEnvironment.class).nodeDataPaths();
         return expectThrows(IllegalStateException.class,
-                            () -> internalCluster().restartRandomDataNode(new TestCluster.RestartCallback() {
+                            () -> cluster().restartRandomDataNode(new TestCluster.RestartCallback() {
                                 @Override
                                 public Settings onNodeStopped(String nodeName) {
                                     try {

--- a/server/src/test/java/org/elasticsearch/gateway/MetadataWriteDataNodesIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MetadataWriteDataNodesIT.java
@@ -35,11 +35,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.IntegTestCase.ClusterScope;
 import org.elasticsearch.test.IntegTestCase.Scope;
 import org.elasticsearch.test.TestCluster;
-
-import org.elasticsearch.test.IntegTestCase;
 
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
@@ -47,8 +46,8 @@ public class MetadataWriteDataNodesIT extends IntegTestCase {
 
     public void testMetaWrittenAlsoOnDataNode() throws Exception {
         // this test checks that index state is written on data only nodes if they have a shard allocated
-        String masterNode = internalCluster().startMasterOnlyNode(Settings.EMPTY);
-        String dataNode = internalCluster().startDataOnlyNode(Settings.EMPTY);
+        String masterNode = cluster().startMasterOnlyNode(Settings.EMPTY);
+        String dataNode = cluster().startDataOnlyNode(Settings.EMPTY);
         execute("create table doc.test(x int) with (number_of_replicas = 0)");
         execute("insert into doc.test values(1)");
         ensureGreen("test");
@@ -58,8 +57,8 @@ public class MetadataWriteDataNodesIT extends IntegTestCase {
 
     public void testIndexFilesAreRemovedIfAllShardsFromIndexRemoved() throws Exception {
         // this test checks that the index data is removed from a data only node once all shards have been allocated away from it
-        String masterNode = internalCluster().startMasterOnlyNode(Settings.EMPTY);
-        List<String> nodeNames= internalCluster().startDataOnlyNodes(2);
+        String masterNode = cluster().startMasterOnlyNode(Settings.EMPTY);
+        List<String> nodeNames= cluster().startDataOnlyNodes(2);
         String node1 = nodeNames.get(0);
         String node2 = nodeNames.get(1);
 
@@ -130,7 +129,7 @@ public class MetadataWriteDataNodesIT extends IntegTestCase {
     }
 
     private ImmutableOpenMap<String, IndexMetadata> getIndicesMetadataOnNode(String nodeName) {
-        final Coordinator coordinator = (Coordinator) internalCluster().getInstance(Discovery.class, nodeName);
+        final Coordinator coordinator = (Coordinator) cluster().getInstance(Discovery.class, nodeName);
         return coordinator.getApplierState().getMetadata().getIndices();
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -479,6 +479,6 @@ public class IndexServiceTests extends IntegTestCase {
     }
 
     private IndicesService getIndicesService() {
-        return internalCluster().getInstances(IndicesService.class).iterator().next();
+        return cluster().getInstances(IndicesService.class).iterator().next();
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncIT.java
@@ -33,16 +33,15 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
-import org.junit.Test;
-
 import org.elasticsearch.test.IntegTestCase;
+import org.junit.Test;
 
 public class RetentionLeaseBackgroundSyncIT extends IntegTestCase {
 
     @Test
     public void testBackgroundRetentionLeaseSync() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
-        internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
+        cluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
         execute(
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
@@ -54,7 +53,7 @@ public class RetentionLeaseBackgroundSyncIT extends IntegTestCase {
         ensureGreen("tbl");
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
                 .getInstance(IndicesService.class, primaryShardNodeName)
                 .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
         // we will add multiple retention leases and expect to see them synced to all replicas
@@ -86,7 +85,7 @@ public class RetentionLeaseBackgroundSyncIT extends IntegTestCase {
                 for (final ShardRouting replicaShard : clusterService().state().routingTable().index("tbl").shard(0).replicaShards()) {
                     final String replicaShardNodeId = replicaShard.currentNodeId();
                     final String replicaShardNodeName = clusterService().state().nodes().get(replicaShardNodeId).getName();
-                    final IndexShard replica = internalCluster()
+                    final IndexShard replica = cluster()
                         .getInstance(IndicesService.class, replicaShardNodeName)
                         .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
                     assertThat(replica.getRetentionLeases(), equalTo(primary.getRetentionLeases()));

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -84,7 +84,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
     @Test
     public void testRetentionLeasesSyncedOnAdd() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
-        internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
+        cluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
         execute(
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (number_of_replicas = ?, \"soft_deletes.enabled\" = true)",
@@ -93,7 +93,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
         ensureGreen("tbl");
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
             .getInstance(IndicesService.class, primaryShardNodeName)
             .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
         // we will add multiple retention leases and expect to see them synced to all replicas
@@ -119,7 +119,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
             for (final ShardRouting replicaShard : clusterService().state().routingTable().index("tbl").shard(0).replicaShards()) {
                 final String replicaShardNodeId = replicaShard.currentNodeId();
                 final String replicaShardNodeName = clusterService().state().nodes().get(replicaShardNodeId).getName();
-                final IndexShard replica = internalCluster()
+                final IndexShard replica = cluster()
                     .getInstance(IndicesService.class, replicaShardNodeName)
                     .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
                 final Map<String, RetentionLease> retentionLeasesOnReplica =
@@ -136,7 +136,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
     @Test
     public void testRetentionLeaseSyncedOnRemove() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
-        internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
+        cluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
 
         execute("create table doc.tbl (x int) clustered into 1 shards with (number_of_replicas = ?)",
                 new Object[]{numberOfReplicas});
@@ -144,7 +144,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
         ensureGreen("tbl");
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
             .getInstance(IndicesService.class, primaryShardNodeName)
             .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
         final int length = randomIntBetween(1, 8);
@@ -180,7 +180,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
             for (final ShardRouting replicaShard : clusterService().state().routingTable().index("tbl").shard(0).replicaShards()) {
                 final String replicaShardNodeId = replicaShard.currentNodeId();
                 final String replicaShardNodeName = clusterService().state().nodes().get(replicaShardNodeId).getName();
-                final IndexShard replica = internalCluster()
+                final IndexShard replica = cluster()
                     .getInstance(IndicesService.class, replicaShardNodeName)
                     .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
                 final Map<String, RetentionLease> retentionLeasesOnReplica =
@@ -197,7 +197,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
     @Test
     public void testRetentionLeasesSyncOnExpiration() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
-        internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
+        cluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
         final long estimatedTimeIntervalMillis = ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.get(Settings.EMPTY).millis();
         final TimeValue retentionLeaseTimeToLive =
                 TimeValue.timeValueMillis(randomLongBetween(estimatedTimeIntervalMillis, 2 * estimatedTimeIntervalMillis));
@@ -215,7 +215,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
         ensureGreen("tbl");
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
                 .getInstance(IndicesService.class, primaryShardNodeName)
                 .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
         // we will add multiple retention leases, wait for some to expire, and assert a consistent view between the primary and the replicas
@@ -237,7 +237,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
             for (final ShardRouting replicaShard : clusterService().state().routingTable().index("tbl").shard(0).replicaShards()) {
                 final String replicaShardNodeId = replicaShard.currentNodeId();
                 final String replicaShardNodeName = clusterService().state().nodes().get(replicaShardNodeId).getName();
-                final IndexShard replica = internalCluster()
+                final IndexShard replica = cluster()
                         .getInstance(IndicesService.class, replicaShardNodeName)
                         .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
                 assertThat(RetentionLeaseUtils.toMapExcludingPeerRecoveryRetentionLeases(replica.getRetentionLeases()).values(),
@@ -258,7 +258,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
                 for (final ShardRouting replicaShard : clusterService().state().routingTable().index("tbl").shard(0).replicaShards()) {
                     final String replicaShardNodeId = replicaShard.currentNodeId();
                     final String replicaShardNodeName = clusterService().state().nodes().get(replicaShardNodeId).getName();
-                    final IndexShard replica = internalCluster()
+                    final IndexShard replica = cluster()
                         .getInstance(IndicesService.class, replicaShardNodeName)
                         .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
 
@@ -272,7 +272,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
     @Test
     public void testBackgroundRetentionLeaseSync() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
-        internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
+        cluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
         execute(
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
@@ -286,7 +286,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
         ensureGreen("tbl");
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
                 .getInstance(IndicesService.class, primaryShardNodeName)
                 .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
         // we will add multiple retention leases and expect to see them synced to all replicas
@@ -318,7 +318,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
                 for (final ShardRouting replicaShard : clusterService().state().routingTable().index("tbl").shard(0).replicaShards()) {
                     final String replicaShardNodeId = replicaShard.currentNodeId();
                     final String replicaShardNodeName = clusterService().state().nodes().get(replicaShardNodeId).getName();
-                    final IndexShard replica = internalCluster()
+                    final IndexShard replica = cluster()
                             .getInstance(IndicesService.class, replicaShardNodeName)
                             .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
                     assertThat(replica.getRetentionLeases(), equalTo(primary.getRetentionLeases()));
@@ -330,7 +330,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
     @Test
     public void testRetentionLeasesSyncOnRecovery() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
-        internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
+        cluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
         /*
          * We effectively disable the background sync to ensure that the retention leases are not synced in the background so that the only
          * source of retention leases on the replicas would be from recovery.
@@ -351,7 +351,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
 
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
             .getInstance(IndicesService.class, primaryShardNodeName)
             .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
         final int length = randomIntBetween(1, 8);
@@ -371,13 +371,13 @@ public class RetentionLeaseIT extends IntegTestCase  {
         execute("set global persistent \"indices.recovery.retry_delay_network\" = '100ms'");
         final Semaphore recoveriesToDisrupt = new Semaphore(scaledRandomIntBetween(0, 4));
         final MockTransportService primaryTransportService
-            = (MockTransportService) internalCluster().getInstance(TransportService.class, primaryShardNodeName);
+            = (MockTransportService) cluster().getInstance(TransportService.class, primaryShardNodeName);
         primaryTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(PeerRecoveryTargetService.Actions.FINALIZE) && recoveriesToDisrupt.tryAcquire()) {
                 if (randomBoolean()) {
                     // return a ConnectTransportException to the START_RECOVERY action
                     final TransportService replicaTransportService
-                        = internalCluster().getInstance(TransportService.class, connection.getNode().getName());
+                        = cluster().getInstance(TransportService.class, connection.getNode().getName());
                     final DiscoveryNode primaryNode = primaryTransportService.getLocalNode();
                     replicaTransportService.disconnectFromNode(primaryNode);
                     AbstractSimpleTransportTestCase.connectToNode(replicaTransportService, primaryNode);
@@ -397,7 +397,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
         for (final ShardRouting replicaShard : clusterService().state().routingTable().index("tbl").shard(0).replicaShards()) {
             final String replicaShardNodeId = replicaShard.currentNodeId();
             final String replicaShardNodeName = clusterService().state().nodes().get(replicaShardNodeId).getName();
-            final IndexShard replica = internalCluster()
+            final IndexShard replica = cluster()
                 .getInstance(IndicesService.class, replicaShardNodeName)
                 .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
             final Map<String, RetentionLease> retentionLeasesOnReplica
@@ -482,7 +482,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
 
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
             .getInstance(IndicesService.class, primaryShardNodeName)
             .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
 
@@ -585,7 +585,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
             final long initialRetainingSequenceNumber,
             final BiConsumer<IndexShard, ActionListener<ReplicationResponse>> primaryConsumer,
             final Consumer<IndexShard> afterSync) throws InterruptedException {
-        final int numDataNodes = internalCluster().numDataNodes();
+        final int numDataNodes = cluster().numDataNodes();
         execute(
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
@@ -604,7 +604,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
 
         final String primaryShardNodeId = clusterService().state().routingTable().index("tbl").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();
-        final IndexShard primary = internalCluster()
+        final IndexShard primary = cluster()
                 .getInstance(IndicesService.class, primaryShardNodeName)
                 .getShardOrNull(new ShardId(resolveIndex("tbl"), 0));
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
@@ -55,22 +55,22 @@ public class DanglingIndicesIT extends IntegTestCase {
      */
     public void testDanglingIndicesAreRecoveredWhenSettingIsEnabled() throws Exception {
         final Settings settings = buildSettings(true, true);
-        internalCluster().startNodes(3, settings);
+        cluster().startNodes(3, settings);
 
         execute("create table doc.test(id integer) clustered into 2 shards with(number_of_replicas = 2)");
         ensureGreen("test");
-        assertBusy(() -> internalCluster().getInstances(IndicesService.class).forEach(
+        assertBusy(() -> cluster().getInstances(IndicesService.class).forEach(
             indicesService -> assertTrue(indicesService.allPendingDanglingIndicesWritten())));
 
         boolean refreshIntervalChanged = randomBoolean();
         if (refreshIntervalChanged) {
             execute("alter table doc.test set (refresh_interval = '42s')");
-            assertBusy(() -> internalCluster().getInstances(IndicesService.class).forEach(
+            assertBusy(() -> cluster().getInstances(IndicesService.class).forEach(
                 indicesService -> assertTrue(indicesService.allPendingDanglingIndicesWritten())));
         }
 
         // Restart node, deleting the index in its absence, so that there is a dangling index to recover
-        internalCluster().restartRandomDataNode(new TestCluster.RestartCallback() {
+        cluster().restartRandomDataNode(new TestCluster.RestartCallback() {
 
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
@@ -93,16 +93,16 @@ public class DanglingIndicesIT extends IntegTestCase {
      * the cluster when the recovery setting is disabled.
      */
     public void testDanglingIndicesAreNotRecoveredWhenSettingIsDisabled() throws Exception {
-        internalCluster().startNodes(3, buildSettings(false, true));
+        cluster().startNodes(3, buildSettings(false, true));
 
         execute("create table doc.test(id integer) clustered into 2 shards with(number_of_replicas = 2)");
         ensureGreen("test");
 
-        assertBusy(() -> internalCluster().getInstances(IndicesService.class).forEach(
+        assertBusy(() -> cluster().getInstances(IndicesService.class).forEach(
             indicesService -> assertTrue(indicesService.allPendingDanglingIndicesWritten())));
 
         // Restart node, deleting the index in its absence, so that there is a dangling index to recover
-        internalCluster().restartRandomDataNode(new TestCluster.RestartCallback() {
+        cluster().restartRandomDataNode(new TestCluster.RestartCallback() {
 
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {

--- a/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -54,7 +54,7 @@ public class CloseIndexIT extends IntegTestCase {
      */
     @Test
     public void testRelocatedClosedIndexIssue() throws Exception {
-        final List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
+        final List<String> dataNodes = cluster().startDataOnlyNodes(2);
         // allocate shard to first data node
         execute("create table doc.test(x int) clustered into 1 shards with (number_of_replicas=0, \"routing.allocation.include._name\" = ?)", new Object[] {dataNodes.get(0)});
         var numDocs = randomIntBetween(0, 50);
@@ -69,7 +69,7 @@ public class CloseIndexIT extends IntegTestCase {
         execute("alter table doc.test close");
         execute("alter table doc.test set (\"routing.allocation.include._name\" = ?)", new Object[] { dataNodes.get(1) });
         ensureGreen("test");
-        internalCluster().fullRestart();
+        cluster().fullRestart();
         ensureGreen("test");
         assertIndexIsClosed("test");
     }

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
@@ -58,13 +58,12 @@ import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.ShardGenerations;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import org.elasticsearch.test.IntegTestCase;
 
 public class BlobStoreRepositoryTest extends IntegTestCase {
 
@@ -233,7 +232,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
     }
 
     protected BlobStoreRepository getRepository() throws Exception {
-        RepositoriesService service = internalCluster().getInstance(RepositoriesService.class, internalCluster().getMasterName());
+        RepositoriesService service = cluster().getInstance(RepositoriesService.class, cluster().getMasterName());
         return (BlobStoreRepository) service.repository(REPOSITORY_NAME);
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -75,13 +75,13 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
     @UseRandomizedSchema(random = false)
     @Test
     public void testIncrementalBehaviorOnPrimaryFailover() throws Exception {
-        internalCluster().startMasterOnlyNode();
-        final String primaryNode = internalCluster().startDataOnlyNode();
+        cluster().startMasterOnlyNode();
+        final String primaryNode = cluster().startDataOnlyNode();
         final String indexName = "test_index";
         execute("CREATE TABLE " + indexName + "(a string) " +
                 "CLUSTERED INTO 1 SHARDS WITH(number_of_replicas=1,\"unassigned.node_left.delayed_timeout\"=0)");
         ensureYellow();
-        final String newPrimary = internalCluster().startDataOnlyNode();
+        final String newPrimary = cluster().startDataOnlyNode();
         ensureGreen();
 
         logger.info("--> adding some documents to test index");
@@ -121,7 +121,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         ensureRestoreSingleShardSuccessfully(repo, indexName, snapshot2, documentCountOriginal);
         assertCountInIndexThenDelete(indexName, documentCountOriginal);
 
-        String newNewPrimary = internalCluster().startDataOnlyNode();
+        String newNewPrimary = cluster().startDataOnlyNode();
         ensureGreen();
 
         // Originally the test restores the index with different name, and here it deletes some
@@ -167,8 +167,8 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
     @UseRandomizedSchema(random = false)
     @Test
     public void testForceMergeCausesFullSnapshot() throws Exception {
-        internalCluster().startMasterOnlyNode();
-        internalCluster().ensureAtLeastNumDataNodes(2);
+        cluster().startMasterOnlyNode();
+        cluster().ensureAtLeastNumDataNodes(2);
         final String indexName = "test_index";
         execute("CREATE TABLE " + indexName + "(a string) CLUSTERED INTO 1 SHARDS");
         ensureGreen();
@@ -205,7 +205,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         execute("CREATE SNAPSHOT " + repo + "." + snapshot2 + " TABLE " + indexName + " WITH (wait_for_completion = true)");
 
         logger.info("--> asserting that the two snapshots refer to different files in the repository");
-        final RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class);
+        final RepositoriesService repositoriesService = cluster().getInstance(RepositoriesService.class);
         final SnapshotInfo snapshotInfo2 = client().admin().cluster()
             .execute(GetSnapshotsAction.INSTANCE, new GetSnapshotsRequest(repo, new String[] { snapshot2 }))
             .get()
@@ -241,7 +241,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         logger.info(
             "--> asserting that snapshots [{}] and [{}] are referring to the same files in the repository", snapshot1, snapshot2);
 
-        final RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class, dataNode);
+        final RepositoriesService repositoriesService = cluster().getInstance(RepositoriesService.class, dataNode);
         final SnapshotInfo snapshotInfo1 = client().admin().cluster()
             .execute(GetSnapshotsAction.INSTANCE, new GetSnapshotsRequest(repo, new String[] { snapshot1 }))
             .get()

--- a/server/src/testFixtures/java/org/elasticsearch/test/test/InternalTestClusterIT.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/test/InternalTestClusterIT.java
@@ -34,19 +34,19 @@ import org.elasticsearch.test.TestCluster;
 public class InternalTestClusterIT extends IntegTestCase {
 
     public void testStartingAndStoppingNodes() throws IOException {
-        logger.info("--> cluster has [{}] nodes", internalCluster().size());
-        if (internalCluster().size() < 5) {
-            final int nodesToStart = randomIntBetween(Math.max(2, internalCluster().size() + 1), 5);
+        logger.info("--> cluster has [{}] nodes", cluster().size());
+        if (cluster().size() < 5) {
+            final int nodesToStart = randomIntBetween(Math.max(2, cluster().size() + 1), 5);
             logger.info("--> growing to [{}] nodes", nodesToStart);
-            internalCluster().startNodes(nodesToStart);
+            cluster().startNodes(nodesToStart);
         }
         ensureGreen();
 
-        while (internalCluster().size() > 1) {
-            final int nodesToRemain = randomIntBetween(1, internalCluster().size() - 1);
+        while (cluster().size() > 1) {
+            final int nodesToRemain = randomIntBetween(1, cluster().size() - 1);
             logger.info("--> reducing to [{}] nodes", nodesToRemain);
-            internalCluster().ensureAtMostNumDataNodes(nodesToRemain);
-            assertThat(internalCluster().size(), lessThanOrEqualTo(nodesToRemain));
+            cluster().ensureAtMostNumDataNodes(nodesToRemain);
+            assertThat(cluster().size(), lessThanOrEqualTo(nodesToRemain));
         }
 
         ensureGreen();
@@ -57,30 +57,30 @@ public class InternalTestClusterIT extends IntegTestCase {
         // If the nodes shut down too quickly then this reconfiguration does not have time to occur and the quorum is lost in the 3->2
         // transition, even though in a stable cluster the 3->2 transition requires no special treatment.
 
-        internalCluster().startNodes(5);
+        cluster().startNodes(5);
         ensureGreen();
 
-        while (internalCluster().size() > 1) {
-            internalCluster().stopRandomNode(s -> true);
+        while (cluster().size() > 1) {
+            cluster().stopRandomNode(s -> true);
         }
 
         ensureGreen();
     }
 
     public void testOperationsDuringRestart() throws Exception {
-        internalCluster().startMasterOnlyNode();
-        internalCluster().startDataOnlyNodes(2);
-        internalCluster().restartRandomDataNode(new TestCluster.RestartCallback() {
+        cluster().startMasterOnlyNode();
+        cluster().startDataOnlyNodes(2);
+        cluster().restartRandomDataNode(new TestCluster.RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
                 ensureGreen();
-                internalCluster().validateClusterFormed();
-                assertNotNull(internalCluster().getInstance(NodeClient.class));
-                internalCluster().restartRandomDataNode(new TestCluster.RestartCallback() {
+                cluster().validateClusterFormed();
+                assertNotNull(cluster().getInstance(NodeClient.class));
+                cluster().restartRandomDataNode(new TestCluster.RestartCallback() {
                     @Override
                     public Settings onNodeStopped(String nodeName) throws Exception {
                         ensureGreen();
-                        internalCluster().validateClusterFormed();
+                        cluster().validateClusterFormed();
                         return super.onNodeStopped(nodeName);
                     }
                 });


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow up to https://github.com/crate/crate/pull/12883

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
