### PR TITLE
Inline RestoreClusterStateListener.createAndRegisterListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreClusterStateListener.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreClusterStateListener.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
+import static org.elasticsearch.snapshots.RestoreService.restoreInProgress;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -31,8 +33,9 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.RestoreInfo;
 import org.elasticsearch.snapshots.RestoreService;
 
-import static org.elasticsearch.snapshots.RestoreService.restoreInProgress;
-
+/**
+ * Listener that fires once when a restore process finishes and removes itself from the clusterService
+ */
 public class RestoreClusterStateListener implements ClusterStateListener {
 
     private static final Logger LOGGER = LogManager.getLogger(RestoreClusterStateListener.class);
@@ -42,7 +45,8 @@ public class RestoreClusterStateListener implements ClusterStateListener {
     private final ActionListener<RestoreSnapshotResponse> listener;
 
 
-    public RestoreClusterStateListener(ClusterService clusterService, RestoreService.RestoreCompletionResponse response,
+    public RestoreClusterStateListener(ClusterService clusterService,
+                                       RestoreService.RestoreCompletionResponse response,
                                        ActionListener<RestoreSnapshotResponse> listener) {
         this.clusterService = clusterService;
         this.uuid = response.getUuid();
@@ -74,14 +78,5 @@ public class RestoreClusterStateListener implements ClusterStateListener {
         } else {
             // restore not completed yet, wait for next cluster state update
         }
-    }
-
-    /**
-     * Creates a cluster state listener and registers it with the cluster service. The listener passed as a
-     * parameter will be called when the restore is complete.
-     */
-    public static void createAndRegisterListener(ClusterService clusterService, RestoreService.RestoreCompletionResponse response,
-                                                 ActionListener<RestoreSnapshotResponse> listener) {
-        clusterService.addListener(new RestoreClusterStateListener(clusterService, response, listener));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
+import java.io.IOException;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
@@ -31,8 +33,6 @@ import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.RestoreService.RestoreCompletionResponse;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-
-import java.io.IOException;
 
 /**
  * Transport action for restore snapshot operation
@@ -91,7 +91,7 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
             @Override
             public void onResponse(RestoreCompletionResponse restoreCompletionResponse) {
                 if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {
-                    RestoreClusterStateListener.createAndRegisterListener(clusterService, restoreCompletionResponse, listener);
+                    clusterService.addListener(new RestoreClusterStateListener(clusterService, restoreCompletionResponse, listener));
                 } else {
                     listener.onResponse(new RestoreSnapshotResponse(restoreCompletionResponse.getRestoreInfo()));
                 }


### PR DESCRIPTION
It's a one line function and removing it makes it easier to see all
usages when looking at the references of the
`RestoreClusterStateListener`

Otherwise there's indirection and one has to check references of two
places.
