### PR TITLE
Add initial ConcurrentSnapshotsIT test case

### DIFF
--- a/devs/docs/es-backports.rst
+++ b/devs/docs/es-backports.rst
@@ -241,7 +241,7 @@ should be crossed out as well.
 - [x] cc7093645cc Cleanup some Serialization Code around Snapshots (#59532) (#59606)
 - [x] b8d73a1e7ee Default gateway.auto_import_dangling_indices to false (#59302)
 - [s] 691759fb1fc Validate snapshot UUID during restore (#59601)
-- [ ] 2dd086445c3 Enable Fully Concurrent Snapshot Operations (#56911) (#59578)
+- [x] 2dd086445c3 Enable Fully Concurrent Snapshot Operations (#56911) (#59578)
 - [x] 06d94cbb2ac Fix TODO about Spurious FAILED Snapshots (#58994) (#59576)
 - [x] e1014038e90 Simplify Repository.finalizeSnapshot Signature (#58834) (#59574)
 - [x] 16a47e0d089 Simplify SnapshotsInProgress Construction (#58893) (#59573)

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
@@ -70,7 +70,7 @@ public abstract class AbstractDisruptionTestCase extends IntegTestCase {
 
     static final TimeValue DISRUPTION_HEALING_OVERHEAD = TimeValue.timeValueSeconds(40);
 
-    protected static final Settings DEFAULT_SETTINGS = Settings.builder()
+    public static final Settings DEFAULT_SETTINGS = Settings.builder()
         .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "5s") // for hitting simulated network failures quickly
         .put(LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING.getKey(), 1) // for hitting simulated network failures quickly
         .put(FollowersChecker.FOLLOWER_CHECK_TIMEOUT_SETTING.getKey(), "5s") // for hitting simulated network failures quickly

--- a/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.snapshots;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.snapshots.mockstore.MockRepository;
+import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.junit.Test;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.integrationtests.disruption.discovery.AbstractDisruptionTestCase;
+import io.crate.testing.UseRandomizedSchema;
+
+@UseRandomizedSchema(random = false)
+@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST, numDataNodes = 0)
+public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(MockTransportService.TestPlugin.class, MockRepository.Plugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+            .put(AbstractDisruptionTestCase.DEFAULT_SETTINGS)
+            .build();
+    }
+
+    @Test
+    @UseRandomizedSchema(random = false)
+    public void testLongRunningSnapshotAllowsConcurrentSnapshot() throws Exception {
+        cluster().startMasterOnlyNode();
+        final String dataNode = cluster().startDataOnlyNode();
+        final String repoName = "repo1";
+        execute(
+            "CREATE REPOSITORY repo1 TYPE mock WITH (location = ?, compress = ?, chunk_size = ?)",
+            new Object[] {
+                randomRepoPath().toAbsolutePath().toString(),
+                randomBoolean(),
+                randomIntBetween(100, 1000)
+            }
+        );
+        execute("""
+            create table tbl_slow (
+                id string primary key,
+                s string
+            ) clustered into 1 shards with (
+                number_of_replicas = 0
+            )
+        """);
+        execute("insert into tbl_slow (id, s) values ('some_id', 'foo')");
+        execute("refresh table tbl_slow");
+
+        CompletableFuture<SnapshotInfo> createSlowFuture = startFullSnapshotBlockedOnDataNode(
+            "slow-snapshot",
+            repoName,
+            dataNode
+        );
+
+        final String dataNode2 = cluster().startDataOnlyNode();
+        ensureStableCluster(3);
+
+        execute("""
+            create table tbl_fast (id string primary key, s string)
+            clustered into 1 shards
+            with (
+                number_of_replicas = 0,
+                "routing.allocation.include._name" = ?,
+                "routing.allocation.exclude._name" = ?
+            )
+            """,
+            new Object[] {
+                dataNode2,
+                dataNode
+            }
+        );
+        execute("insert into tbl_fast (id, s) values ('some_id', 'foo')");
+        execute("refresh table tbl_fast");
+
+        CompletableFuture<SnapshotInfo> future = startFullSnapshot(repoName, "fast-snapshot", "tbl_fast");
+        assertSuccessful(future);
+
+        assertThat(createSlowFuture.isDone()).isFalse();
+        unblockNode(repoName, dataNode);
+        assertSuccessful(createSlowFuture);
+    }
+
+    private CompletableFuture<SnapshotInfo> startFullSnapshot(String repoName, String snapshotName, String... indices) {
+        logger.info("--> creating full snapshot [{}] to repo [{}]", snapshotName, repoName);
+        CreateSnapshotRequest createSnapshotRequest = new CreateSnapshotRequest(repoName, snapshotName)
+            .waitForCompletion(true);
+        if (indices != null && indices.length > 0) {
+            createSnapshotRequest.indices(indices);
+        }
+        return cluster().client()
+            .execute(CreateSnapshotAction.INSTANCE, createSnapshotRequest)
+            .thenApply(x -> x.getSnapshotInfo());
+    }
+
+
+    private void assertSuccessful(CompletableFuture<SnapshotInfo> future) throws Exception {
+        assertBusy(() -> {
+            assertThat(future).isCompletedWithValueMatching(sInfo -> sInfo.state() == SnapshotState.SUCCESS);
+        });
+    }
+
+    private CompletableFuture<SnapshotInfo> startFullSnapshotBlockedOnDataNode(String snapshotName,
+                                                                               String repoName,
+                                                                               String dataNode) throws InterruptedException {
+        blockDataNode(repoName, dataNode);
+        CompletableFuture<SnapshotInfo> future = startFullSnapshot(repoName, snapshotName);
+        waitForBlock(dataNode, repoName, TimeValue.timeValueSeconds(30L));
+        return future;
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -155,10 +155,10 @@ public abstract class AbstractSnapshotIntegTestCase extends IntegTestCase {
     }
 
     public static void waitForBlock(String node, String repository, TimeValue timeout) throws InterruptedException {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         RepositoriesService repositoriesService = cluster().getInstance(RepositoriesService.class, node);
         MockRepository mockRepository = (MockRepository) repositoriesService.repository(repository);
-        while (System.currentTimeMillis() - start < timeout.millis()) {
+        while (System.nanoTime() - start < timeout.nanos()) {
             if (mockRepository.blocked()) {
                 return;
             }
@@ -189,6 +189,11 @@ public abstract class AbstractSnapshotIntegTestCase extends IntegTestCase {
         }
         fail("No nodes for the index " + indexName + " found");
         return null;
+    }
+
+    public static void blockDataNode(String repository, String nodeName) {
+        ((MockRepository) cluster().getInstance(RepositoriesService.class, nodeName)
+                .repository(repository)).blockOnDataFiles(true);
     }
 
     public static void blockAllDataNodes(String repository) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Only adds a single test case from
https://github.com/crate/crate/pull/13289 to get the boilerplate in with
some major adjustements:

- Prefer SQL if possible
- Use `CompletableFuture<SnapshotInfo>` instead of sub-classes. Makes
  the implementation of `startFullSnapshot` much simpler
- Use `System.nanoTime` in `waitForBlock`. `currentTimeMillis` can
  observe clock adjustments and shift backward.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
