### PR TITLE
Add a caution about using `max_num_segments` with low values

### DIFF
--- a/docs/sql/statements/optimize.rst
+++ b/docs/sql/statements/optimize.rst
@@ -138,6 +138,14 @@ Available parameters are:
   Defaults to simply checking if a merge is necessary, and if so,
   executes it.
 
+  .. CAUTION::
+
+    Forcing a merge to a small number of segments can harm query performance
+    if segments become too big.
+
+    If ``max_num_segments`` gets omitted, CrateDB will automatically determine
+    the ideal number of segments based on internal criteria.
+
 :only_expunge_deletes:
   Should the merge process only expunge segments with deletes in it.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
We have seen cases recently where `max_num_segments = 1` was used in an attempt to optimize large data volumes (shard sizes of > 100 GB). Query performance was significantly worse after the forced merge.
Elasticsearch has a similar warning: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html

## Checklist

 - [X] Added an entry in `CHANGES.txt` for user-facing changes
 - [X] Updated documentation & `sql_features` table for user-facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
