### PR TITLE
Introduce memo and group reference

### DIFF
--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -352,7 +352,7 @@ public class ExplainPlan implements Plan {
     private static class CastOptimizer extends LogicalPlanVisitor<PlannerContext, LogicalPlan> {
 
         @Override
-        protected LogicalPlan visitPlan(LogicalPlan logicalPlan, PlannerContext context) {
+        public LogicalPlan visitPlan(LogicalPlan logicalPlan, PlannerContext context) {
             ArrayList<LogicalPlan> newSources = new ArrayList<>(logicalPlan.sources().size());
             for (var source : logicalPlan.sources()) {
                 newSources.add(source.accept(this, context));

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
@@ -21,9 +21,11 @@
 
 package io.crate.planner.operators;
 
+import io.crate.planner.optimizer.iterative.GroupReference;
+
 public class LogicalPlanVisitor<C, R> {
 
-    protected R visitPlan(LogicalPlan logicalPlan, C context) {
+    public R visitPlan(LogicalPlan logicalPlan, C context) {
         return null;
     }
 
@@ -116,6 +118,10 @@ public class LogicalPlanVisitor<C, R> {
     }
 
     public R visitCorrelatedJoin(CorrelatedJoin apply, C context) {
+        return visitPlan(apply, context);
+    }
+
+    public R visitGroupReference(GroupReference apply, C context) {
         return visitPlan(apply, context);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/StatementClassifier.java
+++ b/server/src/main/java/io/crate/planner/operators/StatementClassifier.java
@@ -107,7 +107,7 @@ public final class StatementClassifier extends LogicalPlanVisitor<Set<String>, V
     }
 
     @Override
-    protected Void visitPlan(LogicalPlan logicalPlan, Set<String> context) {
+    public Void visitPlan(LogicalPlan logicalPlan, Set<String> context) {
         for (var source : logicalPlan.sources()) {
             source.accept(this, context);
         }

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.planner.operators.PlanHint;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.statistics.TableStats;
+
+/**
+ * A GroupReference represents a reference from a LogicalPlan to
+ * a {@link Memo} Group.
+ */
+public class GroupReference implements LogicalPlan {
+
+    private final int groupId;
+    private final List<Symbol> outputs;
+
+    public GroupReference(int groupId, List<Symbol> outputs) {
+        this.groupId = groupId;
+        this.outputs = List.copyOf(outputs);
+    }
+
+    public int groupId() {
+        return groupId;
+    }
+
+    @Override
+    public List<LogicalPlan> sources() {
+        return List.of();
+    }
+
+    @Override
+    public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+        return this;
+    }
+
+    @Override
+    public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+        throw new UnsupportedOperationException(
+            "Operation is not supported in GroupReference, it needs to be resolved to it's referenced LogicalPlan"
+        );
+    }
+
+    @Override
+    public Map<LogicalPlan, SelectSymbol> dependencies() {
+        return Map.of();
+    }
+
+    @Override
+    public long numExpectedRows() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long estimatedRowSize() {
+        return 0;
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitGroupReference(this, context);
+    }
+
+    @Override
+    public Set<RelationName> getRelationNames() {
+        return Set.of();
+    }
+
+
+    @Override
+    public ExecutionPlan build(DependencyCarrier dependencyCarrier,
+                               PlannerContext plannerContext,
+                               Set<PlanHint> planHints,
+                               ProjectionBuilder projectionBuilder,
+                               int limit,
+                               int offset,
+                               @Nullable OrderBy order,
+                               @Nullable Integer pageSizeHint,
+                               Row params,
+                               SubQueryResults subQueryResults) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public List<AbstractTableRelation<?>> baseTables() {
+        return List.of();
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReferenceResolver.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReferenceResolver.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,26 +19,23 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.planner.optimizer.matcher;
+package io.crate.planner.optimizer.iterative;
 
 import java.util.function.Function;
 
 import io.crate.planner.operators.LogicalPlan;
 
-class TypeOfPattern<T> extends Pattern<T> {
+/**
+ * The GroupReferenceResolver resolves a GroupReference to the referenced LogicalPlan
+ */
+public interface GroupReferenceResolver extends Function<LogicalPlan, LogicalPlan> {
 
-    private Class<T> expectedClass;
-
-    TypeOfPattern(Class<T> expectedClass) {
-        this.expectedClass = expectedClass;
-    }
-
-    @Override
-    public Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan) {
-        if (expectedClass.isInstance(object)) {
-            return Match.of(expectedClass.cast(object), captures);
-        } else {
-            return Match.empty();
-        }
+    static GroupReferenceResolver from(Function<GroupReference, LogicalPlan> resolver) {
+        return node -> {
+            if (node instanceof GroupReference groupRef) {
+                return resolver.apply(groupRef);
+            }
+            throw new IllegalStateException("Node is not a GroupReference");
+        };
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+import com.carrotsearch.hppc.IntObjectHashMap;
+
+import io.crate.common.collections.Lists2;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanVisitor;
+
+/**
+ * Memo is used as part of an iterative Optimizer as an in-place
+ * Data structure to mutate tree's without rewriting the whole tree.
+ *
+ * Stores a plan in a form that's efficient to mutate locally (i.e. without
+ * having to do full ancestor tree rewrites due to plan nodes being immutable).
+ * <p>
+ * Each node in a plan is placed in a group, and it's children are replaced with
+ * symbolic references to the corresponding groups.
+ * <p>
+ * For example, a plan like:
+ * <pre>
+ *    A -> B -> C -> D
+ *           \> E -> F
+ * </pre>
+ * would be stored as:
+ * <pre>
+ * root: G0
+ *
+ * G0 : { A -> G1 }
+ * G1 : { B -> [G2, G3] }
+ * G2 : { C -> G4 }
+ * G3 : { E -> G5 }
+ * G4 : { D }
+ * G5 : { F }
+ * </pre>
+ * Groups are reference-counted, and groups that become unreachable from the root
+ * due to mutations in a subtree get garbage-collected.
+ */
+public class Memo {
+    private static final int ROOT_GROUP_REF = 0;
+
+    private final int rootGroup;
+
+    private final IntObjectHashMap<Group> groups = new IntObjectHashMap<>();
+
+    private int nextGroupId = ROOT_GROUP_REF + 1;
+
+    public Memo(LogicalPlan plan) {
+        rootGroup = insertRecursive(plan);
+        groups.get(rootGroup).incomingReferences.add(ROOT_GROUP_REF);
+    }
+
+    public int getRootGroup() {
+        return rootGroup;
+    }
+
+    /**
+     * Returns the {@LogicalPlan} referenced by the given group id.
+     *
+     * @param group group id
+     * @return {@LogicalPlan} for the group id, throws an {@IllegalStateException}
+     * if the group does not exist
+     */
+    public LogicalPlan resolve(int group) {
+        return group(group).membership;
+    }
+
+    /**
+     * Returns the  {@LogicalPlan} referenced by the given GroupReference.
+     *
+     * @param groupReference
+     * @return {@LogicalPlan} for the {@GroupReference}, throws an {@IllegalStateException}
+     * ff no {@LogicalPlan} exists
+     */
+    public LogicalPlan resolve(GroupReference groupReference) {
+        return resolve(groupReference.groupId());
+    }
+
+    /**
+     * Returns the full operator tree of {@LogicalPlan}s all {@GroupReference}s resolved.
+     *
+     * @return {@LogicalPlan}
+     */
+    public LogicalPlan extract() {
+        return extract(resolve(rootGroup));
+    }
+
+    private LogicalPlan extract(LogicalPlan node) {
+        return resolveGroupReferences(node, GroupReferenceResolver.from(this::resolve));
+    }
+
+    private Group group(int group) {
+        if (!groups.containsKey(group)) {
+            throw new IllegalStateException("Group not found");
+        }
+        return groups.get(group);
+    }
+
+    /**
+     * Replaces the previous {@LogicalPlan} for a given group id with the new {@LogicalPlan}
+     *
+     * @param groupId exisiting group id
+     * @param node A {@LogicalPlan} which will be added to the group
+     * @return the {@LogicalPlan} where to group is updated to
+     */
+    public LogicalPlan replace(int groupId, LogicalPlan node) {
+        Group group = group(groupId);
+        final LogicalPlan old = group.membership;
+
+        if (node instanceof GroupReference groupRef) {
+            node = resolve(groupRef.groupId());
+        } else {
+            node = insertChildrenAndRewrite(node);
+        }
+
+        incrementReferenceCounts(node, groupId);
+        group.membership = node;
+        decrementReferenceCounts(old, groupId);
+        return node;
+    }
+
+    private void incrementReferenceCounts(LogicalPlan fromNode, int fromGroup) {
+        Set<Integer> references = allReferences(fromNode);
+        for (int group : references) {
+            groups.get(group).incomingReferences.add(fromGroup);
+        }
+    }
+
+    private void decrementReferenceCounts(LogicalPlan fromNode, Integer fromGroup) {
+        Set<Integer> references = allReferences(fromNode);
+
+        for (int group : references) {
+            Group childGroup = groups.get(group);
+            if (!childGroup.incomingReferences.remove(fromGroup)) {
+                throw new IllegalStateException("Reference to remove not found");
+            }
+
+            if (childGroup.incomingReferences.isEmpty()) {
+                deleteGroup(group);
+            }
+        }
+    }
+
+    private Set<Integer> allReferences(LogicalPlan node) {
+        return node.sources().stream()
+            .map(GroupReference.class::cast)
+            .map(GroupReference::groupId)
+            .collect(Collectors.toSet());
+    }
+
+    private void deleteGroup(int group) {
+        LogicalPlan deletedNode = groups.remove(group).membership;
+        decrementReferenceCounts(deletedNode, group);
+    }
+
+    private LogicalPlan insertChildrenAndRewrite(LogicalPlan node) {
+        return node.replaceSources(
+            node.sources().stream()
+                .map(child -> new GroupReference(
+                    insertRecursive(child),
+                    child.outputs()))
+                .collect(Collectors.toList()));
+    }
+
+    private int insertRecursive(LogicalPlan node) {
+        if (node instanceof GroupReference) {
+            return ((GroupReference) node).groupId();
+        }
+
+        int group = nextGroupId();
+        LogicalPlan rewritten = insertChildrenAndRewrite(node);
+
+        groups.put(group, new Group(rewritten));
+        incrementReferenceCounts(rewritten, group);
+
+        return group;
+    }
+
+    private int nextGroupId() {
+        return nextGroupId++;
+    }
+
+    public int groupCount() {
+        return groups.size();
+    }
+
+    private static final class Group {
+
+        private LogicalPlan membership;
+        private final List<Integer> incomingReferences = new ArrayList<>();
+
+        private Group(LogicalPlan member) {
+            this.membership = requireNonNull(member, "member is null");
+        }
+    }
+
+    public static LogicalPlan resolveGroupReferences(LogicalPlan node, GroupReferenceResolver lookup) {
+        requireNonNull(node, "node is null");
+        return node.accept(new ResolvingVisitor(lookup), null);
+    }
+
+    private static class ResolvingVisitor extends LogicalPlanVisitor<Void, LogicalPlan> {
+        private final GroupReferenceResolver lookup;
+
+        public ResolvingVisitor(GroupReferenceResolver lookup) {
+            this.lookup = requireNonNull(lookup, "lookup is null");
+        }
+
+        @Override
+        public LogicalPlan visitPlan(LogicalPlan node, Void context) {
+            List<LogicalPlan> children = Lists2.mapLazy(node.sources(), child -> child.accept(this, context));
+            return node.replaceSources(children);
+        }
+
+        @Override
+        public LogicalPlan visitGroupReference(GroupReference node, Void context) {
+            return lookup.apply(node).accept(this, context);
+        }
+    }
+}
+

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/CapturePattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/CapturePattern.java
@@ -21,6 +21,10 @@
 
 package io.crate.planner.optimizer.matcher;
 
+import java.util.function.Function;
+
+import io.crate.planner.operators.LogicalPlan;
+
 class CapturePattern<T> extends Pattern<T> {
 
     private final Capture<T> capture;
@@ -32,8 +36,8 @@ class CapturePattern<T> extends Pattern<T> {
     }
 
     @Override
-    public Match<T> accept(Object object, Captures captures) {
-        Match<T> match = pattern.accept(object, captures);
+    public Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan) {
+        Match<T> match = pattern.accept(object, captures, resolvePlan);
         return match.flatMap(val -> Match.of(val, captures.add(Captures.of(capture, val))));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import io.crate.planner.operators.LogicalPlan;
+
 public abstract class Pattern<T> {
 
     public static <T> Pattern<T> typeOf(Class<T> expectedClass) {
@@ -43,5 +45,10 @@ public abstract class Pattern<T> {
         return new CapturePattern<>(capture, this);
     }
 
-    public abstract Match<T> accept(Object object, Captures captures);
+    public abstract Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan);
+
+    public Match<T> accept(Object object, Captures captures) {
+        return accept(object, captures, Function.identity());
+    }
+
 }

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/WithPropertyPattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/WithPropertyPattern.java
@@ -21,7 +21,10 @@
 
 package io.crate.planner.optimizer.matcher;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
+
+import io.crate.planner.operators.LogicalPlan;
 
 public class WithPropertyPattern<T> extends Pattern<T> {
 
@@ -34,8 +37,8 @@ public class WithPropertyPattern<T> extends Pattern<T> {
     }
 
     @Override
-    public Match<T> accept(Object object, Captures captures) {
-        Match<T> match = pattern.accept(object, captures);
+    public Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan) {
+        Match<T> match = pattern.accept(object, captures, resolvePlan);
         return match.flatMap(matchedValue -> {
             if (propertyPredicate.test(matchedValue)) {
                 return match;

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import static io.crate.common.collections.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.IntSupplier;
+
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.planner.operators.PlanHint;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.statistics.TableStats;
+
+
+public class MemoTest {
+
+    private int id = 0;
+    private IntSupplier ids = () -> id++;
+
+    @Test
+    public void testInitialization() {
+        var plan = plan(plan());
+        Memo memo = new Memo(plan);
+
+        assertThat(memo.groupCount()).isEqualTo(2);
+        assertMatchesStructure(plan, memo.extract());
+    }
+
+    /*
+      From: X -> Y  -> Z
+      To:   X -> Y' -> Z'
+     */
+    @Test
+    public void testReplaceSubtree() {
+        var plan = plan(plan(plan()));
+
+        Memo memo = new Memo(plan);
+        assertThat(memo.groupCount()).isEqualTo(3);
+
+        // replace child of root node with subtree
+        LogicalPlan transformed = plan(plan());
+        memo.replace(getChildGroup(memo, memo.getRootGroup()), transformed);
+        assertThat(memo.groupCount()).isEqualTo(3);
+        assertMatchesStructure(memo.extract(), plan(plan.id(), transformed));
+    }
+
+    /*
+      From: X -> Y  -> Z
+      To:   X -> Y' -> Z
+     */
+    @Test
+    public void testReplaceNode() {
+        var z = plan();
+        var y = plan(z);
+        var x = plan(y);
+
+        Memo memo = new Memo(x);
+        assertThat(memo.groupCount()).isEqualTo(3);
+
+        // replace child of root node with another node, retaining child's child
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        GroupReference zRef = (GroupReference) getOnlyElement(memo.resolve(yGroup).sources());
+        var transformed = plan(zRef);
+        memo.replace(yGroup, transformed);
+        assertThat(memo.groupCount()).isEqualTo(3);
+        assertMatchesStructure(memo.extract(), plan(x.id(), plan(transformed.id(), z)));
+    }
+
+    /*
+      From: X -> Y  -> Z  -> W
+      To:   X -> Y' -> Z' -> W
+     */
+    @Test
+    public void testReplaceNonLeafSubtree() {
+        var w = plan();
+        var z = plan(w);
+        var y = plan(z);
+        var x = plan(y);
+
+        Memo memo = new Memo(x);
+
+        assertThat(memo.groupCount()).isEqualTo(4);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        int zGroup = getChildGroup(memo, yGroup);
+
+        LogicalPlan rewrittenW = memo.resolve(zGroup).sources().get(0);
+
+        TestPlan newZ = plan(rewrittenW);
+        TestPlan newY = plan(newZ);
+
+        memo.replace(yGroup, newY);
+
+        assertThat(memo.groupCount()).isEqualTo(4);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(x.id(),
+                 plan(newY.id(),
+                      plan(newZ.id(),
+                           plan(w.id())))));
+    }
+
+    /*
+      From: X -> Y -> Z
+      To:   X -> Z
+     */
+    @Test
+    public void testRemoveNode() {
+        var z = plan();
+        var y = plan(z);
+        var x = plan(y);
+
+        Memo memo = new Memo(x);
+
+        assertEquals(memo.groupCount(), 3);
+        assertThat(memo.groupCount()).isEqualTo(3);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        memo.replace(yGroup, memo.resolve(yGroup).sources().get(0));
+
+        assertThat(memo.groupCount()).isEqualTo(2);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(x.id(),
+                 plan(z.id())));
+    }
+
+    /*
+       From: X -> Z
+       To:   X -> Y -> Z
+     */
+    @Test
+    public void testInsertNode() {
+        var z = plan();
+        var x = plan(z);
+
+        Memo memo = new Memo(x);
+
+        assertThat(memo.groupCount()).isEqualTo(2);
+
+        int zGroup = getChildGroup(memo, memo.getRootGroup());
+        var y = plan(memo.resolve(zGroup));
+        memo.replace(zGroup, y);
+
+        assertThat(memo.groupCount()).isEqualTo(3);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(x.id(),
+                 plan(y.id(),
+                      plan(z.id()))));
+    }
+
+    /*
+      From: X -> Y -> Z
+      To:   X --> Y1' --> Z
+              \-> Y2' -/
+     */
+    @Test
+    public void testMultipleReferences() {
+        var z = plan();
+        var y = plan(z);
+        var x = plan(y);
+
+        Memo memo = new Memo(x);
+        assertThat(memo.groupCount()).isEqualTo(3);
+
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+
+        LogicalPlan rewrittenZ = memo.resolve(yGroup).sources().get(0);
+        var y1 = plan(rewrittenZ);
+        var y2 = plan(rewrittenZ);
+
+        var newX = plan(y1, y2);
+        memo.replace(memo.getRootGroup(), newX);
+        assertThat(memo.groupCount()).isEqualTo(4);
+
+        assertMatchesStructure(
+            memo.extract(),
+            plan(newX.id(),
+                 plan(y1.id(), plan(z.id())),
+                 plan(y2.id(), plan(z.id()))));
+    }
+
+
+    private static void assertMatchesStructure(LogicalPlan a, LogicalPlan e) {
+        if (a instanceof TestPlan actual && e instanceof TestPlan expected) {
+            assertThat(actual.getClass()).isEqualTo(expected.getClass());
+            assertThat(actual.id()).isEqualTo(expected.id());
+            assertEquals(actual.sources().size(), expected.sources().size());
+            for (int i = 0; i < actual.sources().size(); i++) {
+                assertMatchesStructure(actual.sources().get(i), expected.sources().get(i));
+            }
+        } else {
+            fail("LogicalPlan is not a TestPlan");
+        }
+    }
+
+    private int getChildGroup(Memo memo, int group) {
+        LogicalPlan node = memo.resolve(group);
+        GroupReference child = (GroupReference) node.sources().get(0);
+
+        return child.groupId();
+    }
+
+    private TestPlan plan(int id, LogicalPlan... children) {
+        return new TestPlan(id, List.of(children));
+    }
+
+    private TestPlan plan(LogicalPlan... children) {
+        return plan(ids.getAsInt(), children);
+    }
+
+    private static class TestPlan implements LogicalPlan {
+        private final List<LogicalPlan> sources;
+        private final int id;
+
+        public TestPlan(int id, List<LogicalPlan> sources) {
+            this.id = id;
+            this.sources = List.copyOf(sources);
+        }
+
+        @Override
+        public List<LogicalPlan> sources() {
+            return sources;
+        }
+
+        @Override
+        public List<Symbol> outputs() {
+            return List.of();
+        }
+
+        @Override
+        public ExecutionPlan build(DependencyCarrier dependencyCarrier,
+                                   PlannerContext plannerContext,
+                                   Set<PlanHint> planHints,
+                                   ProjectionBuilder projectionBuilder,
+                                   int limit,
+                                   int offset,
+                                   @Nullable OrderBy order,
+                                   @Nullable Integer pageSizeHint,
+                                   Row params,
+                                   SubQueryResults subQueryResults) {
+            return null;
+        }
+
+
+        @Override
+        public List<AbstractTableRelation<?>> baseTables() {
+            return null;
+        }
+
+
+        @Override
+        public LogicalPlan replaceSources(List<LogicalPlan> sources) {
+            return new TestPlan(id(), sources);
+        }
+
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
+            return null;
+        }
+
+        @Override
+        public Map<LogicalPlan, SelectSymbol> dependencies() {
+            return null;
+        }
+
+        @Override
+        public long numExpectedRows() {
+            return 0;
+        }
+
+        @Override
+        public long estimatedRowSize() {
+            return 0;
+        }
+
+        @Override
+        public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+            return visitor.visitPlan(this, context);
+        }
+
+        @Override
+        public Set<RelationName> getRelationNames() {
+            return null;
+        }
+    }
+}
+

--- a/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.matcher;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.List;
+import org.junit.Test;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReference;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
+
+public class PatternTest {
+
+    @Test
+    public void test_type_of() {
+        assertMatch(typeOf(Integer.class), 42);
+        assertMatch(typeOf(Number.class), 42);
+        assertNoMatch(typeOf(Integer.class), "foo");
+        assertNoMatch(typeOf(Integer.class), null);
+    }
+
+    @Test
+    public void test_with_property_matching() {
+        assertMatch(typeOf(String.class).with(s -> s.length() == 3), "foo");
+        var pattern = typeOf(String.class)
+            .with(s -> s.startsWith("f"))
+            .with((CharSequence s) -> s.length() < 5);
+        assertMatch(pattern, "foo");
+    }
+
+    @Test
+    public void test_with_source_matching() {
+        Collect source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 1, 1);
+        Filter filter = new Filter(source, mock(Symbol.class));
+        var pattern = typeOf(Filter.class).with(source(), typeOf(Collect.class));
+        assertMatch(pattern, filter);
+    }
+
+    @Test
+    public void test_capture() {
+        Filter source = new Filter(mock(LogicalPlan.class), mock(Symbol.class));
+        Filter filter = new Filter(source, mock(Symbol.class));
+        Capture<Filter> capture = new Capture<>();
+        var pattern = typeOf(Filter.class).with(source(), typeOf(Filter.class)).capturedAs(capture);
+        Match<Filter> match = pattern.accept(filter, Captures.empty());
+        assertMatch(pattern, filter);
+        assertEquals(match.captures().get(capture), filter);
+    }
+
+    @Test
+    public void test_with_match_group_referenced_source() {
+        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
+        var groupReferenceSource = new GroupReference(1, source.outputs());
+        var filter = new Filter(groupReferenceSource, mock(Symbol.class));
+
+        var memo = new HashMap<Integer, LogicalPlan>();
+        memo.put(1, source);
+
+        GroupReferenceResolver groupReferenceResolver = node -> {
+            if (node instanceof GroupReference g) {
+                return memo.get(g.groupId());
+            }
+            return node;
+        };
+
+        Capture<Collect> capture = new Capture<>();
+        Pattern<Filter> pattern = typeOf(Filter.class).with(source(), typeOf(Collect.class).capturedAs(capture));
+
+        Match<Filter> match = pattern.accept(filter, Captures.empty(), groupReferenceResolver);
+
+        assertThat(match.isPresent());
+        assertThat(match.value()).isInstanceOf(Filter.class);
+        assertThat(match.captures().get(capture)).isInstanceOf(Collect.class);
+    }
+
+    @Test
+    public void test_with_property_match_group_referenced_source() {
+        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
+        var groupReferenceSource = new GroupReference(1, source.outputs());
+        var filter = new Filter(groupReferenceSource, mock(Symbol.class));
+
+        var memo = new HashMap<Integer, LogicalPlan>();
+        memo.put(1, source);
+
+        GroupReferenceResolver groupReferenceResolver = node -> {
+            if (node instanceof GroupReference g) {
+                return memo.get(g.groupId());
+            }
+            return node;
+        };
+
+        Capture<Collect> capture = new Capture<>();
+        Pattern<Filter> pattern = typeOf(Filter.class)
+                                    .with(source(), typeOf(Collect.class)
+                                    .with(s -> s.estimatedRowSize() == 10).capturedAs(capture));
+
+        Match<Filter> match = pattern.accept(filter, Captures.empty(), groupReferenceResolver);
+
+        assertThat(match.isPresent());
+        assertThat(match.value()).isInstanceOf(Filter.class);
+        assertThat(match.captures().get(capture)).isInstanceOf(Collect.class);
+    }
+
+    private <T> Match<T> assertMatch(Pattern<T> pattern, T expectedMatch) {
+        Match<T> match = pattern.accept(expectedMatch, Captures.empty());
+        assertEquals(expectedMatch, match.value());
+        return match;
+    }
+
+    private <T> void assertNoMatch(Pattern<T> pattern, Object expectedNoMatch) {
+        Match<T> match = pattern.accept(expectedNoMatch, Captures.empty());
+        assertEquals(Match.empty(), match);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This introduces the Memo datastructure which is the foundation for a Cascade style Optimizer. The main concept is the following:

- On a given tree of operators (LogicalPlans) each source is replaced by GroupReferences and registered in the Memo as part of group(s).
- Now the tree can be mutated efficiently without rewrites of the whole tree.

- When the original LogicalPlan is needed at the rules the GroupReferenceResolver will resolve the Group Reference to it's referenced Logical Plan.

See https://15721.courses.cs.cmu.edu/spring2016/papers/graefe-ieee1995.pdf for details of the concept.

This contains also another pre-requisite commit, which prepares the matching system for the second commit.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
