### PR TITLE
Replace awaitBusy with assertBusy

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.shard;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.elasticsearch.common.lucene.Lucene.cleanLuceneIndex;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
@@ -1496,7 +1497,7 @@ public class IndexShardTests extends IndexShardTestCase {
     }
 
     @Test
-    public void testScheduledRefresh() throws IOException, InterruptedException {
+    public void testScheduledRefresh() throws Exception {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
@@ -1521,7 +1522,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertThat(primary.scheduledRefresh(), is(false));
         assertThat(lastSearchAccess, is(primary.getLastSearcherAccess()));
         // wait until the thread-pool has moved the timestamp otherwise we can't assert on this below
-        awaitBusy(() -> primary.getThreadPool().relativeTimeInMillis() > lastSearchAccess);
+        assertBusy(() -> assertThat(primary.getThreadPool().relativeTimeInMillis()).isGreaterThan(lastSearchAccess));
         CountDownLatch latch = new CountDownLatch(10);
         for (int i = 0; i < 10; i++) {
             primary.awaitShardSearchActive(refreshed -> {

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -41,7 +41,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -719,30 +718,6 @@ public abstract class ESTestCase extends CrateLuceneTestCase {
             }
             throw e;
         }
-    }
-
-    public static boolean awaitBusy(BooleanSupplier breakSupplier) throws InterruptedException {
-        return awaitBusy(breakSupplier, 10, TimeUnit.SECONDS);
-    }
-
-    // After 1s, we stop growing the sleep interval exponentially and just sleep 1s until maxWaitTime
-    private static final long AWAIT_BUSY_THRESHOLD = 1000L;
-
-    public static boolean awaitBusy(BooleanSupplier breakSupplier, long maxWaitTime, TimeUnit unit) throws InterruptedException {
-        long maxTimeInMillis = TimeUnit.MILLISECONDS.convert(maxWaitTime, unit);
-        long timeInMillis = 1;
-        long sum = 0;
-        while (sum + timeInMillis < maxTimeInMillis) {
-            if (breakSupplier.getAsBoolean()) {
-                return true;
-            }
-            Thread.sleep(timeInMillis);
-            sum += timeInMillis;
-            timeInMillis = Math.min(AWAIT_BUSY_THRESHOLD, timeInMillis * 2);
-        }
-        timeInMillis = maxTimeInMillis - sum;
-        Thread.sleep(Math.max(timeInMillis, 0));
-        return breakSupplier.getAsBoolean();
     }
 
     public static boolean terminate(ExecutorService... services) {


### PR DESCRIPTION
As https://github.com/crate/crate/pull/13549 has shown awaitBusy is
error prone as one can await a condition without checking if it actually
became true.

This replaces it with `assertBusy`
