### PR TITLE
Fix flaky testTransientErrorsDuringRecoveryAreRetried

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -793,7 +793,14 @@ public class IndexRecoveryIT extends IntegTestCase {
             }
         };
         TransientReceiveRejected handlingBehavior =
-            new TransientReceiveRejected(recoveryActionToBlock, recoveryStarted, finalizeReceived, connectionBreaker);
+            new TransientReceiveRejected(recoveryActionToBlock, recoveryStarted, connectionBreaker);
+        redTransportService.addRequestHandlingBehavior(
+            PeerRecoveryTargetService.Actions.FINALIZE,
+            (handler, request, channel) -> {
+                finalizeReceived.set(true);
+                handler.messageReceived(request, channel);
+            }
+        );
         redTransportService.addRequestHandlingBehavior(recoveryActionToBlock, handlingBehavior);
 
         try {
@@ -817,17 +824,14 @@ public class IndexRecoveryIT extends IntegTestCase {
 
         private final String actionName;
         private final AtomicBoolean recoveryStarted;
-        private final AtomicBoolean finalizeReceived;
         private final Runnable connectionBreaker;
         private final AtomicInteger blocksRemaining;
 
         private TransientReceiveRejected(String actionName,
                                          AtomicBoolean recoveryStarted,
-                                         AtomicBoolean finalizeReceived,
                                          Runnable connectionBreaker) {
             this.actionName = actionName;
             this.recoveryStarted = recoveryStarted;
-            this.finalizeReceived = finalizeReceived;
             this.connectionBreaker = connectionBreaker;
             this.blocksRemaining = new AtomicInteger(randomIntBetween(1, 3));
         }
@@ -837,9 +841,6 @@ public class IndexRecoveryIT extends IntegTestCase {
                                     TransportRequest request,
                                     TransportChannel channel) throws Exception {
             recoveryStarted.set(true);
-            if (actionName.equals(PeerRecoveryTargetService.Actions.FINALIZE)) {
-                finalizeReceived.set(true);
-            }
             if (blocksRemaining.getAndUpdate(i -> i == 0 ? 0 : i - 1) != 0) {
                 String rejected = "rejected";
                 String circuit = "circuit";


### PR DESCRIPTION
First commit is from https://github.com/crate/crate/pull/13551

`finalizeReceived` wasn't set correctly to `true`, leading to:

    Caused by: java.lang.IllegalStateException: Recovery cannot be started twice
            at org.elasticsearch.indices.recovery.IndexRecoveryIT$SingleStartEnforcer.accept(IndexRecoveryIT.java:886)
            at org.elasticsearch.indices.recovery.IndexRecoveryIT.lambda$testTransientErrorsDuringRecoveryAreRetried$6(IndexRecoveryIT.java:784)
            at org.elasticsearch.test.transport.StubbableTransport$WrappedConnection.sendRequest(StubbableTransport.java:238)
            at org.elasticsearch.transport.TransportService.sendRequestInternal(TransportService.java:617)
            ... 10 more

Which could cause the test to fail with:

    java.lang.AssertionError: timed out waiting for green state

It wasn't set correctly because the `handlingBehavior` is set for a
specific action:

    addRequestHandlingBehavior(recoveryActionToBlock, handlingBehavior)

Depending on the randomization of `recoveryActionToBlock`, the following
condition was always false: `actionName.equals(PeerRecoveryTargetService.Actions.FINALIZE)`
