### PR TITLE
Fix pg array parsing of unquoted string witn many whitespaces

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -110,3 +110,7 @@ Fixes
   This caused metadata corruptions leading to ``StartupExceptions`` and data
   losses. Corrupted metadata recovery is in place to prevent the exceptions
   but not all data can be recovered.
+
+- Fixed an issue in the PostgreSQL wire protocol that would cause
+  de-serialization of arrays to fail if they contained unquoted strings
+  consisting of more than 2 words.

--- a/libs/pgwire/src/main/antlr/PgArray.g4
+++ b/libs/pgwire/src/main/antlr/PgArray.g4
@@ -66,8 +66,7 @@ QUOTED_STRING
     ;
 
 UNQUOTED_STRING
-    : CHAR+ (' ')* CHAR+
-    | CHAR+
+    : CHAR+ ((' ')+ CHAR+)*
     ;
 
 fragment CHAR

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
@@ -134,6 +134,28 @@ public class PGArrayTest extends BasePGTypeTest<PGArray> {
     }
 
     @Test
+    public void test_can_decode_unquoted_words_with_multiple_spaces() throws Exception {
+        String s = "{ \ta   b c  , \t d e   f  \t }";
+        List<Object> values = PGArray.VARCHAR_ARRAY.decodeUTF8Text(s.getBytes(StandardCharsets.UTF_8));
+        // leading/trailing whitespaces are ignored in the unquoted strings
+        assertThat(values, contains(
+            "a   b c",
+            "d e   f"
+        ));
+    }
+
+    @Test
+    public void test_can_decode_quoted_words_with_multiple_spaces() throws Exception {
+        String s = "{\" a b c \t \r\n \", \"  d \t\t  \\\" e \"}";
+        List<Object> values = PGArray.VARCHAR_ARRAY.decodeUTF8Text(s.getBytes(StandardCharsets.UTF_8));
+        // Quoting preserves leading/trailing whitespaces
+        assertThat(values, contains(
+            " a b c \t \r\n ",
+            "  d \t\t  \" e "
+        ));
+    }
+
+    @Test
     public void testDecodeUTF8Text() {
         // 1-dimension array
         Object o = pgArray.decodeUTF8Text("{\"10\",\"20\"}".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/11027 and https://github.com/crate/crate/pull/11051