### PR TITLE
 Add assertj assertions for Logical plans 

### DIFF
--- a/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.planner;
 
-import static io.crate.planner.operators.LogicalPlannerTest.printPlan;
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
@@ -37,7 +36,8 @@ public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest 
     public void test_correlated_subquery_without_using_alias_can_use_outer_column_in_where_clause() {
         SQLExecutor e = SQLExecutor.builder(clusterService).build();
         String statement = "SELECT (SELECT mountain) FROM sys.summits ORDER BY 1 ASC LIMIT 5";
-        assertThat(printPlan(e.logicalPlan(statement))).isEqualTo(
+        LogicalPlan result = e.logicalPlan(statement);
+        assertThat(result).isEqualTo(
             "Eval[(SELECT mountain FROM (empty_row))]\n" +
             "  └ Limit[5::bigint;0]\n" +
             "    └ OrderBy[(SELECT mountain FROM (empty_row)) ASC]\n" +
@@ -55,7 +55,7 @@ public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest 
         SQLExecutor e = SQLExecutor.builder(clusterService).build();
         String statement = "SELECT 'Mountain-' || (SELECT t.mountain) FROM sys.summits t";
         LogicalPlan logicalPlan = e.logicalPlan(statement);
-        assertThat(printPlan(logicalPlan)).isEqualTo(
+        assertThat(logicalPlan).isEqualTo(
             "Eval[concat('Mountain-', (SELECT mountain FROM (empty_row)))]\n" +
             "  └ CorrelatedJoin[mountain, (SELECT mountain FROM (empty_row))]\n" +
             "    └ Rename[mountain] AS t\n" +

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -41,6 +41,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Scalar;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Node;
@@ -94,6 +95,10 @@ public class Asserts extends Assertions {
 
     public static SQLAssert<Expression> assertThat(Expression actual) {
         return new SQLAssert<>(actual);
+    }
+
+    public static LogicalPlanAssert assertThat(LogicalPlan actual) {
+        return new LogicalPlanAssert(actual);
     }
 
     // generic helper methods

--- a/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.assertj.core.api.AbstractAssert;
+
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.PrintContext;
+
+public class LogicalPlanAssert extends AbstractAssert<LogicalPlanAssert, LogicalPlan> {
+
+    protected LogicalPlanAssert(LogicalPlan actual) {
+        super(actual, LogicalPlanAssert.class);
+    }
+
+    private static String printPlan(LogicalPlan logicalPlan) {
+        var printContext = new PrintContext();
+        logicalPlan.print(printContext);
+        return printContext.toString();
+    }
+
+    public LogicalPlanAssert isEqualTo(String expectedPlan) {
+        isNotNull();
+        assertThat(expectedPlan).isNotNull();
+        assertThat(printPlan(actual)).isEqualTo(expectedPlan);
+        return this;
+    }
+
+    public LogicalPlanAssert isEqualTo(LogicalPlan expectedPlan) {
+        isNotNull();
+        assertThat(expectedPlan).isNotNull();
+        assertThat(printPlan(actual)).isEqualTo(printPlan(expectedPlan));
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds assertj assertions for logical plans which provide a nice direct string diff. This makes life easier when working with Logical Plans in tests. It also uses the new assertions in `CorrelatedJoinPlannerTest` to make sure they work. 


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
