### PR TITLE
Fix ClassCastException while querying implicit nested arrays

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -71,6 +71,18 @@ Fixes
 - Fixed an issue that caused the returned column names to be missing the
   subscripts when querying sub-columns of nested object arrays.
 
+- Fixed an issue that caused ``ClassCastException`` when accessing a sub-column
+  of a nested object array where the sub-column resolves to a nested array.
+  An example ::
+
+    CREATE TABLE test (
+      "a" ARRAY(OBJECT AS (
+        "b" ARRAY(OBJECT AS (
+          "s" STRING
+        )))));
+    INSERT INTO test (a) VALUES ([{b=[{s='1'}, {s='2'}, {s='3'}]}]);
+    SELECT a['b'] FROM test; // a['b'] is type of array(array(object))
+
 - Added validation to reject inner column names containing whitespace characters
   to avoid invalid schema definitions.
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -121,7 +121,15 @@ public final class SourceParser {
         } else {
             ArrayList<Object> values = new ArrayList<>();
             Token token = parser.nextToken();
-            if (type instanceof ArrayType) {
+            // Handles nested arrays
+            // ex:
+            //   CREATE TABLE test (
+            //   "a" array(object as (
+            //   "b" array(object as (
+            //   "s" string
+            //   )))));
+            //   SELECT a['b'] from test; -- resolves to array(array(object))
+            while (type instanceof ArrayType) {
                 type = ((ArrayType<?>) type).innerType();
             }
             for (; token != null && token != XContentParser.Token.END_ARRAY; token = parser.nextToken()) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes part of bug #13504 

```
CREATE TABLE doc.test ( 
"a" array(object as ( 
"b" array(object as ( 
"s" string 
)))));
insert into test (a) values ([{b=[{s='1'}, {s='2'}, {s='3'}]}]);
select a['b'] from test;

Before:
ClassCastException[class java.util.HashMap cannot be cast to class [Ljava.lang.Object; (java.util.HashMap and [Ljava.lang.Object; are in module java.base of loader 'bootstrap')]

After:
+----------------------------------------+
| a['b']                                 |
+----------------------------------------+
| [[{"s": "1"}, {"s": "2"}, {"s": "3"}]] |
+----------------------------------------+
```


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
