### PR TITLE
Disallow comparisons between `INTERVAL`s

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -79,3 +79,6 @@ Fixes
   :ref:`INTERVAL <type-interval>` type, and return an error message about
   unsupported type during analysis of a query.
 
+- Disallowed comparison operators between :ref:`INTERVAL <type-interval>` types,
+  except for ``=`` and ``<>``, Previously, ``null`` was returned in any of the
+  ``>``, ``>=``, ``<``, ``<=``, comparisons.

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -72,10 +72,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-- Fix runtime ``ClassCastException`` when attempting to
+- Fixed runtime ``ClassCastException`` when attempting to
   :ref:`ORDER BY <sql-select-order-by>` an :ref:`INTERVAL <type-interval>` type,
-  or when attempting to use :ref:`MAX <aggregation-max>` or
-  :ref:`MIN <aggregation-min>` aggregations on an
+  or when attempting to use :ref:`MIN <aggregation-min>` or
+  :ref:`MAX <aggregation-max>` aggregations on an
   :ref:`INTERVAL <type-interval>` type, and return an error message about
   unsupported type during analysis of a query.
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -2043,8 +2043,14 @@ to days and hours::
 
 .. NOTE::
 
-    Comparisons between intervals except for equality (``=``) and
-    inequality(``<>``) are not allowed.
+    * Comparisons between intervals except for equality (``=``) and
+      inequality(``<>``) are not allowed.
+
+    * Intervals cannot be used in :ref:`ORDER BY <sql-select-order-by>` clause.
+
+    * Intervals cannot be used in :ref:`MIN <aggregation-min>` and
+      :ref:`MAX <aggregation-max>` aggregations.
+
 
 .. _data-types-bit-strings:
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -2041,6 +2041,11 @@ to days and hours::
         SELECT 1 row in set (... sec)
 
 
+.. NOTE::
+
+    Comparisons between intervals except for equality (``=``) and
+    inequality(``<>``) are not allowed.
+
 .. _data-types-bit-strings:
 
 Bit strings

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -29,7 +29,7 @@ public final class GtOperator {
     public static final String NAME = "op_>";
 
     public static void register(OperatorModule module) {
-        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES_WITHOUT_INTERVAL) {
             module.register(
                 Signature.scalar(
                     NAME,

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -29,7 +29,7 @@ public final class GteOperator {
     public static final String NAME = "op_>=";
 
     public static void register(OperatorModule module) {
-        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES_WITHOUT_INTERVAL) {
             module.register(
                 Signature.scalar(
                     NAME,

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -29,7 +29,7 @@ public final class LtOperator {
     public static final String NAME = "op_<";
 
     public static void register(OperatorModule module) {
-        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES_WITHOUT_INTERVAL) {
             module.register(
                 Signature.scalar(
                     NAME,

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -29,7 +29,7 @@ public final class LteOperator {
     public static final String NAME = "op_<=";
 
     public static void register(OperatorModule module) {
-        for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
+        for (var supportedType : DataTypes.PRIMITIVE_TYPES_WITHOUT_INTERVAL) {
             module.register(
                 Signature.scalar(
                     NAME,

--- a/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
@@ -23,6 +23,9 @@ package io.crate.expression.operator;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
 
 import org.junit.Test;
 
@@ -91,5 +94,15 @@ public class CmpOperatorTest extends ScalarTestCase {
         assertEvaluateNull("null between 1 and null");
         assertEvaluateNull("null between null and 10");
         assertEvaluateNull("null between null and null");
+    }
+
+    @Test
+    public void test_comparison_for_intervals_is_not_allowed() {
+        for (String op : List.of(">", ">=", "<", "<=")) {
+            assertThatThrownBy(() -> assertEvaluate("INTERVAL '1' DAY " + op + " INTERVAL '2' HOUR", null))
+                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasMessageStartingWith("Unknown function: ('P1D'::interval " + op + " 'PT2H'::interval), " +
+                                        "no overload found for matching argument types: (interval, interval).");
+        }
     }
 }


### PR DESCRIPTION
See commit messages

Follow up to: #13588
Relates to: #13576


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
