### PR TITLE
Add support for the array || element concat operator 

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -95,6 +95,10 @@ Scalar and Aggregation Functions
 - Changed :ref:`pg_get_userbyid <scalar-pg_get_userbyid>` to return the matching
   user or ``unknown`` instead of always ``crate``.
 
+- Added support of the ``array || element`` operator as an alias for the
+  :ref:`array_append(array, value) <scalar-array_append>` scalar function for
+  improved compatibility with PostgreSQL.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -62,7 +62,7 @@ You can also use the ``||`` :ref:`operator <gloss-operator>`::
 .. TIP::
 
     The ``concat`` function can also be used for merging objects:
-    :ref:`concat(object, object) <scalar-concat-object>`
+    :ref:`concat(object, object) <scalar-concat-object>`.
 
 
 .. _scalar-concat-ws:
@@ -2733,6 +2733,18 @@ Returns: ``array``
     +--------------+
     SELECT 1 row in set (... sec)
 
+
+You can also use the concat :ref:`operator <gloss-operator>` ``||`` to append
+values to an array::
+
+    cr> select
+    ...    [1,2,3] || 4 AS array_append;
+    +--------------+
+    | array_append |
+    +--------------+
+    | [1, 2, 3, 4] |
+    +--------------+
+    SELECT 1 row in set (... sec)
 
 .. _scalar-array_cat:
 

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -56,10 +56,16 @@ public class ArrayAppendFunction extends Scalar<List<Object>, Object> {
     }
 
     private final DataType<?> innerType;
+    private final boolean calledByOperator;
 
     ArrayAppendFunction(Signature signature, BoundSignature boundSignature) {
+        this(signature, boundSignature, false);
+    }
+
+    ArrayAppendFunction(Signature signature, BoundSignature boundSignature, boolean calledByOperator) {
         super(signature, boundSignature);
         this.innerType = ((ArrayType<?>) boundSignature.returnType()).innerType();
+        this.calledByOperator = calledByOperator;
     }
 
     @Override
@@ -73,6 +79,11 @@ public class ArrayAppendFunction extends Scalar<List<Object>, Object> {
                 resultList.add(innerType.sanitizeValue(value));
             }
         }
+        if (valueToAdd == null && calledByOperator) {
+            // array || null -> array (null is ignored)
+            return resultList;
+        }
+
         resultList.add(innerType.sanitizeValue(valueToAdd));
         return resultList;
     }

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -76,7 +76,6 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 .build(),
             ArrayCatFunction::new
         );
-
         module.add(
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
@@ -111,6 +110,18 @@ public abstract class ConcatFunction extends Scalar<String, String> {
         );
         module.add(
             Signature.builder(OPERATOR_NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("E")
+                )
+                .returnType(TypeSignature.parse("array(E)"))
+                .typeVariableConstraints(typeVariable("E"))
+                .features(Feature.DETERMINISTIC)
+                .build(),
+            (signature, boundSignature) -> new ArrayAppendFunction(signature, boundSignature, true)
+        );
+        module.add(
+            Signature.builder(OPERATOR_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                     DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
@@ -118,7 +129,6 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 .build(),
             ObjectMergeFunction::new
         );
-
     }
 
     ConcatFunction(Signature signature, BoundSignature boundSignature) {

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -140,4 +140,9 @@ public class ConcatFunctionTest extends ScalarTestCase {
     public void test_concat_operator_with_objects() {
         assertEvaluate("{a=1} || {a=2,b=2}", Map.of("a",2,"b",2));
     }
+
+    @Test
+    public void test_concat_operator_with_array_and_element() {
+        assertEvaluate("[1] || 2", List.of(1, 2));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Add `array || element` as alias for `array_append(array,element)` scalar function for improved PostgreSQL compatibility.

```sql
select [1,2,3] || 4 AS array_append;                                                                                                                                                                             
+--------------+
| array_append |
+--------------+
| [1, 2, 3, 4] |
+--------------+
```

In line with PostgreSQL (see https://www.postgresql.org/docs/15/functions-array.html)
```
anycompatiblearray || anycompatible → anycompatiblearray
Concatenates an element onto the end of an array (which must be empty or one-dimensional).
ARRAY[4,5,6] || 7 → {4,5,6,7}
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
