### PR TITLE
Increase assertBusy duration in test_schema_changes_of_multiple_tables_are_replicated

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -125,7 +125,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                     "name"
                 );
             }
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The test is flaky and based on the test duration graph it could just be
a timing issue. The gap between failure and success is small:

https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.MetadataTrackerITest/test_schema_changes_of_multiple_tables_are_replicated

![image](https://user-images.githubusercontent.com/38700/215417507-556619a2-3422-44c0-ad63-372057a9f6ce.png)


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
