### PR TITLE
Update subscriptions in MetadataTracker at most once per cluster state change

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -154,27 +154,16 @@ public final class MetadataTracker implements Closeable {
         );
     }
 
-    public boolean startTracking(String subscriptionName) {
+    public void update(Collection<String> subscriptionNames) {
         synchronized (this) {
-            var copy = new HashSet<>(subscriptionsToTrack);
-            var updated = copy.add(subscriptionName);
-            subscriptionsToTrack = copy;
-            if (updated && !isActive) {
-                start();
+            if (subscriptionNames.isEmpty()) {
+                stop();
+            } else {
+                subscriptionsToTrack = new HashSet<>(subscriptionNames);
+                if (!isActive) {
+                    start();
+                }
             }
-            return updated;
-        }
-    }
-
-    public boolean startTracking(Collection<String> subscriptionNames) {
-        synchronized (this) {
-            var copy = new HashSet<>(subscriptionsToTrack);
-            var updated = copy.addAll(subscriptionNames);
-            subscriptionsToTrack = copy;
-            if (updated && !isActive) {
-                start();
-            }
-            return updated;
         }
     }
 


### PR DESCRIPTION
`MetadataTracker.startTracking` and `stopTracking` was called once for
each added or removed subscription in a change event. Internally it
always creates a `HashSet` copy.

This changes the logic to have a single update call