### PR TITLE
Don't register proxy transport actions for subscriber cluster actions

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
@@ -21,12 +21,10 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.execution.ddl.AbstractDDLTransportAction;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
-import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
-import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+
+import java.util.Collection;
+
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -44,12 +42,14 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Collection;
-
-import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 
 public class DropSubscriptionAction extends ActionType<AcknowledgedResponse> {
 
@@ -120,7 +120,6 @@ public class DropSubscriptionAction extends ActionType<AcknowledgedResponse> {
                 AcknowledgedResponse::new,
                 AcknowledgedResponse::new,
                 "drop-subscription");
-            TransportActionProxy.registerProxyAction(transportService, NAME, AcknowledgedResponse::new);
         }
 
         @Override
@@ -153,6 +152,5 @@ public class DropSubscriptionAction extends ActionType<AcknowledgedResponse> {
         protected ClusterBlockException checkBlock(DropSubscriptionRequest request, ClusterState state) {
             return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
         }
-
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
@@ -53,7 +53,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.transport.TransportService;
 
 import io.crate.common.annotations.VisibleForTesting;
@@ -94,8 +93,6 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
                   Request::new,
                   ThreadPool.Names.WRITE,
                   false);
-
-            TransportActionProxy.registerProxyAction(transportService, NAME, ReplicationResponse::new);
         }
 
         @Override

--- a/server/src/main/java/io/crate/replication/logical/action/UpdateSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/UpdateSubscriptionAction.java
@@ -21,11 +21,8 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.common.annotations.VisibleForTesting;
-import io.crate.metadata.RelationName;
-import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
-import io.crate.replication.logical.metadata.Subscription;
-import io.crate.replication.logical.metadata.SubscriptionsMetadata;
+import java.io.IOException;
+import java.util.HashMap;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
@@ -44,11 +41,13 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.HashMap;
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.metadata.RelationName;
+import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
+import io.crate.replication.logical.metadata.Subscription;
+import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 
 public class UpdateSubscriptionAction extends ActionType<AcknowledgedResponse> {
 
@@ -124,7 +123,6 @@ public class UpdateSubscriptionAction extends ActionType<AcknowledgedResponse> {
                   clusterService,
                   threadPool,
                   Request::new);
-            TransportActionProxy.registerProxyAction(transportService, NAME, AcknowledgedResponse::new);
         }
 
         @Override


### PR DESCRIPTION
Proxying is for actions that are invoked on the remote cluster (e.g. via PG
tunnel) but for actions that are run on the local subscriber cluster
proxying is not required. E.g. there is also no proxy support for
something like DROP TABLE.
