### PR TITLE
Backport Lucene 9.5 changes to forked components

### DIFF
--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -45,6 +45,7 @@ import org.apache.lucene.index.TermsEnum.SeekStatus;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.BytesRef;
@@ -85,7 +86,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         merging = false;
 
         // read in the entries from the metadata file.
-        try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, state.context)) {
+        try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, IOContext.READONCE)) {
             Throwable priorE = null;
 
             try {

--- a/server/src/testFixtures/java/org/apache/lucene/tests/util/CrateLuceneTestCase.java
+++ b/server/src/testFixtures/java/org/apache/lucene/tests/util/CrateLuceneTestCase.java
@@ -134,6 +134,8 @@ import org.apache.lucene.index.SimpleMergedSegmentWarmer;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.TermVectors;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.TermsEnum.SeekStatus;
@@ -2442,9 +2444,11 @@ public abstract class CrateLuceneTestCase {
     public void assertStoredFieldsEquals(String info, IndexReader leftReader, IndexReader rightReader)
         throws IOException {
         assert leftReader.maxDoc() == rightReader.maxDoc();
+        StoredFields leftStoredFields = leftReader.storedFields();
+        StoredFields rightStoredFields = rightReader.storedFields();
         for (int i = 0; i < leftReader.maxDoc(); i++) {
-            Document leftDoc = leftReader.document(i);
-            Document rightDoc = rightReader.document(i);
+            Document leftDoc = leftStoredFields.document(i);
+            Document rightDoc = rightStoredFields.document(i);
 
             // TODO: I think this is bogus because we don't document what the order should be
             // from these iterators, etc. I think the codec/IndexReader should be free to order this stuff
@@ -2487,9 +2491,11 @@ public abstract class CrateLuceneTestCase {
     public void assertTermVectorsEquals(String info, IndexReader leftReader, IndexReader rightReader)
         throws IOException {
         assert leftReader.maxDoc() == rightReader.maxDoc();
+        TermVectors leftVectors = leftReader.termVectors();
+        TermVectors rightVectors = rightReader.termVectors();
         for (int i = 0; i < leftReader.maxDoc(); i++) {
-            Fields leftFields = leftReader.getTermVectors(i);
-            Fields rightFields = rightReader.getTermVectors(i);
+            Fields leftFields = leftVectors.get(i);
+            Fields rightFields = rightVectors.get(i);
 
             // Fields could be null if there are no postings,
             // but then it must be null for both


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Applies two minor changes that happened between Lucene 9.4 and 9.5. See commits

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
