### PR TITLE
Fix `CursorIT.test_fetching_from_cursor_positioned_at_end_returns_empty_result`

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Cursor.java
+++ b/server/src/main/java/io/crate/action/sql/Cursor.java
@@ -212,10 +212,7 @@ public final class Cursor implements AutoCloseable {
                 delegate = CompositeBatchIterator.seqComposite(bufferedBi, fullResult);
             }
 
-            cursorPosition = cursorPosition + count;
-            if (cursorPosition < 0) { // overflow
-                cursorPosition = Integer.MAX_VALUE;
-            }
+            cursorPosition = newCursorPosition(count);
             consumer.accept(LimitingBatchIterator.newInstance(delegate, count), null);
         } else {
             resetCursorToMaxBufferedRowsPlus1();
@@ -233,6 +230,16 @@ public final class Cursor implements AutoCloseable {
     private void resetCursorToMaxBufferedRowsPlus1() {
         if (cursorPosition > rows.size() + 1) {
             cursorPosition = rows.size() + 1;
+        }
+    }
+
+    private int newCursorPosition(int count) {
+        // Code copied from Math.addExact(int x, int y)
+        int newCursorPosition = cursorPosition + count;
+        if (((cursorPosition ^ newCursorPosition) & (count ^ newCursorPosition)) < 0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return newCursorPosition;
         }
     }
 


### PR DESCRIPTION
```
REPRODUCE WITH: ./gradlew :server:test --tests "io.crate.integrationtests.CursorITest.test_fetching_from_cursor_positioned_at_end_returns_empty_result" -Dtests.seed=CF1B3998759842D0 -Dtests.locale=mas-Latn-KE -Dtests.timezone=Canada/Atlantic

CursorITest > test_fetching_from_cursor_positioned_at_end_returns_empty_result FAILED
    org.opentest4j.AssertionFailedError at CursorITest.java:100
org.opentest4j.AssertionFailedError:
Expecting value to be false but was true
	at __randomizedtesting.SeedInfo.seed([CF1B3998759842D0:95666F12FFDBF0DB]:0)
```

See commit messages

