### PR TITLE
Improve documentation and health checks around cluster settings

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -27,9 +27,14 @@
 # the owner to 'crate:crate'
 #path.data: /path/to/data1,/path/to/data2
 
-# Clustering: To avoid split-brain situations and data loss on recovery
-#gateway.expected_nodes: 5              # Total amount of nodes
-#gateway.recover_after_nodes: 3         # More than half of the nodes
+# Clustering: The settings below offer a way to delay recovery until a number
+# of data nodes are available, one reason to do this is to avoid the
+# unnecesary creation of new replicas.
+# The specified number of expected data nodes will also be used to give you a
+# health check warning when the actual number of data nodes does not match the
+# expected number.
+#gateway.expected_data_nodes: 5
+#gateway.recover_after_data_nodes: 3
 
 # Networking: Bind to an IP address or interface other than localhost.
 # Be careful! Never expose an unprotected node to the internet.
@@ -42,8 +47,8 @@
 #    - host2
 
 # Bootstrap the cluster using an initial set of master-eligible nodes. All
-# master-eligible nodes must be set here for new (or upgraded from CrateDB < 4.x)
-# production (non loop-back bound) clusters otherwise the cluster is not able to
+# master-eligible nodes must be set here for clusters upgraded from CrateDB <
+# 4.x which are non loop-back bound, otherwise the cluster is not able to
 # initially vote an initial master node:
 #
 #cluster.initial_master_nodes:
@@ -304,18 +309,18 @@ auth:
 # changes. This data is stored persistently across full cluster restarts
 # and recovered after nodes are started again.
 
-# Defines the number of nodes that need to be started before any cluster
+# Defines the number of data nodes that need to be started before any cluster
 # state recovery will start.
-#gateway.recover_after_nodes: 2
+#gateway.recover_after_data_nodes: 2
 
 # Defines the time to wait before starting the recovery once the number
 # of nodes defined in gateway.recover_after_nodes are started.
 #gateway.recover_after_time: 5m
 
-# Defines how many nodes should be waited for until the cluster state is
+# Defines how many data nodes should be waited for until the cluster state is
 # recovered immediately. The value should be equal to the number of nodes
 # in the cluster.
-#gateway.expected_nodes: 3
+#gateway.expected_data_nodes: 3
 
 
 ############################ Recovery Throttling #############################
@@ -374,8 +379,8 @@ auth:
 # 'config/log4j2.properties' to help you doing so.
 
 # Bootstrap the cluster using an initial set of master-eligible nodes. All
-# master-eligible nodes must be set here for new (or upgraded from CrateDB < 4.x)
-# production (non loop-back bound) clusters otherwise the cluster is not able to
+# master-eligible nodes must be set here for clusters upgraded from CrateDB <
+# 4.x which are non loop-back bound, otherwise the cluster is not able to
 # initially vote an initial master node:
 #
 #cluster.initial_master_nodes: ["host1", "host2"]

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -787,8 +787,8 @@ Example query::
   +----+---------...-+--------------------------------------------------------------...-+
   | id | node_id     | description                                                      |
   +----+---------...-+--------------------------------------------------------------...-+
-  |  1 | ...         | The value of the cluster setting 'gateway.expected_data_nodes... |
-  |  2 | ...         | The value of the cluster setting 'gateway.recover_after_data_... |
+  |  1 | ...         | It has been detected that the 'gateway.expected_data_nodes' s... |
+  |  2 | ...         | The cluster setting 'gateway.recover_after_data_nodes' (or th... |
   |  3 | ...         | If any of the "expected data nodes" recovery settings are set... |
   |  5 | ...         | The high disk watermark is exceeded on the node. The cluster ... |
   |  6 | ...         | The low disk watermark is exceeded on the node. The cluster w... |
@@ -830,42 +830,62 @@ flag::
 Description of checked node settings
 ------------------------------------
 
+.. raw:: html
+
+  <span id="recovery-expected-nodes"></span>
+  
 Recovery expected data nodes
 ............................
 
-The check for the
-:ref:`gateway.expected_data_nodes <gateway.expected_data_nodes>` setting checks
-that the number of data nodes that should be waited for the immediate
-cluster state :ref:`recovery <gloss-shard-recovery>`. This value must be equal
-to the maximum number of data nodes in the cluster.
+This check looks at the 
+:ref:`gateway.expected_data_nodes <gateway.expected_data_nodes>` setting and 
+checks if its value matches the actual number of data nodes present in the 
+cluster. 
+If the actual number of nodes is below the expected number, the warning is 
+raised to indicate some nodes are down.
+If the actual number is greater, this is flagged to indicate the setting 
+should be updated.
 
 .. NOTE::
 
    For backward compatibility, setting the deprecated
    :ref:`gateway.expected_nodes <gateway.expected_nodes>` instead is still
-   supported. It must then be equal to the maximum of data and master nodes.
+   supported. It counts all nodes, not only 
+   :ref:`data-carrying nodes <node.data>`.
+
+.. raw:: html
+
+  <span id="recovery-after-nodes"></span>
 
 Recovery after data nodes
 .........................
 
-The check for the :ref:`gateway.recover_after_data_nodes
-<gateway.recover_after_data_nodes>` verifies that the number of started nodes
-before the cluster starts must be greater than the half of the expected number
-of data nodes and equal to or less than number of data nodes in the cluster.
+This check looks at the 
+:ref:`gateway.recover_after_data_nodes <gateway.recover_after_data_nodes>` 
+setting and checks if its value is greater than half the configured expected 
+number, but not greater than the configured expected number.
 
 .. NOTE::
 
    For backward compatibility, setting the deprecated
    :ref:`gateway.recover_after_nodes <gateway.recover_after_nodes>` instead
-   is still supported. It must then be equal to less than the number data and
-   master nodes.
+   is still supported. 
 
 ::
 
   (E / 2) < R <= E
 
 Here, ``R`` is the number of :ref:`recovery <gloss-shard-recovery>` nodes and
-``E`` is the number of expected nodes.
+``E`` is the number of expected (data) nodes.
+
+If recovery is started when some nodes are down, CrateDB proceeds on the
+basis the nodes that are down may not be coming back, and it will create new 
+replicas and rebalance shards as necessary. This is throttled, and it can be
+controlled with :ref:`routing allocation settings <conf_routing>`, but
+depending on the context, you may prefer to delay recovery if the nodes are 
+only down for a short period of time, so it is advisable to review the
+documentation around :ref:`the settings involved <metadata-gateway>` and 
+configure them carefully.
 
 Recovery after time
 ...................
@@ -1633,12 +1653,12 @@ This check warns if any :ref:`partitioned table <partitioned-tables>` has more
 than 1000 partitions to detect the usage of a high cardinality field for
 partitioning.
 
-Tables need to be recreated
-...........................
-
 .. raw:: html
 
   <span id="tables-need-to-be-upgraded"></span>
+
+Tables need to be recreated
+...........................
 
 .. WARNING::
 

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -104,6 +104,10 @@ Changes
   :ref:`standard_conforming_strings <conf-session-standard_conforming_strings>`
   read-only session setting for improved compatibility with PostgreSQL clients.
 
+- The severity of the node checks on the metadata gateway recovery settings
+  has been lowered from `HIGH` to `MEDIUM` as leaving these to default
+  or suboptimal values does not translate into data corruption or loss.
+
 Fixes
 =====
 

--- a/docs/concepts/storage-consistency.rst
+++ b/docs/concepts/storage-consistency.rst
@@ -206,16 +206,17 @@ following information:
 Every node has its own copy of the cluster state. However there is only one
 node allowed to change the cluster state at runtime. This node is called the
 "master" node and gets auto-elected. The "master" node has no special
-configuration at all, any node in the cluster can be elected as a master. There
+configuration at all, all nodes are master-eligible by default, and any 
+master-eligible node can be elected as the master. There
 is also an automatic re-election if the current master node goes down for some
 reason.
 
 .. NOTE::
 
-  To avoid a scenario where two masters are elected due to network partitioning
-  it's required to define a quorum of nodes with which it's possible to elect a
-  master. For details in how to do this and further information see
-  :ref:`concept-master-election`.
+  To avoid a scenario where two masters could be elected due to network 
+  partitioning, CrateDB automatically defines a quorum of nodes with 
+  which it is possible to elect a master. For details on how this works
+  and further information see :ref:`concept-master-election`.
 
 To explain the flow of events for any cluster state change, here is an example
 flow for an ``ALTER TABLE`` statement which changes the schema of a table:

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -686,17 +686,6 @@ Sets size of transaction log prior to flushing.
   Size (bytes) of translog.
 
 
-.. _sql-create-table-translog-interval:
-
-``translog.interval``
----------------------
-
-Sets frequency of flush necessity check.
-
-:value:
-  Frequency in milliseconds.
-
-
 .. _sql-create-table-translog-sync-interval:
 
 ``translog.sync_interval``

--- a/server/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryAfterNodesSysCheck.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryAfterNodesSysCheck.java
@@ -34,15 +34,15 @@ public class RecoveryAfterNodesSysCheck extends AbstractSysNodeCheck {
     private final Settings settings;
 
     static final int ID = 2;
-    private static final String DESCRIPTION = "The value of the cluster setting 'gateway.recover_after_data_nodes' " +
-                                              "(or the deprecated `gateway.recovery_after_nodes` setting)" +
-                                              "needs to be greater than half of the maximum/expected number of (data) " +
-                                              "nodes and equal or less than the maximum/expected number of (data) nodes " +
+    private static final String DESCRIPTION = "The cluster setting 'gateway.recover_after_data_nodes' " +
+                                              "(or the deprecated `gateway.recovery_after_nodes` setting) " +
+                                              "is not configured or it is set to a value that seems low in " +
+                                              "relation to the the maximum/expected number of (data) nodes " +
                                               "in the cluster.";
 
     @Inject
     public RecoveryAfterNodesSysCheck(ClusterService clusterService, Settings settings) {
-        super(ID, DESCRIPTION, Severity.HIGH);
+        super(ID, DESCRIPTION, Severity.MEDIUM);
         this.clusterService = clusterService;
         this.settings = settings;
     }

--- a/server/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryExpectedNodesSysCheck.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryExpectedNodesSysCheck.java
@@ -34,13 +34,13 @@ public class RecoveryExpectedNodesSysCheck extends AbstractSysNodeCheck {
     private final Settings settings;
 
     static final int ID = 1;
-    private static final String DESCRIPTION = "The value of the cluster setting 'gateway.expected_data_nodes' " +
-                                              "(or the deprecated `gateway.recovery_after_nodes` setting)" +
-                                              "must be equal to the maximum/expected number of (data) nodes in the cluster.";
+    private static final String DESCRIPTION = "It has been detected that the 'gateway.expected_data_nodes' setting" +
+                                              "(or the deprecated `gateway.recovery_after_nodes` setting) is not" +
+                                              "configured or it does not match the actual number of (data) nodes in the cluster.";
 
     @Inject
     public RecoveryExpectedNodesSysCheck(ClusterService clusterService, Settings settings) {
-        super(ID, DESCRIPTION, Severity.HIGH);
+        super(ID, DESCRIPTION, Severity.MEDIUM);
         this.clusterService = clusterService;
         this.settings = settings;
     }

--- a/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
@@ -79,7 +79,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryExpectedNodesCheck.isValid(), is(true));
     }
 
@@ -100,7 +100,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
     }
 
@@ -119,7 +119,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
     }
 
@@ -141,7 +141,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryExpectedNodesCheck.isValid(), is(true));
     }
 
@@ -163,7 +163,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
     }
 
@@ -173,7 +173,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryAfterNodesSysCheck(clusterService, Settings.EMPTY);
 
         assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryAfterNodesCheck.isValid(), is(true));
     }
 
@@ -195,7 +195,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryAfterNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryAfterNodesCheck.isValid(), is(false));
     }
 
@@ -215,7 +215,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryAfterNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryAfterNodesCheck.isValid(), is(false));
     }
 
@@ -230,14 +230,14 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
         var settings = Settings.builder()
             .put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2)
-            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 2)
+            .put(GatewayService.EXPECTED_DATA_NODES_SETTING.getKey(), 3)
             .build();
 
         RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
             new RecoveryAfterNodesSysCheck(clusterService, settings);
 
         assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
         assertThat(recoveryAfterNodesCheck.isValid(), is(true));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
@@ -42,10 +42,10 @@ public class SysNodeCheckerIntegrationTest extends IntegTestCase {
                                        "order by id, node_id asc");
         assertThat(response.rowCount(), equalTo(14L));
         assertThat(TestingHelpers.printedTable(response.rows()),
-            is("1| 3| false\n" +  // 1 = recoveryExpectedNodesCheck
-               "1| 3| false\n" +
-               "2| 3| false\n" +  // 2 = RecoveryAfterNodes
-               "2| 3| false\n" +
+            is("1| 2| false\n" +  // 1 = recoveryExpectedNodesCheck
+               "1| 2| false\n" +
+               "2| 2| false\n" +  // 2 = RecoveryAfterNodes
+               "2| 2| false\n" +
                "3| 2| true\n" +   // 3 = RecoveryAfterTime
                "3| 2| true\n" +
                "5| 3| true\n" +   // 5 = HighDiskWatermark


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This PR intends to improve the documentation of cluster-related settings.
It adds an explanation of the voting configuration which is something we were missing.
It also clarifies some statements around recovery settings that looked misleading.
It takes into account the changes that were introduced around 4.0.0

## Checklist

 - [X] Added an entry in `CHANGES.txt` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
