### PR TITLE
Try fix flaky testAbortNotStartedSnapshotWithoutIO

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -565,7 +565,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         execute("drop snapshot repo1.snapshot2");
         assertThat(createSnapshot2Future)
-            .failsWithin(0, TimeUnit.SECONDS)
+            .failsWithin(5, TimeUnit.SECONDS)
             .withThrowableOfType(ExecutionException.class)
             .withRootCauseExactlyInstanceOf(SnapshotException.class);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

    org.gradle.internal.exceptions.DefaultMultiCauseException: Multiple Failures (4 failures)
    	java.lang.AssertionError:
    Expecting actual throwable to be an instance of:
      java.util.concurrent.ExecutionException
    but was:
      java.util.concurrent.TimeoutException
    	at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960)
    	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
    	at org.assertj.core.internal.Futures.assertFailedWithin(Futures.java:128)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
