### PR TITLE
Try to fix flaky testSelectFromClosedPartition

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -211,9 +211,9 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
 
     @Test
     public void testSelectFromClosedPartition() throws Exception {
-        execute("create table t (n integer) partitioned by (n)");
+        execute("create table t (n integer) partitioned by (n) with (number_of_replicas = ?)", $(numberOfReplicas()));
         execute("insert into t (n) values (1)");
-        refresh();
+        ensureGreen();
 
         execute("alter table t partition (n = 1) close");
         assertBusy(() -> {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See https://github.com/crate/crate/pull/13468 for an explanation.

From the logs of a failure:

    updateTask[T#1] adding template [tlyeg..partitioned.t.] for index patterns [tlyeg..partitioned.t.*]
    updateTask[T#1] [tlyeg..partitioned.t.04132] creating index, cause [bulk], templates [tlyeg..partitioned.t.], shards [4]/[0]
    updateTask[T#1] updating number_of_replicas to [1] for indices [tlyeg..partitioned.t.04132]
    updateTask[T#1] completed closing of indices []

Compared to a successful run:

    updateTask[T#1] adding template [mnshlqkci..partitioned.t.] for index patterns [mnshlqkci..partitioned.t.*]
    updateTask[T#1] [mnshlqkci..partitioned.t.04132] creating index, cause [bulk], templates [mnshlqkci..partitioned.t.], shards [4]/[0]
    updateTask[T#1] updating number_of_replicas to [1] for indices [mnshlqkci..partitioned.t.04132]
    updateTask[T#1] completed closing of indices [mnshlqkci..partitioned.t.04132]


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
