### PR TITLE
Handle AddColumnRequest that miss object child parents

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -63,7 +63,7 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
 
     @Override
     public ClusterStateTaskExecutor<AddColumnRequest> clusterStateTaskExecutor(AddColumnRequest request) {
-        return new AddColumnTask(nodeContext, indicesService);
+        return new AddColumnTask(nodeContext, indicesService::createIndexMapperService);
     }
 
 

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -43,6 +43,7 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 import io.crate.types.StorageSupport;
 
 public class SimpleReference implements Reference {
@@ -209,7 +210,7 @@ public class SimpleReference implements Reference {
         Map<String, Object> mapping = new HashMap<>();
         mapping.put("type", DataTypes.esMappingNameFrom(innerType.id()));
         mapping.put("position", position);
-        if (indexType == IndexType.NONE) {
+        if (indexType == IndexType.NONE && type.id() != ObjectType.ID) {
             mapping.put("index", false);
         }
         StorageSupport<?> storageSupport = innerType.storageSupport();

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.junit.Test;
+
+import com.carrotsearch.hppc.IntArrayList;
+
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.IndexEnv;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_can_add_child_column() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, o object)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT,
+            createTempDir()
+        )) {
+            var addColumnTask = new AddColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            ReferenceIdent refIdent = new ReferenceIdent(tbl.ident(), "o", List.of("x"));
+            SimpleReference newColumn = new SimpleReference(
+                refIdent,
+                RowGranularity.DOC,
+                DataTypes.INTEGER,
+                3,
+                null
+            );
+            List<Reference> columns = List.of(newColumn);
+            var request = new AddColumnRequest(
+                tbl.ident(),
+                columns,
+                Map.of(),
+                new IntArrayList()
+            );
+            ClusterState newState = addColumnTask.execute(clusterService.state(), request);
+            DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState);
+
+            Reference addedColumn = newTable.getReference(newColumn.column());
+            assertThat(addedColumn).isEqualTo(newColumn);
+        }
+    }
+}


### PR DESCRIPTION
The "alter table ... add column" logic sends requests which always
contain all the parents, but for dynamic mapping updates it is easier to
only send the child columns.

This extends the AddColumnTask to handle that scenario too.
The implementation is not the most efficient, but an implementation that
avoids copies would be more complex. We can optimize this once we change
the metadata format (e.g. reducing redundancy between index-mapping and
template mapping would have the biggest impact)
