### PR TITLE
Fix output column names that were missing a subscript

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused the returned column names to be missing the
+  subscripts when querying sub-columns of nested object arrays.
+
 - Added validation to reject inner column names containing whitespace characters
   to avoid invalid schema definitions.
 

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -423,9 +423,7 @@ public class Function implements Symbol, Cloneable {
             builder.append("[");
             builder.append(arguments.get(1).toString(style));
             builder.append("]");
-            builder.append("['");
-            builder.append(ref.column().path().get(0));
-            builder.append("']");
+            ref.column().path().forEach(path -> builder.append("['").append(path).append("']"));
         } else {
             builder.append(base.toString(style));
             builder.append("[");


### PR DESCRIPTION
```
CREATE TABLE doc.test (
"a" array(object as (
"b" array(object as (
"s" string
)))));

SELECT a[1]['b']['s'] FROM test;
+-----------------+
| a[1]['b']       | --> should be a[1]['b']['s']
+-----------------+
| ["1", "2", "3"] |
+-----------------+
```

## Summary of the changes / Why this improves CrateDB
Fixes part of #13504 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
