### PR TITLE
Ensure left-right relations order in joinPairsByRelations key

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/join/JoinOperations.java
+++ b/server/src/main/java/io/crate/execution/engine/join/JoinOperations.java
@@ -39,9 +39,9 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,7 +108,8 @@ public final class JoinOperations {
             if (joinPair.condition() == null) {
                 continue;
             }
-            JoinPair prevPair = joinPairsMap.put(new HashSet<>(List.of(joinPair.left(), joinPair.right())), joinPair);
+            // Left/right sides of a join pair have to be consistent with the key set, we ensure that left side is always first in the set.
+            JoinPair prevPair = joinPairsMap.put(new LinkedHashSet<>(List.of(joinPair.left(), joinPair.right())), joinPair);
             if (prevPair != null) {
                 throw new IllegalStateException("joinPairs contains duplicate: " + joinPair + " matches " + prevPair);
             }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -26,9 +26,9 @@ import static io.crate.planner.operators.EquiJoinDetector.isHashJoinPossible;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +97,7 @@ public class JoinPlanBuilder {
 
         final RelationName lhsName = it.next();
         final RelationName rhsName = it.next();
-        Set<RelationName> joinNames = new HashSet<>();
+        Set<RelationName> joinNames = new LinkedHashSet<>();
         joinNames.add(lhsName);
         joinNames.add(rhsName);
 
@@ -289,6 +289,6 @@ public class JoinPlanBuilder {
         }
         return new CorrelatedSubQueries(correlatedSubQueries, remainder);
     }
-    
+
     private record CorrelatedSubQueries(List<Symbol> correlatedSubQueries, List<Symbol> remainder) {}
 }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1168,14 +1168,13 @@ public class JoinIntegrationTest extends IntegTestCase {
         // ensure that the query is using the execution plan we want to test
         // This should prevent from the test case becoming invalid
         assertThat(printedTable(response.rows()), is(
-            "Eval[id, a, id, b, id, c, id, d]\n" +
-            "  └ NestedLoopJoin[LEFT | (id = id)]\n" +
-            "    ├ HashJoin[(id = id)]\n" +
-            "    │  ├ HashJoin[(id = id)]\n" +
-            "    │  │  ├ Get[doc.t2 | id, b | DocKeys{1; 2} | ((id = 1) OR (id = 2))]\n" +
-            "    │  │  └ Collect[doc.t1 | [id, a] | true]\n" +
-            "    │  └ Collect[doc.t3 | [id, c] | true]\n" +
-            "    └ Collect[doc.t4 | [id, d] | true]\n"
+            "NestedLoopJoin[LEFT | (id = id)]\n" +
+                "  ├ HashJoin[(id = id)]\n" +
+                "  │  ├ HashJoin[(id = id)]\n" +
+                "  │  │  ├ Collect[doc.t1 | [id, a] | true]\n" +
+                "  │  │  └ Get[doc.t2 | id, b | DocKeys{1; 2} | ((id = 1) OR (id = 2))]\n" +
+                "  │  └ Collect[doc.t3 | [id, c] | true]\n" +
+                "  └ Collect[doc.t4 | [id, d] | true]\n"
         ));
         execute(stmt);
     }
@@ -1214,12 +1213,11 @@ public class JoinIntegrationTest extends IntegTestCase {
         // ensure that the query is using the execution plan we want to test
         // This should prevent from the test case becoming invalid
         assertThat(printedTable(response.rows()), is(
-            "Eval[id, a, id, b, id, c]\n" +
-            "  └ NestedLoopJoin[INNER | (id = id)]\n" +
-            "    ├ NestedLoopJoin[INNER | (id = id)]\n" +
-            "    │  ├ Get[doc.t2 | id, b | DocKeys{1} | (id = 1)]\n" +
-            "    │  └ Collect[doc.t1 | [id, a] | true]\n" +
-            "    └ Get[doc.t3 | id, c | DocKeys{1} | (id = 1)]\n"));
+            "NestedLoopJoin[INNER | (id = id)]\n" +
+                "  ├ NestedLoopJoin[INNER | (id = id)]\n" +
+                "  │  ├ Collect[doc.t1 | [id, a] | true]\n" +
+                "  │  └ Get[doc.t2 | id, b | DocKeys{1} | (id = 1)]\n" +
+                "  └ Get[doc.t3 | id, c | DocKeys{1} | (id = 1)]\n"));
         execute(stmt);
     }
 

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -107,16 +107,15 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = plan("select t1.a, t2.b, t3.a from t1 " +
                                 "inner join t2 on t1.a = t2.b " +
                                 "inner join t1 as t3 on t3.a = t2.b " +
-                                "order by t2.b");
+                                "order by t1.a");
         assertThat(plan, isPlan(
-            "Eval[a, b, a]\n" +
-            "  └ NestedLoopJoin[INNER | (a = b)]\n" +
-            "    ├ NestedLoopJoin[INNER | (a = b)]\n" +
-            "    │  ├ OrderBy[b ASC]\n" +
-            "    │  │  └ Collect[doc.t2 | [b] | true]\n" +
-            "    │  └ Collect[doc.t1 | [a] | true]\n" +
-            "    └ Rename[a] AS t3\n" +
-            "      └ Collect[doc.t1 | [a] | true]"));
+                "NestedLoopJoin[INNER | (a = b)]\n" +
+                "  ├ NestedLoopJoin[INNER | (a = b)]\n" +
+                "  │  ├ OrderBy[a ASC]\n" +
+                "  │  │  └ Collect[doc.t1 | [a] | true]\n" +
+                "  │  └ Collect[doc.t2 | [b] | true]\n" +
+                "  └ Rename[a] AS t3\n" +
+                "    └ Collect[doc.t1 | [a] | true]"));
     }
 
     @Test
@@ -177,14 +176,13 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                 "left join t1 as t3 on t3.a = t1.a " +
                                 "order by t1.a");
         assertThat(plan, isPlan(
-            "Eval[a, b, a]\n" +
-            "  └ OrderBy[a ASC]\n" +
-            "    └ NestedLoopJoin[LEFT | (a = a)]\n" +
-            "      ├ NestedLoopJoin[INNER | (a = b)]\n" +
-            "      │  ├ Collect[doc.t2 | [b] | true]\n" +
-            "      │  └ Collect[doc.t1 | [a] | true]\n" +
-            "      └ Rename[a] AS t3\n" +
-            "        └ Collect[doc.t1 | [a] | true]"));
+            "OrderBy[a ASC]\n" +
+                "  └ NestedLoopJoin[LEFT | (a = a)]\n" +
+                "    ├ NestedLoopJoin[INNER | (a = b)]\n" +
+                "    │  ├ Collect[doc.t1 | [a] | true]\n" +
+                "    │  └ Collect[doc.t2 | [b] | true]\n" +
+                "    └ Rename[a] AS t3\n" +
+                "      └ Collect[doc.t1 | [a] | true]"));
     }
 
     @Test


### PR DESCRIPTION
Pre-requisite for https://github.com/crate/crate/pull/13577, which accidentally revealed that we can have inconsistent internal state:

`JoinPair` can be (t1,t2) but stored in a map with key (t2,t1) due to usage of regular `HashSet`. So far couldn't find a failing scenario, but there is a working query with unnnessary LEFT->RIGHT switch + extra `Eval` operator because of swapped
 outputs.