### PR TITLE
Add iterative optimizer

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -137,7 +137,11 @@ public class CorrelatedJoin implements LogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return this;
+        return new CorrelatedJoin(
+            Lists2.getOnlyElement(sources),
+            selectSymbol,
+            subQueryPlan
+        );
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -78,6 +78,7 @@ import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.SubqueryPlanner.SubQueries;
 import io.crate.planner.consumer.InsertFromSubQueryPlanner;
 import io.crate.planner.optimizer.Optimizer;
+import io.crate.planner.optimizer.iterative.IterativeOptimizer;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
@@ -112,14 +113,14 @@ import io.crate.types.DataTypes;
  */
 public class LogicalPlanner {
 
-    private final Optimizer optimizer;
+    private final IterativeOptimizer optimizer;
     private final TableStats tableStats;
     private final Visitor statementVisitor = new Visitor();
     private final Optimizer writeOptimizer;
     private final Optimizer fetchOptimizer;
 
     public LogicalPlanner(NodeContext nodeCtx, TableStats tableStats, Supplier<Version> minNodeVersionInCluster) {
-        this.optimizer = new Optimizer(
+        this.optimizer = new IterativeOptimizer(
             nodeCtx,
             minNodeVersionInCluster,
             List.of(

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -74,7 +74,6 @@ public class NestedLoopJoin implements LogicalPlan {
     final LogicalPlan lhs;
     final LogicalPlan rhs;
     private final List<Symbol> outputs;
-    private final List<AbstractTableRelation<?>> baseTables;
     private final Map<LogicalPlan, SelectSymbol> dependencies;
     private boolean orderByWasPushedDown = false;
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
@@ -96,7 +95,6 @@ public class NestedLoopJoin implements LogicalPlan {
         } else {
             this.outputs = Lists2.concat(lhs.outputs(), rhs.outputs());
         }
-        this.baseTables = Lists2.concat(lhs.baseTables(), rhs.baseTables());
         this.topMostLeftRelation = topMostLeftRelation;
         this.joinCondition = joinCondition;
         this.dependencies = Maps.concat(lhs.dependencies(), rhs.dependencies());
@@ -189,7 +187,7 @@ public class NestedLoopJoin implements LogicalPlan {
             executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
 
         PositionalOrderBy orderByFromLeft = left.resultDescription().orderBy();
-        boolean hasDocTables = baseTables.stream().anyMatch(r -> r instanceof DocTableRelation);
+        boolean hasDocTables = baseTables().stream().anyMatch(r -> r instanceof DocTableRelation);
         boolean isDistributed = hasDocTables && isFiltered && !joinType.isOuter();
 
         LogicalPlan leftLogicalPlan = lhs;
@@ -265,7 +263,7 @@ public class NestedLoopJoin implements LogicalPlan {
 
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
-        return baseTables;
+        return Lists2.concat(lhs.baseTables(), rhs.baseTables());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -33,6 +33,8 @@ import io.crate.statistics.TableStats;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
+import java.util.function.Function;
+
 public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert> {
 
     private final Capture<TableFunction> capture;
@@ -54,7 +56,8 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> groupReferenceResolver) {
         TableFunction tableFunction = captures.get(this.capture);
         var relation = tableFunction.relation();
         if (relation.function().name().equals(ValuesFunction.NAME)) {

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -57,7 +57,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> groupReferenceResolver) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         TableFunction tableFunction = captures.get(this.capture);
         var relation = tableFunction.relation();
         if (relation.function().name().equals(ValuesFunction.NAME)) {

--- a/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.optimizer;
 
-import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
@@ -37,6 +36,7 @@ import org.elasticsearch.Version;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class Optimizer {
@@ -67,8 +67,7 @@ public class Optimizer {
         );
     }
 
-    @VisibleForTesting
-    static List<Rule<?>> removeExcludedRules(List<Rule<?>> rules, Set<Class<? extends Rule<?>>> excludedRules) {
+    public static List<Rule<?>> removeExcludedRules(List<Rule<?>> rules, Set<Class<? extends Rule<?>>> excludedRules) {
         final boolean isTraceEnabled = LOGGER.isTraceEnabled();
         if (excludedRules.isEmpty()) {
             return rules;
@@ -106,7 +105,8 @@ public class Optimizer {
                         LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' matched");
                     }
                     @SuppressWarnings("unchecked")
-                    LogicalPlan transformedPlan = rule.apply(match.value(), match.captures(), tableStats, txnCtx, nodeCtx);
+                    LogicalPlan transformedPlan = rule.apply(match.value(), match.captures(), tableStats, txnCtx, nodeCtx,
+                                                             Function.identity());
                     if (transformedPlan != null) {
                         if (isTraceEnabled) {
                             LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' transformed the logical plan");

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -35,12 +35,19 @@ public interface Rule<T> {
 
     Pattern<T> pattern();
 
+    /**
+     *
+     * @param resolvePlan resolvesPlan will resolve a {@GroupReference} to it's referenced {@LogicalPlan} instance.
+     *                    It must be used on a source of {@code plan} if the rule needs to access any properties
+     *                    of the source other than the outputs. This may materialize the sub-tree for the source
+     *                    and could be expensive. If the rule doesn't access source properties, don't call it.
+     */
     LogicalPlan apply(T plan,
                       Captures captures,
                       TableStats tableStats,
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
-                      Function<LogicalPlan, LogicalPlan> resolveLogicalPlan);
+                      Function<LogicalPlan, LogicalPlan> resolvePlan);
 
     /**
      * @return The version all nodes in the cluster must have to be able to use this optimization.

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -21,6 +21,8 @@
 
 package io.crate.planner.optimizer;
 
+import java.util.function.Function;
+
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
@@ -33,7 +35,12 @@ public interface Rule<T> {
 
     Pattern<T> pattern();
 
-    LogicalPlan apply(T plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, NodeContext nodeCtx);
+    LogicalPlan apply(T plan,
+                      Captures captures,
+                      TableStats tableStats,
+                      TransactionContext txnCtx,
+                      NodeContext nodeCtx,
+                      Function<LogicalPlan, LogicalPlan> resolveLogicalPlan);
 
     /**
      * @return The version all nodes in the cluster must have to be able to use this optimization.

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -52,6 +52,8 @@ public class GroupReference implements LogicalPlan {
 
     private final int groupId;
     private final List<Symbol> outputs;
+    private static final String ERROR_MESSAGE =
+        "Operation is not supported in GroupReference, it needs to be resolved to it's referenced LogicalPlan";
 
     public GroupReference(int groupId, List<Symbol> outputs) {
         this.groupId = groupId;
@@ -64,19 +66,17 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public List<LogicalPlan> sources() {
-        return List.of();
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return this;
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
-        throw new UnsupportedOperationException(
-            "Operation is not supported in GroupReference, it needs to be resolved to it's referenced LogicalPlan"
-        );
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override
@@ -86,12 +86,13 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public long numExpectedRows() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+
     }
 
     @Override
     public long estimatedRowSize() {
-        return 0;
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override
@@ -104,7 +105,6 @@ public class GroupReference implements LogicalPlan {
         return Set.of();
     }
 
-
     @Override
     public ExecutionPlan build(DependencyCarrier dependencyCarrier,
                                PlannerContext plannerContext,
@@ -116,7 +116,7 @@ public class GroupReference implements LogicalPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override
@@ -126,6 +126,6 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public List<AbstractTableRelation<?>> baseTables() {
-        return List.of();
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import static io.crate.planner.optimizer.Optimizer.removeExcludedRules;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.statistics.TableStats;
+
+/**
+ * The optimizer takes an operator tree of logical plans and creates an optimized plan.
+ * The optimization loop applies rules recursively until a fixpoint is reached.
+ */
+public class IterativeOptimizer {
+
+    private static final Logger LOGGER = LogManager.getLogger(IterativeOptimizer.class);
+
+    private final List<Rule<?>> rules;
+    private final Supplier<Version> minNodeVersionInCluster;
+    private final NodeContext nodeCtx;
+
+    public IterativeOptimizer(NodeContext nodeCtx, Supplier<Version> minNodeVersionInCluster, List<Rule<?>> rules) {
+        this.rules = rules;
+        this.minNodeVersionInCluster = minNodeVersionInCluster;
+        this.nodeCtx = nodeCtx;
+    }
+
+    public LogicalPlan optimize(LogicalPlan plan, TableStats tableStats, CoordinatorTxnCtx txnCtx) {
+        // Create a new memo for the given plan tree
+        var memo = new Memo(plan);
+
+        // Resolves a Group Reference to it's referenced LogicalPlan.
+        // This is used inside the rules to manifest the LogicalPlan from the sources
+        Function<LogicalPlan, LogicalPlan> groupReferenceResolver = node -> {
+            if (node instanceof GroupReference g) {
+                return memo.resolve(g.groupId());
+            }
+            // not a group reference, return same node
+            return node;
+        };
+        // Remove rules from the applicable rule set if some are disabled by a session setting
+        var applicableRules = removeExcludedRules(rules, txnCtx.sessionSettings().excludedOptimizerRules());
+        // Start exploring from the root, root group is root node from the tree
+        exploreGroup(memo.getRootGroup(), new Context(memo, groupReferenceResolver, applicableRules, txnCtx, tableStats));
+        // Return the final tree with all group references resolved
+        return memo.extract();
+    }
+
+    private boolean exploreGroup(int group, Context context) {
+        // tracks whether this group or any children groups change as
+        // this method executes
+        var progress = exploreNode(group, context);
+
+        while (exploreChildren(group, context)) {
+            progress = true;
+            // This is an important part! We keep track
+            // if the children changed and try again the
+            // current group in case we can match additional rules
+            if (!exploreNode(group, context)) {
+                // no additional matches, so bail out
+                break;
+            }
+        }
+        return progress;
+    }
+
+    private boolean exploreNode(int group, Context context) {
+        final boolean isTraceEnabled = LOGGER.isTraceEnabled();
+        var rules = context.rules;
+        var resolvePlan = context.groupReferenceResolver;
+        var node = context.memo.resolve(group);
+
+        var done = false;
+        var progress = false;
+        var minVersion = minNodeVersionInCluster.get();
+        while (!done) {
+            done = true;
+            for (Rule rule : rules) {
+                if (minVersion.before(rule.requiredVersion())) {
+                    continue;
+                }
+                Match<?> match = rule.pattern().accept(node, Captures.empty(), resolvePlan);
+                if (match.isPresent()) {
+                    if (isTraceEnabled) {
+                        LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' matched");
+                    }
+                    LogicalPlan transformed = rule.apply(
+                        match.value(),
+                        match.captures(),
+                        context.tableStats,
+                        context.txnCtx,
+                        nodeCtx,
+                        context.groupReferenceResolver
+                    );
+                    if (transformed != null) {
+                        if (isTraceEnabled) {
+                            LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' transformed the logical plan");
+                        }
+                        // the plan changed, update memo to reference to the new plan
+                        context.memo.replace(group, transformed);
+                        node = transformed;
+                        done = false;
+                        progress = true;
+                    }
+                }
+            }
+        }
+
+        return progress;
+    }
+
+    private boolean exploreChildren(int group, Context context) {
+        boolean progress = false;
+
+        var expression = context.memo.resolve(group);
+        for (var child : expression.sources()) {
+            if (child instanceof GroupReference g) {
+                if (exploreGroup(g.groupId(), context)) {
+                    progress = true;
+                }
+            } else {
+                throw new IllegalStateException("Expected child to be a group reference. Found: " + child.getClass().getName());
+            }
+        }
+        return progress;
+    }
+
+    private static class Context {
+        final Memo memo;
+        final Function<LogicalPlan, LogicalPlan> groupReferenceResolver;
+        final CoordinatorTxnCtx txnCtx;
+        final TableStats tableStats;
+        final List<Rule<?>> rules;
+
+        public Context(Memo memo,
+                       Function<LogicalPlan, LogicalPlan> groupReferenceResolver,
+                       List<Rule<?>> rules,
+                       CoordinatorTxnCtx txnCtx,
+                       TableStats tableStats) {
+            this.memo = memo;
+            this.groupReferenceResolver = groupReferenceResolver;
+            this.txnCtx = txnCtx;
+            this.tableStats = tableStats;
+            this.rules = rules;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -75,6 +75,16 @@ public class IterativeOptimizer {
         return memo.extract();
     }
 
+    /**
+     *
+     * This processes a group by trying to apply all the rules of the optimizer to the given group and its children.
+     * If any children are changed by a rule, the given group will be reprocessed to check if additional rules
+     * can be matched until a fixpoint is reached.
+     *
+     * @param group the id of the group to explore
+     * @param context the context of the optimizer
+     * @return true if there were any changes of plans on the node or it's children or false if not
+     */
     private boolean exploreGroup(int group, Context context) {
         // tracks whether this group or any children groups change as
         // this method executes

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -157,23 +157,11 @@ public class IterativeOptimizer {
         return progress;
     }
 
-    private static class Context {
-        final Memo memo;
-        final Function<LogicalPlan, LogicalPlan> groupReferenceResolver;
-        final CoordinatorTxnCtx txnCtx;
-        final TableStats tableStats;
-        final List<Rule<?>> rules;
-
-        public Context(Memo memo,
-                       Function<LogicalPlan, LogicalPlan> groupReferenceResolver,
-                       List<Rule<?>> rules,
-                       CoordinatorTxnCtx txnCtx,
-                       TableStats tableStats) {
-            this.memo = memo;
-            this.groupReferenceResolver = groupReferenceResolver;
-            this.txnCtx = txnCtx;
-            this.tableStats = tableStats;
-            this.rules = rules;
-        }
-    }
+    private record Context(
+        Memo memo,
+        Function<LogicalPlan, LogicalPlan> groupReferenceResolver,
+        List<Rule<?>> rules,
+        CoordinatorTxnCtx txnCtx,
+        TableStats tableStats
+    ) {}
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -34,6 +34,8 @@ import io.crate.planner.optimizer.matcher.Pattern;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
+import java.util.function.Function;
+
 /**
  * Transforms
  * <pre>
@@ -68,7 +70,8 @@ public final class DeduplicateOrder implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Order childOrder = captures.get(this.childOrder);
         return plan.replaceSources(childOrder.sources());
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -67,7 +67,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
                        TableStats tableStats,
                        TransactionContext txnCtx,
                        NodeContext nodeCtx,
-                       Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                       Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
         if (countAggregate.filter() != null) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -26,6 +26,7 @@ import io.crate.execution.engine.aggregation.impl.CountAggregation;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Count;
@@ -37,6 +38,8 @@ import io.crate.planner.optimizer.matcher.Pattern;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.function.Function;
 
 public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate> {
 
@@ -63,7 +66,8 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
                        Captures captures,
                        TableStats tableStats,
                        TransactionContext txnCtx,
-                       NodeContext nodeCtx) {
+                       NodeContext nodeCtx,
+                       Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Collect collect = captures.get(collectCapture);
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());
         if (countAggregate.filter() != null) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -24,6 +24,8 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
+import java.util.function.Function;
+
 import io.crate.common.collections.Lists2;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
 import io.crate.expression.symbol.FieldReplacer;
@@ -76,7 +78,8 @@ public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Collect collect = captures.get(collectCapture);
         Rename rename = captures.get(renameCapture);
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -79,7 +79,7 @@ public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
         Rename rename = captures.get(renameCapture);
         var countAggregate = Lists2.getOnlyElement(aggregate.aggregates());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -38,6 +38,8 @@ import io.crate.statistics.TableStats;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
+import java.util.function.Function;
+
 public class MergeFilterAndCollect implements Rule<Filter> {
 
     private final Capture<Collect> collectCapture;
@@ -59,7 +61,8 @@ public class MergeFilterAndCollect implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Collect collect = captures.get(collectCapture);
         Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -62,7 +62,7 @@ public class MergeFilterAndCollect implements Rule<Filter> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
         Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -75,7 +75,7 @@ public class MergeFilters implements Rule<Filter> {
                         TableStats tableStats,
                         TransactionContext txnCtx,
                         NodeContext nodeCtx,
-                        Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                        Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Filter childFilter = captures.get(child);
         Symbol parentQuery = plan.query();
         Symbol childQuery = childFilter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -25,6 +25,7 @@ import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.Rule;
@@ -34,6 +35,8 @@ import io.crate.planner.optimizer.matcher.Pattern;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.function.Function;
 
 /**
  * Transforms
@@ -71,7 +74,8 @@ public class MergeFilters implements Rule<Filter> {
                         Captures captures,
                         TableStats tableStats,
                         TransactionContext txnCtx,
-                        NodeContext nodeCtx) {
+                        NodeContext nodeCtx,
+                        Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Filter childFilter = captures.get(child);
         Symbol parentQuery = plan.query();
         Symbol childQuery = childFilter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.getNewSource;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.expression.operator.AndOperator;
@@ -65,7 +66,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         var conditions = nl.joinCondition();
         var allConditions = QuerySplitter.split(conditions);
         var constantConditions = new HashMap<Set<RelationName>, Symbol>(allConditions.size());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -94,8 +94,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
             );
         } else {
             // Push constant join condition down to source
-            var lhs = nl.lhs();
-            var rhs = nl.rhs();
+            var lhs = resolvePlan.apply(nl.lhs());
+            var rhs = resolvePlan.apply(nl.rhs());
             var queryForLhs = constantConditions.remove(lhs.getRelationNames());
             var queryForRhs = constantConditions.remove(rhs.getRelationNames());
             var newLhs = getNewSource(queryForLhs, lhs);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
@@ -65,7 +65,8 @@ public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Eval eval = captures.get(fetchOrEvalCapture);
-        List<Symbol> outputsOfFetchSource = eval.source().outputs();
+        var source = resolvePlan.apply(eval.source());
+        List<Symbol> outputsOfFetchSource = source.outputs();
         if (outputsOfFetchSource.containsAll(extractColumns(plan.query()))) {
             return transpose(plan, eval);
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
@@ -34,6 +34,7 @@ import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.statistics.TableStats;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
@@ -57,7 +58,12 @@ public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
     }
 
     @Override
-    public LogicalPlan apply(Filter plan, Captures captures, TableStats tableStats, TransactionContext txnCtx, NodeContext nodeCtx) {
+    public LogicalPlan apply(Filter plan,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Eval eval = captures.get(fetchOrEvalCapture);
         List<Symbol> outputsOfFetchSource = eval.source().outputs();
         if (outputsOfFetchSource.containsAll(extractColumns(plan.query()))) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.rule.Util.transpose;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
@@ -77,7 +78,8 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         // Since something like `SELECT x, sum(y) FROM t GROUP BY x HAVING y > 10` is not valid
         // (y would have to be declared as group key) any parts of a HAVING that is not an aggregation can be moved.
         Symbol predicate = filter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -36,6 +36,8 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.moveQueryBelowJoin;
 
+import java.util.function.Function;
+
 public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
 
     private final Capture<HashJoin> joinCapture;
@@ -57,7 +59,8 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         HashJoin hashJoin = captures.get(joinCapture);
         return moveQueryBelowJoin(filter.query(), hashJoin);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.common.collections.Lists2;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
@@ -62,6 +63,6 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         HashJoin hashJoin = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), hashJoin);
+        return moveQueryBelowJoin(filter.query(), hashJoin.replaceSources(Lists2.map(hashJoin.sources(), resolvePlan)));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -36,6 +36,8 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.moveQueryBelowJoin;
 
+import java.util.function.Function;
+
 public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
 
     private final Capture<NestedLoopJoin> joinCapture;
@@ -63,7 +65,8 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         NestedLoopJoin join = captures.get(joinCapture);
         return moveQueryBelowJoin(filter.query(), join);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.optimizer.rule;
 
+import io.crate.common.collections.Lists2;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
@@ -68,6 +69,6 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         NestedLoopJoin join = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), join);
+        return moveQueryBelowJoin(filter.query(), join.replaceSources(Lists2.map(join.sources(), resolvePlan)));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -36,6 +36,8 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
+import java.util.function.Function;
+
 /**
  * Transforms
  *
@@ -81,7 +83,8 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         return transpose(filter, captures.get(orderCapture));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -67,7 +67,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         var projectSet = captures.get(projectSetCapture);
 
         var queryParts = AndOperator.split(filter.query());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -28,9 +28,9 @@ import static io.crate.planner.optimizer.rule.Util.transpose;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import io.crate.expression.operator.AndOperator;
-import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionType;
@@ -66,7 +66,8 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         var projectSet = captures.get(projectSetCapture);
 
         var queryParts = AndOperator.split(filter.query());
@@ -93,6 +94,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
     }
 
     private static boolean isTableFunction(Symbol s) {
-        return s instanceof Function && ((Function) s).signature().getKind() == FunctionType.TABLE;
+        return s instanceof io.crate.expression.symbol.Function &&
+               ((io.crate.expression.symbol.Function) s).signature().getKind() == FunctionType.TABLE;
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -61,7 +61,7 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Rename rename = captures.get(renameCapture);
         Filter newFilter = new Filter(
             rename.source(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -34,6 +34,7 @@ import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.statistics.TableStats;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -59,7 +60,8 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Rename rename = captures.get(renameCapture);
         Filter newFilter = new Filter(
             rename.source(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -62,7 +62,7 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Union union = captures.get(unionCapture);
         LogicalPlan lhs = union.sources().get(0);
         LogicalPlan rhs = union.sources().get(1);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -35,6 +35,7 @@ import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -60,7 +61,8 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Union union = captures.get(unionCapture);
         LogicalPlan lhs = union.sources().get(0);
         LogicalPlan rhs = union.sources().get(1);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -39,6 +39,7 @@ import io.crate.statistics.TableStats;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static io.crate.planner.operators.LogicalPlanner.extractColumns;
@@ -67,7 +68,8 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         WindowAgg windowAgg = captures.get(windowAggCapture);
         WindowDefinition windowDefinition = windowAgg.windowDefinition();
         List<WindowFunction> windowFunctions = windowAgg.windowFunctions();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -69,7 +69,7 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         WindowAgg windowAgg = captures.get(windowAggCapture);
         WindowDefinition windowDefinition = windowAgg.windowDefinition();
         List<WindowFunction> windowFunctions = windowAgg.windowFunctions();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -25,6 +25,8 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
+import java.util.function.Function;
+
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Eval;
@@ -57,7 +59,8 @@ public class MoveLimitBeneathEval implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Eval eval = captures.get(evalCapture);
         return transpose(limit, eval);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -60,7 +60,7 @@ public class MoveLimitBeneathEval implements Rule<Limit> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Eval eval = captures.get(evalCapture);
         return transpose(limit, eval);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -60,7 +60,7 @@ public class MoveLimitBeneathRename implements Rule<Limit> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Rename rename = captures.get(renameCapture);
         return transpose(limit, rename);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -25,6 +25,8 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
+import java.util.function.Function;
+
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Limit;
@@ -57,7 +59,8 @@ public class MoveLimitBeneathRename implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Rename rename = captures.get(renameCapture);
         return transpose(limit, rename);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
@@ -34,6 +34,7 @@ import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.statistics.TableStats;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
@@ -61,7 +62,8 @@ public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Eval eval = captures.get(fetchCapture);
         List<Symbol> outputsOfSourceOfFetch = eval.source().outputs();
         List<Symbol> orderBySymbols = plan.orderBy().orderBySymbols();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -29,6 +29,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import io.crate.analyze.OrderBy;
 import io.crate.expression.symbol.FieldsVisitor;
@@ -81,7 +82,8 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         NestedLoopJoin nestedLoop = captures.get(nlCapture);
         Set<RelationName> relationsInOrderBy =
             Collections.newSetFromMap(new IdentityHashMap<>());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -83,7 +83,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         NestedLoopJoin nestedLoop = captures.get(nlCapture);
         Set<RelationName> relationsInOrderBy =
             Collections.newSetFromMap(new IdentityHashMap<>());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -82,7 +82,7 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Rename rename = captures.get(renameCapture);
         Function<? super Symbol, ? extends Symbol> mapField = FieldReplacer.bind(rename::resolveField);
         OrderBy mappedOrderBy = plan.orderBy().map(mapField);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -81,7 +81,8 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Rename rename = captures.get(renameCapture);
         Function<? super Symbol, ? extends Symbol> mapField = FieldReplacer.bind(rename::resolveField);
         OrderBy mappedOrderBy = plan.orderBy().map(mapField);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -61,7 +61,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Union union = captures.get(unionCapture);
         List<LogicalPlan> unionSources = union.sources();
         assert unionSources.size() == 2 : "A UNION must have exactly 2 unionSources";

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -34,6 +34,7 @@ import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -59,7 +60,8 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         Union union = captures.get(unionCapture);
         List<LogicalPlan> unionSources = union.sources();
         assert unionSources.size() == 2 : "A UNION must have exactly 2 unionSources";

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -68,7 +68,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         var relation = (DocTableRelation) collect.relation();
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, relation);
         WhereClause where = collect.where();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -40,6 +40,7 @@ import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.statistics.TableStats;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
@@ -66,7 +67,8 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         var relation = (DocTableRelation) collect.relation();
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, relation);
         WhereClause where = collect.where();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -32,6 +32,8 @@ import io.crate.planner.optimizer.matcher.Pattern;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
+import java.util.function.Function;
+
 /**
  * Eliminates any Eval nodes that have the same output as their source
  */
@@ -54,7 +56,8 @@ public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         return plan.source();
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -57,7 +57,7 @@ public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         return plan.source();
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.QuerySplitter;
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
@@ -129,8 +130,9 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
         if (splitQueries.size() == 1 && splitQueries.keySet().iterator().next().size() > 1) {
             return null;
         }
-        LogicalPlan lhs = nl.sources().get(0);
-        LogicalPlan rhs = nl.sources().get(1);
+        var sources = Lists2.map(nl.sources(), resolveLogicalPlan);
+        LogicalPlan lhs = sources.get(0);
+        LogicalPlan rhs = sources.get(1);
         Set<RelationName> leftName = lhs.getRelationNames();
         Set<RelationName> rightName = rhs.getRelationNames();
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -122,7 +122,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         final var symbolEvaluator = new NullSymbolEvaluator(txnCtx, nodeCtx);
         NestedLoopJoin nl = captures.get(nlCapture);
         Symbol query = filter.query();
@@ -130,7 +130,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
         if (splitQueries.size() == 1 && splitQueries.keySet().iterator().next().size() > 1) {
             return null;
         }
-        var sources = Lists2.map(nl.sources(), resolveLogicalPlan);
+        var sources = Lists2.map(nl.sources(), resolvePlan);
         LogicalPlan lhs = sources.get(0);
         LogicalPlan rhs = sources.get(1);
         Set<RelationName> leftName = lhs.getRelationNames();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.getNewSource;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -119,7 +120,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         final var symbolEvaluator = new NullSymbolEvaluator(txnCtx, nodeCtx);
         NestedLoopJoin nl = captures.get(nlCapture);
         Symbol query = filter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -24,6 +24,8 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
+import java.util.function.Function;
+
 import io.crate.metadata.NodeContext;
 import org.elasticsearch.Version;
 
@@ -164,7 +166,8 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         GroupHashAggregate groupBy = captures.get(groupCapture);
         if (!eagerTerminateIsLikely(limit, groupBy)) {
             return null;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -79,7 +79,7 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
 
     private static boolean eagerTerminateIsLikely(Limit limit,
                                                   GroupHashAggregate groupAggregate,
-                                                  Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                                                  Function<LogicalPlan, LogicalPlan> resolvePlan) {
         if (groupAggregate.outputs().size() > 1 || !groupAggregate.outputs().get(0).valueType().equals(DataTypes.STRING)) {
             // `GroupByOptimizedIterator` can only be used for single text columns.
             // If that is not the case we can always use LimitDistinct even if a eagerTerminate isn't likely
@@ -95,7 +95,7 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
                 return false;
             }
         }
-        long sourceRows = resolveLogicalPlan.apply(groupAggregate.source()).numExpectedRows();
+        long sourceRows = resolvePlan.apply(groupAggregate.source()).numExpectedRows();
         if (sourceRows == 0) {
             return false;
         }
@@ -169,9 +169,9 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         GroupHashAggregate groupBy = captures.get(groupCapture);
-        if (!eagerTerminateIsLikely(limit, groupBy, resolveLogicalPlan)) {
+        if (!eagerTerminateIsLikely(limit, groupBy, resolvePlan)) {
             return null;
         }
         return new LimitDistinct(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.matcher.Patterns.source;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.symbol.Symbols;
@@ -78,7 +79,8 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
                              Captures captures,
                              TableStats tableStats,
                              TransactionContext txnCtx,
-                             NodeContext nodeCtx) {
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -80,7 +80,7 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
                              TableStats tableStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolveLogicalPlan) {
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -186,7 +186,8 @@ public final class CopyToPlan implements Plan {
                                                          match.captures(),
                                                          tableStats,
                                                          context.transactionContext(),
-                                                         context.nodeContext());
+                                                         context.nodeContext(),
+                                                         Function.identity());
             return plan == null ? collect : plan;
         }
         return collect;

--- a/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -90,11 +90,11 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
             exactlyInstanceOf(EvalProjection.class),
             isLimitAndOffset(10, 0),
             exactlyInstanceOf(OrderedLimitAndOffsetProjection.class),
-            exactlyInstanceOf(EvalProjection.class),
-            isLimitAndOffset(3, 0)
+            isLimitAndOffset(3, 0),
+            exactlyInstanceOf(EvalProjection.class)
         );
         assertSQL(projections.get(0).outputs(), "INPUT(0)");
-        assertSQL(projections.get(4).outputs(), "INPUT(0)");
+        assertSQL(projections.get(4).outputs(), "INPUT(1)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -414,8 +414,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             "Rename[id, name] AS u\n" +
             "  └ OrderBy[id ASC name ASC]\n" +
-            "    └ OrderBy[id ASC name ASC]\n" +
-            "      └ Get[doc.users | id, name | DocKeys{1::bigint} | (id = 1::bigint)]";
+            "    └ Get[doc.users | id, name | DocKeys{1::bigint} | (id = 1::bigint)]";
         assertThat(plan, isPlan(expectedPlan));
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/IterativeOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/IterativeOptimizerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.iterative;
+
+import static io.crate.planner.operators.LogicalPlannerTest.printPlan;
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.junit.Test;
+
+import io.crate.analyze.OrderBy;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.rule.DeduplicateOrder;
+import io.crate.planner.optimizer.rule.MergeFilters;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
+import io.crate.statistics.TableStats;
+
+public class IterativeOptimizerTest {
+
+    private NodeContext nodeCtx = createNodeContext();
+    private CoordinatorTxnCtx ctx = CoordinatorTxnCtx.systemTransactionContext();
+
+    @Test
+    public void test_match_single_rule_merge_filters() {
+        var source = new MemoTest.TestPlan(1, List.of());
+        var filter1 = new Filter(source, Literal.BOOLEAN_TRUE);
+        var filter2 = new Filter(filter1, Literal.BOOLEAN_TRUE);
+
+        IterativeOptimizer optimizer = new IterativeOptimizer(nodeCtx,
+                                                              () -> Version.CURRENT,
+                                                              List.of(new MergeFilters()));
+
+        var result = optimizer.optimize(filter2, new TableStats(), ctx);
+
+        assertThat(printPlan(result)).isEqualTo("Filter[(true AND true)]\n" +
+                                                "  └ TestPlan[]");
+    }
+
+    @Test
+    public void test_match_multiple_rules_merge_filters_and_orders() {
+        var source = new MemoTest.TestPlan(1, List.of());
+        var filter1 = new Filter(source, Literal.BOOLEAN_TRUE);
+        var filter2 = new Filter(filter1, Literal.BOOLEAN_TRUE);
+        var order1 = new Order(filter2, new OrderBy(List.of()));
+        var order2 = new Order(order1, new OrderBy(List.of()));
+
+        IterativeOptimizer optimizer = new IterativeOptimizer(nodeCtx,
+                                                              () -> Version.CURRENT,
+                                                              List.of(new MergeFilters(), new DeduplicateOrder()));
+
+        var result = optimizer.optimize(order2, new TableStats(), ctx);
+
+        assertThat(printPlan(result)).isEqualTo("OrderBy[]\n" +
+                                                "  └ Filter[(true AND true)]\n" +
+                                                "    └ TestPlan[]");
+    }
+
+    @Test
+    public void test_reapply_rules_on_changing_nodes() {
+        // This tests the following scenario:
+        //  OrderBy[]
+        //    └ Filter[true]
+        //      └ OrderBy[]
+        //        └ TestPlan[]
+        // 1. Move the filter beneath order1
+        //   OrderBy[]
+        //    └ OrderBy[]
+        //      └ Filter[true]
+        //        └ TestPlan[]
+        // 2. Now match the next rule and dedup the orders
+        //   OrderBy[]
+        //     └ Filter[true]
+        //       └ TestPlan[]
+        var source = new MemoTest.TestPlan(1, List.of());
+        var order1 = new Order(source, new OrderBy(List.of()));
+        var filter = new Filter(order1, Literal.BOOLEAN_TRUE);
+        var order2 = new Order(filter, new OrderBy(List.of()));
+
+        IterativeOptimizer optimizer = new IterativeOptimizer(nodeCtx,
+                                                              () -> Version.CURRENT,
+                                                              List.of(new MoveFilterBeneathOrder(), new DeduplicateOrder()));
+
+        var result = optimizer.optimize(order2, new TableStats(), ctx);
+
+        assertThat(printPlan(result)).isEqualTo("OrderBy[]\n" +
+                                                "  └ Filter[true]\n" +
+                                                "    └ TestPlan[]");
+    }
+
+}
+

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -254,7 +254,7 @@ public class MemoTest {
         return plan(ids.getAsInt(), children);
     }
 
-    private static class TestPlan implements LogicalPlan {
+    static class TestPlan implements LogicalPlan {
         private final List<LogicalPlan> sources;
         private final int id;
 
@@ -290,7 +290,7 @@ public class MemoTest {
 
         @Override
         public List<AbstractTableRelation<?>> baseTables() {
-            return null;
+            return List.of();
         }
 
 
@@ -310,7 +310,7 @@ public class MemoTest {
 
         @Override
         public Map<LogicalPlan, SelectSymbol> dependencies() {
-            return null;
+            return Map.of();
         }
 
         @Override

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -68,7 +69,12 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
         assertThat(match.isPresent()).isTrue();
         assertThat(match.value()).isSameAs(parentFilter);
 
-        Filter mergedFilter = mergeFilters.apply(match.value(), match.captures(), new TableStats(), CoordinatorTxnCtx.systemTransactionContext(), e.nodeCtx);
+        Filter mergedFilter = mergeFilters.apply(match.value(),
+                                                 match.captures(),
+                                                 new TableStats(),
+                                                 CoordinatorTxnCtx.systemTransactionContext(),
+                                                 e.nodeCtx,
+                                                 Function.identity());
         assertThat(mergedFilter.query()).isSQL("((doc.t2.y > 10) AND (doc.t1.x > 10))");
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -83,7 +84,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
                                                 match.captures(),
                                                 new TableStats(),
                                                 CoordinatorTxnCtx.systemTransactionContext(),
-                                                sqlExpressions.nodeCtx);
+                                                sqlExpressions.nodeCtx,
+                                                Function.identity());
 
         assertThat(result.joinCondition(), is(nonConstantPart));
         assertThat(result.lhs(), is(c1));

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -78,7 +79,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             match.captures(),
             new TableStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
-            e.nodeCtx
+            e.nodeCtx,
+            Function.identity()
         );
 
         assertThat(newPlan, nullValue());
@@ -105,7 +107,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             match.captures(),
             new TableStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
-            e.nodeCtx
+            e.nodeCtx,
+            Function.identity()
         );
 
         assertThat(newPlan, nullValue());
@@ -132,7 +135,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             match.captures(),
             new TableStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
-            e.nodeCtx
+            e.nodeCtx,
+            Function.identity()
         );
         var expectedPlan =
             "WindowAgg[id, row_number() OVER (PARTITION BY id)]\n" +
@@ -163,7 +167,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             match.captures(),
             new TableStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
-            e.nodeCtx
+            e.nodeCtx,
+            Function.identity()
         );
         var expectedPlan =
             "Filter[((row_number() OVER (PARTITION BY id) = 2) AND (x = 1))]\n" +
@@ -195,7 +200,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             match.captures(),
             new TableStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
-            e.nodeCtx
+            e.nodeCtx,
+            Function.identity()
         );
         assertThat(newPlan, nullValue());
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This pr adds a cascade-style optimizer as default optimizer. The optimizer takes an operator tree of logical plans and creates an optimized plan. The optimization loop applies rules recursively until a fixpoint is reached.

The existing optimizer rules are adapted, so they can deal with group references. This also adds a few minor modifications in some operators to make sure group references can be used everywhere as a source.




## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
