### PR TITLE
Fix behaviour of `FETCH RELATIVE`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -68,6 +68,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed behaviour of :ref:`FETCH RELATIVE <sql-fetch>`, which previously behaved
+  identically to `FETCH FORWARD` and `FETCH BACKWARD`, whereas it should behave
+  similarly to `FETCH ABSOLUTE`, with the difference that the position of the 1
+  row to return is calculated relatively to the current cursor position.
+
 - Fixed an issue that caused accounted memory not to be released when using
   :ref:`cursors <sql-fetch>`, even if the ``CURSOR`` was explicitly or
   automatically (session terminated) closed.

--- a/libs/sql-parser/src/main/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/SqlBaseParser.g4
@@ -776,7 +776,7 @@ direction
     | FIRST
     | LAST
     | ABSOLUTE integerLiteral
-    | RELATIVE integerLiteral
+    | RELATIVE (MINUS)? integerLiteral
     | integerLiteral
     | ALL
     | FORWARD

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -1255,7 +1255,11 @@ public final class SqlFormatter {
                     builder.append(fetch.count());
                     builder.append(" ");
                 }
-            } else {
+            } else if (scrollMode == ScrollMode.RELATIVE) {
+                builder.append("RELATIVE ");
+                builder.append(fetch.count());
+                builder.append(" ");
+            } else if (scrollMode == ScrollMode.MOVE) {
                 if (count >= 0) {
                     builder.append("FORWARD ");
                 } else {

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -311,7 +311,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
         long count = 1;
         // See ScrollMode description
         if (direction == null) {
-            scrollMode = Fetch.ScrollMode.RELATIVE;
+            scrollMode = Fetch.ScrollMode.MOVE;
         } else if (direction.FIRST() != null) {
             scrollMode = Fetch.ScrollMode.ABSOLUTE;
             count = 1;
@@ -321,15 +321,21 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
         } else if (direction.ABSOLUTE() != null) {
             scrollMode = Fetch.ScrollMode.ABSOLUTE;
             count = Long.parseLong(direction.integerLiteral().getText());
+        } else if (direction.RELATIVE() != null) {
+            scrollMode = ScrollMode.RELATIVE;
+            count = Long.parseLong(direction.integerLiteral().getText());
+            if (direction.MINUS() != null) {
+                count *= -1;
+            }
         } else {
-            scrollMode = Fetch.ScrollMode.RELATIVE;
+            scrollMode = Fetch.ScrollMode.MOVE;
             if (direction.ALL() != null) {
                 count = Long.MAX_VALUE;
             } else if (direction.integerLiteral() != null) {
                 count = Long.parseLong(direction.integerLiteral().getText());
             }
             if (direction.BACKWARD() != null) {
-                count = count * -1;
+                count *= -1;
             }
         }
         return new Fetch(scrollMode, count, cursorName);

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Fetch.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Fetch.java
@@ -48,6 +48,7 @@ public final class Fetch extends Statement {
      * </pre>
      */
     public enum ScrollMode {
+        MOVE,
         RELATIVE,
         ABSOLUTE
     }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -140,6 +140,7 @@ public class TestStatementBuilder {
         printStatement("FETCH FORWARD 4 FROM c1");
         printStatement("FETCH ABSOLUTE 3 FROM c1");
         printStatement("FETCH BACKWARD 4 FROM c1");
+        printStatement("FETCH RELATIVE -12 FROM c1");
 
         Fetch fetch = (Fetch) SqlParser.createStatement("FETCH FORWARD 3 FROM c1");
         assertThat(fetch.count()).isEqualTo(3L);

--- a/server/src/test/java/io/crate/integrationtests/CursorITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CursorITest.java
@@ -202,6 +202,16 @@ public class CursorITest extends IntegTestCase {
             assertThat(result.next()).isTrue();
             assertThat(result.getInt(1)).isEqualTo(4);
             assertThat(result.next()).isFalse();
+
+            result = statement.executeQuery("FETCH RELATIVE -2 FROM c1");
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(2);
+            assertThat(result.next()).isFalse();
+
+            result = statement.executeQuery("FETCH RELATIVE 7 FROM c1");
+            assertThat(result.next()).isTrue();
+            assertThat(result.getInt(1)).isEqualTo(9);
+            assertThat(result.next()).isFalse();
         }
     }
 


### PR DESCRIPTION
Previously, `FETCH RELATIVE` was behaving identically to `FETCH FORWARD`
and `FETCH BACKWARDS` which is not the case. `FETCH RELATIVE` returns
always 1 row (or 0 rows if boundaries exceeded), at the position
relative to the current cursor position and the number provided.

Fixes: #13460