### PR TITLE
Add SQLErrorAssert

### DIFF
--- a/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -23,12 +23,12 @@ package io.crate.window;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.execution.engine.window.AbstractWindowFunctionTest;
 import io.crate.metadata.ColumnIdent;
 import io.crate.module.ExtraFunctionsModule;
-import io.crate.testing.Asserts;
 
 public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
@@ -138,15 +138,13 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testLagWithIgnoreNullsAndZeroOffsetThrows() {
-        Asserts.assertThrowsMatches(
-            () -> assertEvaluate(
+        Assertions.assertThatThrownBy(() -> assertEvaluate(
                 "lag(x,0,123) ignore nulls over()",
                 null,
                 List.of(new ColumnIdent("x")),
-                new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}),
-            IllegalArgumentException.class,
-            "offset 0 is not a valid argument if ignore nulls flag is set"
-        );
+                new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("offset 0 is not a valid argument if ignore nulls flag is set");
     }
 
     @Test

--- a/extensions/functions/src/test/java/io/crate/window/RankFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/RankFunctionsTest.java
@@ -23,12 +23,12 @@ package io.crate.window;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.execution.engine.window.AbstractWindowFunctionTest;
 import io.crate.metadata.ColumnIdent;
 import io.crate.module.ExtraFunctionsModule;
-import io.crate.testing.Asserts;
 
 
 public class RankFunctionsTest extends AbstractWindowFunctionTest {
@@ -185,15 +185,13 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testIgnoreNullsFlagThrows() {
-        Asserts.assertThrowsMatches(
-            () -> assertEvaluate(
+        Assertions.assertThatThrownBy(() -> assertEvaluate(
                 "rank() ignore nulls over()",
                 null,
                 List.of(new ColumnIdent("x")),
                 new Object[] {1}
-            ),
-            IllegalArgumentException.class,
-            "rank cannot accept RESPECT or IGNORE NULLS flag."
-        );
+            ))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("rank cannot accept RESPECT or IGNORE NULLS flag.");
     }
 }

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
@@ -22,11 +22,9 @@
 package io.crate.analysis.common;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.testing.Asserts.assertThrowsMatches;
-import static io.crate.testing.SQLErrorMatcher.isSQLError;
+import static io.crate.testing.Asserts.assertSQLError;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -149,11 +147,10 @@ public class FulltextITest extends IntegTestCase {
         execute("select * from matchbox where match(o['m'], 'Ford')");
         assertThat(response.rowCount()).isEqualTo(1L);
 
-        assertThrowsMatches(() -> execute("select * from matchbox where match(o_ignored['a'], 'Ford')"),
-                     isSQLError(is("Can only use MATCH on columns of type STRING or GEO_SHAPE, not on 'undefined'"),
-                                INTERNAL_ERROR,
-                                BAD_REQUEST,
-                                4000));
+        assertSQLError(() -> execute("select * from matchbox where match(o_ignored['a'], 'Ford')"))
+            .hasPGError(INTERNAL_ERROR)
+            .hasHTTPError(BAD_REQUEST, 4000)
+            .hasMessageContaining("Can only use MATCH on columns of type STRING or GEO_SHAPE, not on 'undefined'");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -40,6 +39,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.carrotsearch.hppc.cursors.IntCursor;
+
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -711,18 +712,14 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
             .build();
 
         // same name, same type
-        assertThrowsMatches(
-            () -> e.analyze("ALTER TABLE tbl ADD COLUMN o['a']['b'] int primary key, ADD COLUMN int_col INTEGER, ADD COLUMN int_col INTEGER"),
-            IllegalArgumentException.class,
-            "column \"int_col\" specified more than once"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyze("ALTER TABLE tbl ADD COLUMN o['a']['b'] int primary key, ADD COLUMN int_col INTEGER, ADD COLUMN int_col INTEGER"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("column \"int_col\" specified more than once");
 
         // only same name, different type
-        assertThrowsMatches(
-            () -> e.analyze("ALTER TABLE tbl ADD COLUMN o['a']['b'] int primary key, ADD COLUMN col INTEGER, ADD COLUMN col TEXT"),
-            IllegalArgumentException.class,
-            "column \"col\" specified more than once"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyze("ALTER TABLE tbl ADD COLUMN o['a']['b'] int primary key, ADD COLUMN col INTEGER, ADD COLUMN col TEXT"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("column \"col\" specified more than once");
     }
 
 }

--- a/server/src/test/java/io/crate/analyze/AlterTableDropCheckConstraintAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableDropCheckConstraintAnalyzerTest.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import java.io.IOException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,7 +31,6 @@ import io.crate.planner.PlannerContext;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AlterTableDropCheckConstraintAnalyzerTest extends CrateDummyClusterServiceUnitTest {
@@ -60,10 +60,9 @@ public class AlterTableDropCheckConstraintAnalyzerTest extends CrateDummyCluster
 
     @Test
     public void testDropCheckConstraintFailsBecauseTheNameDoesNotReferToAnExistingConstraint() {
-        assertThrowsMatches(
-            () -> e.analyze("alter table t drop constraint bazinga"),
-            IllegalArgumentException.class,
-            "Cannot find a CHECK CONSTRAINT named [bazinga], available constraints are: [check_qty_gt_zero, check_id_ge_zero]"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyze("alter table t drop constraint bazinga"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(
+                    "Cannot find a CHECK CONSTRAINT named [bazinga], available constraints are: [check_qty_gt_zero, check_id_ge_zero]");
     }
 }

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameAnalyzerTest.java
@@ -21,11 +21,10 @@
 
 package io.crate.analyze;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
-
 import java.util.Arrays;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -72,11 +71,10 @@ public class AlterTableRenameAnalyzerTest extends CrateDummyClusterServiceUnitTe
     public void test_rename_is_not_allowed_when_table_is_published() throws Exception {
         var clusterService = clusterServiceWithPublicationMetadata(false, new RelationName("doc", "t1"));
         var executor = SQLExecutor.builder(clusterService).addTable(T3.T1_DEFINITION).build();
-        assertThrowsMatches(
-            () -> executor.analyze("ALTER TABLE t1 rename to t1_renamed"),
-            OperationOnInaccessibleRelationException.class,
-            "The relation \"doc.t1\" doesn't allow ALTER RENAME operations, because it is included in a logical replication publication."
-        );
+        Assertions.assertThatThrownBy(() -> executor.analyze("ALTER TABLE t1 rename to t1_renamed"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessageContaining(
+                    "The relation \"doc.t1\" doesn't allow ALTER RENAME operations, because it is included in a logical replication publication.");
         clusterService.close();
     }
 
@@ -84,11 +82,10 @@ public class AlterTableRenameAnalyzerTest extends CrateDummyClusterServiceUnitTe
     public void test_rename_is_not_allowed_when_all_tables_are_published() throws Exception {
         var clusterService = clusterServiceWithPublicationMetadata(true);
         var executor = SQLExecutor.builder(clusterService).addTable(T3.T1_DEFINITION).build();
-        assertThrowsMatches(
-            () -> executor.analyze("ALTER TABLE t1 rename to t1_renamed"),
-            OperationOnInaccessibleRelationException.class,
-            "The relation \"doc.t1\" doesn't allow ALTER RENAME operations, because it is included in a logical replication publication."
-        );
+        Assertions.assertThatThrownBy(() -> executor.analyze("ALTER TABLE t1 rename to t1_renamed"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessageContaining(
+                    "The relation \"doc.t1\" doesn't allow ALTER RENAME operations, because it is included in a logical replication publication.");
         clusterService.close();
     }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -29,6 +28,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -117,9 +117,9 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void testRerouteMoveShardWithNullShardId() {
-        assertThrowsMatches(() -> analyze("ALTER TABLE users REROUTE MOVE SHARD null FROM 'n2' TO 'n1'"),
-                            IllegalArgumentException.class,
-                            "Shard Id cannot be [null]");
+        Assertions.assertThatThrownBy(() -> analyze("ALTER TABLE users REROUTE MOVE SHARD null FROM 'n2' TO 'n1'"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Shard Id cannot be [null]");
     }
 
     @Test
@@ -159,9 +159,9 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void testRerouteAllocateReplicaShardWithNullShardId() {
-        assertThrowsMatches(() -> analyze("ALTER TABLE users REROUTE ALLOCATE REPLICA SHARD null ON 'n1'"),
-                            IllegalArgumentException.class,
-                            "Shard Id cannot be [null]");
+        Assertions.assertThatThrownBy(() -> analyze("ALTER TABLE users REROUTE ALLOCATE REPLICA SHARD null ON 'n1'"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Shard Id cannot be [null]");
     }
 
     @Test
@@ -186,9 +186,9 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void testRerouteCancelShardWithNullShardId() {
-        assertThrowsMatches(() -> analyze("ALTER TABLE users REROUTE CANCEL SHARD null ON 'n2'"),
-                            IllegalArgumentException.class,
-                            "Shard Id cannot be [null]");
+        Assertions.assertThatThrownBy(() -> analyze("ALTER TABLE users REROUTE CANCEL SHARD null ON 'n2'"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Shard Id cannot be [null]");
     }
 
     @Test
@@ -229,9 +229,9 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
     }
 
     public void test_promote_replica_shard_with_null_shardId() {
-        assertThrowsMatches(() -> analyze("ALTER TABLE users REROUTE PROMOTE REPLICA SHARD null ON 'n1'"),
-            IllegalArgumentException.class,
-            "Shard Id cannot be [null]");
+        Assertions.assertThatThrownBy(() -> analyze("ALTER TABLE users REROUTE PROMOTE REPLICA SHARD null ON 'n1'"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Shard Id cannot be [null]");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1591,10 +1591,8 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void test_create_table_with_invalid_storage_option_errors_with_invalid_property_name() throws Exception {
-        assertThrowsMatches(
-            () -> analyze("create table tbl (name text storage with (foobar = true))"),
-            IllegalArgumentException.class,
-            "Invalid STORAGE WITH option `foobar`"
-        );
+        assertThatThrownBy(() -> analyze("create table tbl (name text storage with (foobar = true))"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid STORAGE WITH option `foobar`");
     }
 }

--- a/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -26,7 +26,6 @@ import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINIT
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION;
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -40,6 +39,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -452,10 +452,8 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_restore_unknown_metadata() {
-        assertThrowsMatches(
-            () -> analyze(e, "RESTORE SNAPSHOT my_repo.my_snapshot UNKNOWN_META"),
-            IllegalArgumentException.class,
-            "Unknown metadata type 'UNKNOWN_META'"
-        );
+        Assertions.assertThatThrownBy(() -> analyze(e, "RESTORE SNAPSHOT my_repo.my_snapshot UNKNOWN_META"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unknown metadata type 'UNKNOWN_META'");
     }
 }

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.crate.types.BitStringType;
+
 import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +68,6 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
@@ -404,11 +404,9 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         var e = SQLExecutor.builder(clusterService)
             .addTable("create table tbl (obj object as (x int))")
             .build();
-        Asserts.assertThrowsMatches(
-            () -> e.asSymbol("obj = {x = 'foo'}"),
-            ConversionException.class,
-            "Cannot cast object element `x` with value `foo` to type `integer`"
-        );
+        assertThatThrownBy(() -> e.asSymbol("obj = {x = 'foo'}"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessageContaining("Cannot cast object element `x` with value `foo` to type `integer`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.ddl.tables;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -31,6 +30,7 @@ import static org.elasticsearch.common.settings.IndexScopedSettings.DEFAULT_SCOP
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
@@ -75,19 +75,17 @@ public class AlterTableOperationTest extends ESTestCase {
         RelationName t1 = new RelationName("doc", "t1");
         var oneTablePublished = Map.of("pub1", new Publication("owner", false, List.of(t1)));
 
-        assertThrowsMatches(
-            () -> AlterTableOperation.validateSettingsForPublishedTables(t1, settings, oneTablePublished, DEFAULT_SCOPED_SETTINGS),
-            IllegalArgumentException.class,
-            "Setting [index.number_of_shards] cannot be applied to table 'doc.t1' because it is included in a logical replication publication 'pub1'"
-        );
+        Assertions.assertThatThrownBy(() -> AlterTableOperation.validateSettingsForPublishedTables(t1, settings, oneTablePublished, DEFAULT_SCOPED_SETTINGS))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(
+                    "Setting [index.number_of_shards] cannot be applied to table 'doc.t1' because it is included in a logical replication publication 'pub1'");
 
         var allTablesPublished = Map.of("pub1", new Publication("owner", true, List.of()));
 
-        assertThrowsMatches(
-            () -> AlterTableOperation.validateSettingsForPublishedTables(t1, settings, allTablesPublished, DEFAULT_SCOPED_SETTINGS),
-            IllegalArgumentException.class,
-            "Setting [index.number_of_shards] cannot be applied to table 'doc.t1' because it is included in a logical replication publication 'pub1'"
-        );
+        Assertions.assertThatThrownBy(() -> AlterTableOperation.validateSettingsForPublishedTables(t1, settings, allTablesPublished, DEFAULT_SCOPED_SETTINGS))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(
+                    "Setting [index.number_of_shards] cannot be applied to table 'doc.t1' because it is included in a logical replication publication 'pub1'");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
@@ -23,10 +23,10 @@ package io.crate.execution.engine.window;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.metadata.ColumnIdent;
-import io.crate.testing.Asserts;
 
 public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
 
@@ -93,15 +93,13 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testIgnoreNullsFlagThrows() {
-        Asserts.assertThrowsMatches(
-            () -> assertEvaluate(
+        Assertions.assertThatThrownBy(() -> assertEvaluate(
                 "row_number() ignore nulls over()",
                 null,
                 List.of(new ColumnIdent("x")),
                 new Object[] {1}
-            ),
-            IllegalArgumentException.class,
-            "row_number cannot accept RESPECT or IGNORE NULLS flag."
-        );
+            ))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("row_number cannot accept RESPECT or IGNORE NULLS flag.");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
@@ -21,12 +21,11 @@
 
 package io.crate.expression.scalar;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Literal;
@@ -82,9 +81,10 @@ public class ArrayMaxFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_empty_array_given_directly_throws_exception() {
-        assertThrowsMatches(() -> assertEvaluate("array_max([])", null),
-                            UnsupportedOperationException.class,
-                            "Unknown function: array_max([]), no overload found for matching argument types: (undefined_array).");
+        Assertions.assertThatThrownBy(() -> assertEvaluate("array_max([])", null))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining(
+                    "Unknown function: array_max([]), no overload found for matching argument types: (undefined_array).");
     }
 
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
@@ -21,12 +21,11 @@
 
 package io.crate.expression.scalar;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Literal;
@@ -82,8 +81,9 @@ public class ArrayMinFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_empty_array_given_directly_throws_exception() {
-        assertThrowsMatches(() -> assertEvaluate("array_min([])", null),
-                            UnsupportedOperationException.class,
-                            "Unknown function: array_min([]), no overload found for matching argument types: (undefined_array).");
+        Assertions.assertThatThrownBy(() -> assertEvaluate("array_min([])", null))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining(
+                    "Unknown function: array_min([]), no overload found for matching argument types: (undefined_array).");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayPositionFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayPositionFunctionTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.expression.scalar;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
-
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
@@ -89,7 +88,8 @@ public class ArrayPositionFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_array_position_find_text_in_int_array_with_start_position_provided_throws_error() {
-        assertThrowsMatches(() -> assertEvaluate("array_position([3,4,1,4,6], 'a', 3)", null),
-            ConversionException.class, "Cannot cast `'a'` of type `text` to type `integer`");
+        Assertions.assertThatThrownBy(() -> assertEvaluate("array_position([3,4,1,4,6], 'a', 3)", null))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessageContaining("Cannot cast `'a'` of type `text` to type `integer`");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
@@ -21,14 +21,13 @@
 
 package io.crate.expression.scalar;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.execution.engine.aggregation.impl.util.KahanSummationForDouble;
@@ -91,12 +90,13 @@ public class ArraySumFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_array_big_numbers_no_casting_results_in_exception() {
-        assertThrowsMatches(() -> assertEvaluate("array_sum(?)", null,
-                                                 Literal.of(List.of(Long.MAX_VALUE, Long.MAX_VALUE),
-                                                            new ArrayType<>(DataTypes.LONG))
-                            ),
-                            ArithmeticException.class,
-                            "long overflow");
+        Assertions.assertThatThrownBy(() -> assertEvaluate(
+            "array_sum(?)",
+            null,
+            Literal.of(List.of(Long.MAX_VALUE, Long.MAX_VALUE), new ArrayType<>(DataTypes.LONG))
+        ))
+            .isExactlyInstanceOf(ArithmeticException.class)
+            .hasMessageContaining("long overflow");
     }
 
     @Test
@@ -134,8 +134,9 @@ public class ArraySumFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_empty_array_given_directly_throws_exception() {
-        assertThrowsMatches(() -> assertEvaluate("array_sum([])", null),
-                            UnsupportedOperationException.class,
-                            "Unknown function: array_sum([]), no overload found for matching argument types: (undefined_array).");
+        Assertions.assertThatThrownBy(() -> assertEvaluate("array_sum([])", null))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining(
+                    "Unknown function: array_sum([]), no overload found for matching argument types: (undefined_array).");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/DateBinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateBinFunctionTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.expression.scalar;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.Asserts.isNotSameInstance;
 import static io.crate.testing.Asserts.isSameInstance;
 
@@ -30,6 +29,7 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneOffset;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class DateBinFunctionTest extends ScalarTestCase {
@@ -56,9 +56,9 @@ public class DateBinFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_interval_is_zero_exception_thrown() {
-        assertThrowsMatches(() -> assertEvaluate("date_bin('0 days' :: INTERVAL, CURRENT_TIMESTAMP, 0)", null),
-                            IllegalArgumentException.class,
-                            "Interval cannot be zero");
+        Assertions.assertThatThrownBy(() -> assertEvaluate("date_bin('0 days' :: INTERVAL, CURRENT_TIMESTAMP, 0)", null))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Interval cannot be zero");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -27,13 +27,13 @@ import static io.crate.testing.Asserts.isLiteral;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
-import io.crate.testing.Asserts;
 
 
 public class SubscriptFunctionTest extends ScalarTestCase {
@@ -86,11 +86,9 @@ public class SubscriptFunctionTest extends ScalarTestCase {
     @Test
     public void testLookupByNameWithUnknownName() throws Exception {
         sqlExpressions.setErrorOnUnknownObjectKey(true);
-        Asserts.assertThrowsMatches(
-            () -> assertEvaluate("{}['y']", null),
-            ColumnUnknownException.class,
-            "The object `{}` does not contain the key `y`"
-        );
+        Assertions.assertThatThrownBy(() -> assertEvaluate("{}['y']", null))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("The object `{}` does not contain the key `y`");
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertEvaluateNull("{}['y']");
     }

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -25,11 +25,11 @@ import static io.crate.testing.Asserts.isLiteral;
 
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Literal;
-import io.crate.testing.Asserts;
 
 public class SubscriptObjectFunctionTest extends ScalarTestCase {
 
@@ -86,20 +86,16 @@ public class SubscriptObjectFunctionTest extends ScalarTestCase {
     public void testEvaluateNestedObjectWithUnknownObjectkeysWithSessionSetting() throws Exception {
         // missing key in the very front
         sqlExpressions.setErrorOnUnknownObjectKey(true);
-        Asserts.assertThrowsMatches(
-            () -> assertEvaluate("subscript_obj(subscript_obj({x={y=10}}, 'y'), 'y')", null),
-            ColumnUnknownException.class,
-            "The object `{x={y=10}}` does not contain the key `y`"
-        );
+        Assertions.assertThatThrownBy(() -> assertEvaluate("subscript_obj(subscript_obj({x={y=10}}, 'y'), 'y')", null))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("The object `{x={y=10}}` does not contain the key `y`");
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertEvaluateNull("subscript_obj(subscript_obj({x={y=10}}, 'y'), 'y')");
         // missing key in the middle
         sqlExpressions.setErrorOnUnknownObjectKey(true);
-        Asserts.assertThrowsMatches(
-            () -> assertEvaluate("{\"x\" = {\"y\" = {\"z\" = 'test'}}}['x']['x']['z']", null),
-            ColumnUnknownException.class,
-            "The object `{y={z=test}}` does not contain the key `x`"
-        );
+        Assertions.assertThatThrownBy(() -> assertEvaluate("{\"x\" = {\"y\" = {\"z\" = 'test'}}}['x']['x']['z']", null))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("The object `{y={z=test}}` does not contain the key `x`");
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertEvaluateNull("{\"x\" = {\"y\" = {\"z\" = 'test'}}}['x']['x']['z']");
     }

--- a/server/src/test/java/io/crate/expression/scalar/bitwise/BitwiseFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/bitwise/BitwiseFunctionsTest.java
@@ -27,6 +27,8 @@ import io.crate.sql.tree.BitString;
 import io.crate.testing.DataTypeTesting;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
+
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.TriFunction;
 import org.junit.Test;
 
@@ -37,7 +39,6 @@ import java.util.Map;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.types.DataTypes.BYTE;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.LONG;
@@ -48,9 +49,9 @@ public class BitwiseFunctionsTest extends ScalarTestCase {
 
     @Test
     public void test_bit_string_operands_must_have_equal_length() {
-        assertThrowsMatches(() -> assertEvaluate("B'10001' | B'001'", null),
-            IllegalArgumentException.class,
-            "Cannot OR bit strings of different sizes");
+        Assertions.assertThatThrownBy(() -> assertEvaluate("B'10001' | B'001'", null))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot OR bit strings of different sizes");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/tablefunctions/GenerateSeriesTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/GenerateSeriesTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.expression.tablefunctions;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
-
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class GenerateSeriesTest extends AbstractTableFunctionsTest {
@@ -154,10 +153,9 @@ public class GenerateSeriesTest extends AbstractTableFunctionsTest {
 
     @Test
     public void test_step_is_mandatory_for_timestamps() {
-        assertThrowsMatches(
-            () -> assertExecute("generate_series(null::timestamptz, '2019-03-04'::timestamptz)", ""),
-            IllegalArgumentException.class,
-            "generate_series(start, stop) has type `timestamp with time zone` for start, but requires long/int values for start and stop, or if used with timestamps, it requires a third argument for the step (interval)"
-        );
+        Assertions.assertThatThrownBy(() -> assertExecute("generate_series(null::timestamptz, '2019-03-04'::timestamptz)", ""))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(
+                    "generate_series(start, stop) has type `timestamp with time zone` for start, but requires long/int values for start and stop, or if used with timestamps, it requires a third argument for the step (interval)");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
@@ -21,11 +21,11 @@
 
 package io.crate.integrationtests;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.PreparedStatement;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 import org.postgresql.util.PSQLException;
@@ -44,7 +44,9 @@ public class PostgresCompatIntegrationTest extends IntegTestCase {
 
     @Test
     public void testStartTransactionStatement() {
-        assertThrowsMatches(() -> execute("START"), PSQLException.class, "ERROR: line 1:6: missing 'TRANSACTION'");
+        Assertions.assertThatThrownBy(() -> execute("START"))
+            .isExactlyInstanceOf(PSQLException.class)
+            .hasMessageContaining("ERROR: line 1:6: missing 'TRANSACTION'");
 
         execute("START TRANSACTION");
         assertNoErrorResponse(response);

--- a/server/src/test/java/io/crate/metadata/IndexPartsTest.java
+++ b/server/src/test/java/io/crate/metadata/IndexPartsTest.java
@@ -21,12 +21,11 @@
 
 package io.crate.metadata;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import org.junit.Test;
-
-import io.crate.testing.Asserts;
 
 public class IndexPartsTest {
 
@@ -52,12 +51,10 @@ public class IndexPartsTest {
         assertThat(new IndexParts(schemaTable).isPartitioned(), is(false));
         assertThat(new IndexParts(partitionedTable).isPartitioned(), is(true));
         assertThat(new IndexParts(schemaPartitionedTable).isPartitioned(), is(true));
-        Asserts.assertThrowsMatches(
-            () -> new IndexParts("schema..partitioned."),
-            IllegalArgumentException.class,
-            "Invalid index name: schema",
-            "Should have failed due to invalid index name"
-        );
+        assertThatThrownBy(() -> new IndexParts("schema..partitioned."))
+            .as("Should have failed due to invalid index name")
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid index name: schema");
 
         assertThat(IndexParts.isPartitioned(table), is(false));
         assertThat(IndexParts.isPartitioned(schemaTable), is(false));

--- a/server/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
+++ b/server/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -55,7 +56,6 @@ import io.crate.execution.ddl.tables.AlterTableRequest;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
-import io.crate.testing.Asserts;
 
 public class AlterTableClusterStateExecutorTest {
 
@@ -160,11 +160,10 @@ public class AlterTableClusterStateExecutorTest {
                                                           Settings.EMPTY,
                                                           Collections.singletonMap("_meta", mapping));
 
-        Asserts.assertThrowsMatches(
-            () -> AlterTableClusterStateExecutor.addExistingMeta(request, currentMeta),
-            IllegalArgumentException.class,
-            "Requested to change the routing column to routing_col_update, but routing columns cannot be changed"
-        );
+        Assertions.assertThatThrownBy(() -> AlterTableClusterStateExecutor.addExistingMeta(request, currentMeta))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(
+                    "Requested to change the routing column to routing_col_update, but routing columns cannot be changed");
     }
 
 }

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
@@ -48,7 +49,6 @@ import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 
@@ -169,21 +169,17 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(info.getDynamic(columnIdent, false, true)).isNull();
 
         // forWrite: true, errorOnUnknownObjectKey: true, parentPolicy: strict
-        Asserts.assertThrowsMatches(
-            () -> info.getDynamic(columnIdent, true, true),
-            ColumnUnknownException.class,
-            "Column foobar['foo']['bar'] unknown"
-        );
+        Assertions.assertThatThrownBy(() -> info.getDynamic(columnIdent, true, true))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("Column foobar['foo']['bar'] unknown");
 
         // forWrite: false, errorOnUnknownObjectKey: false, parentPolicy: strict
         assertThat(info.getDynamic(columnIdent, false, false)).isNull();
 
         // forWrite: true, errorOnUnknownObjectKey: false, parentPolicy: strict
-        Asserts.assertThrowsMatches(
-            () -> assertThat(info.getDynamic(columnIdent, true, false)).isNull(),
-            ColumnUnknownException.class,
-            "Column foobar['foo']['bar'] unknown"
-        );
+        Assertions.assertThatThrownBy(() -> assertThat(info.getDynamic(columnIdent, true, false)).isNull())
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("Column foobar['foo']['bar'] unknown");
 
         final ColumnIdent columnIdent2 = new ColumnIdent("foobar", Collections.singletonList("foo"));
         assertThat(info.getReference(columnIdent2)).isNull();
@@ -192,21 +188,17 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(info.getDynamic(columnIdent2, false, true)).isNull();
 
         // forWrite: true, errorOnUnknownObjectKey: true, parentPolicy: strict
-        Asserts.assertThrowsMatches(
-            () -> assertThat(info.getDynamic(columnIdent2, true, true)).isNull(),
-            ColumnUnknownException.class,
-            "Column foobar['foo'] unknown"
-        );
+        Assertions.assertThatThrownBy(() -> assertThat(info.getDynamic(columnIdent2, true, true)).isNull())
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("Column foobar['foo'] unknown");
 
         // forWrite: false, errorOnUnknownObjectKey: false, parentPolicy: strict
         assertThat(info.getDynamic(columnIdent2, false, false)).isNull();
 
         // forWrite: true, errorOnUnknownObjectKey: false, parentPolicy: strict
-        Asserts.assertThrowsMatches(
-            () -> assertThat(info.getDynamic(columnIdent2, true, false)).isNull(),
-            ColumnUnknownException.class,
-            "Column foobar['foo'] unknown"
-        );
+        Assertions.assertThatThrownBy(() -> assertThat(info.getDynamic(columnIdent2, true, false)).isNull())
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("Column foobar['foo'] unknown");
 
         Reference colInfo = info.getReference(new ColumnIdent("foobar"));
         assertThat(colInfo).isNotNull();

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -22,7 +22,6 @@
 package io.crate.planner;
 
 import static io.crate.testing.Asserts.assertThat;
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
 
 import java.io.IOException;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -99,10 +99,8 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_delete_where_id_and_seq_missing_primary_term() throws Exception {
-        assertThrowsMatches(
-            () -> e.plan("delete from users where id = 1 and _seq_no = 11"),
-            VersioningValidationException.class,
-            VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG
-        );
+        Assertions.assertThatThrownBy(() -> e.plan("delete from users where id = 1 and _seq_no = 11"))
+            .isExactlyInstanceOf(VersioningValidationException.class)
+            .hasMessageContaining(VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG);
     }
 }

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.Randomness;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +50,6 @@ import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.tree.Assignment;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 
 public class PlannerTest extends CrateDummyClusterServiceUnitTest {
@@ -113,18 +113,14 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_invalid_any_param_leads_to_clear_error_message() throws Exception {
         LogicalPlan plan = e.logicalPlan("select name = ANY(?) from sys.cluster");
-        Asserts.assertThrowsMatches(
-            () -> {
-                LogicalPlanner.getNodeOperationTree(
-                    plan,
-                    mock(DependencyCarrier.class),
-                    e.getPlannerContext(clusterService.state()),
-                    new Row1("foo"),
-                    SubQueryResults.EMPTY
-                );
-            },
-            ConversionException.class,
-            "Cannot cast value `foo` to type `text_array`"
-        );
+        Assertions.assertThatThrownBy(() -> LogicalPlanner.getNodeOperationTree(
+                plan,
+                mock(DependencyCarrier.class),
+                e.getPlannerContext(clusterService.state()),
+                new Row1("foo"),
+                SubQueryResults.EMPTY
+            ))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessageContaining("Cannot cast value `foo` to type `text_array`");
     }
 }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -22,7 +22,6 @@
 package io.crate.planner;
 
 import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1381,11 +1380,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
 
-        assertThrowsMatches(
-            () -> e.plan("select id from users where id = 1 and _seq_no = 11"),
-            VersioningValidationException.class,
-            VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG
-        );
+        assertThatThrownBy(() -> e.plan("select id from users where id = 1 and _seq_no = 11"))
+            .isExactlyInstanceOf(VersioningValidationException.class)
+            .hasMessageContaining(VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG);
     }
 
     @Test
@@ -1394,11 +1391,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
 
-        assertThrowsMatches(
-            () -> e.plan("select id from users where _seq_no = 11 and _primary_term = 1"),
-            VersioningValidationException.class,
-            VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG
-        );
+        assertThatThrownBy(() -> e.plan("select id from users where _seq_no = 11 and _primary_term = 1"))
+            .isExactlyInstanceOf(VersioningValidationException.class)
+            .hasMessageContaining(VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG);
     }
 
 

--- a/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
@@ -22,7 +22,6 @@
 package io.crate.planner.node.ddl;
 
 import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -30,6 +29,7 @@ import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,11 +65,9 @@ public class AlterTablePlanTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_alter_forbidden_settings_on_a_replicated_table() throws IOException {
-        assertThrowsMatches(
-            () -> analyze("Alter table doc.test set(number_of_shards = 1)"),
-            IllegalArgumentException.class,
-            "Invalid property \"number_of_shards\" passed to [ALTER | CREATE] TABLE statement"
-        );
+        Assertions.assertThatThrownBy(() -> analyze("Alter table doc.test set(number_of_shards = 1)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid property \"number_of_shards\" passed to [ALTER | CREATE] TABLE statement");
     }
 
     private BoundAlterTable analyze(String stmt) {

--- a/server/src/test/java/io/crate/protocols/postgres/types/DateTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/DateTypeTest.java
@@ -21,13 +21,13 @@
 
 package io.crate.protocols.postgres.types;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.time.format.DateTimeParseException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.netty.buffer.ByteBuf;
@@ -64,8 +64,9 @@ public class DateTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testDecodeUTF8TextWithUnexpectedFormat() {
-        assertThrowsMatches(() -> DateType.INSTANCE.decodeUTF8Text("2016.06.28".getBytes(UTF_8)),
-            DateTimeParseException.class, "");
+        Assertions.assertThatThrownBy(() -> DateType.INSTANCE.decodeUTF8Text("2016.06.28".getBytes(UTF_8)))
+            .isExactlyInstanceOf(DateTimeParseException.class)
+            .hasMessageContaining("");
     }
 
     @Test

--- a/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
@@ -21,11 +21,11 @@
 
 package io.crate.replication.logical.analyze;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Setting;
@@ -102,12 +102,11 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
         var e = SQLExecutor.builder(clusterService).addTable(
                 "create table doc.t1 (x int) with (\"soft_deletes.enabled\" = false)")
             .build();
-        assertThrowsMatches(
-            () -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1"),
-            UnsupportedOperationException.class,
-            "Tables included in a publication must have the table setting 'soft_deletes.enabled' " +
-            "set to `true`, current setting for table 'doc.t1': false"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining(
+                    "Tables included in a publication must have the table setting 'soft_deletes.enabled' " +
+                    "set to `true`, current setting for table 'doc.t1': false");
     }
 
     @Test
@@ -133,16 +132,14 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             .setUser(User.of("owner"))
             .addPublication("pub1", true)
             .build();
-        assertThrowsMatches(
-            () -> e.analyzer.analyze(
-                SqlParser.createStatement("DROP PUBLICATION pub1"),
-                new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY,
-                e.cursors
-            ),
-            UnauthorizedException.class,
-            "A publication can only be dropped by the owner or a superuser"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
+                        SqlParser.createStatement("DROP PUBLICATION pub1"),
+                        new CoordinatorSessionSettings(User.of("other_user")),
+                        ParamTypeHints.EMPTY,
+                        e.cursors
+            ))
+            .isExactlyInstanceOf(UnauthorizedException.class)
+            .hasMessageContaining("A publication can only be dropped by the owner or a superuser");
     }
 
     @Test
@@ -172,11 +169,10 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             .addTable("create table doc.t1 (x int)")
             .addPublication("pub1", true)
             .build();
-        assertThrowsMatches(
-            () -> e.analyze("ALTER PUBLICATION pub1 ADD TABLE doc.t1"),
-            InvalidArgumentException.class,
-            "Publication 'pub1' is defined as FOR ALL TABLES, adding or dropping tables is not supported"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyze("ALTER PUBLICATION pub1 ADD TABLE doc.t1"))
+            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .hasMessageContaining(
+                    "Publication 'pub1' is defined as FOR ALL TABLES, adding or dropping tables is not supported");
     }
 
     @Test
@@ -185,16 +181,14 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             .setUser(User.of("owner"))
             .addPublication("pub1", false, new RelationName("doc", "t1"))
             .build();
-        assertThrowsMatches(
-            () -> e.analyzer.analyze(
-                SqlParser.createStatement("ALTER PUBLICATION pub1 ADD TABLE doc.t2"),
-                new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY,
-                e.cursors
-            ),
-            UnauthorizedException.class,
-            "A publication can only be altered by the owner or a superuser"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
+                        SqlParser.createStatement("ALTER PUBLICATION pub1 ADD TABLE doc.t2"),
+                        new CoordinatorSessionSettings(User.of("other_user")),
+                        ParamTypeHints.EMPTY,
+                        e.cursors
+            ))
+            .isExactlyInstanceOf(UnauthorizedException.class)
+            .hasMessageContaining("A publication can only be altered by the owner or a superuser");
     }
 
     @Test
@@ -231,16 +225,14 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             .setUser(User.of("owner"))
             .addSubscription("sub1", "pub1")
             .build();
-        assertThrowsMatches(
-            () -> e.analyzer.analyze(
-                SqlParser.createStatement("DROP SUBSCRIPTION sub1"),
-                new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY,
-                e.cursors
-            ),
-            UnauthorizedException.class,
-            "A subscription can only be dropped by the owner or a superuser"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
+                        SqlParser.createStatement("DROP SUBSCRIPTION sub1"),
+                        new CoordinatorSessionSettings(User.of("other_user")),
+                        ParamTypeHints.EMPTY,
+                        e.cursors
+            ))
+            .isExactlyInstanceOf(UnauthorizedException.class)
+            .hasMessageContaining("A subscription can only be dropped by the owner or a superuser");
     }
 
     @Test
@@ -249,16 +241,14 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             .setUser(User.of("owner"))
             .addSubscription("sub1", "pub1")
             .build();
-        assertThrowsMatches(
-            () -> e.analyzer.analyze(
-                SqlParser.createStatement("ALTER SUBSCRIPTION sub1 DISABLE"),
-                new CoordinatorSessionSettings(User.of("other_user")),
-                ParamTypeHints.EMPTY,
-                e.cursors
-            ),
-            UnauthorizedException.class,
-            "A subscription can only be altered by the owner or a superuser"
-        );
+        Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
+                        SqlParser.createStatement("ALTER SUBSCRIPTION sub1 DISABLE"),
+                        new CoordinatorSessionSettings(User.of("other_user")),
+                        ParamTypeHints.EMPTY,
+                        e.cursors
+            ))
+            .isExactlyInstanceOf(UnauthorizedException.class)
+            .hasMessageContaining("A subscription can only be altered by the owner or a superuser");
     }
 
     @Test

--- a/server/src/test/java/io/crate/replication/logical/engine/SubscriberEngineTest.java
+++ b/server/src/test/java/io/crate/replication/logical/engine/SubscriberEngineTest.java
@@ -21,10 +21,10 @@
 
 package io.crate.replication.logical.engine;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.elasticsearch.index.engine.EngineTestCase.newUid;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;
@@ -39,11 +39,9 @@ public class SubscriberEngineTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_operation_validation_with_unassigned_seqno_raises_exception() {
         var op = new Engine.Index(newUid("0"), 0, InternalEngineTests.createParsedDoc("0"));
-        assertThrowsMatches(
-            () -> SubscriberEngine.validate(op),
-            UnsupportedFeatureException.class,
-            "A subscriber engine does not accept operations without an assigned sequence number"
-        );
+        Assertions.assertThatThrownBy(() -> SubscriberEngine.validate(op))
+            .isExactlyInstanceOf(UnsupportedFeatureException.class)
+            .hasMessageContaining("A subscriber engine does not accept operations without an assigned sequence number");
     }
 
     @Test
@@ -60,10 +58,8 @@ public class SubscriberEngineTest extends CrateDummyClusterServiceUnitTest {
                                   false,
                                   UNASSIGNED_SEQ_NO,
                                   0);
-        assertThrowsMatches(
-            () -> SubscriberEngine.validate(op),
-            IllegalStateException.class,
-            "Invalid version_type in a subscriber engine; version_type=INTERNAL origin=PRIMARY"
-        );
+        Assertions.assertThatThrownBy(() -> SubscriberEngine.validate(op))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Invalid version_type in a subscriber engine; version_type=INTERNAL origin=PRIMARY");
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
@@ -21,11 +21,11 @@
 
 package io.crate.replication.logical.metadata;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
@@ -36,20 +36,16 @@ public class ConnectionInfoTest extends ESTestCase {
 
     @Test
     public void test_url_has_valid_prefix() {
-        assertThrowsMatches(
-            () -> ConnectionInfo.fromURL("postgres:"),
-            InvalidArgumentException.class,
-            "The connection string must start with \"crate://\" but was: \"postgres:\""
-        );
+        Assertions.assertThatThrownBy(() -> ConnectionInfo.fromURL("postgres:"))
+            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .hasMessageContaining("The connection string must start with \"crate://\" but was: \"postgres:\"");
     }
 
     @Test
     public void test_url_is_not_empty() {
-        assertThrowsMatches(
-            () -> ConnectionInfo.fromURL(""),
-            InvalidArgumentException.class,
-            "The connection string must start with \"crate://\" but was: \"\""
-        );
+        Assertions.assertThatThrownBy(() -> ConnectionInfo.fromURL(""))
+            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .hasMessageContaining("The connection string must start with \"crate://\" but was: \"\"");
     }
 
     @Test
@@ -129,25 +125,19 @@ public class ConnectionInfoTest extends ESTestCase {
 
     @Test
     public void test_invalid_argument() {
-        assertThrowsMatches(
-            () -> ConnectionInfo.fromURL("crate://?foo=bar"),
-            InvalidArgumentException.class,
-            "Connection string argument 'foo' is not supported"
-        );
+        Assertions.assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://?foo=bar"))
+            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .hasMessageContaining("Connection string argument 'foo' is not supported");
     }
 
     @Test
     public void test_setting_invalid_mode_raises_error_including_valid_options() {
-        assertThrowsMatches(
-            () -> ConnectionInfo.fromURL("crate://example.com?mode=foo"),
-            IllegalArgumentException.class,
-            "Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`"
-        );
+        Assertions.assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://example.com?mode=foo"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`");
 
-        assertThrowsMatches(
-            () -> ConnectionInfo.fromURL("crate://example.com:5432?mode=foo"),
-            IllegalArgumentException.class,
-            "Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`"
-        );
+        Assertions.assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://example.com:5432?mode=foo"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`");
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/plan/CreateSubscriptionPlanTest.java
+++ b/server/src/test/java/io/crate/replication/logical/plan/CreateSubscriptionPlanTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.replication.logical.plan;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
-
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.exceptions.InvalidArgumentException;
@@ -35,15 +34,13 @@ public class CreateSubscriptionPlanTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void test_create_subscription_plan_checks_subscribing_user() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService).build();
-        assertThrowsMatches(
-            () -> {
-                CreateSubscriptionPlan plan = e.plan("CREATE SUBSCRIPTION sub CONNECTION 'crate://example.com' publication pub1");
-                PlannerContext plannerContext = e.getPlannerContext(clusterService.state());
-                plan.executeOrFail(null, plannerContext, null, null, null);
-            },
-            InvalidArgumentException.class,
-            "Setting 'user' must be provided on CREATE SUBSCRIPTION"
-        );
+        Assertions.assertThatThrownBy(() -> {
+            CreateSubscriptionPlan plan = e.plan("CREATE SUBSCRIPTION sub CONNECTION 'crate://example.com' publication pub1");
+            PlannerContext plannerContext = e.getPlannerContext(clusterService.state());
+            plan.executeOrFail(null, plannerContext, null, null, null);
+        })
+            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .hasMessageContaining("Setting 'user' must be provided on CREATE SUBSCRIPTION");
     }
 
 }

--- a/server/src/test/java/io/crate/types/BitStringTypeTest.java
+++ b/server/src/test/java/io/crate/types/BitStringTypeTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.function.Supplier;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
@@ -34,7 +35,6 @@ import org.junit.Test;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
-import io.crate.testing.Asserts;
 import io.crate.testing.DataTypeTesting;
 
 public class BitStringTypeTest extends ESTestCase {
@@ -56,11 +56,9 @@ public class BitStringTypeTest extends ESTestCase {
     @Test
     public void test_value_for_insert_only_allows_exact_length_matches() throws Exception {
         BitStringType type = new BitStringType(3);
-        Asserts.assertThrowsMatches(
-            () -> type.valueForInsert(BitString.ofRawBits("00010001")),
-            IllegalArgumentException.class,
-            "bit string length 8 does not match type bit(3)"
-        );
+        Assertions.assertThatThrownBy(() -> type.valueForInsert(BitString.ofRawBits("00010001")))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("bit string length 8 does not match type bit(3)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/DateTypeTest.java
+++ b/server/src/test/java/io/crate/types/DateTypeTest.java
@@ -21,18 +21,18 @@
 
 package io.crate.types;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class DateTypeTest {
 
     @Test
     public void testCastFromInvalidString() {
-        assertThrowsMatches(() -> DateType.INSTANCE.implicitCast("not-a-number"),
-            ClassCastException.class,
-            "Can't cast 'not-a-number' to date");
+        Assertions.assertThatThrownBy(() -> DateType.INSTANCE.implicitCast("not-a-number"))
+            .isExactlyInstanceOf(ClassCastException.class)
+            .hasMessageContaining("Can't cast 'not-a-number' to date");
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/RegclassTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegclassTypeTest.java
@@ -25,13 +25,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import io.crate.exceptions.InvalidRelationName;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
-import io.crate.testing.Asserts;
 
 public class RegclassTypeTest {
 
@@ -43,11 +43,9 @@ public class RegclassTypeTest {
 
     @Test
     public void test_cannot_cast_long_outside_int_range_to_regclass() {
-        Asserts.assertThrowsMatches(
-            () -> RegclassType.INSTANCE.implicitCast(Integer.MAX_VALUE + 42L),
-            IllegalArgumentException.class,
-            "2147483689 is outside of `int` range and cannot be cast to the regclass type"
-        );
+        Assertions.assertThatThrownBy(() -> RegclassType.INSTANCE.implicitCast(Integer.MAX_VALUE + 42L))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("2147483689 is outside of `int` range and cannot be cast to the regclass type");
     }
 
     @Test
@@ -84,10 +82,8 @@ public class RegclassTypeTest {
 
     @Test
     public void test_cast_from_string_raise_exception_if_not_valid_relation_name() {
-        Asserts.assertThrowsMatches(
-            () -> explicitCast("\"\"myTable\"\""),
-            InvalidRelationName.class,
-            "Relation name \"\"\"myTable\"\"\" is invalid"
-        );
+        Assertions.assertThatThrownBy(() -> explicitCast("\"\"myTable\"\""))
+            .isExactlyInstanceOf(InvalidRelationName.class)
+            .hasMessageContaining("Relation name \"\"\"myTable\"\"\" is invalid");
     }
 }

--- a/server/src/test/java/io/crate/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegprocTypeTest.java
@@ -28,13 +28,13 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.metadata.pgcatalog.OidHash;
-import io.crate.testing.Asserts;
 
 public class RegprocTypeTest extends ESTestCase {
 
@@ -107,10 +107,8 @@ public class RegprocTypeTest extends ESTestCase {
 
     @Test
     public void test_cannot_cast_long_outside_int_range_to_regproc() {
-        Asserts.assertThrowsMatches(
-            () -> RegprocType.INSTANCE.implicitCast(Integer.MAX_VALUE + 2038L),
-            IllegalArgumentException.class,
-            "2147485685 is outside of `int` range and cannot be cast to the regproc type"
-        );
+        Assertions.assertThatThrownBy(() -> RegprocType.INSTANCE.implicitCast(Integer.MAX_VALUE + 2038L))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("2147485685 is outside of `int` range and cannot be cast to the regproc type");
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.stream.BytesStream;
@@ -30,7 +31,6 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.EOFException;
 import java.io.IOException;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompressibleBytesOutputStreamTests extends ESTestCase {
@@ -100,11 +100,9 @@ public class CompressibleBytesOutputStreamTests extends ESTestCase {
         StreamInput streamInput =
                 new InputStreamStreamInput(CompressorFactory.COMPRESSOR.threadLocalInputStream(bStream.bytes().streamInput()));
         byte[] actualBytes = new byte[expectedBytes.length];
-        assertThrowsMatches(
-            () -> streamInput.readBytes(actualBytes, 0, expectedBytes.length),
-            EOFException.class,
-            "Unexpected end of ZLIB input stream"
-        );
+        Assertions.assertThatThrownBy(() -> streamInput.readBytes(actualBytes, 0, expectedBytes.length))
+            .isExactlyInstanceOf(EOFException.class)
+            .hasMessageContaining("Unexpected end of ZLIB input stream");
         stream.close();
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClustersTest.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClustersTest.java
@@ -21,7 +21,6 @@
 
 package org.elasticsearch.transport;
 
-import static io.crate.testing.Asserts.assertThrowsMatches;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -96,7 +96,9 @@ public class RemoteClustersTest extends CrateDummyClusterServiceUnitTest {
 
         // Check that failed client is not cached so that later can re-create a subscription with the same name but with valid credentials.
         // https://github.com/crate/crate/issues/12462
-        assertThrowsMatches(() -> remoteClusters.getClient(subName), NoSuchRemoteClusterException.class, "no such remote cluster: [" + subName + "]");
+        Assertions.assertThatThrownBy(() -> remoteClusters.getClient(subName))
+            .isExactlyInstanceOf(NoSuchRemoteClusterException.class)
+            .hasMessageContaining("no such remote cluster: [" + subName + "]");
 
         remoteClusters.close();
     }

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -21,9 +21,6 @@
 
 package io.crate.testing;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
-
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -33,7 +30,6 @@ import org.assertj.core.api.Condition;
 import org.assertj.core.data.Offset;
 import org.elasticsearch.common.settings.Settings;
 import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.function.Executable;
 
 import io.crate.analyze.OrderBy;
@@ -261,20 +257,4 @@ public class Asserts extends Assertions {
         }
     }
 
-    public static void assertThrowsMatches(Executable executable, Class<? extends Throwable> type, String msgSubString) {
-        assertThrowsMatches(executable, type, msgSubString,"Expected exception to be thrown, but nothing was thrown.");
-    }
-
-    public static void assertThrowsMatches(Executable executable,
-                                           Class<? extends Throwable> type,
-                                           String msgSubString,
-                                           String assertionFailMsg) {
-        try {
-            executable.execute();
-            fail(assertionFailMsg);
-        } catch (Throwable t) {
-            MatcherAssert.assertThat(t, instanceOf(type));
-            MatcherAssert.assertThat(t.getMessage(), containsString(msgSubString));
-        }
-    }
 }

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.data.Offset;
 import org.elasticsearch.common.settings.Settings;
 import org.hamcrest.Matcher;
@@ -74,6 +75,10 @@ public class Asserts extends Assertions {
 
     public static SQLResponseAssert assertThat(SQLResponse actual) {
         return new SQLResponseAssert(actual);
+    }
+
+    public static SQLErrorAssert assertSQLError(ThrowingCallable callable) {
+        return new SQLErrorAssert(catchThrowable(callable));
     }
 
     public static DocKeyAssert assertThat(DocKeys.DocKey actual) {
@@ -247,7 +252,11 @@ public class Asserts extends Assertions {
         return scalar -> s -> assertThat(s).isNotSameAs(scalar);
     }
 
-    // Exceptions
+
+    /**
+     * @deprecated use {@link #assertSQLError(ThrowingCallable)} or {@link #assertThatThrownBy(ThrowingCallable)}
+     **/
+    @Deprecated
     public static void assertThrowsMatches(Executable executable, Matcher<? super Throwable> matcher) {
         try {
             executable.execute();
@@ -256,5 +265,4 @@ public class Asserts extends Assertions {
             org.hamcrest.MatcherAssert.assertThat(t, matcher);
         }
     }
-
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLErrorAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLErrorAssert.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
+
+import io.crate.protocols.postgres.PGErrorStatus;
+import io.crate.rest.action.HttpError;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+public final class SQLErrorAssert extends AbstractThrowableAssert<SQLErrorAssert, Throwable> {
+
+    public SQLErrorAssert(Throwable actual) {
+        super(actual, SQLErrorAssert.class);
+        hasBeenThrown();
+    }
+
+    public SQLErrorAssert hasPGError(PGErrorStatus expectedError) {
+        if (actual instanceof PSQLException e) {
+            ServerErrorMessage serverErrorMessage = e.getServerErrorMessage();
+            String sqlState = serverErrorMessage.getSQLState();
+            for (var status : PGErrorStatus.values()) {
+                if (status.code().equals(sqlState)) {
+                    assertThat(status).isEqualTo(expectedError);
+                }
+            }
+            failure("Expected to find error code for: " + sqlState);
+        }
+        return this;
+    }
+
+    public SQLErrorAssert hasHTTPError(HttpResponseStatus httpResponseCode, int errorCode) {
+        if (actual instanceof PSQLException) {
+            return this;
+        }
+        HttpError httpError = HttpError.fromThrowable(actual);
+        assertThat(httpError.errorCode())
+            .as("Expected an exception with errorCode "
+                + errorCode
+                + " but "
+                + actual.getClass().getSimpleName()
+                + " has a different code"
+            )
+            .isEqualTo(errorCode);
+        assertThat(httpError.httpResponseStatus()).isEqualTo(httpResponseCode);
+        return this;
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/SQLErrorMatcher.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLErrorMatcher.java
@@ -39,6 +39,10 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
 public class SQLErrorMatcher {
 
+    /**
+     * @deprecated Use {@link Asserts#assertSQLError(org.assertj.core.api.ThrowableAssert.ThrowingCallable)} or {@link Asserts#assertThatThrownBy(org.assertj.core.api.ThrowableAssert.ThrowingCallable)}
+     */
+    @Deprecated
     public static <T extends Throwable> Matcher<T> isSQLError(Matcher<String> msg,
                                                               PGErrorStatus pgErrorStatus,
                                                               HttpResponseStatus httpResponseStatus,
@@ -76,6 +80,10 @@ public class SQLErrorMatcher {
         };
     }
 
+    /**
+     * @deprecated Use {@link Asserts#assertSQLError(org.assertj.core.api.ThrowableAssert.ThrowingCallable)} or {@link Asserts#assertThatThrownBy(org.assertj.core.api.ThrowableAssert.ThrowingCallable)}
+     */
+    @Deprecated
     public static <T extends Throwable> Matcher<T> isPGError(Matcher<String> msg, PGErrorStatus pgErrorStatus) {
         return allOf(
             instanceOf(PSQLException.class),
@@ -84,6 +92,10 @@ public class SQLErrorMatcher {
         );
     }
 
+    /**
+     * @deprecated Use {@link Asserts#assertSQLError(org.assertj.core.api.ThrowableAssert.ThrowingCallable)} or {@link Asserts#assertThatThrownBy(org.assertj.core.api.ThrowableAssert.ThrowingCallable)}
+     */
+    @Deprecated
     public static <T extends Throwable> Matcher<T> isHttpError(Matcher<String> msg,
                                                                HttpResponseStatus httpResponseStatus,
                                                                int errorCode) {


### PR DESCRIPTION
See commits

Only adapts a single test to use `SQLErrorAssert`, we can change them as we go.
This was motivated by some test failures in another branch where I didn't see the stacktrace of the actual exception.