### PR TITLE
Move fix for corrupted metadata to a command

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,6 +74,16 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Removed the automatic fix mechanism, introduced in
+  :ref:`5.2.1 <version_5.2.1>`, for corrupted metadata due to table swap
+  statements like::
+
+    ALTER CLUSTER SWAP TABLE "myschema"."mytable" TO "myschema.mytable";
+
+  and provide a manual way to fix such issues by running::
+
+    bin/crate-node fix-metadata
+
 
 - Changed the ``typsend`` and ``typreceive`` values in the
   ``pg_catalog.pg_type`` table to match PostgreSQL for improved compatibility.

--- a/docs/cli-tools.rst
+++ b/docs/cli-tools.rst
@@ -195,6 +195,10 @@ Commands
 |                      | to be able to force a node to startup even when the  |
 |                      | node version is not compatible with the meta data.   |
 +----------------------+------------------------------------------------------+
+| ``fix-metadata``     | Fix corrupted metadata after running table swap      |
+|                      | like: ALTER CLUSTER SWAP TABLE "schema"."table" TO   |
+|                      | "schema.table";                                      |
++----------------------+------------------------------------------------------+
 
 
 .. _cli-crate-node-options:

--- a/server/src/main/java/io/crate/cluster/commands/FixCorruptedMetadataCommand.java
+++ b/server/src/main/java/io/crate/cluster/commands/FixCorruptedMetadataCommand.java
@@ -19,16 +19,21 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.metadata.bugfix;
+package io.crate.cluster.commands;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import org.elasticsearch.cli.Terminal;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.ElasticsearchNodeCommand;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
@@ -36,27 +41,31 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.gateway.PersistedClusterStateService;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Maps;
+import io.crate.common.collections.Tuple;
 import io.crate.execution.ddl.Templates;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
+import joptsimple.OptionSet;
 
 /**
  * Class to fix metadata corruption caused by SWAP TABLE statements like
  *
  * <pre>
- *  ALTER CLUSTER SWAP TABLE "telegraf"."metrics_new" TO "telegraf.metrics";
+ *  ALTER CLUSTER SWAP TABLE "myschema"."mytable" TO "myschema.mytable";
  * </pre>
  *
  * <p>
- * Quoting the full name ("telegraf.metrics") instead of schema and table
- * separate ("telegraf"."metrics") corrupted the metadata. It assumed
- * "telegraf.metrics" is the table name, and used "doc" (or current schema from
+ * Quoting the full name ("myschema.mytable") instead of schema and table
+ * separate ("myschema"."mytable") corrupted the metadata. It assumed
+ * "myschema.mytable" is the table name, and used "doc" (or current schema from
  * search path) as schema. A `.` is used in the template and index name to encode schema, table
  * and partition name. Having a `.` within the table name part broke the
  * encoding.
@@ -96,12 +105,12 @@ import io.crate.metadata.RelationName;
  * Below lists the issues that could arise while swapping due to the invalid template name:
  * <ol>
  *  <li> The first step of the swap is to remove existing template/indices - indices are properly identified and remove while template cannot be found/removed.
- *  <p> See {@link CorruptedMetadataFixer#fixInconsistencyBetweenIndexAndTemplates} how the un-removed template is removed.
+ *  <p> See {@link FixCorruptedMetadataCommand#fixInconsistencyBetweenIndexAndTemplates} how the un-removed template is removed.
  *  <li> As part of the swap, there is a table that needs to be renamed to ".partitioned.m.t.[<ident>]" (corrupting both indices/template names)
- *  <p> See {@link CorruptedMetadataFixer#fixNameOfIndexMetadata} and {@link CorruptedMetadataFixer#fixNameOfTemplateMetadata} how the names are fixed.
+ *  <p> See {@link FixCorruptedMetadataCommand#fixNameOfIndexMetadata} and {@link FixCorruptedMetadataCommand#fixNameOfTemplateMetadata} how the names are fixed.
  *  <li> Lastly, m.t also needs to be renamed. Since there is no template named ".partitioned.m.t.", m.t is considered non-partitioned.
  *       Although all concrete indices for m.t are identified, they would overwrite one another and the last one to be renamed remains and is converted to non-partitioned index.
- *  <p> See {@link CorruptedMetadataFixer#fixInconsistencyBetweenIndexAndTemplates} how a partitioned table is recovered using the single remaining non-partitioned index.
+ *  <p> See {@link FixCorruptedMetadataCommand#fixInconsistencyBetweenIndexAndTemplates} how a partitioned table is recovered using the single remaining non-partitioned index.
  * </ol>
  *
  *
@@ -109,22 +118,59 @@ import io.crate.metadata.RelationName;
  * See https://github.com/crate/crate/issues/13380
  * </p>
  **/
-public class CorruptedMetadataFixer {
+public class FixCorruptedMetadataCommand extends ElasticsearchNodeCommand {
 
-    // https://github.com/crate/crate/issues/13380
-    public static Metadata fixCorruptionCausedBySwapTableBug(Metadata metadata) {
-        final Metadata.Builder fixedMetadata = Metadata.builder(metadata);
+    public static final String METADATA_FIXED_MSG = "Metadata has been fixed";
+    public static final String CONFIRMATION_MSG =
+        DELIMITER +
+        "\n" +
+        "You should only run this tool if you have ended up with correupted metadata\n" +
+        "because of a table swap like: ALTER CLUSTER SWAP TABLE \"myschema\".\"mytable\" TO \"myschema.mytable\".\n" +
+        "\n" +
+        "Do you want to proceed?\n";
 
-        fixNameOfTemplateMetadata(metadata.templates(), fixedMetadata);
+    public FixCorruptedMetadataCommand() {
+        super("Fix corrupted metadata as a result of a table swap like: " +
+              "ALTER CLUSTER SWAP TABLE \"myschema\".\"mytable\" TO \"myschema.mytable\"");
+    }
 
-        for (var indexMetadata : metadata) {
+    @Override
+    public void processNodePaths(Terminal terminal,
+                                 Path[] dataPaths,
+                                 OptionSet options,
+                                 Environment env) throws IOException {
+
+        terminal.println(Terminal.Verbosity.VERBOSE, "Loading cluster state");
+
+        final PersistedClusterStateService persistedClusterStateService =
+            createPersistedClusterStateService(env.settings(), dataPaths);
+        final Tuple<Long, ClusterState> termAndClusterState =
+                loadTermAndClusterState(persistedClusterStateService, env);
+        final long currentTerm = termAndClusterState.v1();
+        final ClusterState oldClusterState = termAndClusterState.v2();
+        final Metadata oldMetadata = persistedClusterStateService.loadBestOnDiskState().metadata;
+        final Metadata.Builder fixedMetadata = Metadata.builder(oldMetadata);
+
+        fixNameOfTemplateMetadata(oldMetadata.templates(), fixedMetadata);
+
+        for (var indexMetadata : oldMetadata) {
             fixNameOfIndexMetadata(indexMetadata, fixedMetadata);
         }
-        for (var indexMetadata : metadata) {
+        for (var indexMetadata : oldMetadata) {
             fixInconsistencyBetweenIndexAndTemplates(indexMetadata, fixedMetadata);
         }
 
-        return fixedMetadata.build();
+        final ClusterState newClusterState = ClusterState.builder(oldClusterState)
+            .metadata(fixedMetadata.build()).build();
+
+        terminal.println(Terminal.Verbosity.VERBOSE,
+                         "[old cluster state = " + oldClusterState + ", new cluster state = " + newClusterState + "]");
+
+        confirm(terminal, CONFIRMATION_MSG);
+        try (PersistedClusterStateService.Writer writer = persistedClusterStateService.createWriter()) {
+            writer.writeFullStateAndCommit(currentTerm, newClusterState);
+        }
+        terminal.println(METADATA_FIXED_MSG);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeToolCli.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeToolCli.java
@@ -24,6 +24,8 @@ import org.elasticsearch.cli.MultiCommand;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.env.NodeRepurposeCommand;
 
+import io.crate.cluster.commands.FixCorruptedMetadataCommand;
+
 // NodeToolCli does not extend LoggingAwareCommand, because LoggingAwareCommand performs logging initialization
 // after LoggingAwareCommand instance is constructed.
 // It's too late for us, because before UnsafeBootstrapMasterCommand is added to the list of subcommands
@@ -41,6 +43,7 @@ public class NodeToolCli extends MultiCommand {
         subcommands.put("detach-cluster", new DetachClusterCommand());
         subcommands.put("remove-settings", new RemoveSettingsCommand());
         subcommands.put("remove-customs", new RemoveCustomsCommand());
+        subcommands.put("fix-metadata", new FixCorruptedMetadataCommand());
     }
 
     public static void main(String[] args) throws Exception {

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -71,7 +71,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import io.crate.common.collections.Tuple;
 import io.crate.common.io.IOUtils;
 import io.crate.exceptions.Exceptions;
-import io.crate.metadata.bugfix.CorruptedMetadataFixer;
 
 /**
  * Loads (and maybe upgrades) cluster metadata at startup, and persistently stores cluster metadata for future restarts.
@@ -198,7 +197,6 @@ public class GatewayMetaState implements Closeable {
     Metadata upgradeMetadataForNode(Metadata metadata,
                                     MetadataIndexUpgradeService metadataIndexUpgradeService,
                                     MetadataUpgrader metadataUpgrader) {
-        metadata = CorruptedMetadataFixer.fixCorruptionCausedBySwapTableBug(metadata);
         return upgradeMetadata(metadata, metadataIndexUpgradeService, metadataUpgrader);
     }
 

--- a/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
+++ b/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
@@ -19,12 +19,12 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.metadata.bugfix;
+package io.crate.cluster.commands;
 
-import static io.crate.metadata.bugfix.CorruptedMetadataFixer.fixInconsistencyBetweenIndexAndTemplates;
-import static io.crate.metadata.bugfix.CorruptedMetadataFixer.fixNameOfTemplateMetadata;
-import static io.crate.metadata.bugfix.CorruptedMetadataFixer.fixIndexName;
-import static io.crate.metadata.bugfix.CorruptedMetadataFixer.fixTemplateName;
+import static io.crate.cluster.commands.FixCorruptedMetadataCommand.fixInconsistencyBetweenIndexAndTemplates;
+import static io.crate.cluster.commands.FixCorruptedMetadataCommand.fixIndexName;
+import static io.crate.cluster.commands.FixCorruptedMetadataCommand.fixNameOfTemplateMetadata;
+import static io.crate.cluster.commands.FixCorruptedMetadataCommand.fixTemplateName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -43,7 +43,7 @@ import org.junit.Test;
 import io.crate.common.unit.TimeValue;
 import io.crate.metadata.RelationName;
 
-public class CorruptedMetadataFixerTest {
+public class FixCorruptedMetadataCommandTest {
 
     @Test
     public void test_method_fixNameOfTemplateMetadata_fixes_corrupted_name_only() throws IOException {
@@ -64,9 +64,9 @@ public class CorruptedMetadataFixerTest {
         String fixedName = "m1..partitioned.s1.";
         IndexTemplateMetadata fixed = fixedMetadata.getTemplate(fixedName);
         assertThat(fixed).isNotNull();
-        assertThat(fixed.patterns().size()).isEqualTo(1);
+        assertThat(fixed.patterns()).hasSize(1);
         assertThat(fixed.patterns().get(0)).isEqualTo(fixedName + "*");
-        assertThat(fixed.mapping().toString()).isEqualTo(mapping);
+        assertThat(fixed.mapping().toString()).hasToString(mapping);
         assertThat(fixed.settings().get(INDEX_REFRESH_INTERVAL_SETTING.getKey())).isEqualTo("300ms");
     }
 
@@ -99,9 +99,9 @@ public class CorruptedMetadataFixerTest {
         String fixedName = "m1..partitioned.s1.";
         IndexTemplateMetadata fixed = fixedMetadata.getTemplate(fixedName);
         assertThat(fixed).isNotNull();
-        assertThat(fixed.patterns().size()).isEqualTo(1);
+        assertThat(fixed.patterns()).hasSize(1);
         assertThat(fixed.patterns().get(0)).isEqualTo(fixedName + "*");
-        assertThat(fixed.mapping().toString()).isEqualTo(mapping);
+        assertThat(fixed.mapping()).hasToString(mapping);
         assertThat(fixed.settings().get(INDEX_REFRESH_INTERVAL_SETTING.getKey())).isEqualTo("300ms");
     }
 
@@ -142,17 +142,17 @@ public class CorruptedMetadataFixerTest {
         String fixedName = "m1..partitioned.s1.";
         IndexTemplateMetadata fixed = fixedMetadata.getTemplate(fixedName);
         assertThat(fixed).isNotNull();
-        assertThat(fixed.patterns().size()).isEqualTo(1);
+        assertThat(fixed.patterns()).hasSize(1);
         assertThat(fixed.patterns().get(0)).isEqualTo(fixedName + "*");
-        assertThat(fixed.mapping().toString()).isEqualTo(mapping);
+        assertThat(fixed.mapping()).hasToString(mapping);
         assertThat(fixed.settings().get(INDEX_REFRESH_INTERVAL_SETTING.getKey())).isEqualTo("300ms");
 
         //dummy is untouched
         IndexTemplateMetadata dummyTemplate = fixedMetadata.getTemplate(dummyName);
         assertThat(dummyTemplate).isNotNull();
-        assertThat(dummyTemplate.patterns().size()).isEqualTo(1);
+        assertThat(dummyTemplate.patterns()).hasSize(1);
         assertThat(dummyTemplate.patterns().get(0)).isEqualTo(dummyName + "*");
-        assertThat(dummyTemplate.mapping().toString()).isEqualTo(dummyMapping);
+        assertThat(dummyTemplate.mapping()).hasToString(dummyMapping);
         assertThat(dummyTemplate.settings().get(INDEX_REFRESH_INTERVAL_SETTING.getKey())).isEqualTo("500ms");
     }
 
@@ -295,9 +295,9 @@ public class CorruptedMetadataFixerTest {
         fixInconsistencyBetweenIndexAndTemplates(nonPartitioned, fixedMetadata);
         var afterFix = fixedMetadata.get("m7.s7");
         assertThat(afterFix).isNotNull();
-        assertThat(afterFix.mapping().source().toString()).isEqualTo(mappingForNonPartitioned);
-        assertThat(afterFix.getSettings().getAsStructuredMap().toString())
-            .isEqualTo("{index={number_of_shards=1, number_of_replicas=1, version={created=8030099}}}");
+        assertThat(afterFix.mapping().source()).hasToString(mappingForNonPartitioned);
+        assertThat(afterFix.getSettings().getAsStructuredMap())
+            .hasToString("{index={number_of_shards=1, number_of_replicas=1, version={created=8030099}}}");
 
         // indexMetadata named 'm7.s7' and indexTemplateMetadata 'm7..partitioned.s7.' cannot co-exist.
         IndexTemplateMetadata existingTemplate = fixedMetadata.getTemplate(invalidTemplateName);


### PR DESCRIPTION
There has been a scenario discovered, with tables created in `4.3.3` where the automatic fix of corrupted metadata due to a table swap statements like:
```
ALTER CLUSTER SWAP TABLE "myschema"."mytable" TO "myschema.mytable"
```
led to a different issues, with node/cluster not starting up:
```
org.elasticsearch.bootstrap.StartupException: java.lang.IllegalStateException: index and alias names need to be unique, but the following duplicates were found [doc.test (alias of [doc.test/30EcwHYoThW5UU0q4JFELA])]
	at org.elasticsearch.bootstrap.StartupExceptionProxy.<init>(StartupExceptionProxy.java:30) ~[main/:?]
	at io.crate.bootstrap.CrateDB.init(CrateDB.java:162) ~[main/:?]
	at io.crate.bootstrap.CrateDB.execute(CrateDB.java:138) ~[main/:?]
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:81) ~[main/:?]
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124) ~[main/:?]
	at org.elasticsearch.cli.Command.main(Command.java:90) ~[main/:?]
	at io.crate.bootstrap.CrateDB.main(CrateDB.java:91) ~[main/:?]
	at io.crate.bootstrap.CrateDB.main(CrateDB.java:84) ~[main/:?]
Caused by: java.lang.IllegalStateException: index and alias names need to be unique, but the following duplicates were found [doc.test (alias of [doc.test/30EcwHYoThW5UU0q4JFELA])]
	at org.elasticsearch.cluster.metadata.Metadata$Builder.build(Metadata.java:1072) ~[main/:?]
	at io.crate.metadata.bugfix.CorruptedMetadataFixer.fixCorruptionCausedBySwapTableBug(CorruptedMetadataFixer.java:127) ~[main/:?]
	at org.elasticsearch.gateway.GatewayMetaState.upgradeMetadataForNode(GatewayMetaState.java:201) ~[main/:?]
	at org.elasticsearch.gateway.GatewayMetaState.start(GatewayMetaState.java:135) ~[main/:?]
	at org.elasticsearch.node.Node.start(Node.java:943) ~[main/:?]
	at org.elasticsearch.bootstrap.BootstrapProxy.start(BootstrapProxy.java:204) ~[main/:?]
	at org.elasticsearch.bootstrap.BootstrapProxy.init(BootstrapProxy.java:268) ~[main/:?]
	at io.crate.bootstrap.CrateDB.init(CrateDB.java:158) ~[main/:?]
	... 6 more
```

Extract the fix into a command that can be run with `crate-node fix-corrupted-metadata`

Follows: #13404
Closes: #13617

