### PR TITLE
Fix: Release accounted memory when cursor closed

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused accounted memory not to be released when using
+  :ref:`cursors <sql-fetch>`, even if the ``CURSOR`` was explicitly or
+  automatically (session terminated) closed.
+
 - Fixed an issue that caused the returned column names to be missing the
   subscripts when querying sub-columns of nested object arrays.
 

--- a/server/src/test/java/io/crate/integrationtests/CursorITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CursorITest.java
@@ -29,14 +29,12 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.apache.lucene.tests.util.CrateLuceneTestCase.AwaitsFix;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.protocols.postgres.PostgresNetty;
 
-@AwaitsFix(bugUrl = "https://github.com/crate/crate/pull/13492")
 public class CursorITest extends IntegTestCase {
 
     private Properties properties;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, `rowConsumer` passed to `Cursor` would close long before the `Cursor` would actually close. This would cause the `ramAccounting` to be closed by a callback in a `JobSetup#InnerPreparer` method, e.g.: `visitRoutedCollectPhase()`. In upcoming cursor operations (fetch fwd) new memory would be accounting and there won't be any more callbacks to release this memory.

Create a new `CompletableFuture`, denoting the final result, return this new future from `CursorRowConsumer` and complete it in the `Cursor#close()` method to release the accounted memory.



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
