### PR TITLE
Add ids to logical plans

### DIFF
--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -70,6 +70,7 @@ public class PlannerContext {
     private final ClusterState clusterState;
     private final TransactionState transactionState;
     private int executionPhaseId = 0;
+    private int logicalPlanId = 0;
     private final String handlerNode;
     @Nullable
     private final Row params;
@@ -126,6 +127,10 @@ public class PlannerContext {
 
     public int nextExecutionPhaseId() {
         return executionPhaseId++;
+    }
+
+    public int nextLogicalPlanId() {
+        return logicalPlanId++;
     }
 
     public Routing allocateRouting(TableInfo tableInfo,

--- a/server/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
@@ -43,11 +44,12 @@ public class SubqueryPlanner {
 
     public record SubQueries(Map<LogicalPlan, SelectSymbol> uncorrelated, Map<SelectSymbol, LogicalPlan> correlated) {
 
-        public LogicalPlan applyCorrelatedJoin(LogicalPlan source) {
+        public LogicalPlan applyCorrelatedJoin(LogicalPlan source, IntSupplier ids) {
             for (var entry : correlated.entrySet()) {
                 LogicalPlan plannedSubQuery = entry.getValue();
                 SelectSymbol subQuery = entry.getKey();
                 source = new CorrelatedJoin(
+                    ids.getAsInt(),
                     source,
                     subQuery,
                     plannedSubQuery

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -104,6 +104,6 @@ public final class InsertFromSubQueryPlanner {
         );
         EvalProjection castOutputs = EvalProjection.castValues(
             Symbols.typeView(statement.columns()), plannedSubQuery.outputs());
-        return new Insert(plannedSubQuery, indexWriterProjection, castOutputs);
+        return new Insert(plannerContext.nextLogicalPlanId(), plannedSubQuery, indexWriterProjection, castOutputs);
     }
 }

--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -363,6 +363,7 @@ public class ExplainPlan implements Plan {
         @Override
         public LogicalPlan visitCollect(Collect collect, PlannerContext context) {
             var optimizedCollect = new Collect(
+                context.nextLogicalPlanId(),
                 collect.relation(),
                 collect.outputs(),
                 collect.where().map(s -> Optimizer.optimizeCasts(s, context)),

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -98,13 +98,17 @@ public class Collect implements LogicalPlan {
     WhereClause mutableBoundWhere;
     DetailedQuery detailedQuery;
 
-    public static Collect create(AbstractTableRelation<?> relation,
+    private final int id;
+
+    public static Collect create(int id,
+                                 AbstractTableRelation<?> relation,
                                  List<Symbol> toCollect,
                                  WhereClause where,
                                  TableStats tableStats,
                                  Row params) {
         Stats stats = tableStats.getStats(relation.tableInfo().ident());
         return new Collect(
+            id,
             relation,
             toCollect,
             where,
@@ -126,13 +130,16 @@ public class Collect implements LogicalPlan {
         this.immutableWhere = collect.immutableWhere;
         this.tableInfo = collect.relation.tableInfo();
         this.detailedQuery = detailedQuery;
+        this.id = collect.id;
     }
 
-    public Collect(AbstractTableRelation<?> relation,
+    public Collect(int id,
+                   AbstractTableRelation<?> relation,
                    List<Symbol> outputs,
                    WhereClause where,
                    long numExpectedRows,
                    long estimatedRowSize) {
+        this.id = id;
         this.outputs = outputs;
         this.baseTables = List.of(relation);
         this.numExpectedRows = numExpectedRows;
@@ -352,6 +359,11 @@ public class Collect implements LogicalPlan {
     }
 
     @Override
+    public int id() {
+        return id;
+    }
+
+    @Override
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         ArrayList<Symbol> newOutputs = new ArrayList<>();
         for (Symbol output : outputs) {
@@ -364,6 +376,7 @@ public class Collect implements LogicalPlan {
         }
         Stats stats = tableStats.getStats(relation.relationName());
         return new Collect(
+            id,
             relation,
             newOutputs,
             immutableWhere,
@@ -410,6 +423,7 @@ public class Collect implements LogicalPlan {
         return new FetchRewrite(
             replacedOutputs,
             new Collect(
+                id,
                 relation,
                 newOutputs,
                 immutableWhere,

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -65,15 +65,18 @@ import io.crate.statistics.TableStats;
  **/
 public class CorrelatedJoin implements LogicalPlan {
 
+    private final int id;
     private final LogicalPlan inputPlan;
     private final LogicalPlan subQueryPlan;
 
     private final List<Symbol> outputs;
     private final SelectSymbol selectSymbol;
 
-    public CorrelatedJoin(LogicalPlan inputPlan,
+    public CorrelatedJoin(int id,
+                          LogicalPlan inputPlan,
                           SelectSymbol selectSymbol,
                           LogicalPlan subQueryPlan) {
+        this.id = id;
         this.inputPlan = inputPlan;
         this.subQueryPlan = subQueryPlan;
         this.selectSymbol = selectSymbol;
@@ -138,6 +141,11 @@ public class CorrelatedJoin implements LogicalPlan {
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         return this;
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -62,11 +62,14 @@ public class Count implements LogicalPlan {
 
     private static final String COUNT_PHASE_NAME = "count-merge";
 
+    private final int id;
     final AbstractTableRelation<?> tableRelation;
     final WhereClause where;
     private final List<Symbol> outputs;
 
-    public Count(Function countFunction, AbstractTableRelation<?> tableRelation, WhereClause where) {
+
+    public Count(int id, Function countFunction, AbstractTableRelation<?> tableRelation, WhereClause where) {
+        this.id = id;
         this.outputs = List.of(countFunction);
         this.tableRelation = tableRelation;
         this.where = where;
@@ -123,6 +126,11 @@ public class Count implements LogicalPlan {
             null
         );
         return new CountPlan(countPhase, mergePhase);
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Distinct.java
+++ b/server/src/main/java/io/crate/planner/operators/Distinct.java
@@ -31,11 +31,11 @@ import static io.crate.planner.operators.GroupHashAggregate.approximateDistinctV
 
 public final class Distinct {
 
-    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, TableStats tableStats) {
+    public static LogicalPlan create(int id, LogicalPlan source, boolean distinct, List<Symbol> outputs, TableStats tableStats) {
         if (!distinct) {
             return source;
         }
         long numExpectedRows = approximateDistinctValues(source.numExpectedRows(), tableStats, outputs);
-        return new GroupHashAggregate(source, outputs, Collections.emptyList(), numExpectedRows);
+        return new GroupHashAggregate(id, source, outputs, Collections.emptyList(), numExpectedRows);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -57,17 +57,19 @@ import io.crate.statistics.TableStats;
 public final class Eval extends ForwardingLogicalPlan {
 
     private final List<Symbol> outputs;
+    private final int id;
 
-    public static LogicalPlan create(LogicalPlan source, List<Symbol> outputs) {
+    public static LogicalPlan create(int id, LogicalPlan source, List<Symbol> outputs) {
         if (source.outputs().equals(outputs)) {
             return source;
         }
-        return new Eval(source, outputs);
+        return new Eval(id, source, outputs);
     }
 
-    Eval(LogicalPlan source, List<Symbol> outputs) {
-        super(source);
+    Eval(int id, LogicalPlan source, List<Symbol> outputs) {
+        super(id, source);
         this.outputs = outputs;
+        this.id = id;
     }
 
     @Override
@@ -96,7 +98,7 @@ public final class Eval extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Eval(Lists2.getOnlyElement(sources), outputs);
+        return new Eval(id, Lists2.getOnlyElement(sources), outputs);
     }
 
     @Override
@@ -105,7 +107,7 @@ public final class Eval extends ForwardingLogicalPlan {
         if (source == newSource) {
             return this;
         }
-        return new Eval(newSource, List.copyOf(outputsToKeep));
+        return new Eval(id, newSource, List.copyOf(outputsToKeep));
     }
 
     @Nullable
@@ -130,7 +132,7 @@ public final class Eval extends ForwardingLogicalPlan {
                 newOutputs.add(output);
             }
         }
-        return new FetchRewrite(newReplacedOutputs, Eval.create(newSource, newOutputs));
+        return new FetchRewrite(newReplacedOutputs, Eval.create(id, newSource, newOutputs));
     }
 
     private ExecutionPlan addEvalProjection(PlannerContext plannerContext,
@@ -156,6 +158,11 @@ public final class Eval extends ForwardingLogicalPlan {
             newOrderBy
         );
         return executionPlan;
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/server/src/main/java/io/crate/planner/operators/Fetch.java
@@ -82,20 +82,23 @@ import io.crate.types.DataType;
  */
 public final class Fetch extends ForwardingLogicalPlan {
 
+    private final int id;
     private final List<Symbol> outputs;
     private final List<Reference> fetchRefs;
     private final Map<RelationName, FetchSource> fetchSourceByRelation;
     private final Map<Symbol, Symbol> replacedOutputs;
 
-    public Fetch(Map<Symbol, Symbol> replacedOutputs,
+    public Fetch(int id,
+                 Map<Symbol, Symbol> replacedOutputs,
                  List<Reference> fetchRefs,
                  Map<RelationName, FetchSource> fetchSourceByRelation,
                  LogicalPlan source) {
-        super(source);
+        super(id, source);
         this.outputs = List.copyOf(replacedOutputs.keySet());
         this.replacedOutputs = replacedOutputs;
         this.fetchRefs = fetchRefs;
         this.fetchSourceByRelation = fetchSourceByRelation;
+        this.id = id;
     }
 
     @Override
@@ -173,7 +176,12 @@ public final class Fetch extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Fetch(replacedOutputs, fetchRefs, fetchSourceByRelation, Lists2.getOnlyElement(sources));
+        return new Fetch(id, replacedOutputs, fetchRefs, fetchSourceByRelation, Lists2.getOnlyElement(sources));
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -46,7 +46,7 @@ public final class Filter extends ForwardingLogicalPlan {
 
     final Symbol query;
 
-    public static LogicalPlan create(LogicalPlan source, @Nullable Symbol query) {
+    public static LogicalPlan create(int id, LogicalPlan source, @Nullable Symbol query) {
         if (query == null) {
             return source;
         }
@@ -55,15 +55,15 @@ public final class Filter extends ForwardingLogicalPlan {
         if (isMatchAll(query)) {
             return source;
         }
-        return new Filter(source, query);
+        return new Filter(id, source, query);
     }
 
     private static boolean isMatchAll(Symbol query) {
         return query instanceof Literal && ((Literal<?>) query).value() == Boolean.TRUE;
     }
 
-    public Filter(LogicalPlan source, Symbol query) {
-        super(source);
+    public Filter(int id, LogicalPlan source, Symbol query) {
+        super(id, source);
         this.query = query;
     }
 
@@ -101,12 +101,17 @@ public final class Filter extends ForwardingLogicalPlan {
         if (newSource == source) {
             return this;
         }
-        return new Filter(newSource, query);
+        return new Filter(id, newSource, query);
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Filter(Lists2.getOnlyElement(sources), query);
+        return new Filter(id, Lists2.getOnlyElement(sources), query);
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -34,10 +34,12 @@ import java.util.Set;
 
 public abstract class ForwardingLogicalPlan implements LogicalPlan {
 
+    protected final int id;
     private final List<LogicalPlan> sources;
     final LogicalPlan source;
 
-    public ForwardingLogicalPlan(LogicalPlan source) {
+    public ForwardingLogicalPlan(int id, LogicalPlan source) {
+        this.id = id;
         this.source = source;
         this.sources = List.of(source);
     }
@@ -53,6 +55,11 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
             return this;
         }
         return replaceSources(List.of(newSource));
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -70,17 +70,20 @@ import io.crate.statistics.TableStats;
 
 public class Get implements LogicalPlan {
 
+    private final int id;
     final DocTableRelation tableRelation;
     final DocKeys docKeys;
     final Symbol query;
     final long estimatedSizePerRow;
     private final List<Symbol> outputs;
 
-    public Get(DocTableRelation table,
+    public Get(int id,
+               DocTableRelation table,
                DocKeys docKeys,
                Symbol query,
                List<Symbol> outputs,
                long estimatedSizePerRow) {
+        this.id = id;
         this.tableRelation = table;
         this.docKeys = docKeys;
         this.query = query;
@@ -250,7 +253,7 @@ public class Get implements LogicalPlan {
             }
         }
         if (excludedAny) {
-            return new Get(tableRelation, docKeys, query, newOutputs, estimatedSizePerRow);
+            return new Get(id, tableRelation, docKeys, query, newOutputs, estimatedSizePerRow);
         }
         return this;
     }
@@ -268,6 +271,11 @@ public class Get implements LogicalPlan {
     @Override
     public long numExpectedRows() {
         return docKeys.size();
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -70,7 +70,6 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
     private final List<Symbol> outputs;
     private final long numExpectedRows;
 
-
     static long approximateDistinctValues(long numSourceRows, TableStats tableStats, List<Symbol> groupKeys) {
         long distinctValues = 1;
         int numKeysWithStats = 0;
@@ -115,8 +114,13 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         }
     }
 
-    public GroupHashAggregate(LogicalPlan source, List<Symbol> groupKeys, List<Function> aggregates, long numExpectedRows) {
-        super(source);
+    public GroupHashAggregate(int id,
+                              LogicalPlan source,
+                              List<Symbol> groupKeys,
+                              List<Function> aggregates,
+                              long numExpectedRows
+                              ) {
+        super(id, source);
         this.numExpectedRows = numExpectedRows;
         this.aggregates = List.copyOf(new LinkedHashSet<>(aggregates));
         this.outputs = Lists2.concat(groupKeys, this.aggregates);
@@ -268,12 +272,12 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         if (newSource == source && aggregates.size() == newAggregates.size()) {
             return this;
         }
-        return new GroupHashAggregate(newSource, groupKeys, newAggregates, numExpectedRows);
+        return new GroupHashAggregate(id, newSource, groupKeys, newAggregates, numExpectedRows);
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new GroupHashAggregate(Lists2.getOnlyElement(sources), groupKeys, aggregates, numExpectedRows);
+        return new GroupHashAggregate(id, Lists2.getOnlyElement(sources), groupKeys, aggregates, numExpectedRows);
     }
 
     private ExecutionPlan createMerge(PlannerContext plannerContext,

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -61,8 +61,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
     private static final String MERGE_PHASE_NAME = "mergeOnHandler";
     final List<Function> aggregates;
 
-    HashAggregate(LogicalPlan source, List<Function> aggregates) {
-        super(source);
+    HashAggregate(int id, LogicalPlan source, List<Function> aggregates) {
+        super(id, source);
         this.aggregates = aggregates;
     }
 
@@ -173,7 +173,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new HashAggregate(Lists2.getOnlyElement(sources), aggregates);
+        return new HashAggregate(id, Lists2.getOnlyElement(sources), aggregates);
     }
 
     @Override
@@ -190,7 +190,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
         if (source == newSource && newAggregates == aggregates) {
             return this;
         }
-        return new HashAggregate(newSource, newAggregates);
+        return new HashAggregate(id, newSource, newAggregates);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -63,14 +63,17 @@ import io.crate.statistics.TableStats;
 
 public class HashJoin implements LogicalPlan {
 
+    private final int id;
     private final Symbol joinCondition;
     private final List<Symbol> outputs;
     final LogicalPlan rhs;
     final LogicalPlan lhs;
 
-    public HashJoin(LogicalPlan lhs,
+    public HashJoin(int id,
+                    LogicalPlan lhs,
                     LogicalPlan rhs,
                     Symbol joinCondition) {
+        this.id = id;
         this.outputs = Lists2.concat(lhs.outputs(), rhs.outputs());
         this.lhs = lhs;
         this.rhs = rhs;
@@ -252,6 +255,7 @@ public class HashJoin implements LogicalPlan {
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         return new HashJoin(
+            id,
             sources.get(0),
             sources.get(1),
             joinCondition
@@ -274,6 +278,7 @@ public class HashJoin implements LogicalPlan {
             return this;
         }
         return new HashJoin(
+            id,
             newLhs,
             newRhs,
             joinCondition
@@ -302,6 +307,7 @@ public class HashJoin implements LogicalPlan {
         return new FetchRewrite(
             allReplacedOutputs,
             new HashJoin(
+                id,
                 lhsFetchRewrite == null ? lhs : lhsFetchRewrite.newPlan(),
                 rhsFetchRewrite == null ? rhs : rhsFetchRewrite.newPlan(),
                 joinCondition
@@ -327,6 +333,11 @@ public class HashJoin implements LogicalPlan {
     @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitHashJoin(this, context);
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -52,11 +52,16 @@ public class Insert implements LogicalPlan {
 
     private final ColumnIndexWriterProjection writeToTable;
 
+    private final int id;
     @Nullable
     private final EvalProjection applyCasts;
     final LogicalPlan source;
 
-    public Insert(LogicalPlan source, ColumnIndexWriterProjection writeToTable, @Nullable EvalProjection applyCasts) {
+    public Insert(int id,
+                  LogicalPlan source,
+                  ColumnIndexWriterProjection writeToTable,
+                  @Nullable EvalProjection applyCasts) {
+        this.id = id;
         this.source = source;
         this.writeToTable = writeToTable;
         this.applyCasts = applyCasts;
@@ -132,7 +137,7 @@ public class Insert implements LogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Insert(Lists2.getOnlyElement(sources), writeToTable, applyCasts);
+        return new Insert(id, Lists2.getOnlyElement(sources), writeToTable, applyCasts);
     }
 
     @Override
@@ -147,6 +152,11 @@ public class Insert implements LogicalPlan {
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
         return source.dependencies();
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -116,11 +116,14 @@ import io.crate.types.DataType;
 
 public class InsertFromValues implements LogicalPlan {
 
+    private final int id;
     private final TableFunctionRelation tableFunctionRelation;
     private final ColumnIndexWriterProjection writerProjection;
 
-    InsertFromValues(TableFunctionRelation tableFunctionRelation,
+    InsertFromValues(int id,
+                     TableFunctionRelation tableFunctionRelation,
                      ColumnIndexWriterProjection writerProjection) {
+        this.id = id;
         this.tableFunctionRelation = tableFunctionRelation;
         this.writerProjection = writerProjection;
     }
@@ -821,6 +824,11 @@ public class InsertFromValues implements LogicalPlan {
     @Override
     public List<Symbol> outputs() {
         return List.of();
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -56,19 +56,21 @@ public class Limit extends ForwardingLogicalPlan {
     final Symbol limit;
     final Symbol offset;
 
-    static LogicalPlan create(LogicalPlan source, @Nullable Symbol limit, @Nullable Symbol offset) {
+    static LogicalPlan create(int id, LogicalPlan source, @Nullable Symbol limit, @Nullable Symbol offset) {
         if (limit == null && offset == null) {
             return source;
         } else {
             return new Limit(
+                id,
                 source,
                 Objects.requireNonNullElse(limit, Literal.of(-1L)),
-                Objects.requireNonNullElse(offset, Literal.of(0)));
+                Objects.requireNonNullElse(offset, Literal.of(0))
+            );
         }
     }
 
-    public Limit(LogicalPlan source, Symbol limit, Symbol offset) {
-        super(source);
+    public Limit(int id, LogicalPlan source, Symbol limit, Symbol offset) {
+        super(id, source);
         this.limit = limit;
         this.offset = offset;
     }
@@ -134,7 +136,7 @@ public class Limit extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Limit(Lists2.getOnlyElement(sources), limit, offset);
+        return new Limit(id, Lists2.getOnlyElement(sources), limit, offset);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
@@ -59,8 +59,8 @@ public final class LimitDistinct extends ForwardingLogicalPlan {
     private final List<Symbol> outputs;
     private final Symbol offset;
 
-    public LimitDistinct(LogicalPlan source, Symbol limit, Symbol offset, List<Symbol> outputs) {
-        super(source);
+    public LimitDistinct(int id, LogicalPlan source, Symbol limit, Symbol offset, List<Symbol> outputs) {
+        super(id, source);
         this.limit = limit;
         this.offset = offset;
         this.outputs = outputs;
@@ -168,13 +168,13 @@ public final class LimitDistinct extends ForwardingLogicalPlan {
         if (prunedSource == source) {
             return this;
         }
-        return new LimitDistinct(prunedSource, limit, offset, outputs);
+        return new LimitDistinct(id, prunedSource, limit, offset, outputs);
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
         var source = Lists2.getOnlyElement(sources);
-        return new LimitDistinct(source, limit, offset, outputs);
+        return new LimitDistinct(id, source, limit, offset, outputs);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -115,6 +115,8 @@ public interface LogicalPlan extends Plan {
 
     LogicalPlan replaceSources(List<LogicalPlan> sources);
 
+    int id();
+
     /**
      * Request an operator to return a new version of itself with all outputs removed except the ones contained in `outputsToKeep`.
      * <p>

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 import org.elasticsearch.Version;
@@ -178,7 +179,7 @@ public class LogicalPlanner {
             case SINGLE_COLUMN_EXISTS:
                 // Exists only needs to know if there are any rows
                 fetchSize = 1;
-                maybeApplySoftLimit = plan -> new Limit(plan, Literal.of(1), Literal.of(0));
+                maybeApplySoftLimit = plan -> new Limit(plannerContext.nextLogicalPlanId(), plan, Literal.of(1), Literal.of(0));
                 break;
             case SINGLE_COLUMN_SINGLE_VALUE:
                 // SELECT (SELECT foo FROM t)
@@ -186,7 +187,7 @@ public class LogicalPlanner {
                 // The subquery must return at most 1 row, if more than 1 row is returned semantics require us to throw an error.
                 // So we limit the query to 2 if there is no limit to avoid retrieval of many rows while being able to validate max1row
                 fetchSize = 2;
-                maybeApplySoftLimit = plan -> new Limit(plan, Literal.of(2L), Literal.of(0L));
+                maybeApplySoftLimit = plan -> new Limit(plannerContext.nextLogicalPlanId(), plan, Literal.of(2L), Literal.of(0L));
                 break;
             case SINGLE_COLUMN_MULTIPLE_VALUES:
             default:
@@ -200,20 +201,24 @@ public class LogicalPlanner {
             subqueryPlanner,
             txnCtx,
             tableStats,
-            subSelectPlannerContext.params()
+            subSelectPlannerContext.params(),
+            plannerContext::nextLogicalPlanId
         );
         LogicalPlan plan = relation.accept(planBuilder, relation.outputs());
 
-        plan = tryOptimizeForInSubquery(selectSymbol, relation, plan);
-        LogicalPlan optimizedPlan = optimizer.optimize(maybeApplySoftLimit.apply(plan), tableStats, txnCtx);
-        return new RootRelationBoundary(optimizedPlan);
+        plan = tryOptimizeForInSubquery(selectSymbol, relation, plan, plannerContext::nextLogicalPlanId);
+        LogicalPlan optimizedPlan = optimizer.optimize(maybeApplySoftLimit.apply(plan), tableStats, txnCtx, plannerContext);
+        return new RootRelationBoundary(plannerContext.nextLogicalPlanId(), optimizedPlan);
     }
 
     // In case the subselect is inside an IN() or = ANY() apply a "natural" OrderBy to optimize
     // the building of TermInSetQuery which does a sort on the collection of values.
     // See issue https://github.com/crate/crate/issues/6755
     // If the output values are already sorted (even in desc order) no optimization is needed
-    private LogicalPlan tryOptimizeForInSubquery(SelectSymbol selectSymbol, AnalyzedRelation relation, LogicalPlan planBuilder) {
+    private LogicalPlan tryOptimizeForInSubquery(SelectSymbol selectSymbol,
+                                                 AnalyzedRelation relation,
+                                                 LogicalPlan planBuilder,
+                                                 IntSupplier ids) {
         if (selectSymbol.isCorrelated()) {
             return planBuilder;
         }
@@ -227,7 +232,11 @@ public class LogicalPlanner {
             if ((relationOrderBy == null || relationOrderBy.orderBySymbols().get(0).equals(firstOutput) == false)
                 && DataTypes.isPrimitive(firstOutput.valueType())) {
 
-                return Order.create(planBuilder, new OrderBy(Collections.singletonList(firstOutput)));
+                return Order.create(
+                    ids.getAsInt(),
+                    planBuilder,
+                    new OrderBy(Collections.singletonList(firstOutput))
+                );
             }
         }
         return planBuilder;
@@ -243,17 +252,19 @@ public class LogicalPlanner {
             subqueryPlanner,
             coordinatorTxnCtx,
             tableStats,
-            plannerContext.params()
+            plannerContext.params(),
+            plannerContext::nextLogicalPlanId
         );
         LogicalPlan logicalPlan = relation.accept(planBuilder, relation.outputs());
-        LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, tableStats, coordinatorTxnCtx);
+        LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, tableStats, coordinatorTxnCtx, plannerContext);
         assert logicalPlan.outputs().equals(optimizedPlan.outputs()) : "Optimized plan must have the same outputs as original plan";
         LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(tableStats, relation.outputs());
         assert logicalPlan.outputs().equals(optimizedPlan.outputs()) : "Pruned plan must have the same outputs as original plan";
         LogicalPlan fetchOptimized = fetchOptimizer.optimize(
             prunedPlan,
             tableStats,
-            coordinatorTxnCtx
+            coordinatorTxnCtx,
+            plannerContext
         );
         if (fetchOptimized != prunedPlan || avoidTopLevelFetch) {
             return fetchOptimized;
@@ -265,7 +276,7 @@ public class LogicalPlanner {
         //
         // The reason for this is that some plans are cheaper to execute as fetch
         // even if there is no operator that reduces the number of records
-        return RewriteToQueryThenFetch.tryRewrite(relation, fetchOptimized, tableStats);
+        return RewriteToQueryThenFetch.tryRewrite(relation, fetchOptimized, tableStats, plannerContext::nextLogicalPlanId);
     }
 
     static class PlanBuilder extends AnalyzedRelationVisitor<List<Symbol>, LogicalPlan> {
@@ -274,15 +285,18 @@ public class LogicalPlanner {
         private final CoordinatorTxnCtx txnCtx;
         private final TableStats tableStats;
         private final Row params;
+        private final IntSupplier ids;
 
         private PlanBuilder(SubqueryPlanner subqueryPlanner,
                             CoordinatorTxnCtx txnCtx,
                             TableStats tableStats,
-                            Row params) {
+                            Row params,
+                            IntSupplier ids) {
             this.subqueryPlanner = subqueryPlanner;
             this.txnCtx = txnCtx;
             this.tableStats = tableStats;
             this.params = params;
+            this.ids = ids;
         }
 
         @Override
@@ -299,18 +313,19 @@ public class LogicalPlanner {
             SubQueries subQueries = subqueryPlanner.planSubQueries(relation);
             return MultiPhase.createIfNeeded(
                 subQueries.uncorrelated(),
-                TableFunction.create(relation, relation.outputs(), WhereClause.MATCH_ALL)
+                TableFunction.create(ids.getAsInt(), relation, relation.outputs(), WhereClause.MATCH_ALL),
+                ids
             );
         }
 
         @Override
         public LogicalPlan visitDocTableRelation(DocTableRelation relation, List<Symbol> outputs) {
-            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, tableStats, params);
+            return Collect.create(ids.getAsInt(), relation, outputs, WhereClause.MATCH_ALL, tableStats, params);
         }
 
         @Override
         public LogicalPlan visitTableRelation(TableRelation relation, List<Symbol> outputs) {
-            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, tableStats, params);
+            return Collect.create(ids.getAsInt(), relation, outputs, WhereClause.MATCH_ALL, tableStats, params);
         }
 
         @Override
@@ -319,12 +334,12 @@ public class LogicalPlanner {
             if (child instanceof AbstractTableRelation<?>) {
                 List<Symbol> mappedOutputs = Lists2.map(outputs, FieldReplacer.bind(relation::resolveField));
                 var source = child.accept(this, mappedOutputs);
-                return new Rename(outputs, relation.relationName(), relation, source);
+                return new Rename(ids.getAsInt(), outputs, relation.relationName(), relation, source);
             } else {
                 // Can't do outputs propagation because field reverse resolving could be ambiguous
                 //  `SELECT * FROM (select * from t as t1, t as t2)` -> x can refer to t1.x or t2.x
                 var source = child.accept(this, child.outputs());
-                return new Rename(relation.outputs(), relation.relationName(), relation, source);
+                return new Rename(ids.getAsInt(), relation.outputs(), relation.relationName(), relation, source);
             }
         }
 
@@ -332,7 +347,7 @@ public class LogicalPlanner {
         public LogicalPlan visitView(AnalyzedView view, List<Symbol> outputs) {
             var child = view.relation();
             var source = child.accept(this, child.outputs());
-            return new Rename(view.outputs(), view.relationName(), view, source);
+            return new Rename(ids.getAsInt(), view.outputs(), view.relationName(), view, source);
         }
 
         @Override
@@ -340,10 +355,13 @@ public class LogicalPlanner {
             var lhsRel = union.left();
             var rhsRel = union.right();
             return Distinct.create(
+                ids.getAsInt(),
                 new Union(
+                    ids.getAsInt(),
                     lhsRel.accept(this, lhsRel.outputs()),
                     rhsRel.accept(this, rhsRel.outputs()),
-                    union.outputs()),
+                    union.outputs()
+                ),
                 union.isDistinct(),
                 union.outputs(),
                 tableStats
@@ -395,7 +413,8 @@ public class LogicalPlanner {
                         return rel.accept(this, List.copyOf(toCollect));
                     }
                 },
-                txnCtx.sessionSettings().hashJoinsEnabled()
+                txnCtx.sessionSettings().hashJoinsEnabled(),
+                ids
             );
             Symbol having = relation.having();
             if (having != null && Symbols.containsCorrelatedSubQuery(having)) {
@@ -404,14 +423,23 @@ public class LogicalPlanner {
             return MultiPhase.createIfNeeded(
                 subQueries.uncorrelated(),
                 Eval.create(
+                    ids.getAsInt(),
                     Limit.create(
+                        ids.getAsInt(),
                         Order.create(
+                            ids.getAsInt(),
                             Distinct.create(
+                                ids.getAsInt(),
                                 ProjectSet.create(
+                                    ids.getAsInt(),
                                     WindowAgg.create(
+                                        ids,
                                         Filter.create(
+                                            ids.getAsInt(),
                                             groupByOrAggregate(
+                                                ids,
                                                 ProjectSet.create(
+                                                    ids.getAsInt(),
                                                     source,
                                                     splitPoints.tableFunctionsBelowGroupBy()
                                                 ),
@@ -435,21 +463,23 @@ public class LogicalPlanner {
                         relation.offset()
                     ),
                     outputs
-                )
-            );
+                ),
+                ids
+                );
         }
     }
 
-    private static LogicalPlan groupByOrAggregate(LogicalPlan source,
+    private static LogicalPlan groupByOrAggregate(IntSupplier ids,
+                                                  LogicalPlan source,
                                                   List<Symbol> groupKeys,
                                                   List<Function> aggregates,
                                                   TableStats tableStats) {
         if (!groupKeys.isEmpty()) {
             long numExpectedRows = GroupHashAggregate.approximateDistinctValues(source.numExpectedRows(), tableStats, groupKeys);
-            return new GroupHashAggregate(source, groupKeys, aggregates, numExpectedRows);
+            return new GroupHashAggregate(ids.getAsInt(), source, groupKeys, aggregates, numExpectedRows);
         }
         if (!aggregates.isEmpty()) {
-            return new HashAggregate(source, aggregates);
+            return new HashAggregate(ids.getAsInt(), source, aggregates);
         }
         return source;
     }
@@ -577,7 +607,7 @@ public class LogicalPlanner {
         public LogicalPlan visitSelectStatement(AnalyzedRelation relation, PlannerContext context) {
             SubqueryPlanner subqueryPlanner = new SubqueryPlanner(s -> planSubSelect(s, context));
             LogicalPlan logicalPlan = plan(relation, context, subqueryPlanner, false);
-            return new RootRelationBoundary(logicalPlan);
+            return new RootRelationBoundary(context.nextLogicalPlanId(), logicalPlan);
         }
 
         @Override
@@ -590,7 +620,8 @@ public class LogicalPlanner {
                     LogicalPlanner.this,
                     subqueryPlanner),
                 tableStats,
-                context.transactionContext()
+                context.transactionContext(),
+                context
             );
         }
     }

--- a/server/src/main/java/io/crate/planner/operators/Order.java
+++ b/server/src/main/java/io/crate/planner/operators/Order.java
@@ -56,16 +56,16 @@ public class Order extends ForwardingLogicalPlan {
     final OrderBy orderBy;
     private final List<Symbol> outputs;
 
-    static LogicalPlan create(LogicalPlan source, @Nullable OrderBy orderBy) {
+    static LogicalPlan create(int id, LogicalPlan source, @Nullable OrderBy orderBy) {
         if (orderBy == null) {
             return source;
         } else {
-            return new Order(source, orderBy);
+            return new Order(id, source, orderBy);
         }
     }
 
-    public Order(LogicalPlan source, OrderBy orderBy) {
-        super(source);
+    public Order(int id, LogicalPlan source, OrderBy orderBy) {
+        super(id, source);
         this.outputs = Lists2.concatUnique(source.outputs(), orderBy.orderBySymbols());
         this.orderBy = orderBy;
     }
@@ -100,7 +100,7 @@ public class Order extends ForwardingLogicalPlan {
             return null;
         }
         LogicalPlan newSource = fetchRewrite.newPlan();
-        Order newOrderBy = new Order(newSource, orderBy);
+        Order newOrderBy = new Order(id, newSource, orderBy);
         Map<Symbol, Symbol> replacedOutputs = fetchRewrite.replacedOutputs();
         if (newOrderBy.outputs.size() > newSource.outputs().size()) {
             // This is the case if the `orderBy` contains computations on top of the source outputs.
@@ -181,7 +181,7 @@ public class Order extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Order(Lists2.getOnlyElement(sources), orderBy);
+        return new Order(id, Lists2.getOnlyElement(sources), orderBy);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -52,7 +52,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
     final List<Symbol> standalone;
     private final List<Symbol> outputs;
 
-    static LogicalPlan create(LogicalPlan source, List<Function> tableFunctions) {
+    static LogicalPlan create(int id, LogicalPlan source, List<Function> tableFunctions) {
         if (tableFunctions.isEmpty()) {
             return source;
         }
@@ -93,13 +93,13 @@ public class ProjectSet extends ForwardingLogicalPlan {
             List<Symbol> standalone = result.outputs().stream()
                 .filter(x -> !(x instanceof Function && ((Function) x).signature().getKind() == FunctionType.TABLE))
                 .collect(Collectors.toList());
-            result = new ProjectSet(result, nestedFunctions.get(i), standalone);
+            result = new ProjectSet(id, result, nestedFunctions.get(i), standalone);
         }
         return result;
     }
 
-    private ProjectSet(LogicalPlan source, List<Function> tableFunctions, List<Symbol> standalone) {
-        super(source);
+    private ProjectSet(int id, LogicalPlan source, List<Function> tableFunctions, List<Symbol> standalone) {
+        super(id, source);
         this.outputs = Lists2.concat(tableFunctions, standalone);
         this.tableFunctions = tableFunctions;
         this.standalone = standalone;
@@ -164,12 +164,12 @@ public class ProjectSet extends ForwardingLogicalPlan {
         if (newSource == source) {
             return this;
         }
-        return new ProjectSet(newSource, tableFunctions, List.copyOf(newStandalone));
+        return new ProjectSet(id, newSource, tableFunctions, List.copyOf(newStandalone));
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new ProjectSet(Lists2.getOnlyElement(sources), tableFunctions, standalone);
+        return new ProjectSet(id, Lists2.getOnlyElement(sources), tableFunctions, standalone);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -72,8 +72,8 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
     private final FieldResolver fieldResolver;
     final RelationName name;
 
-    public Rename(List<Symbol> outputs, RelationName name, FieldResolver fieldResolver, LogicalPlan source) {
-        super(source);
+    public Rename(int id, List<Symbol> outputs, RelationName name, FieldResolver fieldResolver, LogicalPlan source) {
+        super(id, source);
         this.outputs = outputs;
         this.name = name;
         this.fieldResolver = fieldResolver;
@@ -123,6 +123,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
             newOutputs.add(childToParentMap.get(sourceOutput));
         }
         return new Rename(
+            id,
             newOutputs,
             name,
             fieldResolver,
@@ -178,7 +179,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
             );
             replacedOutputs.put(parentSymbolForKey, convertChildrenToScopedSymbols.apply(value));
         }
-        Rename newRename = new Rename(newOutputs, name, fieldResolver, newSource);
+        Rename newRename = new Rename(id, newOutputs, name, fieldResolver, newSource);
         return new FetchRewrite(replacedOutputs, newRename);
     }
 
@@ -199,7 +200,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Rename(outputs, name, fieldResolver, Lists2.getOnlyElement(sources));
+        return new Rename(id, outputs, name, fieldResolver, Lists2.getOnlyElement(sources));
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
@@ -54,11 +55,12 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         TableFunction tableFunction = captures.get(this.capture);
         var relation = tableFunction.relation();
         if (relation.function().name().equals(ValuesFunction.NAME)) {
-            return new InsertFromValues(tableFunction.relation(), plan.columnIndexWriterProjection());
+            return new InsertFromValues(plannerContext.nextLogicalPlanId(), tableFunction.relation(), plan.columnIndexWriterProjection());
         } else {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/server/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -42,8 +42,8 @@ import io.crate.planner.PlannerContext;
  */
 public class RootRelationBoundary extends ForwardingLogicalPlan {
 
-    public RootRelationBoundary(LogicalPlan source) {
-        super(source);
+    public RootRelationBoundary(int id, LogicalPlan source) {
+        super(id, source);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class RootRelationBoundary extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new RootRelationBoundary(Lists2.getOnlyElement(sources));
+        return new RootRelationBoundary(id, Lists2.getOnlyElement(sources));
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -53,15 +53,17 @@ import java.util.Set;
 
 public final class TableFunction implements LogicalPlan {
 
+    private final int id;
     private final TableFunctionRelation relation;
     private final List<Symbol> toCollect;
     final WhereClause where;
 
-    public static LogicalPlan create(TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
-        return new TableFunction(relation, toCollect, where);
+    public static LogicalPlan create(int id, TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
+        return new TableFunction(id, relation, toCollect, where);
     }
 
-    public TableFunction(TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
+    public TableFunction(int id, TableFunctionRelation relation, List<Symbol> toCollect, WhereClause where) {
+        this.id = id;
         this.relation = relation;
         this.toCollect = toCollect;
         this.where = where;
@@ -145,7 +147,7 @@ public final class TableFunction implements LogicalPlan {
         if (outputsToKeep.containsAll(toCollect)) {
             return this;
         }
-        return new TableFunction(relation, List.copyOf(outputsToKeep), where);
+        return new TableFunction(id, relation, List.copyOf(outputsToKeep), where);
     }
 
     @Override
@@ -156,6 +158,11 @@ public final class TableFunction implements LogicalPlan {
     @Override
     public long numExpectedRows() {
         return -1;
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -70,13 +70,15 @@ import io.crate.types.DataTypes;
  */
 public class Union implements LogicalPlan {
 
+    private final int id;
     private final List<Symbol> outputs;
     final LogicalPlan lhs;
     final LogicalPlan rhs;
     private final Map<LogicalPlan, SelectSymbol> dependencies;
 
 
-    public Union(LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
+    public Union(int id, LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
+        this.id = id;
         this.lhs = lhs;
         this.rhs = rhs;
         this.outputs = outputs;
@@ -203,7 +205,7 @@ public class Union implements LogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Union(sources.get(0), sources.get(1), outputs);
+        return new Union(id, sources.get(0), sources.get(1), outputs);
     }
 
     @Override
@@ -229,7 +231,12 @@ public class Union implements LogicalPlan {
         if (newLhs == lhs && newRhs == rhs) {
             return this;
         }
-        return new Union(newLhs, newRhs, newOutputs);
+        return new Union(id, newLhs, newRhs, newOutputs);
+    }
+
+    @Override
+    public int id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -33,7 +34,12 @@ public interface Rule<T> {
 
     Pattern<T> pattern();
 
-    LogicalPlan apply(T plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, NodeContext nodeCtx);
+    LogicalPlan apply(T plan,
+                      Captures captures,
+                      TableStats tableStats,
+                      TransactionContext txnCtx,
+                      NodeContext nodeCtx,
+                      PlannerContext plannerContext);
 
     /**
      * @return The version all nodes in the cluster must have to be able to use this optimization.

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -68,7 +69,8 @@ public final class DeduplicateOrder implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         Order childOrder = captures.get(this.childOrder);
         return plan.replaceSources(childOrder.sources());
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -26,6 +26,7 @@ import io.crate.execution.engine.aggregation.impl.CountAggregation;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Count;
@@ -63,16 +64,18 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
                        Captures captures,
                        TableStats tableStats,
                        TransactionContext txnCtx,
-                       NodeContext nodeCtx) {
+                       NodeContext nodeCtx,
+                       PlannerContext plannerContext) {
         Collect collect = captures.get(collectCapture);
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
         if (countAggregate.filter() != null) {
             return new Count(
+                plannerContext.nextLogicalPlanId(),
                 countAggregate,
                 collect.relation(),
                 collect.where().add(countAggregate.filter()));
         } else {
-            return new Count(countAggregate, collect.relation(), collect.where());
+            return new Count(plannerContext.nextLogicalPlanId(), countAggregate, collect.relation(), collect.where());
         }
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -24,6 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -59,11 +60,13 @@ public class MergeFilterAndCollect implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         Collect collect = captures.get(collectCapture);
         Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(
+            plannerContext.nextLogicalPlanId(),
             collect.relation(),
             collect.outputs(),
             newWhere,

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -25,6 +25,7 @@ import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.Rule;
@@ -71,10 +72,11 @@ public class MergeFilters implements Rule<Filter> {
                         Captures captures,
                         TableStats tableStats,
                         TransactionContext txnCtx,
-                        NodeContext nodeCtx) {
+                        NodeContext nodeCtx,
+                        PlannerContext plannerContext) {
         Filter childFilter = captures.get(child);
         Symbol parentQuery = plan.query();
         Symbol childQuery = childFilter.query();
-        return new Filter(childFilter.source(), AndOperator.of(parentQuery, childQuery));
+        return new Filter(plannerContext.nextLogicalPlanId(), childFilter.source(), AndOperator.of(parentQuery, childQuery));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
@@ -24,6 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -57,7 +58,12 @@ public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, NodeContext nodeCtx) {
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         Eval eval = captures.get(fetchOrEvalCapture);
         List<Symbol> outputsOfFetchSource = eval.source().outputs();
         if (outputsOfFetchSource.containsAll(extractColumns(plan.query()))) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.HashJoin;
@@ -57,8 +58,9 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         HashJoin hashJoin = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), hashJoin);
+        return moveQueryBelowJoin(filter.query(), hashJoin, plannerContext::nextLogicalPlanId);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -63,8 +64,9 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         NestedLoopJoin join = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), join);
+        return moveQueryBelowJoin(filter.query(), join, plannerContext::nextLogicalPlanId);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -81,7 +82,8 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         return transpose(filter, captures.get(orderCapture));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -24,6 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
@@ -59,9 +60,11 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         Rename rename = captures.get(renameCapture);
         Filter newFilter = new Filter(
+            plannerContext.nextLogicalPlanId(),
             rename.source(),
             FieldReplacer.replaceFields(plan.query(), rename::resolveField)
         );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -28,6 +28,7 @@ import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
@@ -67,7 +68,8 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         WindowAgg windowAgg = captures.get(windowAggCapture);
         WindowDefinition windowDefinition = windowAgg.windowDefinition();
         List<WindowFunction> windowFunctions = windowAgg.windowFunctions();
@@ -139,8 +141,11 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
          * Filter (id = 1)
          */
         LogicalPlan newWindowAgg = windowAgg.replaceSources(
-            List.of(new Filter(windowAgg.source(), AndOperator.join(windowPartitionedBasedFilters))));
+            List.of(new Filter(plannerContext.nextLogicalPlanId(),
+                               windowAgg.source(),
+                               AndOperator.join(windowPartitionedBasedFilters)
+                               )));
 
-        return new Filter(newWindowAgg, AndOperator.join(remainingFilterSymbols));
+        return new Filter(plannerContext.nextLogicalPlanId(), newWindowAgg, AndOperator.join(remainingFilterSymbols));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.rule.Util.transpose;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
@@ -57,7 +58,8 @@ public class MoveLimitBeneathEval implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         Eval eval = captures.get(evalCapture);
         return transpose(limit, eval);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.rule.Util.transpose;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
@@ -57,7 +58,8 @@ public class MoveLimitBeneathRename implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         Rename rename = captures.get(renameCapture);
         return transpose(limit, rename);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
@@ -24,6 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -61,7 +62,8 @@ public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         Eval eval = captures.get(fetchCapture);
         List<Symbol> outputsOfSourceOfFetch = eval.source().outputs();
         List<Symbol> orderBySymbols = plan.orderBy().orderBySymbols();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -39,6 +39,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Order;
@@ -81,7 +82,8 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         NestedLoopJoin nestedLoop = captures.get(nlCapture);
         Set<RelationName> relationsInOrderBy =
             Collections.newSetFromMap(new IdentityHashMap<>());
@@ -98,6 +100,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                 LogicalPlan lhs = nestedLoop.sources().get(0);
                 LogicalPlan newLhs = order.replaceSources(List.of(lhs));
                 return new NestedLoopJoin(
+                    plannerContext.nextLogicalPlanId(),
                     newLhs,
                     nestedLoop.sources().get(1),
                     nestedLoop.joinType(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -30,6 +30,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.WhereClauseOptimizer;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Get;
@@ -66,7 +67,8 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         var relation = (DocTableRelation) collect.relation();
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, relation);
         WhereClause where = collect.where();
@@ -81,6 +83,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
         //noinspection OptionalIsPresent no capturing lambda allocation
         if (docKeys.isPresent()) {
             return new Get(
+                plannerContext.nextLogicalPlanId(),
                 relation,
                 docKeys.get(),
                 detailedQuery.query(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
@@ -54,7 +55,8 @@ public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         return plan.source();
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -29,6 +29,7 @@ import org.elasticsearch.Version;
 
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.GroupHashAggregate;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
@@ -164,12 +165,14 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         GroupHashAggregate groupBy = captures.get(groupCapture);
         if (!eagerTerminateIsLikely(limit, groupBy)) {
             return null;
         }
         return new LimitDistinct(
+            plannerContext.nextLogicalPlanId(),
             groupBy.source(),
             limit.limit(),
             limit.offset(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.matcher.Patterns.source;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.IntSupplier;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.symbol.Symbols;
@@ -35,6 +36,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.planner.PlannerContext;
 import io.crate.planner.node.fetch.FetchSource;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Eval;
@@ -78,7 +80,8 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             PlannerContext plannerContext) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }
@@ -89,6 +92,7 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
         List<Reference> fetchRefs = fetchRewrite.extractFetchRefs();
         Map<RelationName, FetchSource> fetchSourceByRelation = fetchRewrite.createFetchSources();
         return new Fetch(
+            plannerContext.nextLogicalPlanId(),
             fetchRewrite.replacedOutputs(),
             fetchRefs,
             fetchSourceByRelation,
@@ -97,19 +101,19 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
     }
 
 
-    public static LogicalPlan tryRewrite(AnalyzedRelation relation, LogicalPlan plan, TableStats tableStats) {
+    public static LogicalPlan tryRewrite(AnalyzedRelation relation, LogicalPlan plan, TableStats tableStats, IntSupplier ids) {
         Match<?> match = ORDER_COLLECT.accept(plan, Captures.empty());
         if (match.isPresent()) {
-            return doRewrite(relation, plan, tableStats);
+            return doRewrite(relation, plan, tableStats, ids);
         }
         match = RENAME_ORDER_COLLECT.accept(plan, Captures.empty());
         if (match.isPresent()) {
-            return doRewrite(relation, plan, tableStats);
+            return doRewrite(relation, plan, tableStats, ids);
         }
         return plan;
     }
 
-    private static LogicalPlan doRewrite(AnalyzedRelation relation, LogicalPlan plan, TableStats tableStats) {
+    private static LogicalPlan doRewrite(AnalyzedRelation relation, LogicalPlan plan, TableStats tableStats, IntSupplier ids) {
         FetchRewrite fetchRewrite = plan.rewriteToFetch(tableStats, List.of());
         if (fetchRewrite == null) {
             return plan;
@@ -117,12 +121,12 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
         List<Reference> fetchRefs = fetchRewrite.extractFetchRefs();
         Map<RelationName, FetchSource> fetchSourceByRelation = fetchRewrite.createFetchSources();
         Fetch fetch = new Fetch(
+            ids.getAsInt(),
             fetchRewrite.replacedOutputs(),
             fetchRefs,
             fetchSourceByRelation,
             fetchRewrite.newPlan()
-
         );
-        return Eval.create(fetch, relation.outputs());
+        return Eval.create(ids.getAsInt(), fetch, relation.outputs());
     }
 }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -161,6 +161,7 @@ public final class CopyToPlan implements Plan {
             boundedCopyTo.withClauseOptions());
 
         LogicalPlan collect = Collect.create(
+            context.nextLogicalPlanId(),
             new DocTableRelation(boundedCopyTo.table()),
             boundedCopyTo.outputs(),
             boundedCopyTo.whereClause(),
@@ -186,7 +187,8 @@ public final class CopyToPlan implements Plan {
                                                          match.captures(),
                                                          tableStats,
                                                          context.transactionContext(),
-                                                         context.nodeContext());
+                                                         context.nodeContext(),
+                                                         context);
             return plan == null ? collect : plan;
         }
         return collect;

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -56,6 +56,7 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
         TableStats tableStats = new TableStats();
         Symbol x = e.asSymbol("x");
         Collect collect = Collect.create(
+            1,
             new DocTableRelation(e.resolveTableInfo("t")),
             List.of(x, e.asSymbol("y")),
             WhereClause.MATCH_ALL,

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -67,8 +67,9 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(1, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         var eval = new Eval(
+            2,
             collect,
             List.of(
                 new Function(
@@ -102,10 +103,10 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         Reference x = (Reference) e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
         var alias = new AliasedAnalyzedRelation(relation, new RelationName(null, "t1"));
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(1, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         Symbol t1X = alias.getField(x.column(), Operation.READ, true);
         assertThat(t1X, Matchers.notNullValue());
-        var rename = new Rename(List.of(t1X), alias.relationName(), alias, collect);
+        var rename = new Rename(1, List.of(t1X), alias.relationName(), alias, collect);
 
         FetchRewrite fetchRewrite = rename.rewriteToFetch(new TableStats(), List.of());
         assertThat(fetchRewrite, Matchers.notNullValue());
@@ -141,8 +142,9 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = new AliasSymbol("x_alias", e.asSymbol("x"));
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(1, relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         var eval = new Eval(
+            2,
             collect,
             List.of(x)
         );

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -112,7 +112,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.joinPairs(),
             new SubQueries(Map.of(), Map.of()),
             rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, true),
-            txnCtx.sessionSettings().hashJoinsEnabled()
+            txnCtx.sessionSettings().hashJoinsEnabled(),
+            plannerCtx::nextLogicalPlanId
         );
     }
 
@@ -268,7 +269,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.joinPairs(),
             new SubQueries(Map.of(), Map.of()),
             rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, false),
-            false
+            false,
+            context::nextLogicalPlanId
         );
         Join nl = (Join) operator.build(
             mock(DependencyCarrier.class), context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -63,8 +63,11 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation queriedDocTable = e.analyze("select name from users");
 
         LogicalPlan plan = Limit.create(
+            1,
             Limit.create(
+                2,
                 Collect.create(
+                    3,
                     ((AbstractTableRelation<?>) queriedDocTable.from().get(0)),
                     queriedDocTable.outputs(),
                     new WhereClause(queriedDocTable.where()),

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -71,43 +71,45 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
         t1Relation = new DocTableRelation(t1);
         t1RenamedRelationName = new RelationName("doc", "t1_renamed");
         var t1Alias = new AliasedAnalyzedRelation(t1Relation, t1RenamedRelationName);
-        var t1Collect = new Collect(t1Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var t1Collect = new Collect(1, t1Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         Symbol t1Output = t1Alias.getField(x.column(), Operation.READ, true);
-        t1Rename = new Rename(List.of(t1Output), t1Alias.relationName(), t1Alias, t1Collect);
+        t1Rename = new Rename(2, List.of(t1Output), t1Alias.relationName(), t1Alias, t1Collect);
 
         DocTableInfo t2 = e.resolveTableInfo("t2");
         Reference y = (Reference) e.asSymbol("y");
         t2Relation = new DocTableRelation(t2);
         t2RenamedRelationName = new RelationName("doc", "t2_renamed");
         var t2Alias = new AliasedAnalyzedRelation(t2Relation, t2RenamedRelationName);
-        var t2Collect = new Collect(t2Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var t2Collect = new Collect(3, t2Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
         Symbol t2Output = t2Alias.getField(y.column(), Operation.READ, true);
-        t2Rename = new Rename(List.of(t2Output), t2Alias.relationName(), t2Alias, t2Collect);
+        t2Rename = new Rename(4, List.of(t2Output), t2Alias.relationName(), t2Alias, t2Collect);
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
+        var hashJoin = new HashJoin(1, t1Rename, t2Rename, e.asSymbol("x = y"));
         assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_nestedloopjoin() {
-        var nestedLoopJoin = new NestedLoopJoin(t1Rename,
+        var nestedLoopJoin = new NestedLoopJoin(1,
+                                                t1Rename,
                                                 t2Rename,
                                                 JoinType.INNER,
                                                 e.asSymbol("x = y"),
                                                 false,
                                                 t1Relation,
-                                                false);
+                                                false
+                                                );
         assertThat(nestedLoopJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_union() {
-        var union = new Union(t1Rename, t2Rename, List.of());
+        var union = new Union(1, t1Rename, t2Rename, List.of());
         assertThat(union.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(union.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }
@@ -116,21 +118,21 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
     public void test_relationnames_are_based_on_sources_in_table_function() {
         QueriedSelectRelation relation = e.analyze("select * from abs(1)");
         TableFunctionRelation tableFunctionRelation = (TableFunctionRelation) relation.from().get(0);
-        var tableFunction = new TableFunction(tableFunctionRelation, List.of(), new WhereClause(null));
+        var tableFunction = new TableFunction(1, tableFunctionRelation, List.of(), new WhereClause(null));
         assertThat(tableFunction.baseTables(), containsInAnyOrder());
         assertThat(tableFunction.getRelationNames(), containsInAnyOrder(new RelationName(null, "abs")));
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_collect() {
-        var collect = new Collect(t1Relation, List.of(), new WhereClause(null), 1,1);
+        var collect = new Collect(1, t1Relation, List.of(), new WhereClause(null), 1,1);
         assertThat(collect.baseTables(), containsInAnyOrder(t1Relation));
         assertThat(collect.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_get() {
-        var get = new Get(t1Relation, new DocKeys(List.of(List.of()), false, false, 1, null), null, List.of(), 1);
+        var get = new Get(1, t1Relation, new DocKeys(List.of(List.of()), false, false, 1, null), null, List.of(), 1);
         assertThat(get.baseTables(), containsInAnyOrder(t1Relation));
         assertThat(get.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
     }
@@ -139,7 +141,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
     public void test_relationnames_are_based_on_sources_in_count() {
         QueriedSelectRelation relation = e.analyze("select count(1)");
         Function function = (Function) relation.outputs().get(0);
-        var count = new Count(function, t1Relation, new WhereClause(null));
+        var count = new Count(1, function, t1Relation, new WhereClause(null));
         assertThat(count.baseTables(), containsInAnyOrder(t1Relation));
         assertThat(count.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
     }

--- a/server/src/test/java/io/crate/planner/optimizer/matcher/CapturePatternTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/matcher/CapturePatternTest.java
@@ -35,7 +35,7 @@ public class CapturePatternTest {
 
     @Test
     public void testCapturePatternAddsToCaptureOnMatch() {
-        Filter filter = new Filter(mock(LogicalPlan.class), Literal.BOOLEAN_TRUE);
+        Filter filter = new Filter(1, mock(LogicalPlan.class), Literal.BOOLEAN_TRUE);
 
         Capture<Filter> captureFilter = new Capture<>();
         Pattern<Filter> filterPattern = Pattern.typeOf(Filter.class).capturedAs(captureFilter);

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -94,6 +94,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
 
     private void assertCollectQuery(String query, String expected) {
         var collect = new Collect(
+            1,
             tr1,
             Collections.emptyList(),
             new WhereClause(e.asSymbol(query)),


### PR DESCRIPTION
This assigns to each logical plan node an id as part of the planning phase. This makes logical plans identifiable. This is useful for keeping track of changes on the logical operator node tree.

Main concepts:
- Each newly created logical plan gets a new id
- Id's of logical plans have to be unique within one planning phase 
- An incrementing int on the planner context is used to generate the ids


This is a pre-requisite for the iterative optimizer https://github.com/crate/crate/issues/13340

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
