### PR TITLE
Fix warnings in ESTestCase

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -172,6 +172,8 @@ import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+
 import io.crate.Constants;
 import io.crate.common.collections.Tuple;
 import io.crate.common.unit.TimeValue;
@@ -1079,7 +1081,7 @@ public class IndexShardTests extends IndexShardTestCase {
                         .startObject()
                         .field("count", randomInt())
                         .field("point", randomFloat())
-                        .field("description", randomUnicodeOfCodepointLength(100))
+                        .field("description", RandomizedTest.randomUnicodeOfCodepointLength(100))
                         .endObject()
                 );
                 indexDoc(indexShard, Integer.toString(i), doc);

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -146,6 +146,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import io.crate.common.collections.Tuple;
@@ -311,7 +312,7 @@ public class TranslogTests extends ESTestCase {
         boolean validPathString;
         do {
             validPathString = false;
-            string = randomRealisticUnicodeOfCodepointLength(randomIntBetween(min, max));
+            string = RandomizedTest.randomRealisticUnicodeOfCodepointLength(randomIntBetween(min, max));
             try {
                 final Path resolved = translogDir.resolve(string);
                 // some strings (like '/' , '..') do not refer to a file, which we this method should return
@@ -2070,7 +2071,7 @@ public class TranslogTests extends ESTestCase {
                         case CREATE:
                         case INDEX:
                             op = new Translog.Index(threadId + "_" + opCount, seqNoGenerator.getAndIncrement(),
-                                primaryTerm.get(), randomUnicodeOfLengthBetween(1, 20 * 1024).getBytes("UTF-8"));
+                                primaryTerm.get(), RandomizedTest.randomUnicodeOfLengthBetween(1, 20 * 1024).getBytes("UTF-8"));
                             break;
                         case DELETE:
                             op = new Translog.Delete(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Addresses some deprecation and unchecked warnings and also inlines a few
one liner methods that only had a single use.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
