### PR TITLE
Improve error when `ORDER BY` or `MIN`/`MAX` on `INTERVAL`

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -72,5 +72,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fix runtime ``ClassCastException`` when attempting to
+  :ref:`ORDER BY <sql-select-order-by>` an :ref:`INTERVAL <type-interval>` type,
+  or when attempting to use :ref:`MAX <aggregation-max>` or
+  :ref:`MIN <aggregation-min>` aggregations on an
+  :ref:`INTERVAL <type-interval>` type, and return an error message about
+  unsupported type during analysis of a query.
 

--- a/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -45,7 +45,7 @@ public class SemanticSortValidator {
     // Instead of this we should probably have a property on DataType
     // that indicates if ordering is supported and encapsulate the required functionality somehow
     public static final Set<Integer> SUPPORTED_TYPES = Stream.concat(
-        DataTypes.PRIMITIVE_TYPES.stream(),
+        DataTypes.PRIMITIVE_TYPES_WITHOUT_INTERVAL.stream(),
         Stream.of(
             DataTypes.REGCLASS,
             DataTypes.REGPROC,

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -63,7 +63,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Comparable,
     public static final String NAME = "max";
 
     public static void register(AggregationImplModule mod) {
-        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES_WITHOUT_INTERVAL) {
             var fixedWidthType = supportedType instanceof FixedWidthType;
             mod.register(
                 Signature.aggregate(

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -63,7 +63,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Comparable,
     public static final String NAME = "min";
 
     public static void register(AggregationImplModule mod) {
-        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES_WITHOUT_INTERVAL) {
             var fixedWidthType = supportedType instanceof FixedWidthType;
             mod.register(
                 Signature.aggregate(

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -123,6 +123,22 @@ public final class DataTypes {
         DATE
     );
 
+    public static final List<DataType<?>> PRIMITIVE_TYPES_WITHOUT_INTERVAL = List.of(
+        BYTE,
+        BOOLEAN,
+        CHARACTER,
+        STRING,
+        IP,
+        DOUBLE,
+        FLOAT,
+        SHORT,
+        INTEGER,
+        LONG,
+        TIMESTAMPZ,
+        TIMESTAMP,
+        DATE
+    );
+
     private static final Set<Integer> PRIMITIVE_TYPE_IDS =
         PRIMITIVE_TYPES.stream()
             .map(DataType::id)

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1130,6 +1130,22 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void testOrderByOnInterval() throws Exception {
+        var executor = SQLExecutor.builder(clusterService)
+            .build();
+        assertThatThrownBy(() ->
+                executor.analyze("select INTERVAL '12' HOUR AS \"interval\" from sys.nodes order by 1"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Cannot ORDER BY ''PT12H'::interval AS interval': invalid data type 'interval'.");
+        assertThatThrownBy(() ->
+                               executor.analyze("select current_timestamp - process['probe_timestamp'] AS \"interval\" " +
+                                                "from sys.nodes order by 1"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Cannot ORDER BY '(CURRENT_TIMESTAMP - process['probe_timestamp']) AS interval': " +
+                        "invalid data type 'interval'.");
+    }
+
+    @Test
     public void testOrderByOnArray() throws Exception {
         var executor = SQLExecutor.builder(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -21,9 +21,8 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -58,85 +57,84 @@ public class MaximumAggregationTest extends AggregationTestCase {
     @Test
     public void testDouble() throws Exception {
         Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.8d}, {0.3d}});
-
-        assertEquals(0.8d, result);
+        assertThat(result).isEqualTo(0.8d);
     }
 
     @Test
     public void testFloat() throws Exception {
         Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.8f}, {0.3f}});
-
-        assertEquals(0.8f, result);
+        assertThat(result).isEqualTo(0.8f);
     }
 
     @Test
     public void testInteger() throws Exception {
         Object result = executeAggregation(DataTypes.INTEGER, new Object[][]{{8}, {3}});
-
-        assertEquals(8, result);
+        assertThat(result).isEqualTo(8);
     }
 
     @Test
     public void test_aggregate_double_zero() throws Exception {
         Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.0}, {0.0}});
-        assertThat(result, is(0.0d));
+        assertThat(result).isEqualTo((0.0d));
     }
 
     @Test
     public void test_aggregate_float_zero() throws Exception {
         Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.0f}, {0.0f}});
-        assertThat(result, is(0.0f));
+        assertThat(result).isEqualTo((0.0f));
     }
 
     @Test
     public void test_aggregate_min_float() throws Exception {
         Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{- Float.MAX_VALUE}, {- Float.MAX_VALUE}});
-        assertThat(result, is(- Float.MAX_VALUE));
+        assertThat(result).isEqualTo((- Float.MAX_VALUE));
     }
 
     @Test
     public void test_aggregate_min_double() throws Exception {
         Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{- Double.MAX_VALUE}, {- Double.MAX_VALUE}});
-        assertThat(result, is(- Double.MAX_VALUE));
+        assertThat(result).isEqualTo((- Double.MAX_VALUE));
     }
 
     @Test
     public void test_aggregate_min_long() throws Exception {
         Object result = executeAggregation(DataTypes.LONG, new Object[][]{{Long.MIN_VALUE}, {Long.MIN_VALUE}});
-        assertThat(result, is(Long.MIN_VALUE));
+        assertThat(result).isEqualTo((Long.MIN_VALUE));
     }
 
     @Test
     public void testLong() throws Exception {
         Object result = executeAggregation(DataTypes.LONG, new Object[][]{{8L}, {3L}});
 
-        assertEquals(8L, result);
+        assertThat(result).isEqualTo(8L);
     }
 
     @Test
     public void testShort() throws Exception {
         Object result = executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 8}, {(short) 3}});
 
-        assertEquals((short) 8, result);
+        assertThat(result).isEqualTo((short) 8);
     }
 
     @Test
     public void test_max_with_byte_argument_type() throws Exception {
-        assertThat(executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 1}, {(byte) 0}}), is((byte) 1));
+        assertThat(executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 1}, {(byte) 0}})).isEqualTo(((byte) 1));
     }
 
     @Test
     public void testString() throws Exception {
         Object result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
 
-        assertEquals("Youri", result);
+        assertThat(result).isEqualTo("Youri");
     }
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unknown function: max(INPUT(0))," +
-                                        " no overload found for matching argument types: (object).");
-        executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
+        assertThatThrownBy(() -> executeAggregation(DataTypes.INTERVAL, new Object[][]{{new Object()}}))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageStartingWith("Unknown function: max(INPUT(0)), no overload found for matching argument types: (interval).");
+        assertThatThrownBy(() -> executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}}))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageStartingWith("Unknown function: max(INPUT(0)), no overload found for matching argument types: (object).");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -21,9 +21,8 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -58,67 +57,63 @@ public class MinimumAggregationTest extends AggregationTestCase {
     @Test
     public void testDouble() throws Exception {
         Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.8d}, {0.3d}});
-
-        assertEquals(0.3d, result);
+        assertThat(result).isEqualTo(0.3d);
     }
 
     @Test
     public void testFloat() throws Exception {
         Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.8f}, {0.3f}});
-
-        assertEquals(0.3f, result);
+        assertThat(result).isEqualTo(0.3f);
     }
 
     @Test
     public void test_aggregate_double_zero() throws Exception {
         Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{{0.0}, {0.0}});
-        assertThat(result, is(0.0d));
+        assertThat(result).isEqualTo((0.0d));
     }
 
     @Test
     public void test_aggregate_float_zero() throws Exception {
         Object result = executeAggregation(DataTypes.FLOAT, new Object[][]{{0.0f}, {0.0f}});
-        assertThat(result, is(0.0f));
+        assertThat(result).isEqualTo((0.0f));
     }
 
     @Test
     public void testInteger() throws Exception {
         Object result = executeAggregation(DataTypes.INTEGER, new Object[][]{{8}, {3}});
-
-        assertEquals(3, result);
+        assertThat(result).isEqualTo(3);
     }
 
     @Test
     public void testLong() throws Exception {
         Object result = executeAggregation(DataTypes.LONG, new Object[][]{{8L}, {3L}});
-
-        assertEquals(3L, result);
+        assertThat(result).isEqualTo(3L);
     }
 
     @Test
     public void testShort() throws Exception {
         Object result = executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 8}, {(short) 3}});
-
-        assertEquals((short) 3, result);
+        assertThat(result).isEqualTo((short) 3);
     }
 
     @Test
     public void test_min_with_byte_argument_type() throws Exception {
-        assertThat(executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 1}, {(byte) 0}}), is((byte) 0));
+        assertThat(executeAggregation(DataTypes.BYTE, new Object[][]{{(byte) 1}, {(byte) 0}})).isEqualTo(((byte) 0));
     }
 
     @Test
     public void testString() throws Exception {
         Object result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
-
-        assertEquals("Ruben", result);
+        assertThat(result).isEqualTo("Ruben");
     }
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unknown function: min(INPUT(0))," +
-                                        " no overload found for matching argument types: (object).");
-        executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});
+        assertThatThrownBy(() -> executeAggregation(DataTypes.INTERVAL, new Object[][]{{new Object()}}))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageStartingWith("Unknown function: min(INPUT(0)), no overload found for matching argument types: (interval).");
+        assertThatThrownBy(() -> executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}}))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageStartingWith("Unknown function: min(INPUT(0)), no overload found for matching argument types: (object).");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, since `org.joda.time.Period` is used for `INTERVAL` types, which doesn't implement `Comparable` and therefore, ordering (see `OrderingByPostion#rowOrdering()` and
`OrderingByPosition#arrayOrdering()`) as well as `MIN`/`MAX` aggregations throwed `ClassCastException` during runtime.

Catch this early during analysis and return the standard error message for unsupported types.

Relates: #13576


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
