### PR TITLE
Don't cache parsed analyze statement in TableStatsService

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -82,9 +81,9 @@ import io.crate.protocols.postgres.Portal;
 import io.crate.protocols.postgres.RetryOnFailureResultReceiver;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Declare.Hold;
 import io.crate.sql.tree.DiscardStatement.Target;
 import io.crate.sql.tree.Statement;
-import io.crate.sql.tree.Declare.Hold;
 import io.crate.types.DataType;
 
 /**
@@ -187,22 +186,15 @@ public class Session implements AutoCloseable {
     }
 
     /**
-     * See {@link #quickExec(String, Function, ResultReceiver, Row)}
-     */
-    public void quickExec(String statement, ResultReceiver<?> resultReceiver, Row params) {
-        quickExec(statement, SqlParser::createStatement, resultReceiver, params);
-    }
-
-    /**
      * Execute a query in one step, avoiding the parse/bind/execute/sync procedure.
      * Opposed to using parse/bind/execute/sync this method is thread-safe.
      *
      * @param parse A function to parse the statement; This can be used to cache the parsed statement.
      *              Use {@link #quickExec(String, ResultReceiver, Row)} to use the regular parser
      */
-    public void quickExec(String statement, Function<String, Statement> parse, ResultReceiver<?> resultReceiver, Row params) {
+    public void quickExec(String statement, ResultReceiver<?> resultReceiver, Row params) {
         CoordinatorTxnCtx txnCtx = new CoordinatorTxnCtx(sessionSettings);
-        Statement parsedStmt = parse.apply(statement);
+        Statement parsedStmt = SqlParser.createStatement(statement);
         AnalyzedStatement analyzedStatement = analyzer.analyze(
             parsedStmt,
             sessionSettings,

--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -22,28 +22,27 @@
 package io.crate.statistics;
 
 
-import io.crate.action.sql.BaseResultReceiver;
-import io.crate.action.sql.Sessions;
-import io.crate.action.sql.Session;
-import io.crate.common.annotations.VisibleForTesting;
-import io.crate.common.unit.TimeValue;
-import io.crate.data.Row;
-import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.Statement;
+import javax.annotation.Nullable;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import javax.annotation.Nullable;
+import io.crate.action.sql.BaseResultReceiver;
+import io.crate.action.sql.Session;
+import io.crate.action.sql.Sessions;
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.common.unit.TimeValue;
+import io.crate.data.Row;
 
 /**
  * Periodically refresh {@link TableStats} based on {@link #refreshInterval}.
@@ -60,7 +59,6 @@ public class TableStatsService implements Runnable {
         "stats.service.max_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB), Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     static final String STMT = "ANALYZE";
-    private static final Statement PARSED_STMT = SqlParser.createStatement(STMT);
 
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
@@ -113,7 +111,7 @@ public class TableStatsService implements Runnable {
                     LOGGER.error("Error running periodic " + STMT + "", err);
                 }
             });
-            session.quickExec(STMT, stmt -> PARSED_STMT, resultReceiver, Row.EMPTY);
+            session.quickExec(STMT, resultReceiver, Row.EMPTY);
         } catch (Throwable t) {
             LOGGER.error("error retrieving table stats", t);
         }

--- a/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
+++ b/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
@@ -32,8 +32,8 @@ import org.mockito.Answers;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-import io.crate.action.sql.Sessions;
 import io.crate.action.sql.Session;
+import io.crate.action.sql.Sessions;
 import io.crate.common.unit.TimeValue;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
@@ -103,7 +103,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
         );
         statsService.run();
 
-        Mockito.verify(session, Mockito.times(1)).quickExec(ArgumentMatchers.eq(TableStatsService.STMT), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+        Mockito.verify(session, Mockito.times(1)).quickExec(ArgumentMatchers.eq(TableStatsService.STMT), ArgumentMatchers.any(), ArgumentMatchers.any());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Spotted this while looking at profiles of test runs where I didn't
expect so see anything getting parsed.

Not really an issue, but seems it's not worth to cache a statement
indefinitely that is used only once every 24 hours. Parsing is cheap
enough.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
