### PR TITLE
Fix testMemorySize on machines with large memory

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -126,6 +126,7 @@ public class SettingTests extends ESTestCase {
         assertThat(value.get(), equalTo(new ByteSizeValue(12)));
     }
 
+    @Test
     public void testMemorySize() {
         Setting<ByteSizeValue> memorySizeValueSetting = Setting.memorySizeSetting("a.byte.size", new ByteSizeValue(1024), Property.Dynamic,
                 Property.NodeScope);
@@ -157,7 +158,7 @@ public class SettingTests extends ESTestCase {
         assertEquals(new ByteSizeValue(12), value.get());
 
         assertTrue(settingUpdater.apply(Settings.builder().put("a.byte.size", "20%").build(), Settings.EMPTY));
-        assertEquals(new ByteSizeValue((int) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.2)), value.get());
+        assertEquals(new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.2)), value.get());
     }
 
     @Test


### PR DESCRIPTION
Casting the result of `getHeapMax().getBytes() * 0.2` to `int` caps the
result at `2147483647`

This can cause an assertion error if 20% of the max heap is >
`2147483647`

This was only an issue if the test runner JVM doesn't restrict max heap
itself. (Gradle currently does, but the IDE/Editor setup may not)
