### PR TITLE
Add Iterative Optimizer

### DIFF
--- a/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
+++ b/server/src/main/java/io/crate/metadata/CoordinatorTxnCtx.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.Objects;
 
 import io.crate.metadata.settings.CoordinatorSessionSettings;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
 
 /**
  * TransactionContext is a context that is used to keep state which is valid during a transaction.
@@ -36,6 +37,7 @@ public final class CoordinatorTxnCtx implements TransactionContext {
 
     private final CoordinatorSessionSettings sessionSettings;
     private Instant currentInstant;
+    private LogicalPlanIdAllocator idAllocator = new LogicalPlanIdAllocator();
 
     public static CoordinatorTxnCtx systemTransactionContext() {
         return new CoordinatorTxnCtx(CoordinatorSessionSettings.systemDefaults());
@@ -60,5 +62,10 @@ public final class CoordinatorTxnCtx implements TransactionContext {
     @Override
     public CoordinatorSessionSettings sessionSettings() {
         return sessionSettings;
+    }
+
+    @Override
+    public LogicalPlanIdAllocator idAllocator() {
+        return idAllocator;
     }
 }

--- a/server/src/main/java/io/crate/metadata/TransactionContext.java
+++ b/server/src/main/java/io/crate/metadata/TransactionContext.java
@@ -22,26 +22,32 @@
 package io.crate.metadata;
 
 import io.crate.metadata.settings.SessionSettings;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
 
 import java.time.Instant;
 
 public interface TransactionContext {
 
     static TransactionContext of(SessionSettings sessionSettings) {
-        return new StaticTransactionContext(sessionSettings);
+        return new StaticTransactionContext(sessionSettings, new LogicalPlanIdAllocator());
     }
 
     Instant currentInstant();
 
     SessionSettings sessionSettings();
 
+    LogicalPlanIdAllocator idAllocator();
+
     class StaticTransactionContext implements TransactionContext {
 
         private final SessionSettings sessionSettings;
         private Instant currentInstant;
+        private final LogicalPlanIdAllocator idAllocator;
 
-        StaticTransactionContext(SessionSettings sessionSettings) {
+
+        StaticTransactionContext(SessionSettings sessionSettings, LogicalPlanIdAllocator idAllocator) {
             this.sessionSettings = sessionSettings;
+            this.idAllocator = idAllocator;
         }
 
         @Override
@@ -56,5 +62,11 @@ public interface TransactionContext {
         public SessionSettings sessionSettings() {
             return sessionSettings;
         }
+
+        @Override
+        public LogicalPlanIdAllocator idAllocator() {
+            return idAllocator;
+        }
+
     }
 }

--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -85,7 +85,8 @@ public class PlannerContext {
                           int fetchSize,
                           @Nullable Row params,
                           Cursors cursors,
-                          TransactionState transactionState) {
+                          TransactionState transactionState
+                          ) {
         this.routingProvider = routingProvider;
         this.nodeCtx = nodeCtx;
         this.params = params;
@@ -162,4 +163,5 @@ public class PlannerContext {
     public TransactionState transactionState() {
         return transactionState;
     }
+
 }

--- a/server/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -32,6 +32,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.planner.operators.CorrelatedJoin;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
 
 public class SubqueryPlanner {
 
@@ -43,11 +44,12 @@ public class SubqueryPlanner {
 
     public record SubQueries(Map<LogicalPlan, SelectSymbol> uncorrelated, Map<SelectSymbol, LogicalPlan> correlated) {
 
-        public LogicalPlan applyCorrelatedJoin(LogicalPlan source) {
+        public LogicalPlan applyCorrelatedJoin(LogicalPlan source, LogicalPlanIdAllocator idAllocator) {
             for (var entry : correlated.entrySet()) {
                 LogicalPlan plannedSubQuery = entry.getValue();
                 SelectSymbol subQuery = entry.getKey();
                 source = new CorrelatedJoin(
+                    idAllocator.nextId(),
                     source,
                     subQuery,
                     plannedSubQuery

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -104,6 +104,6 @@ public final class InsertFromSubQueryPlanner {
         );
         EvalProjection castOutputs = EvalProjection.castValues(
             Symbols.typeView(statement.columns()), plannedSubQuery.outputs());
-        return new Insert(plannedSubQuery, indexWriterProjection, castOutputs);
+        return new Insert(plannerContext.transactionContext().idAllocator().nextId(), plannedSubQuery, indexWriterProjection, castOutputs);
     }
 }

--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -363,6 +363,7 @@ public class ExplainPlan implements Plan {
         @Override
         public LogicalPlan visitCollect(Collect collect, PlannerContext context) {
             var optimizedCollect = new Collect(
+                context.transactionContext().idAllocator().nextId(),
                 collect.relation(),
                 collect.outputs(),
                 collect.where().map(s -> Optimizer.optimizeCasts(s, context)),

--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -352,7 +352,7 @@ public class ExplainPlan implements Plan {
     private static class CastOptimizer extends LogicalPlanVisitor<PlannerContext, LogicalPlan> {
 
         @Override
-        protected LogicalPlan visitPlan(LogicalPlan logicalPlan, PlannerContext context) {
+        public LogicalPlan visitPlan(LogicalPlan logicalPlan, PlannerContext context) {
             ArrayList<LogicalPlan> newSources = new ArrayList<>(logicalPlan.sources().size());
             for (var source : logicalPlan.sources()) {
                 newSources.add(source.accept(this, context));

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -65,15 +65,18 @@ import io.crate.statistics.TableStats;
  **/
 public class CorrelatedJoin implements LogicalPlan {
 
+    private final LogicalPlanId id;
     private final LogicalPlan inputPlan;
     private final LogicalPlan subQueryPlan;
 
     private final List<Symbol> outputs;
     private final SelectSymbol selectSymbol;
 
-    public CorrelatedJoin(LogicalPlan inputPlan,
+    public CorrelatedJoin(LogicalPlanId id,
+                          LogicalPlan inputPlan,
                           SelectSymbol selectSymbol,
                           LogicalPlan subQueryPlan) {
+        this.id = id;
         this.inputPlan = inputPlan;
         this.subQueryPlan = subQueryPlan;
         this.selectSymbol = selectSymbol;
@@ -138,6 +141,11 @@ public class CorrelatedJoin implements LogicalPlan {
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         return this;
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -140,7 +140,7 @@ public class CorrelatedJoin implements LogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return this;
+        return new CorrelatedJoin(this.id, sources.get(0), this.selectSymbol, this.subQueryPlan);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -62,11 +62,14 @@ public class Count implements LogicalPlan {
 
     private static final String COUNT_PHASE_NAME = "count-merge";
 
+    private final LogicalPlanId id;
     final AbstractTableRelation<?> tableRelation;
     final WhereClause where;
     private final List<Symbol> outputs;
 
-    public Count(Function countFunction, AbstractTableRelation<?> tableRelation, WhereClause where) {
+
+    public Count(LogicalPlanId id, Function countFunction, AbstractTableRelation<?> tableRelation, WhereClause where) {
+        this.id = id;
         this.outputs = List.of(countFunction);
         this.tableRelation = tableRelation;
         this.where = where;
@@ -123,6 +126,11 @@ public class Count implements LogicalPlan {
             null
         );
         return new CountPlan(countPhase, mergePhase);
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/server/src/main/java/io/crate/planner/operators/Fetch.java
@@ -82,20 +82,23 @@ import io.crate.types.DataType;
  */
 public final class Fetch extends ForwardingLogicalPlan {
 
+    private final LogicalPlanId id;
     private final List<Symbol> outputs;
     private final List<Reference> fetchRefs;
     private final Map<RelationName, FetchSource> fetchSourceByRelation;
     private final Map<Symbol, Symbol> replacedOutputs;
 
-    public Fetch(Map<Symbol, Symbol> replacedOutputs,
+    public Fetch(LogicalPlanId id,
+                 Map<Symbol, Symbol> replacedOutputs,
                  List<Reference> fetchRefs,
                  Map<RelationName, FetchSource> fetchSourceByRelation,
                  LogicalPlan source) {
-        super(source);
+        super(id, source);
         this.outputs = List.copyOf(replacedOutputs.keySet());
         this.replacedOutputs = replacedOutputs;
         this.fetchRefs = fetchRefs;
         this.fetchSourceByRelation = fetchSourceByRelation;
+        this.id = id;
     }
 
     @Override
@@ -173,7 +176,12 @@ public final class Fetch extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Fetch(replacedOutputs, fetchRefs, fetchSourceByRelation, Lists2.getOnlyElement(sources));
+        return new Fetch(id, replacedOutputs, fetchRefs, fetchSourceByRelation, Lists2.getOnlyElement(sources));
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -46,7 +46,7 @@ public final class Filter extends ForwardingLogicalPlan {
 
     final Symbol query;
 
-    public static LogicalPlan create(LogicalPlan source, @Nullable Symbol query) {
+    public static LogicalPlan create(LogicalPlanId id, LogicalPlan source, @Nullable Symbol query) {
         if (query == null) {
             return source;
         }
@@ -55,15 +55,15 @@ public final class Filter extends ForwardingLogicalPlan {
         if (isMatchAll(query)) {
             return source;
         }
-        return new Filter(source, query);
+        return new Filter(id, source, query);
     }
 
     private static boolean isMatchAll(Symbol query) {
         return query instanceof Literal && ((Literal<?>) query).value() == Boolean.TRUE;
     }
 
-    public Filter(LogicalPlan source, Symbol query) {
-        super(source);
+    public Filter(LogicalPlanId id, LogicalPlan source, Symbol query) {
+        super(id, source);
         this.query = query;
     }
 
@@ -101,12 +101,17 @@ public final class Filter extends ForwardingLogicalPlan {
         if (newSource == source) {
             return this;
         }
-        return new Filter(newSource, query);
+        return new Filter(id, newSource, query);
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Filter(Lists2.getOnlyElement(sources), query);
+        return new Filter(id, Lists2.getOnlyElement(sources), query);
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -34,10 +34,12 @@ import java.util.Set;
 
 public abstract class ForwardingLogicalPlan implements LogicalPlan {
 
+    protected final LogicalPlanId id;
     private final List<LogicalPlan> sources;
     final LogicalPlan source;
 
-    public ForwardingLogicalPlan(LogicalPlan source) {
+    public ForwardingLogicalPlan(LogicalPlanId id, LogicalPlan source) {
+        this.id = id;
         this.source = source;
         this.sources = List.of(source);
     }
@@ -53,6 +55,11 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
             return this;
         }
         return replaceSources(List.of(newSource));
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -70,17 +70,20 @@ import io.crate.statistics.TableStats;
 
 public class Get implements LogicalPlan {
 
+    private final LogicalPlanId id;
     final DocTableRelation tableRelation;
     final DocKeys docKeys;
     final Symbol query;
     final long estimatedSizePerRow;
     private final List<Symbol> outputs;
 
-    public Get(DocTableRelation table,
+    public Get(LogicalPlanId id,
+               DocTableRelation table,
                DocKeys docKeys,
                Symbol query,
                List<Symbol> outputs,
                long estimatedSizePerRow) {
+        this.id = id;
         this.tableRelation = table;
         this.docKeys = docKeys;
         this.query = query;
@@ -250,7 +253,7 @@ public class Get implements LogicalPlan {
             }
         }
         if (excludedAny) {
-            return new Get(tableRelation, docKeys, query, newOutputs, estimatedSizePerRow);
+            return new Get(id, tableRelation, docKeys, query, newOutputs, estimatedSizePerRow);
         }
         return this;
     }
@@ -268,6 +271,11 @@ public class Get implements LogicalPlan {
     @Override
     public long numExpectedRows() {
         return docKeys.size();
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -70,7 +70,6 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
     private final List<Symbol> outputs;
     private final long numExpectedRows;
 
-
     static long approximateDistinctValues(long numSourceRows, TableStats tableStats, List<Symbol> groupKeys) {
         long distinctValues = 1;
         int numKeysWithStats = 0;
@@ -115,8 +114,13 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         }
     }
 
-    public GroupHashAggregate(LogicalPlan source, List<Symbol> groupKeys, List<Function> aggregates, long numExpectedRows) {
-        super(source);
+    public GroupHashAggregate(LogicalPlanId id,
+                              LogicalPlan source,
+                              List<Symbol> groupKeys,
+                              List<Function> aggregates,
+                              long numExpectedRows
+                              ) {
+        super(id, source);
         this.numExpectedRows = numExpectedRows;
         this.aggregates = List.copyOf(new LinkedHashSet<>(aggregates));
         this.outputs = Lists2.concat(groupKeys, this.aggregates);
@@ -268,12 +272,12 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         if (newSource == source && aggregates.size() == newAggregates.size()) {
             return this;
         }
-        return new GroupHashAggregate(newSource, groupKeys, newAggregates, numExpectedRows);
+        return new GroupHashAggregate(id, newSource, groupKeys, newAggregates, numExpectedRows);
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new GroupHashAggregate(Lists2.getOnlyElement(sources), groupKeys, aggregates, numExpectedRows);
+        return new GroupHashAggregate(id, Lists2.getOnlyElement(sources), groupKeys, aggregates, numExpectedRows);
     }
 
     private ExecutionPlan createMerge(PlannerContext plannerContext,

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -61,8 +61,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
     private static final String MERGE_PHASE_NAME = "mergeOnHandler";
     final List<Function> aggregates;
 
-    HashAggregate(LogicalPlan source, List<Function> aggregates) {
-        super(source);
+    HashAggregate(LogicalPlanId id, LogicalPlan source, List<Function> aggregates) {
+        super(id, source);
         this.aggregates = aggregates;
     }
 
@@ -173,7 +173,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new HashAggregate(Lists2.getOnlyElement(sources), aggregates);
+        return new HashAggregate(id, Lists2.getOnlyElement(sources), aggregates);
     }
 
     @Override
@@ -190,7 +190,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
         if (source == newSource && newAggregates == aggregates) {
             return this;
         }
-        return new HashAggregate(newSource, newAggregates);
+        return new HashAggregate(id, newSource, newAggregates);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -63,14 +63,17 @@ import io.crate.statistics.TableStats;
 
 public class HashJoin implements LogicalPlan {
 
+    private final LogicalPlanId id;
     private final Symbol joinCondition;
     private final List<Symbol> outputs;
     final LogicalPlan rhs;
     final LogicalPlan lhs;
 
-    public HashJoin(LogicalPlan lhs,
+    public HashJoin(LogicalPlanId id,
+                    LogicalPlan lhs,
                     LogicalPlan rhs,
                     Symbol joinCondition) {
+        this.id = id;
         this.outputs = Lists2.concat(lhs.outputs(), rhs.outputs());
         this.lhs = lhs;
         this.rhs = rhs;
@@ -252,6 +255,7 @@ public class HashJoin implements LogicalPlan {
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         return new HashJoin(
+            id,
             sources.get(0),
             sources.get(1),
             joinCondition
@@ -274,6 +278,7 @@ public class HashJoin implements LogicalPlan {
             return this;
         }
         return new HashJoin(
+            id,
             newLhs,
             newRhs,
             joinCondition
@@ -302,6 +307,7 @@ public class HashJoin implements LogicalPlan {
         return new FetchRewrite(
             allReplacedOutputs,
             new HashJoin(
+                id,
                 lhsFetchRewrite == null ? lhs : lhsFetchRewrite.newPlan(),
                 rhsFetchRewrite == null ? rhs : rhsFetchRewrite.newPlan(),
                 joinCondition
@@ -327,6 +333,11 @@ public class HashJoin implements LogicalPlan {
     @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitHashJoin(this, context);
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -52,11 +52,16 @@ public class Insert implements LogicalPlan {
 
     private final ColumnIndexWriterProjection writeToTable;
 
+    private final LogicalPlanId id;
     @Nullable
     private final EvalProjection applyCasts;
     final LogicalPlan source;
 
-    public Insert(LogicalPlan source, ColumnIndexWriterProjection writeToTable, @Nullable EvalProjection applyCasts) {
+    public Insert(LogicalPlanId id,
+                  LogicalPlan source,
+                  ColumnIndexWriterProjection writeToTable,
+                  @Nullable EvalProjection applyCasts) {
+        this.id = id;
         this.source = source;
         this.writeToTable = writeToTable;
         this.applyCasts = applyCasts;
@@ -132,7 +137,7 @@ public class Insert implements LogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Insert(Lists2.getOnlyElement(sources), writeToTable, applyCasts);
+        return new Insert(id, Lists2.getOnlyElement(sources), writeToTable, applyCasts);
     }
 
     @Override
@@ -147,6 +152,11 @@ public class Insert implements LogicalPlan {
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
         return source.dependencies();
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -116,11 +116,14 @@ import io.crate.types.DataType;
 
 public class InsertFromValues implements LogicalPlan {
 
+    private final LogicalPlanId id;
     private final TableFunctionRelation tableFunctionRelation;
     private final ColumnIndexWriterProjection writerProjection;
 
-    InsertFromValues(TableFunctionRelation tableFunctionRelation,
+    InsertFromValues(LogicalPlanId id,
+                     TableFunctionRelation tableFunctionRelation,
                      ColumnIndexWriterProjection writerProjection) {
+        this.id = id;
         this.tableFunctionRelation = tableFunctionRelation;
         this.writerProjection = writerProjection;
     }
@@ -821,6 +824,11 @@ public class InsertFromValues implements LogicalPlan {
     @Override
     public List<Symbol> outputs() {
         return List.of();
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -69,10 +69,11 @@ public class JoinPlanBuilder {
                                      List<JoinPair> joinPairs,
                                      SubQueries subQueries,
                                      Function<AnalyzedRelation, LogicalPlan> plan,
-                                     boolean hashJoinEnabled) {
+                                     boolean hashJoinEnabled,
+                                     LogicalPlanIdAllocator logicalPlanIdAllocator) {
         if (from.size() == 1) {
-            LogicalPlan source = subQueries.applyCorrelatedJoin(plan.apply(from.get(0)));
-            return Filter.create(source, whereClause);
+            LogicalPlan source = subQueries.applyCorrelatedJoin(plan.apply(from.get(0)), logicalPlanIdAllocator);
+            return Filter.create(logicalPlanIdAllocator.nextId(), source, whereClause);
         }
         Map<Set<RelationName>, Symbol> queryParts = QuerySplitter.split(whereClause);
         List<JoinPair> allJoinPairs = JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, queryParts);
@@ -131,9 +132,10 @@ public class JoinPlanBuilder {
                 lhs,
                 subQueries,
                 query,
-                hashJoinEnabled);
+                hashJoinEnabled,
+                logicalPlanIdAllocator);
         } else {
-            lhsPlan = subQueries.applyCorrelatedJoin(lhsPlan);
+            lhsPlan = subQueries.applyCorrelatedJoin(lhsPlan, logicalPlanIdAllocator);
             joinPlan = createJoinPlan(
                 lhsPlan,
                 rhsPlan,
@@ -141,10 +143,11 @@ public class JoinPlanBuilder {
                 joinCondition,
                 lhs,
                 query,
-                hashJoinEnabled);
+                hashJoinEnabled,
+                logicalPlanIdAllocator);
         }
 
-        joinPlan = Filter.create(joinPlan, query);
+        joinPlan = Filter.create(logicalPlanIdAllocator.nextId(), joinPlan, query);
         while (it.hasNext()) {
             AnalyzedRelation nextRel = sources.get(it.next());
             joinPlan = joinWithNext(
@@ -155,12 +158,13 @@ public class JoinPlanBuilder {
                 joinPairsByRelations,
                 queryParts,
                 lhs,
-                hashJoinEnabled
+                hashJoinEnabled,
+                logicalPlanIdAllocator
             );
             joinNames.add(nextRel.relationName());
         }
         if (!queryParts.isEmpty()) {
-            joinPlan = Filter.create(joinPlan, AndOperator.join(queryParts.values()));
+            joinPlan = Filter.create(logicalPlanIdAllocator.nextId(), joinPlan, AndOperator.join(queryParts.values()));
             queryParts.clear();
         }
         assert joinPairsByRelations.isEmpty() : "Must've applied all joinPairs";
@@ -197,7 +201,8 @@ public class JoinPlanBuilder {
         AnalyzedRelation lhs,
         SubQueries subQueries,
         Symbol query,
-        boolean hashJoinEnabled
+        boolean hashJoinEnabled,
+        LogicalPlanIdAllocator logicalPlanIdAllocator
     ) {
         var validJoinConditions = new ArrayList<Symbol>();
         var joinConditionsForFilters = new ArrayList<Symbol>();
@@ -217,10 +222,11 @@ public class JoinPlanBuilder {
             AndOperator.join(validJoinConditions),
             lhs,
             query,
-            hashJoinEnabled);
+            hashJoinEnabled,
+            logicalPlanIdAllocator);
 
-        joinPlan = subQueries.applyCorrelatedJoin(joinPlan);
-        joinPlan = Filter.create(joinPlan, AndOperator.join(joinConditionsForFilters));;
+        joinPlan = subQueries.applyCorrelatedJoin(joinPlan, logicalPlanIdAllocator);
+        joinPlan = Filter.create(logicalPlanIdAllocator.nextId(), joinPlan, AndOperator.join(joinConditionsForFilters));;
 
         return joinPlan;
     }
@@ -246,15 +252,18 @@ public class JoinPlanBuilder {
                                               Symbol joinCondition,
                                               AnalyzedRelation lhs,
                                               Symbol query,
-                                              boolean hashJoinEnabled) {
+                                              boolean hashJoinEnabled,
+                                              LogicalPlanIdAllocator logicalPlanIdAllocator) {
         if (hashJoinEnabled && isHashJoinPossible(joinType, joinCondition)) {
             return new HashJoin(
+                logicalPlanIdAllocator.nextId(),
                 lhsPlan,
                 rhsPlan,
                 joinCondition
             );
         } else {
             return new NestedLoopJoin(
+                logicalPlanIdAllocator.nextId(),
                 lhsPlan,
                 rhsPlan,
                 joinType,
@@ -283,7 +292,8 @@ public class JoinPlanBuilder {
                                             Map<Set<RelationName>, JoinPair> joinPairs,
                                             Map<Set<RelationName>, Symbol> queryParts,
                                             AnalyzedRelation leftRelation,
-                                            boolean hashJoinEnabled) {
+                                            boolean hashJoinEnabled,
+                                            LogicalPlanIdAllocator logicalPlanIdAllocator) {
         RelationName nextName = nextRel.relationName();
 
         JoinPair joinPair = removeMatch(joinPairs, joinNames, nextName);
@@ -305,6 +315,7 @@ public class JoinPlanBuilder {
                 .filter(Objects::nonNull).iterator()
         );
         return Filter.create(
+            logicalPlanIdAllocator.nextId(),
             createJoinPlan(
                 source,
                 nextPlan,
@@ -312,7 +323,8 @@ public class JoinPlanBuilder {
                 condition,
                 leftRelation,
                 query,
-                hashJoinEnabled),
+                hashJoinEnabled,
+                logicalPlanIdAllocator),
             query
         );
     }

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -56,19 +56,21 @@ public class Limit extends ForwardingLogicalPlan {
     final Symbol limit;
     final Symbol offset;
 
-    static LogicalPlan create(LogicalPlan source, @Nullable Symbol limit, @Nullable Symbol offset) {
+    static LogicalPlan create(LogicalPlanId id, LogicalPlan source, @Nullable Symbol limit, @Nullable Symbol offset) {
         if (limit == null && offset == null) {
             return source;
         } else {
             return new Limit(
+                id,
                 source,
                 Objects.requireNonNullElse(limit, Literal.of(-1L)),
-                Objects.requireNonNullElse(offset, Literal.of(0)));
+                Objects.requireNonNullElse(offset, Literal.of(0))
+            );
         }
     }
 
-    public Limit(LogicalPlan source, Symbol limit, Symbol offset) {
-        super(source);
+    public Limit(LogicalPlanId id, LogicalPlan source, Symbol limit, Symbol offset) {
+        super(id, source);
         this.limit = limit;
         this.offset = offset;
     }
@@ -134,7 +136,7 @@ public class Limit extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Limit(Lists2.getOnlyElement(sources), limit, offset);
+        return new Limit(id, Lists2.getOnlyElement(sources), limit, offset);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
@@ -59,8 +59,8 @@ public final class LimitDistinct extends ForwardingLogicalPlan {
     private final List<Symbol> outputs;
     private final Symbol offset;
 
-    public LimitDistinct(LogicalPlan source, Symbol limit, Symbol offset, List<Symbol> outputs) {
-        super(source);
+    public LimitDistinct(LogicalPlanId id, LogicalPlan source, Symbol limit, Symbol offset, List<Symbol> outputs) {
+        super(id, source);
         this.limit = limit;
         this.offset = offset;
         this.outputs = outputs;
@@ -168,13 +168,13 @@ public final class LimitDistinct extends ForwardingLogicalPlan {
         if (prunedSource == source) {
             return this;
         }
-        return new LimitDistinct(prunedSource, limit, offset, outputs);
+        return new LimitDistinct(id, prunedSource, limit, offset, outputs);
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         var source = Lists2.getOnlyElement(sources);
-        return new LimitDistinct(source, limit, offset, outputs);
+        return new LimitDistinct(id, source, limit, offset, outputs);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -115,6 +115,8 @@ public interface LogicalPlan extends Plan {
 
     LogicalPlan replaceSources(List<LogicalPlan> sources);
 
+    LogicalPlanId id();
+
     /**
      * Request an operator to return a new version of itself with all outputs removed except the ones contained in `outputsToKeep`.
      * <p>

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanId.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanId.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -21,21 +21,32 @@
 
 package io.crate.planner.operators;
 
-import io.crate.expression.symbol.Symbol;
-import io.crate.statistics.TableStats;
+import java.util.Objects;
 
-import java.util.Collections;
-import java.util.List;
+public class LogicalPlanId {
 
-import static io.crate.planner.operators.GroupHashAggregate.approximateDistinctValues;
+    private final String id;
 
-public final class Distinct {
-
-    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, TableStats tableStats, LogicalPlanId id) {
-        if (!distinct) {
-            return source;
-        }
-        long numExpectedRows = approximateDistinctValues(source.numExpectedRows(), tableStats, outputs);
-        return new GroupHashAggregate(id, source, outputs, Collections.emptyList(), numExpectedRows);
+    public LogicalPlanId(String id) {
+        this.id = id;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LogicalPlanId that = (LogicalPlanId) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanIdAllocator.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanIdAllocator.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -21,21 +21,14 @@
 
 package io.crate.planner.operators;
 
-import io.crate.expression.symbol.Symbol;
-import io.crate.statistics.TableStats;
+public class LogicalPlanIdAllocator {
 
-import java.util.Collections;
-import java.util.List;
+    private int nextId;
 
-import static io.crate.planner.operators.GroupHashAggregate.approximateDistinctValues;
+    public LogicalPlanIdAllocator() {}
 
-public final class Distinct {
-
-    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, TableStats tableStats, LogicalPlanId id) {
-        if (!distinct) {
-            return source;
-        }
-        long numExpectedRows = approximateDistinctValues(source.numExpectedRows(), tableStats, outputs);
-        return new GroupHashAggregate(id, source, outputs, Collections.emptyList(), numExpectedRows);
+    public LogicalPlanId nextId() {
+        return new LogicalPlanId(Integer.toString(nextId++));
     }
+
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
@@ -21,9 +21,11 @@
 
 package io.crate.planner.operators;
 
+import io.crate.planner.optimizer.iterative.GroupReference;
+
 public class LogicalPlanVisitor<C, R> {
 
-    protected R visitPlan(LogicalPlan logicalPlan, C context) {
+    public R visitPlan(LogicalPlan logicalPlan, C context) {
         return null;
     }
 
@@ -118,4 +120,9 @@ public class LogicalPlanVisitor<C, R> {
     public R visitCorrelatedJoin(CorrelatedJoin apply, C context) {
         return visitPlan(apply, context);
     }
+
+    public R visitGroupReference(GroupReference apply, C context) {
+        return visitPlan(apply, context);
+    }
+
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -78,31 +78,32 @@ import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.SubqueryPlanner.SubQueries;
 import io.crate.planner.consumer.InsertFromSubQueryPlanner;
 import io.crate.planner.optimizer.Optimizer;
-import io.crate.planner.optimizer.rule.DeduplicateOrder;
-import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
-import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
-import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
-import io.crate.planner.optimizer.rule.MergeFilters;
-import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathNestedLoop;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathHashJoin;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathNestedLoop;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathProjectSet;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathRename;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathUnion;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathWindowAgg;
-import io.crate.planner.optimizer.rule.MoveLimitBeneathEval;
-import io.crate.planner.optimizer.rule.MoveLimitBeneathRename;
-import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
-import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
-import io.crate.planner.optimizer.rule.MoveOrderBeneathRename;
-import io.crate.planner.optimizer.rule.MoveOrderBeneathUnion;
-import io.crate.planner.optimizer.rule.OptimizeCollectWhereClauseAccess;
-import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
-import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
-import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
+import io.crate.planner.optimizer.iterative.IterativeOptimizer;
+import io.crate.planner.optimizer.iterative.rule.DeduplicateOrder;
+import io.crate.planner.optimizer.iterative.rule.MergeAggregateAndCollectToCount;
+import io.crate.planner.optimizer.iterative.rule.MergeAggregateRenameAndCollectToCount;
+import io.crate.planner.optimizer.iterative.rule.MergeFilterAndCollect;
+import io.crate.planner.optimizer.iterative.rule.MergeFilters;
+import io.crate.planner.optimizer.iterative.rule.MoveConstantJoinConditionsBeneathNestedLoop;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathFetchOrEval;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathGroupBy;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathHashJoin;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathNestedLoop;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathOrder;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathProjectSet;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathRename;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathUnion;
+import io.crate.planner.optimizer.iterative.rule.MoveFilterBeneathWindowAgg;
+import io.crate.planner.optimizer.iterative.rule.MoveLimitBeneathEval;
+import io.crate.planner.optimizer.iterative.rule.MoveLimitBeneathRename;
+import io.crate.planner.optimizer.iterative.rule.MoveOrderBeneathFetchOrEval;
+import io.crate.planner.optimizer.iterative.rule.MoveOrderBeneathNestedLoop;
+import io.crate.planner.optimizer.iterative.rule.MoveOrderBeneathRename;
+import io.crate.planner.optimizer.iterative.rule.MoveOrderBeneathUnion;
+import io.crate.planner.optimizer.iterative.rule.OptimizeCollectWhereClauseAccess;
+import io.crate.planner.optimizer.iterative.rule.RemoveRedundantFetchOrEval;
+import io.crate.planner.optimizer.iterative.rule.RewriteFilterOnOuterJoinToInnerJoin;
+import io.crate.planner.optimizer.iterative.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
 import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
@@ -112,7 +113,7 @@ import io.crate.types.DataTypes;
  */
 public class LogicalPlanner {
 
-    private final Optimizer optimizer;
+    private final IterativeOptimizer optimizer;
     private final TableStats tableStats;
     private final Visitor statementVisitor = new Visitor();
     private final Optimizer writeOptimizer;
@@ -121,7 +122,7 @@ public class LogicalPlanner {
     public LogicalPlanner(NodeContext nodeCtx,
                           TableStats tableStats,
                           Supplier<Version> minNodeVersionInCluster) {
-        this.optimizer = new Optimizer(
+        this.optimizer = new IterativeOptimizer(
             nodeCtx,
             minNodeVersionInCluster,
             List.of(

--- a/server/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/server/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -46,20 +46,24 @@ import io.crate.planner.PlannerContext;
 public class MultiPhase extends ForwardingLogicalPlan {
 
     private final Map<LogicalPlan, SelectSymbol> subQueries;
+    private final LogicalPlanId id;
 
-    public static LogicalPlan createIfNeeded(Map<LogicalPlan, SelectSymbol> uncorrelatedSubQueries, LogicalPlan source) {
+    public static LogicalPlan createIfNeeded(Map<LogicalPlan, SelectSymbol> uncorrelatedSubQueries,
+                                             LogicalPlan source,
+                                             LogicalPlanId id) {
         if (uncorrelatedSubQueries.isEmpty()) {
             return source;
         } else {
-            return new MultiPhase(source, uncorrelatedSubQueries);
+            return new MultiPhase(source, uncorrelatedSubQueries, id);
         }
     }
 
-    private MultiPhase(LogicalPlan source, Map<LogicalPlan, SelectSymbol> subQueries) {
-        super(source);
+    private MultiPhase(LogicalPlan source, Map<LogicalPlan, SelectSymbol> subQueries, LogicalPlanId id) {
+        super(id, source);
         HashMap<LogicalPlan, SelectSymbol> allSubQueries = new HashMap<>(source.dependencies());
         allSubQueries.putAll(subQueries);
         this.subQueries = Collections.unmodifiableMap(allSubQueries);
+        this.id = id;
     }
 
     @Override
@@ -79,7 +83,7 @@ public class MultiPhase extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new MultiPhase(Lists2.getOnlyElement(sources), subQueries);
+        return new MultiPhase(Lists2.getOnlyElement(sources), subQueries, id);
     }
 
     @Override
@@ -90,6 +94,10 @@ public class MultiPhase extends ForwardingLogicalPlan {
     @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitMultiPhase(this, context);
+    }
+
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -66,6 +66,7 @@ import io.crate.statistics.TableStats;
 
 public class NestedLoopJoin implements LogicalPlan {
 
+    private final LogicalPlanId id;
     @Nullable
     private final Symbol joinCondition;
     private final AnalyzedRelation topMostLeftRelation;
@@ -80,13 +81,15 @@ public class NestedLoopJoin implements LogicalPlan {
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
     private final boolean joinConditionOptimised;
 
-    NestedLoopJoin(LogicalPlan lhs,
+    NestedLoopJoin(LogicalPlanId id,
+                   LogicalPlan lhs,
                    LogicalPlan rhs,
                    JoinType joinType,
                    @Nullable Symbol joinCondition,
                    boolean isFiltered,
                    AnalyzedRelation topMostLeftRelation,
                    boolean joinConditionOptimised) {
+        this.id = id;
         this.joinType = joinType;
         this.isFiltered = isFiltered || joinCondition != null;
         this.lhs = lhs;
@@ -103,7 +106,8 @@ public class NestedLoopJoin implements LogicalPlan {
         this.joinConditionOptimised = joinConditionOptimised;
     }
 
-    public NestedLoopJoin(LogicalPlan lhs,
+    public NestedLoopJoin(LogicalPlanId id,
+                          LogicalPlan lhs,
                           LogicalPlan rhs,
                           JoinType joinType,
                           @Nullable Symbol joinCondition,
@@ -112,7 +116,7 @@ public class NestedLoopJoin implements LogicalPlan {
                           boolean orderByWasPushedDown,
                           boolean rewriteFilterOnOuterJoinToInnerJoinDone,
                           boolean joinConditionOptimised) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation, joinConditionOptimised);
+        this(id, lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation, joinConditionOptimised);
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
     }
@@ -276,6 +280,7 @@ public class NestedLoopJoin implements LogicalPlan {
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         return new NestedLoopJoin(
+            id,
             sources.get(0),
             sources.get(1),
             joinType,
@@ -306,6 +311,7 @@ public class NestedLoopJoin implements LogicalPlan {
             return this;
         }
         return new NestedLoopJoin(
+            id,
             newLhs,
             newRhs,
             joinType,
@@ -342,6 +348,7 @@ public class NestedLoopJoin implements LogicalPlan {
         return new FetchRewrite(
             allReplacedOutputs,
             new NestedLoopJoin(
+                id,
                 lhsFetchRewrite == null ? lhs : lhsFetchRewrite.newPlan(),
                 rhsFetchRewrite == null ? rhs : rhsFetchRewrite.newPlan(),
                 joinType,
@@ -415,6 +422,11 @@ public class NestedLoopJoin implements LogicalPlan {
             // We don't have any cardinality estimates, so just take the bigger table
             return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
         }
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Order.java
+++ b/server/src/main/java/io/crate/planner/operators/Order.java
@@ -56,16 +56,16 @@ public class Order extends ForwardingLogicalPlan {
     final OrderBy orderBy;
     private final List<Symbol> outputs;
 
-    static LogicalPlan create(LogicalPlan source, @Nullable OrderBy orderBy) {
+    static LogicalPlan create(LogicalPlanId id, LogicalPlan source, @Nullable OrderBy orderBy) {
         if (orderBy == null) {
             return source;
         } else {
-            return new Order(source, orderBy);
+            return new Order(id, source, orderBy);
         }
     }
 
-    public Order(LogicalPlan source, OrderBy orderBy) {
-        super(source);
+    public Order(LogicalPlanId id, LogicalPlan source, OrderBy orderBy) {
+        super(id, source);
         this.outputs = Lists2.concatUnique(source.outputs(), orderBy.orderBySymbols());
         this.orderBy = orderBy;
     }
@@ -100,7 +100,7 @@ public class Order extends ForwardingLogicalPlan {
             return null;
         }
         LogicalPlan newSource = fetchRewrite.newPlan();
-        Order newOrderBy = new Order(newSource, orderBy);
+        Order newOrderBy = new Order(id, newSource, orderBy);
         Map<Symbol, Symbol> replacedOutputs = fetchRewrite.replacedOutputs();
         if (newOrderBy.outputs.size() > newSource.outputs().size()) {
             // This is the case if the `orderBy` contains computations on top of the source outputs.
@@ -181,7 +181,7 @@ public class Order extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Order(Lists2.getOnlyElement(sources), orderBy);
+        return new Order(id, Lists2.getOnlyElement(sources), orderBy);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -52,7 +52,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
     final List<Symbol> standalone;
     private final List<Symbol> outputs;
 
-    static LogicalPlan create(LogicalPlan source, List<Function> tableFunctions) {
+    static LogicalPlan create(LogicalPlanId id, LogicalPlan source, List<Function> tableFunctions) {
         if (tableFunctions.isEmpty()) {
             return source;
         }
@@ -93,13 +93,13 @@ public class ProjectSet extends ForwardingLogicalPlan {
             List<Symbol> standalone = result.outputs().stream()
                 .filter(x -> !(x instanceof Function && ((Function) x).signature().getKind() == FunctionType.TABLE))
                 .collect(Collectors.toList());
-            result = new ProjectSet(result, nestedFunctions.get(i), standalone);
+            result = new ProjectSet(id, result, nestedFunctions.get(i), standalone);
         }
         return result;
     }
 
-    private ProjectSet(LogicalPlan source, List<Function> tableFunctions, List<Symbol> standalone) {
-        super(source);
+    private ProjectSet(LogicalPlanId id, LogicalPlan source, List<Function> tableFunctions, List<Symbol> standalone) {
+        super(id, source);
         this.outputs = Lists2.concat(tableFunctions, standalone);
         this.tableFunctions = tableFunctions;
         this.standalone = standalone;
@@ -164,12 +164,12 @@ public class ProjectSet extends ForwardingLogicalPlan {
         if (newSource == source) {
             return this;
         }
-        return new ProjectSet(newSource, tableFunctions, List.copyOf(newStandalone));
+        return new ProjectSet(id, newSource, tableFunctions, List.copyOf(newStandalone));
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new ProjectSet(Lists2.getOnlyElement(sources), tableFunctions, standalone);
+        return new ProjectSet(id, Lists2.getOnlyElement(sources), tableFunctions, standalone);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -72,8 +72,8 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
     private final FieldResolver fieldResolver;
     final RelationName name;
 
-    public Rename(List<Symbol> outputs, RelationName name, FieldResolver fieldResolver, LogicalPlan source) {
-        super(source);
+    public Rename(LogicalPlanId id, List<Symbol> outputs, RelationName name, FieldResolver fieldResolver, LogicalPlan source) {
+        super(id, source);
         this.outputs = outputs;
         this.name = name;
         this.fieldResolver = fieldResolver;
@@ -123,6 +123,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
             newOutputs.add(childToParentMap.get(sourceOutput));
         }
         return new Rename(
+            id,
             newOutputs,
             name,
             fieldResolver,
@@ -178,7 +179,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
             );
             replacedOutputs.put(parentSymbolForKey, convertChildrenToScopedSymbols.apply(value));
         }
-        Rename newRename = new Rename(newOutputs, name, fieldResolver, newSource);
+        Rename newRename = new Rename(id, newOutputs, name, fieldResolver, newSource);
         return new FetchRewrite(replacedOutputs, newRename);
     }
 
@@ -199,7 +200,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Rename(outputs, name, fieldResolver, Lists2.getOnlyElement(sources));
+        return new Rename(id, outputs, name, fieldResolver, Lists2.getOnlyElement(sources));
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -58,7 +58,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
         TableFunction tableFunction = captures.get(this.capture);
         var relation = tableFunction.relation();
         if (relation.function().name().equals(ValuesFunction.NAME)) {
-            return new InsertFromValues(tableFunction.relation(), plan.columnIndexWriterProjection());
+            return new InsertFromValues(txnCtx.idAllocator().nextId(), tableFunction.relation(), plan.columnIndexWriterProjection());
         } else {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -42,8 +42,8 @@ import io.crate.planner.PlannerContext;
  */
 public class RootRelationBoundary extends ForwardingLogicalPlan {
 
-    public RootRelationBoundary(LogicalPlan source) {
-        super(source);
+    public RootRelationBoundary(LogicalPlanId id, LogicalPlan source) {
+        super(id, source);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class RootRelationBoundary extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new RootRelationBoundary(Lists2.getOnlyElement(sources));
+        return new RootRelationBoundary(id, Lists2.getOnlyElement(sources));
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/StatementClassifier.java
+++ b/server/src/main/java/io/crate/planner/operators/StatementClassifier.java
@@ -107,7 +107,7 @@ public final class StatementClassifier extends LogicalPlanVisitor<Set<String>, V
     }
 
     @Override
-    protected Void visitPlan(LogicalPlan logicalPlan, Set<String> context) {
+    public Void visitPlan(LogicalPlan logicalPlan, Set<String> context) {
         for (var source : logicalPlan.sources()) {
             source.accept(this, context);
         }

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -53,15 +53,17 @@ import java.util.Set;
 
 public final class TableFunction implements LogicalPlan {
 
+    private final LogicalPlanId id;
     private final TableFunctionRelation relation;
     private final List<Symbol> toCollect;
     final WhereClause where;
 
-    public static LogicalPlan create(TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
-        return new TableFunction(relation, toCollect, where);
+    public static LogicalPlan create(LogicalPlanId id, TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
+        return new TableFunction(id, relation, toCollect, where);
     }
 
-    public TableFunction(TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
+    public TableFunction(LogicalPlanId id, TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
+        this.id = id;
         this.relation = relation;
         this.toCollect = toCollect;
         this.where = where;
@@ -145,7 +147,7 @@ public final class TableFunction implements LogicalPlan {
         if (outputsToKeep.containsAll(toCollect)) {
             return this;
         }
-        return new TableFunction(relation, List.copyOf(outputsToKeep), where);
+        return new TableFunction(id, relation, List.copyOf(outputsToKeep), where);
     }
 
     @Override
@@ -156,6 +158,11 @@ public final class TableFunction implements LogicalPlan {
     @Override
     public long numExpectedRows() {
         return -1;
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -70,13 +70,15 @@ import io.crate.types.DataTypes;
  */
 public class Union implements LogicalPlan {
 
+    private final LogicalPlanId id;
     private final List<Symbol> outputs;
     final LogicalPlan lhs;
     final LogicalPlan rhs;
     private final Map<LogicalPlan, SelectSymbol> dependencies;
 
 
-    public Union(LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
+    public Union(LogicalPlanId id, LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
+        this.id = id;
         this.lhs = lhs;
         this.rhs = rhs;
         this.outputs = outputs;
@@ -203,7 +205,7 @@ public class Union implements LogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Union(sources.get(0), sources.get(1), outputs);
+        return new Union(id, sources.get(0), sources.get(1), outputs);
     }
 
     @Override
@@ -229,7 +231,12 @@ public class Union implements LogicalPlan {
         if (newLhs == lhs && newRhs == rhs) {
             return this;
         }
-        return new Union(newLhs, newRhs, newOutputs);
+        return new Union(id, newLhs, newRhs, newOutputs);
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -67,7 +67,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
     private final List<Symbol> outputs;
 
     @VisibleForTesting
-    public static LogicalPlan create(LogicalPlan source, List<WindowFunction> windowFunctions) {
+    public static LogicalPlan create(LogicalPlanIdAllocator idAllocator, LogicalPlan source, List<WindowFunction> windowFunctions) {
         if (windowFunctions.isEmpty()) {
             return source;
         }
@@ -88,15 +88,15 @@ public class WindowAgg extends ForwardingLogicalPlan {
             WindowDefinition windowDefinition = entry.getKey();
             OrderBy orderBy = windowDefinition.orderBy();
             if (orderBy == null || lastWindowAgg.outputs().containsAll(orderBy.orderBySymbols())) {
-                lastWindowAgg = new WindowAgg(lastWindowAgg, windowDefinition, functions, lastWindowAgg.outputs());
+                lastWindowAgg = new WindowAgg(lastWindowAgg, windowDefinition, functions, lastWindowAgg.outputs(), idAllocator.nextId());
             } else {
                 // ``WindowProjector.createUpdateProbeValueFunction` expects that all OrderBY symbols are `InputColumn`
                 // Here we have a case where there is a function or something in the orderBy expression that is *not*
                 // already provided by the source.
                 // -> Inject `eval` so that the `orderBy` of the window-function will turn into a `InputColumn`
                 Eval eval = new Eval(
-                    lastWindowAgg, Lists2.concatUnique(lastWindowAgg.outputs(), orderBy.orderBySymbols()));
-                lastWindowAgg = new WindowAgg(eval, windowDefinition, functions, eval.outputs());
+                    idAllocator.nextId(), lastWindowAgg, Lists2.concatUnique(lastWindowAgg.outputs(), orderBy.orderBySymbols()));
+                lastWindowAgg = new WindowAgg(eval, windowDefinition, functions, eval.outputs(), idAllocator.nextId());
             }
         }
         return lastWindowAgg;
@@ -105,8 +105,10 @@ public class WindowAgg extends ForwardingLogicalPlan {
     private WindowAgg(LogicalPlan source,
                       WindowDefinition windowDefinition,
                       List<WindowFunction> windowFunctions,
-                      List<Symbol> standalone) {
-        super(source);
+                      List<Symbol> standalone,
+                      LogicalPlanId id
+    ) {
+        super(id, source);
         this.outputs = Lists2.concat(standalone, windowFunctions);
         this.windowDefinition = windowDefinition;
         this.windowFunctions = windowFunctions;
@@ -131,7 +133,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
         if (newWindowFunctions.isEmpty()) {
             return newSource;
         } else {
-            return new WindowAgg(newSource, windowDefinition, List.copyOf(newWindowFunctions), newSource.outputs());
+            return new WindowAgg(newSource, windowDefinition, List.copyOf(newWindowFunctions), newSource.outputs(), id);
         }
     }
 
@@ -246,7 +248,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new WindowAgg(Lists2.getOnlyElement(sources), windowDefinition, windowFunctions, standalone);
+        return new WindowAgg(Lists2.getOnlyElement(sources), windowDefinition, windowFunctions, standalone, id);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanId;
+import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.planner.operators.PlanHint;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.statistics.TableStats;
+
+/**
+ *
+ */
+public class GroupReference implements LogicalPlan {
+
+    private final LogicalPlanId id;
+    private final int groupId;
+    private final List<Symbol> outputs;
+
+    public GroupReference(LogicalPlanId id, int groupId, List<Symbol> outputs) {
+        this.id = id;
+        this.groupId = groupId;
+        this.outputs = List.copyOf(outputs);
+    }
+
+    public int groupId() {
+        return groupId;
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of();
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return this;
+    }
+
+    @Override
+    public LogicalPlanId id() {
+        return id;
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<LogicalPlan, SelectSymbol> dependencies() {
+        return Map.of();
+    }
+
+    @Override
+    public long numExpectedRows() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long estimatedRowSize() {
+        return 0;
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitGroupReference(this, context);
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
+    }
+
+
+    @Override
+    public ExecutionPlan build(DependencyCarrier dependencyCarrier,
+                               PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
+                               ProjectionBuilder projectionBuilder,
+                               int limit,
+                               int offset,
+                               @Nullable OrderBy order,
+                               @Nullable Integer pageSizeHint,
+                               Row params,
+                               SubQueryResults subQueryResults) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public List<AbstractTableRelation<?>> baseTables() {
+        return List.of();
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReferenceResolver.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReferenceResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import java.util.function.Function;
+
+import io.crate.planner.operators.LogicalPlan;
+
+/**
+ *
+ */
+public interface GroupReferenceResolver {
+
+    LogicalPlan apply(LogicalPlan node);
+
+    static GroupReferenceResolver from(Function<GroupReference, LogicalPlan> resolver) {
+        return node -> {
+            if (!(node instanceof GroupReference)) {
+                throw new IllegalStateException("Node is not a GroupReference");
+            }
+            return resolver.apply((GroupReference) node);
+        };
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.elasticsearch.Version;
+
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Match;
+import io.crate.statistics.TableStats;
+
+public class IterativeOptimizer {
+
+    private final List<Rule<?>> rules;
+    private final Supplier<Version> minNodeVersionInCluster;
+    private final NodeContext nodeCtx;
+
+    public IterativeOptimizer(NodeContext nodeCtx, Supplier<Version> minNodeVersionInCluster, List<Rule<?>> rules) {
+        this.rules = rules;
+        this.minNodeVersionInCluster = minNodeVersionInCluster;
+        this.nodeCtx = nodeCtx;
+    }
+
+    public LogicalPlan optimize(LogicalPlan plan, TableStats tableStats, CoordinatorTxnCtx txnCtx) {
+
+        Memo memo = new Memo(txnCtx.idAllocator(), plan);
+
+        GroupReferenceResolver lookup = node -> {
+            if (node instanceof GroupReference) {
+                return memo.resolve(((GroupReference) node).groupId());
+            }
+            // not a group reference, return same node
+            return node;
+        };
+
+        exploreGroup(memo.getRootGroup(), new Context(memo, lookup, txnCtx, tableStats));
+
+        return memo.extract();
+    }
+
+    private boolean exploreGroup(int group, Context context) {
+        // tracks whether this group or any children groups change as
+        // this method executes
+        boolean progress = exploreNode(group, context);
+
+        while (exploreChildren(group, context)) {
+            progress = true;
+            // if children changed, try current group again
+            // in case we can match additional rules
+            if (!exploreNode(group, context)) {
+                // no additional matches, so bail out
+                break;
+            }
+        }
+        return progress;
+    }
+
+    private boolean exploreNode(int group, Context context) {
+        var node = context.memo().resolve(group);
+
+        var done = false;
+        var progress = false;
+        var minVersion = minNodeVersionInCluster.get();
+        while (!done) {
+            done = true;
+            for (Rule rule : rules) {
+                if (minVersion.before(rule.requiredVersion())) {
+                    continue;
+                }
+                Match<?> match = rule.pattern().accept(node, Captures.empty(), context.lookup);
+                if (match.isPresent()) {
+                    @SuppressWarnings("unchecked")
+                    LogicalPlan transformed = rule.apply(node,
+                                                         match.captures(),
+                                                         context.tableStats(),
+                                                         context.txnCtx,
+                                                         nodeCtx,
+                                                         context.lookup
+                    );
+                    if (transformed != null) {
+                        context.memo().replace(group, transformed);
+                        node = transformed;
+                        done = false;
+                        progress = true;
+                    }
+                }
+            }
+        }
+
+        return progress;
+    }
+
+    private boolean exploreChildren(int group, Context context) {
+        boolean progress = false;
+
+        LogicalPlan expression = context.memo().resolve(group);
+        for (LogicalPlan child : expression.sources()) {
+            if (!(child instanceof GroupReference)) {
+                throw new IllegalStateException("Expected child to be a group reference. Found: " + child.getClass().getName());
+            }
+            if (exploreGroup(((GroupReference) child).groupId(), context)) {
+                progress = true;
+            }
+        }
+
+        return progress;
+    }
+
+    private static class Context {
+        private final Memo memo;
+        private final GroupReferenceResolver lookup;
+        private final CoordinatorTxnCtx txnCtx;
+        private final TableStats tableStats;
+
+        public Context(Memo memo, GroupReferenceResolver lookup, CoordinatorTxnCtx txnCtx, TableStats tableStats) {
+            this.memo = memo;
+            this.lookup = lookup;
+            this.txnCtx = txnCtx;
+            this.tableStats = tableStats;
+        }
+
+        public Memo memo() {
+            return memo;
+        }
+
+        public GroupReferenceResolver lookup() {
+            return lookup;
+        }
+
+        public TableStats tableStats() {
+            return tableStats;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
+import io.crate.planner.operators.LogicalPlanVisitor;
+
+/**
+ * Stores a plan in a form that's efficient to mutate locally (i.e. without
+ * having to do full ancestor tree rewrites due to plan nodes being immutable).
+ * <p>
+ * Each node in a plan is placed in a group, and it's children are replaced with
+ * symbolic references to the corresponding groups.
+ * <p>
+ * For example, a plan like:
+ * <pre>
+ *    A -> B -> C -> D
+ *           \> E -> F
+ * </pre>
+ * would be stored as:
+ * <pre>
+ * root: G0
+ *
+ * G0 : { A -> G1 }
+ * G1 : { B -> [G2, G3] }
+ * G2 : { C -> G4 }
+ * G3 : { E -> G5 }
+ * G4 : { D }
+ * G5 : { F }
+ * </pre>
+ * Groups are reference-counted, and groups that become unreachable from the root
+ * due to mutations in a subtree get garbage-collected.
+ */
+public class Memo {
+    private static final int ROOT_GROUP_REF = 0;
+
+    private final LogicalPlanIdAllocator idAllocator;
+    private final int rootGroup;
+
+    private final Map<Integer, Group> groups = new HashMap<>();
+
+    private int nextGroupId = ROOT_GROUP_REF + 1;
+
+    public Memo(LogicalPlanIdAllocator idAllocator, LogicalPlan plan) {
+        this.idAllocator = idAllocator;
+        rootGroup = insertRecursive(plan);
+        groups.get(rootGroup).incomingReferences.add(ROOT_GROUP_REF);
+    }
+
+    public int getRootGroup() {
+        return rootGroup;
+    }
+
+    public LogicalPlan resolve(int group) {
+        return group(group).membership;
+    }
+
+    public LogicalPlan resolve(GroupReference groupReference) {
+        return resolve(groupReference.groupId());
+    }
+
+    public LogicalPlan extract() {
+        return extract(resolve(rootGroup));
+    }
+
+    private LogicalPlan extract(LogicalPlan node) {
+        return resolveGroupReferences(node, GroupReferenceResolver.from(this::resolve));
+    }
+
+    private Group group(int group) {
+        if (!groups.containsKey(group)) {
+            throw new IllegalStateException();
+        }
+        return groups.get(group);
+    }
+
+    public LogicalPlan replace(int groupId, LogicalPlan node) {
+        Group group = group(groupId);
+        final LogicalPlan old = group.membership;
+
+        if (node instanceof GroupReference) {
+            node = resolve(((GroupReference) node).groupId());
+        } else {
+            node = insertChildrenAndRewrite(node);
+        }
+
+        incrementReferenceCounts(node, groupId);
+        group.membership = node;
+        decrementReferenceCounts(old, groupId);
+        return node;
+    }
+
+    private void incrementReferenceCounts(LogicalPlan fromNode, int fromGroup) {
+        Set<Integer> references = allReferences(fromNode);
+        for (int group : references) {
+            groups.get(group).incomingReferences.add(fromGroup);
+        }
+    }
+
+    private void decrementReferenceCounts(LogicalPlan fromNode, Integer fromGroup) {
+        Set<Integer> references = allReferences(fromNode);
+
+        for (int group : references) {
+            Group childGroup = groups.get(group);
+            if (!childGroup.incomingReferences.remove(fromGroup)) {
+                throw new IllegalStateException("Reference to remove not found");
+            }
+            ;
+            if (childGroup.incomingReferences.isEmpty()) {
+                deleteGroup(group);
+            }
+        }
+    }
+
+    private Set<Integer> allReferences(LogicalPlan node) {
+        return node.sources().stream()
+            .map(GroupReference.class::cast)
+            .map(GroupReference::groupId)
+            .collect(Collectors.toSet());
+    }
+
+    private void deleteGroup(int group) {
+        LogicalPlan deletedNode = groups.remove(group).membership;
+        decrementReferenceCounts(deletedNode, group);
+    }
+
+    private LogicalPlan insertChildrenAndRewrite(LogicalPlan node) {
+        return node.replaceSources(
+            node.sources().stream()
+                .map(child -> new GroupReference(
+                    idAllocator.nextId(),
+                    insertRecursive(child),
+                    child.outputs()))
+                .collect(Collectors.toList()));
+    }
+
+    private int insertRecursive(LogicalPlan node) {
+        if (node instanceof GroupReference) {
+            return ((GroupReference) node).groupId();
+        }
+
+        int group = nextGroupId();
+        LogicalPlan rewritten = insertChildrenAndRewrite(node);
+
+        groups.put(group, Group.withMember(rewritten));
+        incrementReferenceCounts(rewritten, group);
+
+        return group;
+    }
+
+    private int nextGroupId() {
+        return nextGroupId++;
+    }
+
+    public int groupCount() {
+        return groups.size();
+    }
+
+    private static final class Group {
+        static Group withMember(LogicalPlan member) {
+            return new Group(member);
+        }
+
+        private LogicalPlan membership;
+        private final List<Integer> incomingReferences = new ArrayList<>();
+
+        private Group(LogicalPlan member) {
+            this.membership = requireNonNull(member, "member is null");
+        }
+    }
+
+    public static LogicalPlan resolveGroupReferences(LogicalPlan node, GroupReferenceResolver lookup) {
+        requireNonNull(node, "node is null");
+        return node.accept(new ResolvingVisitor(lookup), null);
+    }
+
+    private static class ResolvingVisitor extends LogicalPlanVisitor<Void, LogicalPlan> {
+        private final GroupReferenceResolver lookup;
+
+        public ResolvingVisitor(GroupReferenceResolver lookup) {
+            this.lookup = requireNonNull(lookup, "lookup is null");
+        }
+
+        @Override
+        public LogicalPlan visitPlan(LogicalPlan node, Void context) {
+            List<LogicalPlan> children = node.sources().stream()
+                .map(child -> child.accept(this, context))
+                .collect(Collectors.toList());
+
+            return node.replaceSources(children);
+        }
+
+        @Override
+        public LogicalPlan visitGroupReference(GroupReference node, Void context) {
+            return lookup.apply(node).accept(this, context);
+        }
+    }
+}
+

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Rule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import org.elasticsearch.Version;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public interface Rule<T> {
+
+    Pattern<T> pattern();
+
+    LogicalPlan apply(T plan,
+                      Captures captures,
+                      TableStats tableStats,
+                      TransactionContext txnCtx,
+                      NodeContext nodeCtx,
+                      GroupReferenceResolver lookup);
+
+    /**
+     * @return The version all nodes in the cluster must have to be able to use this optimization.
+     */
+    default Version requiredVersion() {
+        return Version.V_4_0_0;
+    }
+
+}
+

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Capture.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Capture.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+public class Capture<T> {
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/CapturePattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/CapturePattern.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+class CapturePattern<T> extends Pattern<T> {
+
+    private final Capture<T> capture;
+    private final Pattern<T> pattern;
+
+    CapturePattern(Capture<T> capture, Pattern<T> pattern) {
+        this.capture = capture;
+        this.pattern = pattern;
+    }
+
+
+    @Override
+    public Match<T> accept(Object object, Captures captures, GroupReferenceResolver lookup) {
+        Match<T> match = pattern.accept(object, captures, lookup);
+        return match.flatMap(val -> Match.of(val, captures.add(Captures.of(capture, val))));
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Captures.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Captures.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+
+import java.util.NoSuchElementException;
+
+public class Captures {
+
+    private static final Captures NIL = new Captures(null, null, null);
+
+    private final Capture<?> capture;
+    private final Object value;
+    private final Captures tail;
+
+    private Captures(Capture<?> capture, Object value, Captures tail) {
+        this.capture = capture;
+        this.value = value;
+        this.tail = tail;
+    }
+
+    public static Captures empty() {
+        return NIL;
+    }
+
+    public static <T> Captures of(Capture<T> capture, T value) {
+        return new Captures(capture, value, NIL);
+    }
+
+    public <T> T get(Capture<T> capture) {
+        if (this.equals(NIL)) {
+            throw new NoSuchElementException("Requested value for unknown Capture");
+        } else if (this.capture.equals(capture)) {
+            return (T) value;
+        } else {
+            return tail.get(capture);
+        }
+    }
+
+    public Captures add(Captures other) {
+        if (this.equals(NIL)) {
+            return other;
+        } else {
+            return new Captures(capture, value, tail.add(other));
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Match.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Match.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+public abstract class Match<T> {
+
+    public static <T> Match<T> of(T value, Captures captures) {
+        return new Present<>(value, captures);
+    }
+
+    public static <T> Match<T> empty() {
+        //noinspection unchecked
+        return (Match<T>) Empty.INSTANCE;
+    }
+
+    public abstract Captures captures();
+
+    public abstract boolean isPresent();
+
+    public abstract T value();
+
+    public abstract <U> Match<U> map(Function<? super T, ? extends U> mapper);
+
+    public abstract <U> Match<U> flatMap(Function<? super T, Match<U>> mapper);
+
+    static class Present<T> extends Match<T> {
+
+        private final T value;
+        private final Captures captures;
+
+        Present(T value, Captures captures) {
+            this.value = value;
+            this.captures = captures;
+        }
+
+        @Override
+        public Captures captures() {
+            return captures;
+        }
+
+        @Override
+        public boolean isPresent() {
+            return true;
+        }
+
+        @Override
+        public T value() {
+            return value;
+        }
+
+        @Override
+        public <U> Match<U> map(Function<? super T, ? extends U> mapper) {
+            return Match.of(mapper.apply(value), captures);
+        }
+
+        @Override
+        public <U> Match<U> flatMap(Function<? super T, Match<U>> mapper) {
+            return mapper.apply(value);
+        }
+    }
+
+    static class Empty<T> extends Match<T> {
+
+        static final Empty INSTANCE = new Empty<>();
+
+        @Override
+        public Captures captures() {
+            return Captures.empty();
+        }
+
+        @Override
+        public boolean isPresent() {
+            return false;
+        }
+
+        @Override
+        public T value() {
+            throw new NoSuchElementException("Empty match contains no value");
+        }
+
+        @Override
+        public <U> Match<U> map(Function<? super T, ? extends U> mapper) {
+            return empty();
+        }
+
+        @Override
+        public <U> Match<U> flatMap(Function<? super T, Match<U>> mapper) {
+            return empty();
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Pattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Pattern.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+public abstract class Pattern<T> {
+
+    public static <T> Pattern<T> typeOf(Class<T> expectedClass) {
+        return new TypeOfPattern<>(expectedClass);
+    }
+
+    public <U, V> Pattern<T> with(BiFunction<? super T, GroupReferenceResolver, Optional<U>> getProperty, Pattern<V> propertyPattern) {
+        return new WithPattern<>(this, getProperty, propertyPattern);
+    }
+
+    public Pattern<T> with(Predicate<? super T> propertyPredicate) {
+        return new WithPropertyPattern<>(this, propertyPredicate);
+    }
+
+    public Pattern<T> capturedAs(Capture<T> capture) {
+        return new CapturePattern<>(capture, this);
+    }
+
+    public abstract Match<T> accept(Object object, Captures captures, GroupReferenceResolver lookup);
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Patterns.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/Patterns.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public final class Patterns {
+
+    private Patterns() {
+    }
+
+    public static BiFunction<LogicalPlan, GroupReferenceResolver, Optional<LogicalPlan>> source() {
+        return (plan, resolver) -> {
+            return plan.sources().size() == 1
+                ? Optional.of(resolver.apply(plan.sources().get(0)))
+                : Optional.empty();
+        };
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/TypeOfPattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/TypeOfPattern.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+class TypeOfPattern<T> extends Pattern<T> {
+
+    private Class<T> expectedClass;
+
+    TypeOfPattern(Class<T> expectedClass) {
+        this.expectedClass = expectedClass;
+    }
+
+    @Override
+    public Match<T> accept(Object object, Captures captures, GroupReferenceResolver lookup) {
+        if (expectedClass.isInstance(object)) {
+            return Match.of(expectedClass.cast(object), captures);
+        } else {
+            return Match.empty();
+        }
+    }
+}
+

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/WithPattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/WithPattern.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+class WithPattern<T, U, V> extends Pattern<T> {
+
+    private final Pattern<T> firstPattern;
+    private final BiFunction<? super T, GroupReferenceResolver, Optional<U>> getProperty;
+    private final Pattern<V> propertyPattern;
+
+    WithPattern(Pattern<T> firstPattern, BiFunction<? super T, GroupReferenceResolver, Optional<U>> getProperty, Pattern<V> propertyPattern) {
+        this.firstPattern = firstPattern;
+        this.getProperty = getProperty;
+        this.propertyPattern = propertyPattern;
+    }
+
+    @Override
+    public Match<T> accept(Object object, Captures captures, GroupReferenceResolver lookup) {
+        Match<T> match = firstPattern.accept(object, captures, lookup);
+        return match.flatMap(matchedValue -> {
+            Optional<?> optProperty = getProperty.apply(matchedValue, lookup);
+            Match<V> propertyMatch = optProperty
+                .map(property -> propertyPattern.accept(property, match.captures(), lookup))
+                .orElse(Match.empty());
+            return propertyMatch.map(ignored -> match.value());
+        });
+    }
+
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/WithPropertyPattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/matcher/WithPropertyPattern.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.matcher;
+
+import java.util.function.Predicate;
+
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+public class WithPropertyPattern<T> extends Pattern<T> {
+
+    private final Pattern<T> pattern;
+    private final Predicate<? super T> propertyPredicate;
+
+    WithPropertyPattern(Pattern<T> pattern, Predicate<? super T> propertyPredicate) {
+        this.pattern = pattern;
+        this.propertyPredicate = propertyPredicate;
+    }
+
+    @Override
+    public Match<T> accept(Object object, Captures captures, GroupReferenceResolver lookup) {
+        Match<T> match = pattern.accept(object, captures, lookup);
+        return match.flatMap(matchedValue -> {
+            if (propertyPredicate.test(matchedValue)) {
+                return match;
+            } else {
+                return Match.empty();
+            }
+        });
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/DeduplicateOrder.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+/**
+ * Transforms
+ * <pre>
+ * OrderA
+ *  - OrderB
+ * </pre>
+ * into
+ * <pre>
+ * OrderA
+ * </pre>
+ *
+ * The OrderB is redundant and would get re-sorted into OrderA
+ */
+public final class DeduplicateOrder implements Rule<Order> {
+
+    private final Capture<Order> childOrder;
+    private final Pattern<Order> pattern;
+
+    public DeduplicateOrder() {
+        this.childOrder = new Capture<>();
+        this.pattern = typeOf(Order.class)
+            .with(source(), typeOf(Order.class).capturedAs(childOrder));
+    }
+
+    @Override
+    public Pattern<Order> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Order plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Order childOrder = captures.get(this.childOrder);
+        return plan.replaceSources(childOrder.sources());
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/FilterOnJoinsUtil.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/FilterOnJoinsUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+final class FilterOnJoinsUtil {
+
+    private FilterOnJoinsUtil() {
+    }
+
+    static LogicalPlan getNewSource(@Nullable Symbol splitQuery,
+                                    LogicalPlan source,
+                                    LogicalPlanIdAllocator idAllocator,
+                                    GroupReferenceResolver resolver) {
+        LogicalPlan newSource = resolver.apply(source);
+        return splitQuery == null ? newSource : new Filter(idAllocator.nextId(), newSource, splitQuery);
+    }
+
+    static LogicalPlan moveQueryBelowJoin(Symbol query, LogicalPlan join, LogicalPlanIdAllocator idAllocator, GroupReferenceResolver resolver) {
+        if (!WhereClause.canMatch(query)) {
+            return join.replaceSources(List.of(
+                getNewSource(query, resolver.apply(join.sources().get(0)), idAllocator, resolver),
+                getNewSource(query, resolver.apply(join.sources().get(1)), idAllocator, resolver)
+            ));
+        }
+        Map<Set<RelationName>, Symbol> splitQuery = QuerySplitter.split(query);
+        int initialParts = splitQuery.size();
+        if (splitQuery.size() == 1 && splitQuery.keySet().iterator().next().size() > 1) {
+            return null;
+        }
+        assert join.sources().size() == 2 : "Join operator must only have 2 children, LHS and RHS";
+        LogicalPlan lhs = resolver.apply(join.sources().get(0));
+        LogicalPlan rhs = resolver.apply(join.sources().get(1));
+        Set<RelationName> leftName = lhs.getRelationNames();
+        Set<RelationName> rightName = rhs.getRelationNames();
+        Symbol queryForLhs = splitQuery.remove(leftName);
+        Symbol queryForRhs = splitQuery.remove(rightName);
+        LogicalPlan newLhs = getNewSource(queryForLhs, lhs, idAllocator, resolver);
+        LogicalPlan newRhs = getNewSource(queryForRhs, rhs, idAllocator, resolver);
+        LogicalPlan newJoin = join.replaceSources(List.of(newLhs, newRhs));
+        if (splitQuery.isEmpty()) {
+            return newJoin;
+        } else if (initialParts == splitQuery.size()) {
+            return null;
+        } else {
+            return new Filter(idAllocator.nextId(), newJoin, AndOperator.join(splitQuery.values()));
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeAggregateAndCollectToCount.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import io.crate.common.collections.Lists2;
+import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Count;
+import io.crate.planner.operators.HashAggregate;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate> {
+
+    private final Capture<Collect> collectCapture;
+    private final Pattern<HashAggregate> pattern;
+
+    public MergeAggregateAndCollectToCount() {
+        this.collectCapture = new Capture<>();
+        this.pattern = typeOf(HashAggregate.class)
+            .with(source(), typeOf(Collect.class).capturedAs(collectCapture)
+                .with(collect -> collect.relation().tableInfo() instanceof DocTableInfo))
+            .with(aggregate ->
+                      aggregate.aggregates().size() == 1
+                      && aggregate.aggregates().get(0).signature().equals(CountAggregation.COUNT_STAR_SIGNATURE));
+    }
+
+    @Override
+    public Pattern<HashAggregate> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(HashAggregate aggregate,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Collect collect = captures.get(collectCapture);
+        var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
+        if (countAggregate.filter() != null) {
+            return new Count(
+                txnCtx.idAllocator().nextId(),
+                countAggregate,
+                collect.relation(),
+                collect.where().add(countAggregate.filter()));
+        } else {
+            return new Count(txnCtx.idAllocator().nextId(), countAggregate, collect.relation(), collect.where());
+        }
+    }
+
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeAggregateRenameAndCollectToCount.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import io.crate.common.collections.Lists2;
+import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.expression.symbol.FieldReplacer;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Count;
+import io.crate.planner.operators.HashAggregate;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Rename;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate> {
+
+    private final Capture<Collect> collectCapture;
+    private final Capture<Rename> renameCapture;
+    private final Pattern<HashAggregate> pattern;
+
+    public MergeAggregateRenameAndCollectToCount() {
+        this.collectCapture = new Capture<>();
+        this.renameCapture = new Capture<>();
+        this.pattern = typeOf(HashAggregate.class)
+            .with(
+                source(),
+                typeOf(Rename.class).capturedAs(renameCapture)
+                    .with(
+                        source(),
+                        typeOf(Collect.class)
+                            .capturedAs(collectCapture)
+                            .with(collect -> collect.relation().tableInfo() instanceof DocTableInfo)
+                    )
+            )
+            .with(aggregate ->
+                      aggregate.aggregates().size() == 1
+                      && aggregate.aggregates().get(0).signature().equals(CountAggregation.COUNT_STAR_SIGNATURE));
+    }
+
+    @Override
+    public Pattern<HashAggregate> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(HashAggregate aggregate,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Collect collect = captures.get(collectCapture);
+        Rename rename = captures.get(renameCapture);
+        var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
+        var filter = countAggregate.filter();
+        if (filter != null) {
+            var mappedFilter = FieldReplacer.replaceFields(filter, rename::resolveField);
+            return new Count(
+                txnCtx.idAllocator().nextId(),
+                countAggregate,
+                collect.relation(),
+                collect.where().add(mappedFilter));
+        } else {
+            return new Count(txnCtx.idAllocator().nextId(), countAggregate, collect.relation(), collect.where());
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeFilterAndCollect.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import io.crate.analyze.WhereClause;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.planner.selectivity.SelectivityFunctions;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+
+public class MergeFilterAndCollect implements Rule<Filter> {
+
+    private final Capture<Collect> collectCapture;
+    private final Pattern<Filter> pattern;
+
+    public MergeFilterAndCollect() {
+        this.collectCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Collect.class).capturedAs(collectCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Collect collect = captures.get(collectCapture);
+        Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
+        WhereClause newWhere = collect.where().add(filter.query());
+        return new Collect(
+            collect.id(),
+            collect.relation(),
+            collect.outputs(),
+            newWhere,
+            SelectivityFunctions.estimateNumRows(stats, newWhere.queryOrFallback(), null),
+            stats.averageSizePerRowInBytes()
+        );
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MergeFilters.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+/**
+ * Transforms
+ * <pre>
+ * - Filter
+ *   - Filter
+ *     - Source
+ * </pre>
+ * into
+ * <pre>
+ * - Filter
+ *   - Source
+ * </pre>
+ *
+ * By merging the conditions of both filters
+ */
+public class MergeFilters implements Rule<Filter> {
+
+    private final Capture<Filter> child;
+    private final Pattern<Filter> pattern;
+
+    public MergeFilters() {
+        child = new Capture<>();
+        pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Filter.class).capturedAs(child));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Filter childFilter = captures.get(child);
+        Symbol parentQuery = plan.query();
+        Symbol childQuery = childFilter.query();
+        return new Filter(plan.id(), childFilter.source(), AndOperator.of(parentQuery, childQuery));
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.rule.FilterOnJoinsUtil.getNewSource;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.consumer.RelationNameCollector;
+import io.crate.planner.node.dql.join.JoinType;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedLoopJoin> {
+
+    private final Pattern<NestedLoopJoin> pattern;
+
+    public MoveConstantJoinConditionsBeneathNestedLoop() {
+        this.pattern = typeOf(NestedLoopJoin.class)
+            .with(nl -> nl.joinType() == JoinType.INNER &&
+                        !nl.isJoinConditionOptimised() &&
+                        nl.joinCondition() != null);
+    }
+
+    @Override
+    public Pattern<NestedLoopJoin> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(NestedLoopJoin nl,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        var conditions = nl.joinCondition();
+        var allConditions = QuerySplitter.split(conditions);
+        var constantConditions = new HashMap<Set<RelationName>, Symbol>(allConditions.size());
+        var nonConstantConditions = new HashSet<Symbol>(allConditions.size());
+        for (var condition : allConditions.entrySet()) {
+            if (numberOfRelationsUsed(condition.getValue()) <= 1) {
+                constantConditions.put(condition.getKey(), condition.getValue());
+            } else {
+                nonConstantConditions.add(condition.getValue());
+            }
+        }
+        if (constantConditions.isEmpty() || nonConstantConditions.isEmpty()) {
+            // Nothing to optimize, just mark nestedLoopJoin to skip the rule the next time
+            return new NestedLoopJoin(
+                nl.id(),
+                nl.lhs(),
+                nl.rhs(),
+                nl.joinType(),
+                nl.joinCondition(),
+                nl.isFiltered(),
+                nl.topMostLeftRelation(),
+                nl.orderByWasPushedDown(),
+                nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
+                true // Mark joinConditionOptimised = true
+            );
+        } else {
+            // Push constant join condition down to source
+            var lhs = resolver.apply(nl.lhs());
+            var rhs = resolver.apply(nl.rhs());
+            var queryForLhs = constantConditions.remove(lhs.getRelationNames());
+            var queryForRhs = constantConditions.remove(rhs.getRelationNames());
+            var newLhs = getNewSource(queryForLhs, lhs, txnCtx.idAllocator(), resolver);
+            var newRhs = getNewSource(queryForRhs, rhs, txnCtx.idAllocator(), resolver);
+            return new HashJoin(
+                txnCtx.idAllocator().nextId(),
+                newLhs,
+                newRhs,
+                AndOperator.join(nonConstantConditions)
+            );
+        }
+    }
+
+    private static int numberOfRelationsUsed(Symbol joinCondition) {
+        return RelationNameCollector.collect(joinCondition).size();
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathFetchOrEval.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import java.util.List;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
+
+    private final Capture<Eval> fetchOrEvalCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathFetchOrEval() {
+        this.fetchOrEvalCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Eval.class).capturedAs(fetchOrEvalCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Eval eval = captures.get(fetchOrEvalCapture);
+        List<Symbol> outputsOfFetchSource = resolver.apply(eval.source()).outputs();
+        if (outputsOfFetchSource.containsAll(extractColumns(plan.query()))) {
+            return transpose(plan, eval, resolver);
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathGroupBy.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.GroupHashAggregate;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+/**
+ * Transforms queries like
+ *
+ * <pre>
+ *     SELECT x, count(*) FROM t GROUP BY x HAVING x > 10
+ * </pre>
+ *
+ * into
+ *
+ * <pre>
+ *     SELECT x, count(*) FROM t WHERE x > 10 GROUP BY x
+ * </pre>
+ */
+public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
+
+    private final Pattern<Filter> pattern;
+    private final Capture<GroupHashAggregate> groupByCapture;
+
+    public MoveFilterBeneathGroupBy() {
+        this.groupByCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(GroupHashAggregate.class).capturedAs(groupByCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        // Since something like `SELECT x, sum(y) FROM t GROUP BY x HAVING y > 10` is not valid
+        // (y would have to be declared as group key) any parts of a HAVING that is not an aggregation can be moved.
+        Symbol predicate = filter.query();
+        List<Symbol> parts = AndOperator.split(predicate);
+        ArrayList<Symbol> withAggregates = new ArrayList<>();
+        ArrayList<Symbol> withoutAggregates = new ArrayList<>();
+        for (Symbol part : parts) {
+            if (SymbolVisitors.any(Symbols::isAggregate, part)) {
+                withAggregates.add(part);
+            } else {
+                withoutAggregates.add(part);
+            }
+        }
+        if (withoutAggregates.isEmpty()) {
+            return null;
+        }
+        GroupHashAggregate groupBy = captures.get(groupByCapture);
+        if (withoutAggregates.size() == parts.size()) {
+            return transpose(filter, groupBy, resolver);
+        }
+
+        /* HAVING `count(*) > 1 AND x = 10`
+         * withAggregates:    [count(*) > 1]
+         * withoutAggregates: [x = 10]
+         *
+         * Filter
+         *  |
+         * GroupBy
+         *
+         * transforms to
+         *
+         * Filter (count(*) > 1)
+         *  |
+         * GroupBy
+         *  |
+         * Filter (x = 10)
+         */
+        LogicalPlan newGroupBy = groupBy.replaceSources(
+            List.of(new Filter(txnCtx.idAllocator().nextId(), resolver.apply(groupBy.source()), AndOperator.join(withoutAggregates)))
+        );
+        return new Filter(filter.id(), newGroupBy, AndOperator.join(withAggregates));
+    }
+
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathHashJoin.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.FilterOnJoinsUtil.moveQueryBelowJoin;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
+
+    private final Capture<HashJoin> joinCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathHashJoin() {
+        this.joinCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(HashJoin.class).capturedAs(joinCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        HashJoin hashJoin = captures.get(joinCapture);
+        return moveQueryBelowJoin(filter.query(), hashJoin, txnCtx.idAllocator(), resolver);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathNestedLoop.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.FilterOnJoinsUtil.moveQueryBelowJoin;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
+
+    private final Capture<NestedLoopJoin> joinCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathNestedLoop() {
+        this.joinCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(),
+                  typeOf(NestedLoopJoin.class)
+                      .capturedAs(joinCapture)
+                      // Can't apply this on OUTER JOINs as outer join actively produce new null rows
+                      // We need to run the filter on top of these null rows to produce the correct results
+                      .with(join -> !join.joinType().isOuter())
+            );
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        NestedLoopJoin join = captures.get(joinCapture);
+        return moveQueryBelowJoin(filter.query(), join, txnCtx.idAllocator(), resolver);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathOrder.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+/**
+ * Transforms
+ *
+ * <pre>
+ *     Filter
+ *     |
+ *     Order
+ *     |
+ *     X
+ * </pre>
+ *
+ * into
+ *
+ * <pre>
+ *     Order
+ *     |
+ *     Filter
+ *     |
+ *     X
+ * </pre>
+ *
+ * Which is always safe to do as Order doesn't produce new outputs and the order operation becomes cheaper if we can
+ * remove data up-front.
+ */
+public final class MoveFilterBeneathOrder implements Rule<Filter> {
+
+    private final Capture<Order> orderCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathOrder() {
+        this.orderCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Order.class).capturedAs(orderCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        return transpose(filter, captures.get(orderCapture), resolver);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathProjectSet.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.ProjectSet;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
+
+    private final Capture<ProjectSet> projectSetCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathProjectSet() {
+        this.projectSetCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(ProjectSet.class).capturedAs(projectSetCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        var projectSet = captures.get(projectSetCapture);
+
+        var queryParts = AndOperator.split(filter.query());
+        ArrayList<Symbol> toPushDown = new ArrayList<>();
+        ArrayList<Symbol> toKeep = new ArrayList<>();
+        for (var part : queryParts) {
+            if (!SymbolVisitors.any(MoveFilterBeneathProjectSet::isTableFunction, part)
+                && projectSet.standaloneOutputs().containsAll(extractColumns(part))) {
+                toPushDown.add(part);
+            } else {
+                toKeep.add(part);
+            }
+        }
+
+        if (toPushDown.isEmpty()) {
+            return null;
+        } else if (toKeep.isEmpty()) {
+            return transpose(filter, projectSet, resolver);
+        } else {
+            var newProjectSet = projectSet.replaceSources(
+                List.of(new Filter(txnCtx.idAllocator().nextId(), projectSet.source(), AndOperator.join(toPushDown))));
+            return new Filter(txnCtx.idAllocator().nextId(), newProjectSet, AndOperator.join(toKeep));
+        }
+    }
+
+    private static boolean isTableFunction(Symbol s) {
+        return s instanceof Function && ((Function) s).signature().getKind() == FunctionType.TABLE;
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathRename.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import java.util.List;
+
+import io.crate.expression.symbol.FieldReplacer;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Rename;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MoveFilterBeneathRename implements Rule<Filter> {
+
+    private final Capture<Rename> renameCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathRename() {
+        this.renameCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Rename.class).capturedAs(renameCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Rename rename = captures.get(renameCapture);
+        Filter newFilter = new Filter(
+            plan.id(),
+            resolver.apply(rename.source()),
+            FieldReplacer.replaceFields(plan.query(), rename::resolveField)
+        );
+        return rename.replaceSources(List.of(newFilter));
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathUnion.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import java.util.List;
+
+import io.crate.expression.symbol.FieldReplacer;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveFilterBeneathUnion implements Rule<Filter> {
+
+    private final Capture<Union> unionCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathUnion() {
+        this.unionCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(Union.class).capturedAs(unionCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Union union = captures.get(unionCapture);
+        LogicalPlan lhs = resolver.apply(union.sources().get(0));
+        LogicalPlan rhs = resolver.apply(union.sources().get(1));
+        return union.replaceSources(List.of(
+            createNewFilter(filter, lhs),
+            createNewFilter(filter, rhs)
+        ));
+    }
+
+    private static Filter createNewFilter(Filter filter, LogicalPlan newSource) {
+        Symbol newQuery = FieldReplacer.replaceFields(filter.query(), f -> {
+            int idx = filter.source().outputs().indexOf(f);
+            if (idx < 0) {
+                throw new IllegalArgumentException(
+                    "Field used in filter must be present in its source outputs." +
+                    f + " missing in " + filter.source().outputs());
+            }
+            return newSource.outputs().get(idx);
+        });
+        return new Filter(filter.id(), newSource, newQuery);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveFilterBeneathWindowAgg.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import io.crate.analyze.WindowDefinition;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
+import io.crate.expression.symbol.WindowFunction;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.WindowAgg;
+
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
+
+    private final Capture<WindowAgg> windowAggCapture;
+    private final Pattern<Filter> pattern;
+
+    public MoveFilterBeneathWindowAgg() {
+        this.windowAggCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(WindowAgg.class).capturedAs(windowAggCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        WindowAgg windowAgg = captures.get(windowAggCapture);
+        WindowDefinition windowDefinition = windowAgg.windowDefinition();
+        List<WindowFunction> windowFunctions = windowAgg.windowFunctions();
+
+        Predicate<Symbol> containsWindowFunction =
+            symbol -> symbol instanceof WindowFunction && windowFunctions.contains(symbol);
+
+        Symbol predicate = filter.query();
+        List<Symbol> filterParts = AndOperator.split(predicate);
+
+        ArrayList<Symbol> remainingFilterSymbols = new ArrayList<>();
+        ArrayList<Symbol> windowPartitionedBasedFilters = new ArrayList<>();
+
+        for (Symbol part : filterParts) {
+            if (SymbolVisitors.any(containsWindowFunction, part) == false
+                && windowDefinition.partitions().containsAll(extractColumns(part))) {
+                windowPartitionedBasedFilters.add(part);
+            } else {
+                remainingFilterSymbols.add(part);
+            }
+        }
+        assert remainingFilterSymbols.size() > 0 || windowPartitionedBasedFilters.size() > 0 :
+            "Splitting the filter symbol must result in at least one group";
+
+        /* SELECT ROW_NUMBER() OVER(PARTITION BY id)
+         * WHERE `x = 1`
+         *
+         * `x` is not the window partition column.
+         * We cannot push down the filter as it would change the window aggregation value
+         *
+         */
+        if (windowPartitionedBasedFilters.isEmpty()) {
+            return null;
+        }
+
+        /* SELECT ROW_NUMBER() OVER(PARTITION BY id)
+         * WHERE `id = 1`
+         * remainingFilterSymbols:                  []
+         * windowPartitionedBasedFilters:           [id = 1]
+         *
+         * Filter
+         *  |
+         * WindowsAgg
+         *
+         * transforms to
+         *
+         * WindowAgg
+         *  |
+         * Filter (id = 1)
+         */
+        if (remainingFilterSymbols.isEmpty()) {
+            return transpose(filter, windowAgg, resolver);
+        }
+
+        /* WHERE `ROW_NUMBER() OVER(PARTITION BY id) = 2 AND id = 1`
+         * remainingFilterSymbols:                  [ROW_NUMBER() OVER(PARTITION BY id) = 2]
+         * windowPartitionedBasedFilters:           [id = 1]
+         *
+         * Filter
+         *  |
+         * WindowsAgg
+         *
+         * transforms to
+         *
+         * Filter (ROW_NUMBER() OVER(PARTITION BY id) = 2)
+         *  |
+         * WindowAgg
+         *  |
+         * Filter (id = 1)
+         */
+        LogicalPlan newWindowAgg = windowAgg.replaceSources(
+            List.of(new Filter(txnCtx.idAllocator().nextId(),
+                               windowAgg.source(),
+                               AndOperator.join(windowPartitionedBasedFilters)
+                               )));
+
+        return new Filter(txnCtx.idAllocator().nextId(), newWindowAgg, AndOperator.join(remainingFilterSymbols));
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveLimitBeneathEval.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MoveLimitBeneathEval implements Rule<Limit> {
+
+    private final Capture<Eval> evalCapture;
+    private final Pattern<Limit> pattern;
+
+    public MoveLimitBeneathEval() {
+        this.evalCapture = new Capture<>();
+        this.pattern = typeOf(Limit.class)
+            .with(source(), typeOf(Eval.class).capturedAs(evalCapture));
+    }
+
+    @Override
+    public Pattern<Limit> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Limit limit,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Eval eval = captures.get(evalCapture);
+        return transpose(limit, eval, resolver);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveLimitBeneathRename.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Rename;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class MoveLimitBeneathRename implements Rule<Limit> {
+
+    private final Capture<Rename> renameCapture;
+    private final Pattern<Limit> pattern;
+
+    public MoveLimitBeneathRename() {
+        this.renameCapture = new Capture<>();
+        this.pattern = typeOf(Limit.class)
+            .with(source(), typeOf(Rename.class).capturedAs(renameCapture));
+    }
+
+    @Override
+    public Pattern<Limit> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Limit limit,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Rename rename = captures.get(renameCapture);
+        return transpose(limit, rename, resolver);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathFetchOrEval.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.Util.transpose;
+
+import java.util.List;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
+
+    private final Capture<Eval> fetchCapture;
+    private final Pattern<Order> pattern;
+
+    public MoveOrderBeneathFetchOrEval() {
+        this.fetchCapture = new Capture<>();
+        this.pattern = typeOf(Order.class)
+            .with(source(), typeOf(Eval.class).capturedAs(fetchCapture));
+    }
+
+    @Override
+    public Pattern<Order> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Order plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Eval eval = captures.get(fetchCapture);
+        List<Symbol> outputsOfSourceOfFetch = eval.source().outputs();
+        List<Symbol> orderBySymbols = plan.orderBy().orderBySymbols();
+        if (outputsOfSourceOfFetch.containsAll(orderBySymbols)
+            || outputsOfSourceOfFetch.containsAll(extractColumns(orderBySymbols))) {
+            return transpose(plan, eval, resolver);
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathNestedLoop.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import io.crate.analyze.OrderBy;
+import io.crate.expression.symbol.FieldsVisitor;
+import io.crate.expression.symbol.RefVisitor;
+import io.crate.expression.symbol.ScopedSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+/* Move the orderBy expression to the sub-relation if possible.
+ *
+ * This is possible because a nested loop preserves the ordering of the input-relation
+ * IF:
+ *   - the order by expressions only operate using fields from a single relation
+ *   - that relation happens to be on the left-side of the join
+ *   - there is no outer join involved in the whole join (outer joins may create null rows - breaking the ordering)
+ */
+public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
+
+    private final Capture<NestedLoopJoin> nlCapture;
+    private final Pattern<Order> pattern;
+
+    public MoveOrderBeneathNestedLoop() {
+        this.nlCapture = new Capture<>();
+        this.pattern = typeOf(Order.class)
+            .with(source(),
+                  typeOf(NestedLoopJoin.class)
+                      .capturedAs(nlCapture)
+                      .with(nl -> !nl.joinType().isOuter())
+            );
+    }
+
+    @Override
+    public Pattern<Order> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Order order,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        NestedLoopJoin nestedLoop = captures.get(nlCapture);
+        Set<RelationName> relationsInOrderBy =
+            Collections.newSetFromMap(new IdentityHashMap<>());
+        Consumer<ScopedSymbol> gatherRelationsFromField = f -> relationsInOrderBy.add(f.relation());
+        Consumer<Reference> gatherRelationsFromRef = r -> relationsInOrderBy.add(r.ident().tableIdent());
+        OrderBy orderBy = order.orderBy();
+        for (Symbol orderExpr : orderBy.orderBySymbols()) {
+            FieldsVisitor.visitFields(orderExpr, gatherRelationsFromField);
+            RefVisitor.visitRefs(orderExpr, gatherRelationsFromRef);
+        }
+        if (relationsInOrderBy.size() == 1) {
+            RelationName relationInOrderBy = relationsInOrderBy.iterator().next();
+            if (relationInOrderBy == nestedLoop.topMostLeftRelation().relationName()) {
+                LogicalPlan lhs = resolver.apply(nestedLoop.sources().get(0));
+                LogicalPlan newLhs = order.replaceSources(List.of(lhs));
+                return new NestedLoopJoin(
+                    nestedLoop.id(),
+                    newLhs,
+                    resolver.apply(nestedLoop.sources().get(1)),
+                    nestedLoop.joinType(),
+                    nestedLoop.joinCondition(),
+                    nestedLoop.isFiltered(),
+                    nestedLoop.topMostLeftRelation(),
+                    true,
+                    nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
+                    false
+                );
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathRename.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import java.util.List;
+import java.util.function.Function;
+
+import io.crate.analyze.OrderBy;
+import io.crate.expression.symbol.FieldReplacer;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.operators.Rename;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+/**
+ * <pre>
+ *     Order
+ *       |
+ *     Rename
+ *       |
+ *     Source
+ * </pre>
+ *
+ * to
+ *
+ * <pre>
+ *     Rename
+ *       |
+ *     Order
+ *       |
+ *     Source
+ * </pre>
+ */
+public final class MoveOrderBeneathRename implements Rule<Order> {
+
+    private final Capture<Rename> renameCapture;
+    private final Pattern<Order> pattern;
+
+    public MoveOrderBeneathRename() {
+        this.renameCapture = new Capture<>();
+        this.pattern = typeOf(Order.class)
+            .with(source(), typeOf(Rename.class).capturedAs(renameCapture));
+    }
+
+    @Override
+    public Pattern<Order> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Order plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Rename rename = captures.get(renameCapture);
+        Function<? super Symbol, ? extends Symbol> mapField = FieldReplacer.bind(rename::resolveField);
+        OrderBy mappedOrderBy = plan.orderBy().map(mapField);
+        if (rename.source().outputs().containsAll(mappedOrderBy.orderBySymbols())) {
+            Order newOrder = new Order(plan.id(), rename.source(), mappedOrderBy);
+            return rename.replaceSources(List.of(newOrder));
+        } else {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/MoveOrderBeneathUnion.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import java.util.List;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class MoveOrderBeneathUnion implements Rule<Order> {
+
+    private final Capture<Union> unionCapture;
+    private final Pattern<Order> pattern;
+
+    public MoveOrderBeneathUnion() {
+        this.unionCapture = new Capture<>();
+        this.pattern = typeOf(Order.class)
+            .with(source(), typeOf(Union.class).capturedAs(unionCapture));
+    }
+
+    @Override
+    public Pattern<Order> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Order order,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        Union union = captures.get(unionCapture);
+        List<LogicalPlan> unionSources = union.sources();
+        assert unionSources.size() == 2 : "A UNION must have exactly 2 unionSources";
+        Order lhsOrder = updateSources(order, unionSources.get(0));
+        Order rhsOrder = updateSources(order, unionSources.get(1));
+        return union.replaceSources(List.of(lhsOrder, rhsOrder));
+    }
+
+    private static Order updateSources(Order order, LogicalPlan child) {
+        List<Symbol> sourceOutputs = order.source().outputs();
+        return new Order(order.id(), child, order.orderBy().map(s -> {
+            int idx = sourceOutputs.indexOf(s);
+            if (idx < 0) {
+                throw new IllegalArgumentException(
+                    "The ORDER BY expression " + s + " must be part of the child union: " + sourceOutputs);
+            }
+            return child.outputs().get(idx);
+        }));
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/OptimizeCollectWhereClauseAccess.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+
+import java.util.Optional;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.where.DocKeys;
+import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocSysColumns;
+import io.crate.planner.WhereClauseOptimizer;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Get;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
+
+    private final Pattern<Collect> pattern;
+
+    public OptimizeCollectWhereClauseAccess() {
+        this.pattern = typeOf(Collect.class)
+            .with(collect ->
+                      collect.relation() instanceof DocTableRelation
+                      && collect.where().hasQuery()
+                      && !Symbols.containsColumn(collect.outputs(), DocSysColumns.FETCHID)
+            );
+    }
+
+    @Override
+    public Pattern<Collect> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Collect collect,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        var relation = (DocTableRelation) collect.relation();
+        var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, relation);
+        WhereClause where = collect.where();
+        var detailedQuery = WhereClauseOptimizer.optimize(
+            normalizer,
+            where.queryOrFallback(),
+            relation.tableInfo(),
+            txnCtx,
+            nodeCtx
+        );
+        Optional<DocKeys> docKeys = detailedQuery.docKeys();
+        //noinspection OptionalIsPresent no capturing lambda allocation
+        if (docKeys.isPresent()) {
+            return new Get(
+                txnCtx.idAllocator().nextId(),
+                relation,
+                docKeys.get(),
+                detailedQuery.query(),
+                collect.outputs(),
+                tableStats.estimatedSizePerRow(relation.relationName())
+            );
+        } else if (!detailedQuery.clusteredBy().isEmpty() && collect.detailedQuery() == null) {
+            return new Collect(collect, detailedQuery);
+        } else {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/RemoveRedundantFetchOrEval.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+/**
+ * Eliminates any Eval nodes that have the same output as their source
+ */
+public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
+
+    private final Pattern<Eval> pattern;
+
+    public RemoveRedundantFetchOrEval() {
+        this.pattern = typeOf(Eval.class)
+            .with(fetchOrEval -> fetchOrEval.outputs().equals(fetchOrEval.source().outputs()));
+    }
+
+    @Override
+    public Pattern<Eval> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Eval plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        return resolver.apply(plan.source());
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+import static io.crate.planner.optimizer.iterative.rule.FilterOnJoinsUtil.getNewSource;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.data.Input;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.node.dql.join.JoinType;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.planner.optimizer.rule.NullSymbolEvaluator;
+import io.crate.statistics.TableStats;
+
+/**
+ * If we can determine that a filter on an OUTER JOIN turns all NULL rows that the join could generate into a NO-MATCH
+ * we can push down the filter and turn the OUTER JOIN into an inner join.
+ *
+ * <p>
+ * So this tries to transform
+ * </p>
+ *
+ * <pre>
+ *     Filter (lhs.x = 1 AND rhs.x = 2)
+ *       |
+ *     NestedLoop (outerJoin)
+ *       /  \
+ *     LHS  RHS
+ * </pre>
+ *
+ * into
+ *
+ * <pre>
+ *     Filter
+ *       |
+ *     NestedLoop (innerJoin)
+ *       /      \
+ *   Filter      Filter
+ * (lhs.x = 1)    (rhs.x = 2)
+ *     |              |
+ *    LHS            RHS
+ * </pre>
+ *
+ * A case where this is *NOT* safe is for example:
+ *
+ * <pre>
+ * SELECT * FROM t1
+ *     LEFT JOIN t2 ON t1.t2_id = t2.id
+ * WHERE
+ *     coalesce(t2.x, 20) > 10   # becomes TRUE for null rows
+ * </pre>
+ *
+ *
+ * A case where the FILTER turns all null rows into no-matches:
+ *
+ * <pre>
+ * SELECT * FROM t1
+ *      LEFT JOIN t2 ON t1.t2_id = t2.id
+ * WHERE
+ *      t2.x = 10           # null = 10 -> null -> no match
+ * </pre>
+ */
+public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
+
+    private final Capture<NestedLoopJoin> nlCapture;
+    private final Pattern<Filter> pattern;
+
+    public RewriteFilterOnOuterJoinToInnerJoin() {
+        this.nlCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(NestedLoopJoin.class).capturedAs(nlCapture)
+                .with(nl -> nl.joinType().isOuter() && !nl.isRewriteFilterOnOuterJoinToInnerJoinDone())
+            );
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        final var symbolEvaluator = new NullSymbolEvaluator(txnCtx, nodeCtx);
+        NestedLoopJoin nl = captures.get(nlCapture);
+        Symbol query = filter.query();
+        Map<Set<RelationName>, Symbol> splitQueries = QuerySplitter.split(query);
+        if (splitQueries.size() == 1 && splitQueries.keySet().iterator().next().size() > 1) {
+            return null;
+        }
+        LogicalPlan lhs = resolver.apply(nl.sources().get(0));
+        LogicalPlan rhs = resolver.apply(nl.sources().get(1));
+        Set<RelationName> leftName = lhs.getRelationNames();
+        Set<RelationName> rightName = rhs.getRelationNames();
+
+        Symbol leftQuery = splitQueries.remove(leftName);
+        Symbol rightQuery = splitQueries.remove(rightName);
+
+        final LogicalPlan newLhs;
+        final LogicalPlan newRhs;
+        final boolean newJoinIsInnerJoin;
+        switch (nl.joinType()) {
+            case LEFT:
+                /* LEFT OUTER JOIN -> NULL rows are generated for the RHS if the join-condition doesn't match
+                 *
+                 * cr> select t1.x as t1x, t2.x as t2x from t1 left join t2 on t1.x = t2.x;
+                 * +-----+------+
+                 * | t1x |  t2x |
+                 * +-----+------+
+                 * |   3 |    3 |
+                 * |   2 |    2 |
+                 * |   1 | NULL |
+                 * +-----+------+
+                 */
+                newLhs = getNewSource(leftQuery, lhs, txnCtx.idAllocator(), resolver);
+                if (rightQuery == null) {
+                    newRhs = rhs;
+                    newJoinIsInnerJoin = false;
+                } else if (couldMatchOnNull(rightQuery, symbolEvaluator)) {
+                    newRhs = rhs;
+                    newJoinIsInnerJoin = false;
+                    splitQueries.put(rightName, rightQuery);
+                } else {
+                    newRhs = getNewSource(rightQuery, rhs, txnCtx.idAllocator(), resolver);
+                    newJoinIsInnerJoin = true;
+                }
+                break;
+            case RIGHT:
+                /* RIGHT OUTER JOIN -> NULL rows are generated for the LHS if the join-condition doesn't match
+
+                 * cr> select t1.x as t1x, t2.x as t2x from t1 right join t2 on t1.x = t2.x;
+                 * +------+-----+
+                 * |  t1x | t2x |
+                 * +------+-----+
+                 * |    3 |   3 |
+                 * |    2 |   2 |
+                 * | NULL |   4 |
+                 * +------+-----+
+                 */
+                if (leftQuery == null) {
+                    newLhs = lhs;
+                    newJoinIsInnerJoin = false;
+                } else if (couldMatchOnNull(leftQuery, symbolEvaluator)) {
+                    newLhs = lhs;
+                    newJoinIsInnerJoin = false;
+                    splitQueries.put(leftName, leftQuery);
+                } else {
+                    newLhs = getNewSource(leftQuery, lhs, txnCtx.idAllocator(), resolver);
+                    newJoinIsInnerJoin = true;
+                }
+                newRhs = getNewSource(rightQuery, rhs, txnCtx.idAllocator(), resolver);
+                break;
+            case FULL:
+                /*
+                 * cr> select t1.x as t1x, t2.x as t2x from t1 full outer join t2 on t1.x = t2.x;
+                 * +------+------+
+                 * |  t1x |  t2x |
+                 * +------+------+
+                 * |    3 |    3 |
+                 * |    2 |    2 |
+                 * |    1 | NULL |
+                 * | NULL |    4 |
+                 * +------+------+
+                 */
+
+                if (couldMatchOnNull(leftQuery, symbolEvaluator)) {
+                    newLhs = lhs;
+                } else {
+                    newLhs = getNewSource(leftQuery, lhs, txnCtx.idAllocator(), resolver);
+                    if (leftQuery != null) {
+                        splitQueries.put(leftName, leftQuery);
+                    }
+                }
+                if (couldMatchOnNull(rightQuery, symbolEvaluator)) {
+                    newRhs = rhs;
+                } else {
+                    newRhs = getNewSource(rightQuery, rhs, txnCtx.idAllocator(), resolver);
+                }
+
+                /*
+                 * Filters on each side must be put back into the Filter as each side can generate NULL's on outer joins
+                 * which must be filtered out AFTER the join operation.
+                 * In case the filter is only on one side, the join could be rewritten to a LEFT/RIGHT OUTER.
+                 * TODO: Create a dedicated rule RewriteFilterOnOuterJoinToLeftOrRight
+                 *
+                 * cr> select t1.x as t1x, t2.x as t2x, t2.y as t2y from t1 full outer join t2 on t1.x = t2.x where t2y = 1;
+                 * +------+------+------+
+                 * |  t1x |  t2x |  t2y |
+                 * +------+------+------+
+                 * |    3 |    3 |    1 |
+                 * |    2 |    2 |    1 |
+                 * | NULL |    4 |    1 |
+                 * +------+------+------+
+                 */
+                if (leftQuery != null) {
+                    splitQueries.put(leftName, leftQuery);
+                }
+                if (rightQuery != null) {
+                    splitQueries.put(rightName, rightQuery);
+                }
+
+                newJoinIsInnerJoin = newLhs != lhs && newRhs != rhs;
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                    "The Rule to rewrite filter+outer-joins to inner joins must not be run on joins of type=" + nl.joinType());
+        }
+        if (newLhs == lhs && newRhs == rhs) {
+            return null;
+        }
+        NestedLoopJoin newJoin = new NestedLoopJoin(
+            nl.id(),
+            newLhs,
+            newRhs,
+            newJoinIsInnerJoin ? JoinType.INNER : nl.joinType(),
+            nl.joinCondition(),
+            nl.isFiltered(),
+            nl.topMostLeftRelation(),
+            nl.orderByWasPushedDown(),
+            true,
+            false
+        );
+        assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";
+        return splitQueries.isEmpty() ? newJoin : new Filter(filter.id(), newJoin, AndOperator.join(splitQueries.values()));
+    }
+
+    private static boolean couldMatchOnNull(@Nullable Symbol query,
+                                            NullSymbolEvaluator evaluator) {
+        if (query == null) {
+            return false;
+        }
+        Input<?> input = query.accept(evaluator, null);
+        return WhereClause.canMatch(input);
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+
+
+import static io.crate.planner.optimizer.iterative.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.iterative.matcher.Patterns.source;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.GroupHashAggregate;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LimitDistinct;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+import io.crate.planner.optimizer.iterative.Rule;
+import io.crate.planner.optimizer.iterative.matcher.Capture;
+import io.crate.planner.optimizer.iterative.matcher.Captures;
+import io.crate.planner.optimizer.iterative.matcher.Pattern;
+import io.crate.statistics.TableStats;
+import io.crate.types.DataTypes;
+
+
+/**
+ * A rule to rewrite a `SELECT DISTINCT [...] LIMIT n` to use a special LimitDistinct operator.
+ *
+ * <p>
+ * The {@link LimitDistinct} operator support early termination, reducing the amount of keys that have to be
+ * consumed/processed from the source.
+ * </p>
+ *
+ * <p>
+ * This optimization is more efficient the lower the limit and the higher the cardinality ratio. (E.g. a unique column).
+ * On a ENUM style column that only has like 5 distinct values in a large table, this {@link LimitDistinct}
+ * operator could cause a slow down:
+ *
+ * The "early terminate" case wouldn't happen; It would process almost all rows.
+ * In that case our "optimized group by iterator" is more efficient as it contains a ordinal optimization.
+ * (It already knows which values are unique and skips everything else)
+ * </p>
+ */
+public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit> {
+
+    private final Pattern<Limit> pattern;
+    private final Capture<GroupHashAggregate> groupCapture;
+
+    public RewriteGroupByKeysLimitToLimitDistinct() {
+        this.groupCapture = new Capture<>();
+        this.pattern = typeOf(Limit.class)
+            .with(
+                source(),
+                typeOf(GroupHashAggregate.class)
+                    .capturedAs(groupCapture)
+                    .with(groupAggregate -> groupAggregate.aggregates().isEmpty())
+            );
+    }
+
+    private static boolean eagerTerminateIsLikely(Limit limit, GroupHashAggregate groupAggregate, GroupReferenceResolver resolver) {
+        if (groupAggregate.outputs().size() > 1 || !groupAggregate.outputs().get(0).valueType().equals(DataTypes.STRING)) {
+            // `GroupByOptimizedIterator` can only be used for single text columns.
+            // If that is not the case we can always use LimitDistinct even if a eagerTerminate isn't likely
+            // because a regular GROUP BY would have to do at least the same amount of work in any case.
+            return true;
+        }
+        var limitSymbol = limit.limit();
+        if (limitSymbol instanceof Literal) {
+            var limitVal = DataTypes.INTEGER.sanitizeValue(((Literal<?>) limitSymbol).value());
+            // Would consume all source rows -> prefer default group by implementation which has other optimizations
+            // which are more beneficial in this scenario
+            if (limitVal > groupAggregate.numExpectedRows()) {
+                return false;
+            }
+        }
+        long sourceRows = resolver.apply(groupAggregate.source()).numExpectedRows();
+        if (sourceRows == 0) {
+            return false;
+        }
+        var cardinalityRatio = groupAggregate.numExpectedRows() / sourceRows;
+        /*
+         * The threshold was chosen after comparing `with limitDistinct` vs. `without limitDistinct`
+         *
+         * create table ids_with_tags (id text primary key, tag text not null)
+         *
+         * Running:
+         *      select distinct tag from ids_with_tags limit 5
+         *      `ids_with_tags` containing 5000 rows
+         *
+         * Data having been generated using:
+         *
+         *  mkjson --num <num_unique_tags> tag="ulid()" | jq -r '.tag' >! tags.txt
+         *  mkjson --num 5000 id="ulid()" tag="oneOf(fromFile('tags.txt'))" >! specs/data/ids_with_tag.json
+         *
+         *      Number of unique tags: 1
+         *      median: +  50.91%
+         *      median: +  46.94%
+         *      Number of unique tags: 2
+         *      median: +  10.30%
+         *      median: +  69.29%
+         *      Number of unique tags: 3
+         *      median: +  51.35%
+         *      median: -  15.93%
+         *      Number of unique tags: 4
+         *      median: +   4.35%
+         *      median: +  18.13%
+         *      Number of unique tags: 5
+         *      median: - 157.07%
+         *      median: - 120.55%
+         *      Number of unique tags: 6
+         *      median: - 129.60%
+         *      median: - 150.84%
+         *      Number of unique tags: 7
+         *
+         * With 500_000 rows:
+         *
+         *      Number of unique tags: 1
+         *      median: +  98.69%
+         *      median: +  81.54%
+         *      Number of unique tags: 2
+         *      median: +  73.22%
+         *      median: +  82.40%
+         *      Number of unique tags: 3
+         *      median: + 124.86%
+         *      median: + 107.27%
+         *      Number of unique tags: 4
+         *      median: + 102.73%
+         *      median: +  69.48%
+         *      Number of unique tags: 5
+         *      median: - 199.17%
+         *      median: - 199.36%
+         *      Number of unique tags: 6
+         *
+         */
+        double threshold = 0.001;
+        return cardinalityRatio > threshold;
+    }
+
+    @Override
+    public Pattern<Limit> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Limit limit,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             GroupReferenceResolver resolver) {
+        GroupHashAggregate groupBy = captures.get(groupCapture);
+        if (!eagerTerminateIsLikely(limit, groupBy, resolver)) {
+            return null;
+        }
+        return new LimitDistinct(
+            groupBy.id(),
+            resolver.apply(groupBy.source()),
+            limit.limit(),
+            limit.offset(),
+            groupBy.outputs()
+        );
+    }
+
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/rule/Util.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/rule/Util.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative.rule;
+
+import java.util.List;
+
+import io.crate.common.collections.Lists2;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+public final class Util {
+
+    private Util() {
+    }
+
+    /**
+     * @return a new Plan where parent-child (A-B-C) are exchanged to child-parent (B-A-C)
+     */
+    static LogicalPlan transpose(LogicalPlan parent, LogicalPlan child, GroupReferenceResolver resolver) {
+        return child.replaceSources(List.of(
+            parent.replaceSources(Lists2.map(child.sources(), resolver::apply)
+            )));
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -28,6 +28,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -39,15 +40,15 @@ final class FilterOnJoinsUtil {
     private FilterOnJoinsUtil() {
     }
 
-    static LogicalPlan getNewSource(@Nullable Symbol splitQuery, LogicalPlan source) {
-        return splitQuery == null ? source : new Filter(source, splitQuery);
+    static LogicalPlan getNewSource(@Nullable Symbol splitQuery, LogicalPlan source, LogicalPlanIdAllocator idAllocator) {
+        return splitQuery == null ? source : new Filter(idAllocator.nextId(), source, splitQuery);
     }
 
-    static LogicalPlan moveQueryBelowJoin(Symbol query, LogicalPlan join) {
+    static LogicalPlan moveQueryBelowJoin(Symbol query, LogicalPlan join, LogicalPlanIdAllocator idAllocator) {
         if (!WhereClause.canMatch(query)) {
             return join.replaceSources(List.of(
-                getNewSource(query, join.sources().get(0)),
-                getNewSource(query, join.sources().get(1))
+                getNewSource(query, join.sources().get(0), idAllocator),
+                getNewSource(query, join.sources().get(1), idAllocator)
             ));
         }
         Map<Set<RelationName>, Symbol> splitQuery = QuerySplitter.split(query);
@@ -62,15 +63,15 @@ final class FilterOnJoinsUtil {
         Set<RelationName> rightName = rhs.getRelationNames();
         Symbol queryForLhs = splitQuery.remove(leftName);
         Symbol queryForRhs = splitQuery.remove(rightName);
-        LogicalPlan newLhs = getNewSource(queryForLhs, lhs);
-        LogicalPlan newRhs = getNewSource(queryForRhs, rhs);
+        LogicalPlan newLhs = getNewSource(queryForLhs, lhs, idAllocator);
+        LogicalPlan newRhs = getNewSource(queryForRhs, rhs, idAllocator);
         LogicalPlan newJoin = join.replaceSources(List.of(newLhs, newRhs));
         if (splitQuery.isEmpty()) {
             return newJoin;
         } else if (initialParts == splitQuery.size()) {
             return null;
         } else {
-            return new Filter(newJoin, AndOperator.join(splitQuery.values()));
+            return new Filter(idAllocator.nextId(), newJoin, AndOperator.join(splitQuery.values()));
         }
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -68,11 +68,12 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
         if (countAggregate.filter() != null) {
             return new Count(
+                txnCtx.idAllocator().nextId(),
                 countAggregate,
                 collect.relation(),
                 collect.where().add(countAggregate.filter()));
         } else {
-            return new Count(countAggregate, collect.relation(), collect.where());
+            return new Count(txnCtx.idAllocator().nextId(), countAggregate, collect.relation(), collect.where());
         }
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -84,11 +84,13 @@ public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate
         if (filter != null) {
             var mappedFilter = FieldReplacer.replaceFields(filter, rename::resolveField);
             return new Count(
+                txnCtx.idAllocator().nextId(),
                 countAggregate,
                 collect.relation(),
-                collect.where().add(mappedFilter));
+                collect.where().add(mappedFilter)
+                );
         } else {
-            return new Count(countAggregate, collect.relation(), collect.where());
+            return new Count(txnCtx.idAllocator().nextId(), countAggregate, collect.relation(), collect.where());
         }
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -64,6 +64,7 @@ public class MergeFilterAndCollect implements Rule<Filter> {
         Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(
+            collect.id(),
             collect.relation(),
             collect.outputs(),
             newWhere,

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -75,6 +75,6 @@ public class MergeFilters implements Rule<Filter> {
         Filter childFilter = captures.get(child);
         Symbol parentQuery = plan.query();
         Symbol childQuery = childFilter.query();
-        return new Filter(childFilter.source(), AndOperator.of(parentQuery, childQuery));
+        return new Filter(txnCtx.idAllocator().nextId(), childFilter.source(), AndOperator.of(parentQuery, childQuery));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -80,6 +80,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
         if (constantConditions.isEmpty() || nonConstantConditions.isEmpty()) {
             // Nothing to optimize, just mark nestedLoopJoin to skip the rule the next time
             return new NestedLoopJoin(
+                nl.id(),
                 nl.lhs(),
                 nl.rhs(),
                 nl.joinType(),
@@ -96,9 +97,10 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
             var rhs = nl.rhs();
             var queryForLhs = constantConditions.remove(lhs.getRelationNames());
             var queryForRhs = constantConditions.remove(rhs.getRelationNames());
-            var newLhs = getNewSource(queryForLhs, lhs);
-            var newRhs = getNewSource(queryForRhs, rhs);
+            var newLhs = getNewSource(queryForLhs, lhs, txnCtx.idAllocator());
+            var newRhs = getNewSource(queryForRhs, rhs, txnCtx.idAllocator());
             return new HashJoin(
+                nl.id(),
                 newLhs,
                 newRhs,
                 AndOperator.join(nonConstantConditions)

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -116,9 +116,9 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
          * Filter (x = 10)
          */
         LogicalPlan newGroupBy = groupBy.replaceSources(
-            List.of(new Filter(groupBy.source(), AndOperator.join(withoutAggregates))));
-
-        return new Filter(newGroupBy, AndOperator.join(withAggregates));
+            List.of(new Filter(txnCtx.idAllocator().nextId(), groupBy.source(), AndOperator.join(withoutAggregates)))
+        );
+        return new Filter(txnCtx.idAllocator().nextId(), newGroupBy, AndOperator.join(withAggregates));
     }
 
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -59,6 +59,6 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
                              TransactionContext txnCtx,
                              NodeContext nodeCtx) {
         HashJoin hashJoin = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), hashJoin);
+        return moveQueryBelowJoin(filter.query(), hashJoin, txnCtx.idAllocator());
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -65,6 +65,6 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
                              TransactionContext txnCtx,
                              NodeContext nodeCtx) {
         NestedLoopJoin join = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), join);
+        return moveQueryBelowJoin(filter.query(), join, txnCtx.idAllocator());
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -87,8 +87,8 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
             return transpose(filter, projectSet);
         } else {
             var newProjectSet = projectSet.replaceSources(
-                List.of(new Filter(projectSet.source(), AndOperator.join(toPushDown))));
-            return new Filter(newProjectSet, AndOperator.join(toKeep));
+                List.of(new Filter(txnCtx.idAllocator().nextId(), projectSet.source(), AndOperator.join(toPushDown))));
+            return new Filter(txnCtx.idAllocator().nextId(), newProjectSet, AndOperator.join(toKeep));
         }
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -62,6 +62,7 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
                              NodeContext nodeCtx) {
         Rename rename = captures.get(renameCapture);
         Filter newFilter = new Filter(
+            txnCtx.idAllocator().nextId(),
             rename.source(),
             FieldReplacer.replaceFields(plan.query(), rename::resolveField)
         );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -65,12 +65,12 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
         LogicalPlan lhs = union.sources().get(0);
         LogicalPlan rhs = union.sources().get(1);
         return union.replaceSources(List.of(
-            createNewFilter(filter, lhs),
-            createNewFilter(filter, rhs)
+            createNewFilter(filter, lhs, txnCtx),
+            createNewFilter(filter, rhs, txnCtx)
         ));
     }
 
-    private static Filter createNewFilter(Filter filter, LogicalPlan newSource) {
+    private static Filter createNewFilter(Filter filter, LogicalPlan newSource, TransactionContext txnCtx) {
         Symbol newQuery = FieldReplacer.replaceFields(filter.query(), f -> {
             int idx = filter.source().outputs().indexOf(f);
             if (idx < 0) {
@@ -80,6 +80,6 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
             }
             return newSource.outputs().get(idx);
         });
-        return new Filter(newSource, newQuery);
+        return new Filter(txnCtx.idAllocator().nextId(), newSource, newQuery);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -139,8 +139,11 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
          * Filter (id = 1)
          */
         LogicalPlan newWindowAgg = windowAgg.replaceSources(
-            List.of(new Filter(windowAgg.source(), AndOperator.join(windowPartitionedBasedFilters))));
+            List.of(new Filter(txnCtx.idAllocator().nextId(),
+                               windowAgg.source(),
+                               AndOperator.join(windowPartitionedBasedFilters)
+                               )));
 
-        return new Filter(newWindowAgg, AndOperator.join(remainingFilterSymbols));
+        return new Filter(txnCtx.idAllocator().nextId(), newWindowAgg, AndOperator.join(remainingFilterSymbols));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -98,6 +98,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                 LogicalPlan lhs = nestedLoop.sources().get(0);
                 LogicalPlan newLhs = order.replaceSources(List.of(lhs));
                 return new NestedLoopJoin(
+                    nestedLoop.id(),
                     newLhs,
                     nestedLoop.sources().get(1),
                     nestedLoop.joinType(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -86,7 +86,7 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
         Function<? super Symbol, ? extends Symbol> mapField = FieldReplacer.bind(rename::resolveField);
         OrderBy mappedOrderBy = plan.orderBy().map(mapField);
         if (rename.source().outputs().containsAll(mappedOrderBy.orderBySymbols())) {
-            Order newOrder = new Order(rename.source(), mappedOrderBy);
+            Order newOrder = new Order(plan.id(), rename.source(), mappedOrderBy);
             return rename.replaceSources(List.of(newOrder));
         } else {
             return null;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -70,7 +70,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
 
     private static Order updateSources(Order order, LogicalPlan child) {
         List<Symbol> sourceOutputs = order.source().outputs();
-        return new Order(child, order.orderBy().map(s -> {
+        return new Order(order.id(), child, order.orderBy().map(s -> {
             int idx = sourceOutputs.indexOf(s);
             if (idx < 0) {
                 throw new IllegalArgumentException(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/NullSymbolEvaluator.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/NullSymbolEvaluator.java
@@ -32,7 +32,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
 
-final class NullSymbolEvaluator extends BaseImplementationSymbolVisitor<Void> {
+public final class NullSymbolEvaluator extends BaseImplementationSymbolVisitor<Void> {
 
     public NullSymbolEvaluator(TransactionContext txnCtx, NodeContext nodeCtx) {
         super(txnCtx, nodeCtx);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -81,6 +81,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
         //noinspection OptionalIsPresent no capturing lambda allocation
         if (docKeys.isPresent()) {
             return new Get(
+                txnCtx.idAllocator().nextId(),
                 relation,
                 docKeys.get(),
                 detailedQuery.query(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -151,7 +151,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                  * |   1 | NULL |
                  * +-----+------+
                  */
-                newLhs = getNewSource(leftQuery, lhs);
+                newLhs = getNewSource(leftQuery, lhs, txnCtx.idAllocator());
                 if (rightQuery == null) {
                     newRhs = rhs;
                     newJoinIsInnerJoin = false;
@@ -160,7 +160,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                     newJoinIsInnerJoin = false;
                     splitQueries.put(rightName, rightQuery);
                 } else {
-                    newRhs = getNewSource(rightQuery, rhs);
+                    newRhs = getNewSource(rightQuery, rhs, txnCtx.idAllocator());
                     newJoinIsInnerJoin = true;
                 }
                 break;
@@ -184,10 +184,10 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                     newJoinIsInnerJoin = false;
                     splitQueries.put(leftName, leftQuery);
                 } else {
-                    newLhs = getNewSource(leftQuery, lhs);
+                    newLhs = getNewSource(leftQuery, lhs, txnCtx.idAllocator());
                     newJoinIsInnerJoin = true;
                 }
-                newRhs = getNewSource(rightQuery, rhs);
+                newRhs = getNewSource(rightQuery, rhs, txnCtx.idAllocator());
                 break;
             case FULL:
                 /*
@@ -205,7 +205,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                 if (couldMatchOnNull(leftQuery, symbolEvaluator)) {
                     newLhs = lhs;
                 } else {
-                    newLhs = getNewSource(leftQuery, lhs);
+                    newLhs = getNewSource(leftQuery, lhs, txnCtx.idAllocator());
                     if (leftQuery != null) {
                         splitQueries.put(leftName, leftQuery);
                     }
@@ -213,7 +213,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                 if (couldMatchOnNull(rightQuery, symbolEvaluator)) {
                     newRhs = rhs;
                 } else {
-                    newRhs = getNewSource(rightQuery, rhs);
+                    newRhs = getNewSource(rightQuery, rhs, txnCtx.idAllocator());
                 }
 
                 /*
@@ -248,6 +248,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             return null;
         }
         NestedLoopJoin newJoin = new NestedLoopJoin(
+            nl.id(),
             newLhs,
             newRhs,
             newJoinIsInnerJoin ? JoinType.INNER : nl.joinType(),
@@ -259,7 +260,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             false
         );
         assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";
-        return splitQueries.isEmpty() ? newJoin : new Filter(newJoin, AndOperator.join(splitQueries.values()));
+        return splitQueries.isEmpty() ? newJoin : new Filter(filter.id(), newJoin, AndOperator.join(splitQueries.values()));
     }
 
     private static boolean couldMatchOnNull(@Nullable Symbol query,

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -170,6 +170,7 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
             return null;
         }
         return new LimitDistinct(
+            txnCtx.idAllocator().nextId(),
             groupBy.source(),
             limit.limit(),
             limit.offset(),

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -161,6 +161,7 @@ public final class CopyToPlan implements Plan {
             boundedCopyTo.withClauseOptions());
 
         LogicalPlan collect = Collect.create(
+            context.transactionContext().idAllocator().nextId(),
             new DocTableRelation(boundedCopyTo.table()),
             boundedCopyTo.outputs(),
             boundedCopyTo.whereClause(),

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -98,6 +98,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             null,
             Cursors.EMPTY,
             TransactionState.IDLE
+
         );
 
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -38,6 +38,7 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -48,6 +49,8 @@ import io.crate.types.DataTypes;
 
 public class CollectTest extends CrateDummyClusterServiceUnitTest {
 
+    private CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+
     @Test
     public void test_prune_output_of_collect_updates_estimated_row_size() throws Exception {
         var e = SQLExecutor.builder(clusterService)
@@ -56,6 +59,7 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
         TableStats tableStats = new TableStats();
         Symbol x = e.asSymbol("x");
         Collect collect = Collect.create(
+            txnCtx.idAllocator().nextId(),
             new DocTableRelation(e.resolveTableInfo("t")),
             List.of(x, e.asSymbol("y")),
             WhereClause.MATCH_ALL,

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -112,7 +112,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.joinPairs(),
             new SubQueries(Map.of(), Map.of()),
             rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, true),
-            txnCtx.sessionSettings().hashJoinsEnabled()
+            txnCtx.sessionSettings().hashJoinsEnabled(),
+            txnCtx.idAllocator()
         );
     }
 
@@ -268,7 +269,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.joinPairs(),
             new SubQueries(Map.of(), Map.of()),
             rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, false),
-            false
+            false,
+            txnCtx.idAllocator()
         );
         Join nl = (Join) operator.build(
             mock(DependencyCarrier.class), context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -55,6 +55,8 @@ import io.crate.testing.SQLExecutor;
 
 public class LimitTest extends CrateDummyClusterServiceUnitTest {
 
+    private static LogicalPlanIdAllocator logicalPlanIdAllocator = new LogicalPlanIdAllocator();
+
     @Test
     public void testLimitOnLimitOperator() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
@@ -63,8 +65,11 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation queriedDocTable = e.analyze("select name from users");
 
         LogicalPlan plan = Limit.create(
+            logicalPlanIdAllocator.nextId(),
             Limit.create(
+                logicalPlanIdAllocator.nextId(),
                 Collect.create(
+                    logicalPlanIdAllocator.nextId(),
                     ((AbstractTableRelation<?>) queriedDocTable.from().get(0)),
                     queriedDocTable.outputs(),
                     new WhereClause(queriedDocTable.where()),

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import static io.crate.common.collections.Iterables.getOnlyElement;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanId;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
+import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.planner.operators.PlanHint;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.statistics.TableStats;
+
+
+public class MemoTest {
+
+    private final LogicalPlanIdAllocator idAllocator = new LogicalPlanIdAllocator();
+
+    @Test
+    public void testInitialization() {
+        LogicalPlan plan = plan(plan());
+        Memo memo = new Memo(idAllocator, plan);
+
+        assertEquals(memo.groupCount(), 2);
+        assertMatchesStructure(plan, memo.extract());
+    }
+
+    /*
+      From: X -> Y  -> Z
+      To:   X -> Y' -> Z'
+     */
+    @Test
+    public void testReplaceSubtree() {
+        LogicalPlan plan = plan(plan(plan()));
+
+        Memo memo = new Memo(idAllocator, plan);
+        assertEquals(memo.groupCount(), 3);
+
+        // replace child of root node with subtree
+        LogicalPlan transformed = plan(plan());
+        memo.replace(getChildGroup(memo, memo.getRootGroup()), transformed);
+        assertEquals(memo.groupCount(), 3);
+        assertMatchesStructure(memo.extract(), plan(plan.id(), transformed));
+    }
+
+    /*
+      From: X -> Y  -> Z
+      To:   X -> Y' -> Z
+     */
+    @Test
+    public void testReplaceNode() {
+        LogicalPlan z = plan();
+        LogicalPlan y = plan(z);
+        LogicalPlan x = plan(y);
+
+        Memo memo = new Memo(idAllocator, x);
+        assertEquals(memo.groupCount(), 3);
+
+        // replace child of root node with another node, retaining child's child
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        GroupReference zRef = (GroupReference) getOnlyElement(memo.resolve(yGroup).sources());
+        LogicalPlan transformed = plan(zRef);
+        memo.replace(yGroup, transformed);
+        assertEquals(memo.groupCount(), 3);
+        assertMatchesStructure(memo.extract(), plan(x.id(), plan(transformed.id(), z)));
+    }
+
+    /*
+      From: X -> Y  -> Z  -> W
+      To:   X -> Y' -> Z' -> W
+     */
+    @Test
+    public void testReplaceNonLeafSubtree() {
+        LogicalPlan w = plan();
+        LogicalPlan z = plan(w);
+        LogicalPlan y = plan(z);
+        LogicalPlan x = plan(y);
+
+        Memo memo = new Memo(idAllocator, x);
+
+        assertEquals(memo.groupCount(), 4);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        int zGroup = getChildGroup(memo, yGroup);
+
+        LogicalPlan rewrittenW = memo.resolve(zGroup).sources().get(0);
+
+        LogicalPlan newZ = plan(rewrittenW);
+        LogicalPlan newY = plan(newZ);
+
+        memo.replace(yGroup, newY);
+
+        assertEquals(memo.groupCount(), 4);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(x.id(),
+                 plan(newY.id(),
+                      plan(newZ.id(),
+                           plan(w.id())))));
+    }
+
+    /*
+      From: X -> Y -> Z
+      To:   X -> Z
+     */
+    @Test
+    public void testRemoveNode() {
+        LogicalPlan z = plan();
+        LogicalPlan y = plan(z);
+        LogicalPlan x = plan(y);
+
+        Memo memo = new Memo(idAllocator, x);
+
+        assertEquals(memo.groupCount(), 3);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        memo.replace(yGroup, memo.resolve(yGroup).sources().get(0));
+
+        assertEquals(memo.groupCount(), 2);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(x.id(),
+                 plan(z.id())));
+    }
+
+    /*
+       From: X -> Z
+       To:   X -> Y -> Z
+     */
+    @Test
+    public void testInsertNode() {
+        LogicalPlan z = plan();
+        LogicalPlan x = plan(z);
+
+        Memo memo = new Memo(idAllocator, x);
+
+        assertEquals(memo.groupCount(), 2);
+
+        int zGroup = getChildGroup(memo, memo.getRootGroup());
+        LogicalPlan y = plan(memo.resolve(zGroup));
+        memo.replace(zGroup, y);
+
+        assertEquals(memo.groupCount(), 3);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(x.id(),
+                 plan(y.id(),
+                      plan(z.id()))));
+    }
+
+    /*
+      From: X -> Y -> Z
+      To:   X --> Y1' --> Z
+              \-> Y2' -/
+     */
+    @Test
+    public void testMultipleReferences() {
+        LogicalPlan z = plan();
+        LogicalPlan y = plan(z);
+        LogicalPlan x = plan(y);
+
+        Memo memo = new Memo(idAllocator, x);
+        assertEquals(memo.groupCount(), 3);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+
+        LogicalPlan rewrittenZ = memo.resolve(yGroup).sources().get(0);
+        LogicalPlan y1 = plan(rewrittenZ);
+        LogicalPlan y2 = plan(rewrittenZ);
+
+        LogicalPlan newX = plan(y1, y2);
+        memo.replace(memo.getRootGroup(), newX);
+        assertEquals(memo.groupCount(), 4);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(newX.id(),
+                 plan(y1.id(), plan(z.id())),
+                 plan(y2.id(), plan(z.id()))));
+    }
+
+
+    private static void assertMatchesStructure(LogicalPlan actual, LogicalPlan expected) {
+        assertEquals(actual.getClass(), expected.getClass());
+        assertEquals(actual.id(), expected.id());
+        assertEquals(actual.sources().size(), expected.sources().size());
+
+        for (int i = 0; i < actual.sources().size(); i++) {
+            assertMatchesStructure(actual.sources().get(i), expected.sources().get(i));
+        }
+    }
+
+    private int getChildGroup(Memo memo, int group) {
+        LogicalPlan node = memo.resolve(group);
+        GroupReference child = (GroupReference) node.sources().get(0);
+
+        return child.groupId();
+    }
+
+    private TestPlan plan(LogicalPlanId id, LogicalPlan... children) {
+        return new TestPlan(id, List.of(children));
+    }
+
+    private TestPlan plan(LogicalPlan... children) {
+        return plan(idAllocator.nextId(), children);
+    }
+
+    private static class TestPlan implements LogicalPlan {
+        private final List<LogicalPlan> sources;
+        private final LogicalPlanId id;
+
+        public TestPlan(LogicalPlanId id, List<LogicalPlan> sources) {
+            this.sources = List.copyOf(sources);
+            this.id = id;
+        }
+
+        @Override
+        public List<LogicalPlan> sources() {
+            return sources;
+        }
+
+        @Override
+        public List<Symbol> outputs() {
+            return List.of();
+        }
+
+        @Override
+        public ExecutionPlan build(DependencyCarrier dependencyCarrier,
+                                   PlannerContext plannerContext,
+                                   Set<PlanHint> planHints,
+                                   ProjectionBuilder projectionBuilder,
+                                   int limit,
+                                   int offset,
+                                   @Nullable OrderBy order,
+                                   @Nullable Integer pageSizeHint,
+                                   Row params,
+                                   SubQueryResults subQueryResults) {
+            return null;
+        }
+
+
+        @Override
+        public List<AbstractTableRelation<?>> baseTables() {
+            return null;
+        }
+
+
+        @Override
+        public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+            return new TestPlan(id(), sources);
+        }
+
+        @Override
+        public LogicalPlanId id() {
+            return id;
+        }
+
+        @Override
+        public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+            return null;
+        }
+
+        @Override
+        public Map<LogicalPlan, SelectSymbol> dependencies() {
+            return null;
+        }
+
+        @Override
+        public long numExpectedRows() {
+            return 0;
+        }
+
+        @Override
+        public long estimatedRowSize() {
+            return 0;
+        }
+
+        @Override
+        public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+            return visitor.visitPlan(this, context);
+        }
+
+        @Override
+        public Set<RelationName> getRelationNames() {
+            return null;
+        }
+    }
+}
+

--- a/server/src/test/java/io/crate/planner/optimizer/matcher/CapturePatternTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/matcher/CapturePatternTest.java
@@ -30,12 +30,13 @@ import org.junit.Test;
 import io.crate.expression.symbol.Literal;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanIdAllocator;
 
 public class CapturePatternTest {
-
+    static LogicalPlanIdAllocator logicalPlanIdAllocator = new LogicalPlanIdAllocator();
     @Test
     public void testCapturePatternAddsToCaptureOnMatch() {
-        Filter filter = new Filter(mock(LogicalPlan.class), Literal.BOOLEAN_TRUE);
+        Filter filter = new Filter(logicalPlanIdAllocator.nextId(), mock(LogicalPlan.class), Literal.BOOLEAN_TRUE);
 
         Capture<Filter> captureFilter = new Capture<>();
         Pattern<Filter> filterPattern = Pattern.typeOf(Filter.class).capturedAs(captureFilter);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -47,6 +47,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
     private SqlExpressions e;
     private AbstractTableRelation<?> tr1;
+    private CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void setUp() throws Exception {
@@ -58,9 +59,9 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testMergeFiltersMatchesOnAFilterWithAnotherFilterAsChild() {
-        Collect source = new Collect(tr1, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
-        Filter sourceFilter = new Filter(source, e.asSymbol("x > 10"));
-        Filter parentFilter = new Filter(sourceFilter, e.asSymbol("y > 10"));
+        Collect source = new Collect(txnCtx.idAllocator().nextId(), tr1, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
+        Filter sourceFilter = new Filter(txnCtx.idAllocator().nextId(), source, e.asSymbol("x > 10"));
+        Filter parentFilter = new Filter(txnCtx.idAllocator().nextId(), sourceFilter, e.asSymbol("y > 10"));
 
         MergeFilters mergeFilters = new MergeFilters();
         Match<Filter> match = mergeFilters.pattern().accept(parentFilter, Captures.empty());

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -47,6 +47,8 @@ import io.crate.testing.SQLExecutor;
 
 public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnitTest {
 
+    private CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+
     private SQLExecutor e;
 
     @Before
@@ -62,10 +64,10 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var collect = e.logicalPlan("SELECT id FROM t1");
 
         WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION by id)");
-        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(txnCtx.idAllocator(), collect, List.of(windowFunction));
 
         Symbol query = e.asSymbol("ROW_NUMBER() OVER(PARTITION by id) = 2");
-        Filter filter = new Filter(windowAgg, query);
+        Filter filter = new Filter(txnCtx.idAllocator().nextId(), windowAgg, query);
 
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
@@ -89,10 +91,10 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var collect = e.logicalPlan("SELECT id, x FROM t1");
 
         WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION by id)");
-        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(txnCtx.idAllocator(), collect, List.of(windowFunction));
 
         Symbol query = e.asSymbol("x = 1");
-        Filter filter = new Filter(windowAgg, query);
+        Filter filter = new Filter(txnCtx.idAllocator().nextId(), windowAgg, query);
 
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
@@ -116,10 +118,10 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var collect = e.logicalPlan("SELECT id FROM t1");
 
         WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id)");
-        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(txnCtx.idAllocator(), collect, List.of(windowFunction));
 
         Symbol query = e.asSymbol("id = 10");
-        Filter filter = new Filter(windowAgg, query);
+        Filter filter = new Filter(txnCtx.idAllocator().nextId(), windowAgg, query);
 
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
@@ -147,10 +149,10 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var collect = e.logicalPlan("SELECT id FROM t1");
 
         WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id)");
-        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(txnCtx.idAllocator(), collect, List.of(windowFunction));
 
         Symbol query = e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id) = 2 AND id = 10 AND x = 1");
-        Filter filter = new Filter(windowAgg, query);
+        Filter filter = new Filter(txnCtx.idAllocator().nextId(), windowAgg, query);
 
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
@@ -179,10 +181,10 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var collect = e.logicalPlan("SELECT id FROM t1");
 
         WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id)");
-        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(txnCtx.idAllocator(), collect, List.of(windowFunction));
 
         Symbol query = e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id) = 1 OR id = 10");
-        Filter filter = new Filter(windowAgg, query);
+        Filter filter = new Filter(txnCtx.idAllocator().nextId(), windowAgg, query);
 
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -94,6 +94,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
 
     private void assertCollectQuery(String query, String expected) {
         var collect = new Collect(
+            plannerContext.transactionContext().idAllocator().nextId(),
             tr1,
             Collections.emptyList(),
             new WhereClause(e.asSymbol(query)),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This draft has two major parts:
-  It first introduces id's to LogicalPlans to make them identifiable. This is all done in the commit https://github.com/crate/crate/pull/13489/commits/e6c7281bc54c4264f8af2e300b39877fd95aca42 . This is a pre-requisite for the second part.
- The second part https://github.com/crate/crate/pull/13489/commits/5d26c0e8b95ce4f3dc92ce43201cd7921ab9e2df introduces an iterative optimizer with memoization. A great introduction to why this makes sense to have is https://www.querifylabs.com/blog/memoization-in-cost-based-optimizers
- The reason for the duplication of the rule and capture system was to be able to run both optimizers side by side, because the capture system and the rules had to be modified to be able to work with group references and the group reference resolver. 
- It should be possible to make the capture system and the rules work for both optimizers.







## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
