### PR TITLE
Run RemoveRedundantFetchOrEval rule again after column pruning

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -153,7 +153,10 @@ public class LogicalPlanner {
         this.fetchOptimizer = new Optimizer(
             nodeCtx,
             minNodeVersionInCluster,
-            List.of(new RewriteToQueryThenFetch())
+            List.of(
+                new RemoveRedundantFetchOrEval(),
+                new RewriteToQueryThenFetch()
+            )
         );
         this.writeOptimizer = new Optimizer(
             nodeCtx,

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -1306,13 +1306,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String expectedPlan =
             "HashJoin[(a = b)]\n" +
             "  ├ Rename[a] AS v1\n" +
-            "  │  └ Eval[a]\n" +
-            "  │    └ Rename[a] AS a1\n" +
-            "  │      └ Collect[doc.t1 | [a] | true]\n" +
+            "  │  └ Rename[a] AS a1\n" +
+            "  │    └ Collect[doc.t1 | [a] | true]\n" +
             "  └ Rename[b] AS v2\n" +
-            "    └ Eval[b]\n" +
-            "      └ Rename[b] AS a2\n" +
-            "        └ Collect[doc.t2 | [b] | true]";
+            "    └ Rename[b] AS a2\n" +
+            "      └ Collect[doc.t2 | [b] | true]";
         assertThat(plan, isPlan(expectedPlan));
     }
 
@@ -1333,13 +1331,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String expectedPlan =
             "NestedLoopJoin[INNER | (a > b)]\n" +
             "  ├ Rename[a] AS v1\n" +
-            "  │  └ Eval[a]\n" +
-            "  │    └ Rename[a] AS a1\n" +
-            "  │      └ Collect[doc.t1 | [a] | true]\n" +
+            "  │  └ Rename[a] AS a1\n" +
+            "  │    └ Collect[doc.t1 | [a] | true]\n" +
             "  └ Rename[b] AS v2\n" +
-            "    └ Eval[b]\n" +
-            "      └ Rename[b] AS a2\n" +
-            "        └ Collect[doc.t2 | [b] | true]";
+            "    └ Rename[b] AS a2\n" +
+            "      └ Collect[doc.t2 | [b] | true]";
         assertThat(plan, isPlan(expectedPlan));
     }
 

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -151,13 +151,12 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
                       " order by x";
         var logicalPlan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Eval[x]\n" +
-            "  └ Rename[x] AS o\n" +
-            "    └ Union[x]\n" +
-            "      ├ OrderBy[1 AS x ASC]\n" +
-            "      │  └ Collect[doc.users | [1 AS x] | true]\n" +
-            "      └ OrderBy[2 ASC]\n" +
-            "        └ Collect[doc.users | [2] | true]";
+            "Rename[x] AS o\n" +
+            "  └ Union[x]\n" +
+            "    ├ OrderBy[1 AS x ASC]\n" +
+            "    │  └ Collect[doc.users | [1 AS x] | true]\n" +
+            "    └ OrderBy[2 ASC]\n" +
+            "      └ Collect[doc.users | [2] | true]";
         assertThat(logicalPlan, is(LogicalPlannerTest.isPlan(expectedPlan)));
     }
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -39,8 +39,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.analyze.TableDefinitions;
-import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.LimitDistinctProjection;
+import io.crate.execution.dsl.projection.Projection;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
@@ -421,11 +421,10 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void test_unused_table_function_in_subquery_is_not_pruned() {
         LogicalPlan plan = plan("select name from (select name, unnest(counters), text from users) u");
         assertThat(plan, isPlan(
-            "Eval[name]\n" +
-            "  └ Rename[name] AS u\n" +
-            "    └ Eval[name]\n" +
-            "      └ ProjectSet[unnest(counters), name]\n" +
-            "        └ Collect[doc.users | [counters, name] | true]"
+            "Rename[name] AS u\n" +
+            "  └ Eval[name]\n" +
+            "    └ ProjectSet[unnest(counters), name]\n" +
+            "      └ Collect[doc.users | [counters, name] | true]"
         ));
     }
 

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -82,9 +82,8 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             isPlan(
                 "Union[name]\n" +
                 "  ├ Rename[name] AS a\n" +
-                "  │  └ Eval[name]\n" +
-                "  │    └ OrderBy[name ASC]\n" +
-                "  │      └ Collect[doc.users | [name] | true]\n" +
+                "  │  └ OrderBy[name ASC]\n" +
+                "  │    └ Collect[doc.users | [name] | true]\n" +
                 "  └ OrderBy[text ASC]\n" +
                 "    └ Collect[doc.users | [text] | true]"));
     }
@@ -230,9 +229,8 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             plan,
             LogicalPlannerTest.isPlan(
-                "Eval[name]\n" +
-                "  └ Rename[name] AS t\n" +
-                "    └ Collect[sys.nodes | [name] | (id = 'nodeName')]"
+                "Rename[name] AS t\n" +
+                "  └ Collect[sys.nodes | [name] | (id = 'nodeName')]"
             )
         );
     }

--- a/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
@@ -89,10 +89,8 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
     public void test_window_agg_is_removed_if_unused_in_upper_select() {
         var plan = plan("select x from (select x, ROW_NUMBER() OVER (PARTITION BY y) from t1) t");
         var expectedPlan =
-            "Eval[x]\n" +
-                "  └ Rename[x] AS t\n" +
-                "    └ Eval[x]\n" +
-                "      └ Collect[doc.t1 | [x] | true]";
+            "Rename[x] AS t\n" +
+            "  └ Collect[doc.t1 | [x] | true]";
         assertThat(plan, isPlan(expectedPlan));
     }
 


### PR DESCRIPTION
The rule can often remove operators after pruning unused columns
