### PR TITLE
Migrate some Repository methods to CompletableFuture

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -115,7 +115,7 @@ public interface Repository extends LifecycleComponent {
      * @param indexId    the {@link IndexId} to load the metadata from
      * @param listener   listener invoked on completion
      */
-    void getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, IndexId indexId, ActionListener<IndexMetadata> listener);
+    CompletableFuture<IndexMetadata> getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, IndexId indexId);
 
 
     /**
@@ -125,7 +125,7 @@ public interface Repository extends LifecycleComponent {
      * @param indexIds   the Collection of {@link IndexId} to load the metadata from
      * @param listener   listener invoked on completion
      */
-    void getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, Collection<IndexId> indexIds, ActionListener<Collection<IndexMetadata>> listener);
+    CompletableFuture<Collection<IndexMetadata>> getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, Collection<IndexId> indexIds);
 
 
     /**

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -105,9 +105,8 @@ public interface Repository extends LifecycleComponent {
      * Returns global metadata associated with the snapshot.
      *
      * @param snapshotId the snapshot id to load the global metadata from
-     * @param listener   listener invoked on completion
      */
-    void getSnapshotGlobalMetadata(SnapshotId snapshotId, ActionListener<Metadata> listener);
+    CompletableFuture<Metadata> getSnapshotGlobalMetadata(SnapshotId snapshotId);
 
     /**
      * Returns the index metadata associated with the snapshot.

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1079,13 +1079,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     @Override
-    public void getSnapshotGlobalMetadata(final SnapshotId snapshotId, ActionListener<Metadata> listener) {
+    public CompletableFuture<Metadata> getSnapshotGlobalMetadata(final SnapshotId snapshotId) {
         try {
-            listener.onResponse(GLOBAL_METADATA_FORMAT.read(blobContainer(), snapshotId.getUUID(), namedXContentRegistry));
+            return CompletableFuture.completedFuture(GLOBAL_METADATA_FORMAT.read(blobContainer(), snapshotId.getUUID(), namedXContentRegistry));
         } catch (NoSuchFileException ex) {
-            listener.onFailure(new SnapshotMissingException(metadata.name(), snapshotId, ex));
+            return CompletableFuture.failedFuture(new SnapshotMissingException(metadata.name(), snapshotId, ex));
         } catch (IOException ex) {
-            listener.onFailure(new SnapshotException(metadata.name(), snapshotId, "failed to read global metadata", ex));
+            return CompletableFuture.failedFuture(new SnapshotException(metadata.name(), snapshotId, "failed to read global metadata", ex));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1089,28 +1089,28 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
-    public void getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, IndexId index, ActionListener<IndexMetadata> listener) {
+    public CompletableFuture<IndexMetadata> getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, IndexId index) {
         try {
             IndexMetadata result = INDEX_METADATA_FORMAT.read(indexContainer(index),
                 repositoryData.indexMetaDataGenerations().indexMetaBlobId(snapshotId, index), namedXContentRegistry);
-            listener.onResponse(result);
+            return CompletableFuture.completedFuture(result);
         } catch (IOException ex) {
-            listener.onFailure(ex);
+            return CompletableFuture.failedFuture(ex);
         }
     }
 
 
     @Override
-    public void getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, Collection<IndexId> indexIds, ActionListener<Collection<IndexMetadata>> listener) {
+    public CompletableFuture<Collection<IndexMetadata>> getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, Collection<IndexId> indexIds) {
         try {
-            var result = new ArrayList<IndexMetadata>();
+            var result = new ArrayList<IndexMetadata>(indexIds.size());
             for (IndexId index : indexIds) {
                 result.add(INDEX_METADATA_FORMAT.read(indexContainer(index),
                     repositoryData.indexMetaDataGenerations().indexMetaBlobId(snapshotId, index), namedXContentRegistry));
             }
-            listener.onResponse(result);
+            return CompletableFuture.completedFuture(result);
         } catch (IOException ex) {
-            listener.onFailure(ex);
+            return CompletableFuture.failedFuture(ex);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -227,7 +227,7 @@ public class RestoreService implements ClusterStateApplier {
                             || request.includeGlobalSettings()
                             || request.allTemplates()
                             || (request.templates() != null && request.templates().length > 0)) {
-                            repository.getSnapshotGlobalMetadata(snapshotId, globalMetadataListener);
+                            repository.getSnapshotGlobalMetadata(snapshotId).whenComplete(globalMetadataListener);
                         } else {
                             globalMetadataListener.onResponse(Metadata.EMPTY_METADATA);
                         }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -235,7 +235,7 @@ public class RestoreService implements ClusterStateApplier {
                             var metadataBuilder = Metadata.builder(globalMetadata);
                             var indexIdsInSnapshot = repositoryData.resolveIndices(indicesInSnapshot);
                             var snapshotIndexMetadataListener = new StepListener<Collection<IndexMetadata>>();
-                            repository.getSnapshotIndexMetadata(repositoryData, snapshotId, indexIdsInSnapshot, snapshotIndexMetadataListener);
+                            repository.getSnapshotIndexMetadata(repositoryData, snapshotId, indexIdsInSnapshot).whenComplete(snapshotIndexMetadataListener);
                             snapshotIndexMetadataListener.whenComplete(snapshotIndexMetadata -> {
                                 for (IndexMetadata indexMetadata : snapshotIndexMetadata) {
                                     metadataBuilder.put(indexMetadata, false);

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -72,9 +72,9 @@ public abstract class RestoreOnlyRepository implements Repository {
     }
 
     @Override
-    public void getSnapshotGlobalMetadata(SnapshotId snapshotId,
-                                          ActionListener<Metadata> listener) {
-
+    public CompletableFuture<Metadata> getSnapshotGlobalMetadata(SnapshotId snapshotId) {
+        return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("getSnapshotGlobalMetadata not supported in RestoreOnlyRepository"));
     }
 
     public void getSnapshotIndexMetadata(RepositoryData repositoryData,

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -77,17 +77,18 @@ public abstract class RestoreOnlyRepository implements Repository {
             new UnsupportedOperationException("getSnapshotGlobalMetadata not supported in RestoreOnlyRepository"));
     }
 
-    public void getSnapshotIndexMetadata(RepositoryData repositoryData,
-                                         SnapshotId snapshotId,
-                                         IndexId indexId,
-                                         ActionListener<IndexMetadata> listener) {
+    public CompletableFuture<IndexMetadata> getSnapshotIndexMetadata(RepositoryData repositoryData,
+                                                                     SnapshotId snapshotId,
+                                                                     IndexId indexId) {
+        return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("getSnapshotIndexMetadata is not supported in RestoreOnlyRepository"));
     }
 
-
-    public void getSnapshotIndexMetadata(RepositoryData repositoryData,
-                                         SnapshotId snapshotId,
-                                         Collection<IndexId> indexIds,
-                                         ActionListener<Collection<IndexMetadata>> listener) {
+    public CompletableFuture<Collection<IndexMetadata>> getSnapshotIndexMetadata(RepositoryData repositoryData,
+                                                                                 SnapshotId snapshotId,
+                                                                                 Collection<IndexId> indexIds) {
+        return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("getSnapshotIndexMetadata is not supported in RestoreOnlyRepository"));
     }
 
     @Override

--- a/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -78,7 +79,6 @@ import org.elasticsearch.test.TestCluster;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.common.unit.TimeValue;
-import java.util.Set;
 
 public final class BlobStoreTestUtil {
 
@@ -225,7 +225,7 @@ public final class BlobStoreTestUtil {
                 assertThat(indexContainer.listBlobs(),
                     hasKey(String.format(Locale.ROOT, BlobStoreRepository.METADATA_NAME_FORMAT,
                         repositoryData.indexMetaDataGenerations().indexMetaBlobId(snapshotId, indexId))));
-                final IndexMetadata indexMetadata = PlainActionFuture.get(x -> repository.getSnapshotIndexMetadata(repositoryData, snapshotId, indexId, x));
+                IndexMetadata indexMetadata = repository.getSnapshotIndexMetadata(repositoryData, snapshotId, indexId).get();
                 for (Map.Entry<String, BlobContainer> entry : indexContainer.children().entrySet()) {
                     // Skip Lucene MockFS extraN directory
                     if (entry.getKey().startsWith("extra")) {


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11940

Mainly motivated by `RestoreService.restoreService`. With these changes it
should be easier to shorten it and reduce its indentation level.
