### PR TITLE
Fix issues with backwards fetching

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -78,6 +78,9 @@ Fixes
 - Improved error message when :ref:`fetching <sql-fetch>` using ``ABSOLUTE``,
   past the last row returned by the cursor query.
 
+- Fixed and issue that caused wrong or 0 rows to be returned when trying to
+  fetch all rows backwards from a ``CURSOR`` using: ``FETCH BACKWARDS ALL``.
+
 - Fixed an issue that caused :ref:`swap table <alter_cluster_swap_table>` to
   consume invalid table names provided in a double-quoted string format
   containing ``.`` such as ``"table.t"`` by mis-interpreting it as

--- a/server/src/main/java/io/crate/action/sql/Cursor.java
+++ b/server/src/main/java/io/crate/action/sql/Cursor.java
@@ -155,8 +155,8 @@ public final class Cursor implements AutoCloseable {
         if (lCount == Long.MAX_VALUE) {
             lCount = Integer.MAX_VALUE;
         }
-        if (lCount > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException("Count must not exceed " + Integer.MAX_VALUE);
+        if (lCount == - Long.MAX_VALUE) {
+            lCount = - Integer.MAX_VALUE;
         }
         int count = (int) lCount;
         boolean moveForward = mode == ScrollMode.RELATIVE && count >= 0 || mode == ScrollMode.ABSOLUTE && count > cursorPosition;

--- a/server/src/test/java/io/crate/integrationtests/CursorITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CursorITest.java
@@ -144,53 +144,63 @@ public class CursorITest extends IntegTestCase {
         try (var conn = DriverManager.getConnection(url(), properties)) {
             Statement statement = conn.createStatement();
             conn.setAutoCommit(false);
+            statement.execute("CREATE TABLE t1 AS SELECT * FROM generate_series(1,10,1)");
+            statement.execute("REFRESH TABLE t1");
 
-            String declare = "declare c1 scroll cursor for select * from generate_series(1, 7)";
-            statement.execute(declare);
-            ResultSet result = statement.executeQuery("FETCH 3 FROM c1");
+            statement.execute("DECLARE c1 SCROLL CURSOR FOR SELECT * FROM t1 ORDER BY 1");
+            ResultSet result = statement.executeQuery("FETCH 2 FROM c1");
             assertThat(result.next()).isTrue();
             assertThat(result.getInt(1)).isEqualTo(1);
             assertThat(result.next()).isTrue();
             assertThat(result.getInt(1)).isEqualTo(2);
-            assertThat(result.next()).isTrue();
-            assertThat(result.getInt(1)).isEqualTo(3);
             assertThat(result.next()).isFalse();
 
-            result = statement.executeQuery("FETCH ABSOLUTE 5 FROM c1");
+            result = statement.executeQuery("FETCH 2 FROM c1");
             assertThat(result.next()).isTrue();
-            assertThat(result.getInt(1)).isEqualTo(5);
+            assertThat(result.getInt(1)).isEqualTo(3);
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(4);
+            assertThat(result.next()).isFalse();
+
+            result = statement.executeQuery("FETCH ABSOLUTE 7 FROM c1");
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(7);
             assertThat(result.next()).isFalse();
 
             result = statement.executeQuery("FETCH BACKWARD 2 FROM c1");
             assertThat(result.next()).isTrue();
-            assertThat(result.getInt(1)).isEqualTo(4);
+            assertThat(result.getInt(1)).isEqualTo(6);
             assertThat(result.next()).isTrue();
-            assertThat(result.getInt(1)).isEqualTo(3);
+            assertThat(result.getInt(1)).isEqualTo(5);
             assertThat(result.next()).isFalse();
 
             result = statement.executeQuery("FETCH BACKWARD 0 FROM c1");
             assertThat(result.next()).isTrue();
-            assertThat(result.getInt(1)).isEqualTo(3);
+            assertThat(result.getInt(1)).isEqualTo(5);
             assertThat(result.next()).isFalse();
 
             result = statement.executeQuery("FETCH ALL FROM c1");
             assertThat(result.next()).isTrue();
-            assertThat(result.getInt(1)).isEqualTo(4);
-            assertThat(result.next()).isTrue();
-            assertThat(result.getInt(1)).isEqualTo(5);
-            assertThat(result.next()).isTrue();
             assertThat(result.getInt(1)).isEqualTo(6);
             assertThat(result.next()).isTrue();
             assertThat(result.getInt(1)).isEqualTo(7);
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(8);
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(9);
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(10);
             assertThat(result.next()).isFalse();
 
             result = statement.executeQuery("FETCH ABSOLUTE 6 FROM c1");
             assertThat(result.next()).isTrue();
             assertThat(result.getInt(1)).isEqualTo(6);
             assertThat(result.next()).isFalse();
-            result = statement.executeQuery("FETCH backward FROM c1");
+            result = statement.executeQuery("FETCH backward 2 FROM c1");
             assertThat(result.next()).isTrue();
             assertThat(result.getInt(1)).isEqualTo(5);
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(4);
             assertThat(result.next()).isFalse();
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Fix calculation of `cursorPosition`: remove increase in `moveNext()` and always
  set it appropriately at the end of each operation.

- Fix `FETCH BACKWARD ALL`, which previously returned 0 or wrong rows, as `- Long.MAX_VALUE`
  was not handled correctly.


Follows: #13471
Fixes: #13475


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
