### PR TITLE
Fix early application of correlated subqueries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,4 +74,14 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue that caused correlated sub-queries to fail with an
+  `IllegalStateException` when the outer query contained multiple joins.
+  An example ::
+
+    CREATE TABLE a (x INT, y INT, z INT); // tables b, c, d created as a
+    SELECT
+      (SELECT 1 WHERE a.x=1 AND b.y=1 AND c.z=1)
+    FROM a, b, c, d;
+    IllegalStateException[OuterColumn `y` must appear in input of
+    CorrelatedJoin]
+

--- a/server/src/main/java/io/crate/expression/operator/AndOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AndOperator.java
@@ -39,6 +39,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.planner.operators.Filter;
 import io.crate.types.DataTypes;
 
 public class AndOperator extends Operator<Boolean> {
@@ -173,7 +174,10 @@ public class AndOperator extends Operator<Boolean> {
         }
         Symbol first = symbols.next();
         while (symbols.hasNext()) {
-            first = new Function(SIGNATURE, List.of(first, symbols.next()), Operator.RETURN_TYPE);
+            var next = symbols.next();
+            if (!Filter.isMatchAll(next)) {
+                first = new Function(SIGNATURE, List.of(first, next), Operator.RETURN_TYPE);
+            }
         }
         return first;
     }

--- a/server/src/main/java/io/crate/expression/operator/AndOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AndOperator.java
@@ -169,8 +169,16 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     public static Symbol join(Iterator<? extends Symbol> symbols) {
+        return join(symbols, Literal.BOOLEAN_TRUE);
+    }
+
+    public static Symbol join(Iterable<? extends Symbol> symbols, Symbol defaultSymbol) {
+        return join(symbols.iterator(), defaultSymbol);
+    }
+
+    public static Symbol join(Iterator<? extends Symbol> symbols, Symbol defaultSymbol) {
         if (!symbols.hasNext()) {
-            return Literal.BOOLEAN_TRUE;
+            return defaultSymbol;
         }
         Symbol first = symbols.next();
         while (symbols.hasNext()) {

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -58,7 +58,7 @@ public final class Filter extends ForwardingLogicalPlan {
         return new Filter(source, query);
     }
 
-    private static boolean isMatchAll(Symbol query) {
+    public static boolean isMatchAll(Symbol query) {
         return query instanceof Literal && ((Literal<?>) query).value() == Boolean.TRUE;
     }
 

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -290,17 +290,18 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "Eval[table_name, column_name]\n" +
             "  └ Limit[3::bigint;0]\n" +
             "    └ OrderBy[table_name ASC column_name DESC]\n" +
-            "      └ NestedLoopJoin[LEFT | ((attname = column_name) AND (attrelid = (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace))))]\n" +
-            "        ├ CorrelatedJoin[table_name, column_name, table_schema, (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace))]\n" +
-            "        │  └ Collect[information_schema.columns | [table_name, column_name, table_schema] | true]\n" +
-            "        │  └ SubPlan\n" +
-            "        │    └ Eval[oid]\n" +
-            "        │      └ Limit[2::bigint;0::bigint]\n" +
-            "        │        └ NestedLoopJoin[INNER | (oid = relnamespace)]\n" +
-            "        │          ├ Collect[pg_catalog.pg_class | [oid, relnamespace, relname] | (relname = table_name)]\n" +
-            "        │          └ Collect[pg_catalog.pg_namespace | [oid, nspname] | (nspname = table_schema)]\n" +
-            "        └ Rename[attname, attrelid] AS col_attr\n" +
-            "          └ Collect[pg_catalog.pg_attribute | [attname, attrelid] | true]\n"
+            "      └ Filter[(attrelid = (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace)))]\n" +
+            "        └ CorrelatedJoin[table_name, column_name, table_schema, attname, attrelid, (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace))]\n" +
+            "          └ NestedLoopJoin[LEFT | (attname = column_name)]\n" +
+            "            ├ Collect[information_schema.columns | [table_name, column_name, table_schema] | true]\n" +
+            "            └ Rename[attname, attrelid] AS col_attr\n" +
+            "              └ Collect[pg_catalog.pg_attribute | [attname, attrelid] | true]\n" +
+            "          └ SubPlan\n" +
+            "            └ Eval[oid]\n" +
+            "              └ Limit[2::bigint;0::bigint]\n" +
+            "                └ NestedLoopJoin[INNER | (oid = relnamespace)]\n" +
+            "                  ├ Collect[pg_catalog.pg_class | [oid, relnamespace, relname] | (relname = table_name)]\n" +
+            "                  └ Collect[pg_catalog.pg_namespace | [oid, nspname] | (nspname = table_schema)]\n"
         );
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/13592

The failing query
```
SELECT somethingdescription,
	(SELECT value
	FROM listofanotherthing
	WHERE listofanotherthing.anotherid=mappingtable.anotherthingidfk
	ORDER BY versionid DESC
	LIMIT 1)
FROM listofsomething
JOIN mappingtable ON listofsomething.somethingid=mappingtable.somethingidfk;
```
fails because subqueries cannot access all tables from the joined outer query (in this specific case, `mappingtable`).
Therefore, the scenario can be reduced to
```
create table a (x int, y int, z int); 
create table b (x int, y int, z int); 
create table d (x int, y int, z int); 
create table d (x int, y int, z int); 
select (select 1 where a.x=1 and b.x=1 and c.x=1) from a,b,c,d; 
```

Before fix,

```
cr> explain select 
        (select 1 where a.x=1 and b.x=1 and c.x=1) 
    from a,b,c,d;                                                                                                                                   
+---------------------------------------------------------------+
| EXPLAIN                                                       |
+---------------------------------------------------------------+
| Eval[(SELECT 1 FROM (empty_row))]                             |
|   └ NestedLoopJoin[CROSS]                                     |
|     ├ NestedLoopJoin[CROSS]                                   |
|     │  ├ CorrelatedJoin[x, x, (SELECT 1 FROM (empty_row))]    |
|     │  │  └ NestedLoopJoin[CROSS]                             |
|     │  │    ├ Collect[doc.a | [x] | true]                     |
|     │  │    └ Collect[doc.b | [x] | true]                     |
|     │  │  └ SubPlan                                           |
|     │  │    └ Eval[1]                                         |
|     │  │      └ Limit[2::bigint;0::bigint]                    |
|     │  │        └ Filter[(((x = 1) AND (x = 1)) AND (x = 1))] |
|     │  │          └ TableFunction[empty_row | [] | true]      |
|     │  └ Collect[doc.c | [] | true] <-- this is not under CorrelatedJoin and inaccessible by the subquery                          
|     └ Collect[doc.d | [] | true]                              |
+---------------------------------------------------------------+
EXPLAIN 1 row in set (0.705 sec)
```

After fix (the idea is to apply `CorrelatedJoin` late),

```
cr> explain select 
        (select 1 where a.x=1 and b.x=1 and c.x=1) 
    from a,b,c,d;                                                                                                                                   
+----------------------------------------------------------+
| EXPLAIN                                                  |
+----------------------------------------------------------+
| Eval[(SELECT 1 FROM (empty_row))]                        |
|   └ CorrelatedJoin[x, x, x, (SELECT 1 FROM (empty_row))] |
|     └ NestedLoopJoin[CROSS]                              |
|       ├ NestedLoopJoin[CROSS]                            |
|       │  ├ NestedLoopJoin[CROSS]                         |
|       │  │  ├ Collect[doc.a | [x] | true]                |
|       │  │  └ Collect[doc.b | [x] | true]                |
|       │  └ Collect[doc.c | [x] | true]  <-- this is under CorrelatedJoin and accessible by the subquery                
|       └ Collect[doc.d | [] | true] <-- this does not need to be under CorrelatedJoin but done for simplicity of the logic                      
|     └ SubPlan                                            |
|       └ Eval[1]                                          |
|         └ Limit[2::bigint;0::bigint]                     |
|           └ Filter[(((x = 1) AND (x = 1)) AND (x = 1))]  |
|             └ TableFunction[empty_row | [] | true]       |
+----------------------------------------------------------+
EXPLAIN 1 row in set (0.008 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
