### PR TITLE
Always use disabled cache for IndexMetadata verification

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -292,7 +292,7 @@ public final class IndexModule {
         if (indexSettings.getValue(INDEX_QUERY_CACHE_ENABLED_SETTING)) {
             queryCache = indicesQueryCache;
         } else {
-            queryCache = new DisabledQueryCache(indexSettings);
+            queryCache = DisabledQueryCache.instance();
         }
         return new IndexService(
             indexSettings,

--- a/server/src/main/java/org/elasticsearch/index/cache/query/DisabledQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/query/DisabledQueryCache.java
@@ -19,17 +19,23 @@
 
 package org.elasticsearch.index.cache.query;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.Weight;
-import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexSettings;
 
-public class DisabledQueryCache extends AbstractIndexComponent implements QueryCache {
+public class DisabledQueryCache implements QueryCache {
 
-    public DisabledQueryCache(IndexSettings indexSettings) {
-        super(indexSettings);
-        logger.debug("Using no query cache");
+    private static final Logger LOGGER = LogManager.getLogger(DisabledQueryCache.class);
+    private static final DisabledQueryCache INSTANCE = new DisabledQueryCache();
+
+    public static DisabledQueryCache instance() {
+        LOGGER.debug("Using no query cache");
+        return INSTANCE;
+    }
+
+    private DisabledQueryCache() {
     }
 
     @Override

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -511,7 +511,7 @@ public abstract class AggregationTestCase extends ESTestCase {
                                        ShardPath shardPath,
                                        IndexMetadata indexMetadata) throws IOException {
         var indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
-        var queryCache = new DisabledQueryCache(indexSettings);
+        var queryCache = DisabledQueryCache.instance();
         var store = new Store(
             shardPath.getShardId(),
             indexSettings,

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -106,7 +106,7 @@ public final class IndexEnv implements AutoCloseable {
             indexMetadata.mapping().source(),
             MapperService.MergeReason.MAPPING_UPDATE
         );
-        queryCache = new DisabledQueryCache(idxSettings);
+        queryCache = DisabledQueryCache.instance();
         IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, List.of(), Collections.emptyMap());
         nodeEnvironment = new NodeEnvironment(Settings.EMPTY, env);
         luceneReferenceResolver = new LuceneReferenceResolver(

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -511,7 +511,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         final Store store = storeProvider.apply(indexSettings);
         boolean success = false;
         try {
-            var queryCache = new DisabledQueryCache(indexSettings);
+            var queryCache = DisabledQueryCache.instance();
             MapperService mapperService = MapperTestUtils.newMapperService(
                 xContentRegistry(),
                 createTempDir(),


### PR DESCRIPTION
The QueryCache instance in the indexMetadata verification doesn't really
end up being used - we can use a DisabledQueryCache singleton instead of
creating a LRUQueryCache (which creates some map instances)
