### PR TITLE
Simplify subscript expressions of aliased tables as strings

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -72,6 +72,13 @@ Fixes
   :ref:`cursors <sql-fetch>`, even if the ``CURSOR`` was explicitly or
   automatically (session terminated) closed.
 
+- Fixed an issue that caused ``ColumnUnknownException`` when querying
+  sub-columns of nested object arrays of aliased tables.
+  An example ::
+
+    SELECT a[1]['b']['s'] FROM (SELECT a[1]['b']['s'] FROM test) AS q;
+    ColumnUnknownException[Column a['b']['s'] unknown]
+
 - Fixed an issue that caused the returned column names to be missing the
   subscripts when querying sub-columns of nested object arrays.
 

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -711,7 +711,14 @@ public class ExpressionAnalyzer {
                             context
                         );
                     } catch (ColumnUnknownException e2) {
-                        throw e;
+                        // ex) select a[1]['b']['s'] from (select a[1]['b']['s'] from test) q;
+                        //     In this case, a[1]['b']['s'] is not really a subscript expression but a string constant
+                        //     representing a column name.
+                        return fieldProvider.resolveField(
+                            new QualifiedName(node.toString().replace("\"", "")),
+                            null,
+                            operation,
+                            context.errorOnUnknownObjectKey());
                     }
                 }
                 Expression idxExpression = subscriptContext.index();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes part of https://github.com/crate/crate/issues/13504

```
cr> select a[1]['b']['s'] from (select a[1]['b']['s'] from test) q;                                              
ColumnUnknownException[Column a['b']['s'] unknown]
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
