### PR TITLE
Remove uneeded topMostLeftRelation in nestedloop-join

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -192,7 +192,6 @@ public class JoinPlanBuilder {
                 joinType,
                 joinCondition,
                 !query.symbolType().isValueSymbol(),
-                lhs,
                 false);
         }
     }
@@ -289,6 +288,6 @@ public class JoinPlanBuilder {
         }
         return new CorrelatedSubQueries(correlatedSubQueries, remainder);
     }
-    
+
     private record CorrelatedSubQueries(List<Symbol> correlatedSubQueries, List<Symbol> remainder) {}
 }

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -37,7 +37,6 @@ import javax.annotation.Nullable;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
-import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Maps;
@@ -68,7 +67,6 @@ public class NestedLoopJoin implements LogicalPlan {
 
     @Nullable
     private final Symbol joinCondition;
-    private final AnalyzedRelation topMostLeftRelation;
     private final JoinType joinType;
     private final boolean isFiltered;
     final LogicalPlan lhs;
@@ -84,7 +82,6 @@ public class NestedLoopJoin implements LogicalPlan {
                    JoinType joinType,
                    @Nullable Symbol joinCondition,
                    boolean isFiltered,
-                   AnalyzedRelation topMostLeftRelation,
                    boolean joinConditionOptimised) {
         this.joinType = joinType;
         this.isFiltered = isFiltered || joinCondition != null;
@@ -95,7 +92,6 @@ public class NestedLoopJoin implements LogicalPlan {
         } else {
             this.outputs = Lists2.concat(lhs.outputs(), rhs.outputs());
         }
-        this.topMostLeftRelation = topMostLeftRelation;
         this.joinCondition = joinCondition;
         this.dependencies = Maps.concat(lhs.dependencies(), rhs.dependencies());
         this.joinConditionOptimised = joinConditionOptimised;
@@ -106,11 +102,10 @@ public class NestedLoopJoin implements LogicalPlan {
                           JoinType joinType,
                           @Nullable Symbol joinCondition,
                           boolean isFiltered,
-                          AnalyzedRelation topMostLeftRelation,
                           boolean orderByWasPushedDown,
                           boolean rewriteFilterOnOuterJoinToInnerJoinDone,
                           boolean joinConditionOptimised) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation, joinConditionOptimised);
+        this(lhs, rhs, joinType, joinCondition, isFiltered, joinConditionOptimised);
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
     }
@@ -138,10 +133,6 @@ public class NestedLoopJoin implements LogicalPlan {
 
     public boolean isFiltered() {
         return true;
-    }
-
-    public AnalyzedRelation topMostLeftRelation() {
-        return topMostLeftRelation;
     }
 
     public JoinType joinType() {
@@ -279,7 +270,6 @@ public class NestedLoopJoin implements LogicalPlan {
             joinType,
             joinCondition,
             isFiltered,
-            topMostLeftRelation,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
             joinConditionOptimised
@@ -309,7 +299,6 @@ public class NestedLoopJoin implements LogicalPlan {
             joinType,
             joinCondition,
             isFiltered,
-            topMostLeftRelation,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
             joinConditionOptimised
@@ -345,7 +334,6 @@ public class NestedLoopJoin implements LogicalPlan {
                 joinType,
                 joinCondition,
                 isFiltered,
-                topMostLeftRelation,
                 orderByWasPushedDown,
                 rewriteFilterOnOuterJoinToInnerJoinDone,
                 joinConditionOptimised

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -52,12 +52,14 @@ public class GroupReference implements LogicalPlan {
 
     private final int groupId;
     private final List<Symbol> outputs;
+    private final Set<RelationName> relationNames;
     private static final String ERROR_MESSAGE =
         "Operation is not supported in GroupReference, it needs to be resolved to it's referenced LogicalPlan";
 
-    public GroupReference(int groupId, List<Symbol> outputs) {
+    public GroupReference(int groupId, List<Symbol> outputs, Set<RelationName> relationNames) {
         this.groupId = groupId;
         this.outputs = List.copyOf(outputs);
+        this.relationNames = Set.copyOf(relationNames);
     }
 
     public int groupId() {
@@ -102,7 +104,7 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public Set<RelationName> getRelationNames() {
-        return Set.of();
+        return relationNames;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
@@ -186,7 +186,8 @@ public class Memo {
             node.sources().stream()
                 .map(child -> new GroupReference(
                     insertRecursive(child),
-                    child.outputs()))
+                    child.outputs(),
+                    child.getRelationNames()))
                 .collect(Collectors.toList()));
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -87,7 +87,6 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 nl.joinType(),
                 nl.joinCondition(),
                 nl.isFiltered(),
-                nl.topMostLeftRelation(),
                 nl.orderByWasPushedDown(),
                 nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                 true // Mark joinConditionOptimised = true

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -96,16 +96,15 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
         }
         if (relationsInOrderBy.size() == 1) {
             RelationName relationInOrderBy = relationsInOrderBy.iterator().next();
-            if (relationInOrderBy == nestedLoop.topMostLeftRelation().relationName()) {
-                LogicalPlan lhs = nestedLoop.sources().get(0);
-                LogicalPlan newLhs = order.replaceSources(List.of(lhs));
+            var lhs = resolvePlan.apply(nestedLoop.lhs());
+            if (lhs.getRelationNames().contains(relationInOrderBy)) {
+                LogicalPlan newLhs = order.replaceSources(List.of(nestedLoop.lhs()));
                 return new NestedLoopJoin(
                     newLhs,
                     nestedLoop.sources().get(1),
                     nestedLoop.joinType(),
                     nestedLoop.joinCondition(),
                     nestedLoop.isFiltered(),
-                    nestedLoop.topMostLeftRelation(),
                     true,
                     nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                     false

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -257,7 +257,6 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             newJoinIsInnerJoin ? JoinType.INNER : nl.joinType(),
             nl.joinCondition(),
             nl.isFiltered(),
-            nl.topMostLeftRelation(),
             nl.orderByWasPushedDown(),
             true,
             false

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -99,7 +99,6 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
                                                 JoinType.INNER,
                                                 e.asSymbol("x = y"),
                                                 false,
-                                                t1Relation,
                                                 false);
         assertThat(nestedLoopJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -330,7 +330,7 @@ public class MemoTest {
 
         @Override
         public Set<RelationName> getRelationNames() {
-            return null;
+            return Set.of();
         }
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
+
 import org.junit.Test;
 
 import io.crate.analyze.WhereClause;
@@ -81,7 +83,7 @@ public class PatternTest {
     @Test
     public void test_with_match_group_referenced_source() {
         var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
-        var groupReferenceSource = new GroupReference(1, source.outputs());
+        var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 
         var memo = new HashMap<Integer, LogicalPlan>();
@@ -107,7 +109,7 @@ public class PatternTest {
     @Test
     public void test_with_property_match_group_referenced_source() {
         var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
-        var groupReferenceSource = new GroupReference(1, source.outputs());
+        var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 
         var memo = new HashMap<Integer, LogicalPlan>();

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -73,7 +73,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false);
+        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, false, false, false);
         var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
         Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`topMostLeftRelation` in `NestedLoopJoin` is only used in one place and can be replaced with `getRelationNames`.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
