### PR TITLE
Avoid calls to unsupported methods in Group References

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.node.dql.join.JoinType;
+
+public interface JoinPlan extends LogicalPlan {
+
+    LogicalPlan lhs();
+
+    LogicalPlan rhs();
+
+    Set<RelationName> lhsRelationNames();
+
+    Set<RelationName> rhsRelationNames();
+
+    JoinType joinType();
+
+    @Nullable
+    Symbol joinCondition();
+
+}

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -183,12 +183,16 @@ public class JoinPlanBuilder {
             return new HashJoin(
                 lhsPlan,
                 rhsPlan,
+                lhsPlan.getRelationNames(),
+                rhsPlan.getRelationNames(),
                 joinCondition
             );
         } else {
             return new NestedLoopJoin(
                 lhsPlan,
                 rhsPlan,
+                lhsPlan.getRelationNames(),
+                rhsPlan.getRelationNames(),
                 joinType,
                 joinCondition,
                 !query.symbolType().isValueSymbol(),

--- a/server/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/server/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -21,8 +21,6 @@
 
 package io.crate.planner.operators;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,6 +29,7 @@ import javax.annotation.Nullable;
 
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists2;
+import io.crate.common.collections.Maps;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
@@ -57,9 +56,7 @@ public class MultiPhase extends ForwardingLogicalPlan {
 
     private MultiPhase(LogicalPlan source, Map<LogicalPlan, SelectSymbol> subQueries) {
         super(source);
-        HashMap<LogicalPlan, SelectSymbol> allSubQueries = new HashMap<>(source.dependencies());
-        allSubQueries.putAll(subQueries);
-        this.subQueries = Collections.unmodifiableMap(allSubQueries);
+        this.subQueries = subQueries;
     }
 
     @Override
@@ -84,7 +81,7 @@ public class MultiPhase extends ForwardingLogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return subQueries;
+        return Maps.concat(source.dependencies(), subQueries);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -74,7 +74,6 @@ public class NestedLoopJoin implements LogicalPlan {
     final LogicalPlan lhs;
     final LogicalPlan rhs;
     private final List<Symbol> outputs;
-    private final Map<LogicalPlan, SelectSymbol> dependencies;
     private boolean orderByWasPushedDown = false;
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
     private final boolean joinConditionOptimised;
@@ -97,7 +96,6 @@ public class NestedLoopJoin implements LogicalPlan {
         }
         this.topMostLeftRelation = topMostLeftRelation;
         this.joinCondition = joinCondition;
-        this.dependencies = Maps.concat(lhs.dependencies(), rhs.dependencies());
         this.joinConditionOptimised = joinConditionOptimised;
     }
 
@@ -155,7 +153,7 @@ public class NestedLoopJoin implements LogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return dependencies;
+        return Maps.concat(lhs.dependencies(), rhs.dependencies());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -73,14 +73,11 @@ public class Union implements LogicalPlan {
     private final List<Symbol> outputs;
     final LogicalPlan lhs;
     final LogicalPlan rhs;
-    private final Map<LogicalPlan, SelectSymbol> dependencies;
-
 
     public Union(LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.outputs = outputs;
-        this.dependencies = Maps.concat(lhs.dependencies(), rhs.dependencies());
     }
 
     @Override
@@ -234,7 +231,7 @@ public class Union implements LogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return dependencies;
+        return Maps.concat(lhs.dependencies(), rhs.dependencies());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -81,13 +81,12 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Map.of();
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override
     public long numExpectedRows() {
         throw new UnsupportedOperationException(ERROR_MESSAGE);
-
     }
 
     @Override
@@ -102,7 +101,7 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public Set<RelationName> getRelationNames() {
-        return Set.of();
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -28,11 +28,13 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.iterative.GroupReferenceResolver;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 final class FilterOnJoinsUtil {
 
@@ -43,7 +45,7 @@ final class FilterOnJoinsUtil {
         return splitQuery == null ? source : new Filter(source, splitQuery);
     }
 
-    static LogicalPlan moveQueryBelowJoin(Symbol query, LogicalPlan join) {
+    static LogicalPlan moveQueryBelowJoin(Symbol query, LogicalPlan join, Function<LogicalPlan, LogicalPlan> resolvePlan) {
         if (!WhereClause.canMatch(query)) {
             return join.replaceSources(List.of(
                 getNewSource(query, join.sources().get(0)),
@@ -56,8 +58,11 @@ final class FilterOnJoinsUtil {
             return null;
         }
         assert join.sources().size() == 2 : "Join operator must only have 2 children, LHS and RHS";
-        LogicalPlan lhs = join.sources().get(0);
-        LogicalPlan rhs = join.sources().get(1);
+        // getRelationNames will do recursive calls down the operator tree,
+        // thus group references need to be fully resolved
+        GroupReferenceResolver resolver = new GroupReferenceResolver(resolvePlan);
+        LogicalPlan lhs = resolver.resolveFully(join.sources().get(0));
+        LogicalPlan rhs = resolver.resolveFully(join.sources().get(1));
         Set<RelationName> leftName = lhs.getRelationNames();
         Set<RelationName> rightName = rhs.getRelationNames();
         Symbol queryForLhs = splitQuery.remove(leftName);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -62,6 +62,6 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         HashJoin hashJoin = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), hashJoin, resolvePlan);
+        return moveQueryBelowJoin(filter.query(), hashJoin);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathHashJoin.java
@@ -21,10 +21,14 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.common.collections.Lists2;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.moveQueryBelowJoin;
+
+import java.util.function.Function;
+
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
@@ -32,12 +36,7 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.moveQueryBelowJoin;
-
-import java.util.function.Function;
+import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
 
@@ -63,6 +62,6 @@ public final class MoveFilterBeneathHashJoin implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         HashJoin hashJoin = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), hashJoin.replaceSources(Lists2.map(hashJoin.sources(), resolvePlan)));
+        return moveQueryBelowJoin(filter.query(), hashJoin, resolvePlan);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.common.collections.Lists2;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.TableStats;
@@ -69,6 +68,6 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         NestedLoopJoin join = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(), join.replaceSources(Lists2.map(join.sources(), resolvePlan)));
+        return moveQueryBelowJoin(filter.query(),join, resolvePlan);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathNestedLoop.java
@@ -68,6 +68,6 @@ public final class MoveFilterBeneathNestedLoop implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         NestedLoopJoin join = captures.get(joinCapture);
-        return moveQueryBelowJoin(filter.query(),join, resolvePlan);
+        return moveQueryBelowJoin(filter.query(),join);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -101,7 +101,9 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                 LogicalPlan newLhs = order.replaceSources(List.of(lhs));
                 return new NestedLoopJoin(
                     newLhs,
-                    nestedLoop.sources().get(1),
+                    nestedLoop.rhs(),
+                    nestedLoop.lhsRelationNames(),
+                    nestedLoop.rhsRelationNames(),
                     nestedLoop.joinType(),
                     nestedLoop.joinCondition(),
                     nestedLoop.isFiltered(),

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -87,7 +87,11 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
+        var hashJoin = new HashJoin(t1Rename,
+                                    t2Rename,
+                                    t1Rename.getRelationNames(),
+                                    t2Rename.getRelationNames(),
+                                    e.asSymbol("x = y"));
         assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }
@@ -96,6 +100,8 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
     public void test_relationnames_are_based_on_sources_in_nestedloopjoin() {
         var nestedLoopJoin = new NestedLoopJoin(t1Rename,
                                                 t2Rename,
+                                                t1Rename.getRelationNames(),
+                                                t2Rename.getRelationNames(),
                                                 JoinType.INNER,
                                                 e.asSymbol("x = y"),
                                                 false,

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -73,7 +73,17 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false);
+        NestedLoopJoin nl = new NestedLoopJoin(c1,
+                                               c2,
+                                               c1.getRelationNames(),
+                                               c2.getRelationNames(),
+                                               JoinType.INNER,
+                                               joinCondition,
+                                               false,
+                                               t1,
+                                               false,
+                                               false,
+                                               false);
         var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
         Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
 


### PR DESCRIPTION
This prevents calls to unsupported methods from Logical Plans
in Group References with the following steps:

- Add Exceptions to all unsupported methods in Group References.
- Make sure no ctor in all Logical Plans is calling one of the
  unsupported methods.
- Add a resolveFully method to GroupReferenceResolver to resolve
  Group References and it's children to support methods in Logical
  Plans that call across the operator tree. 

This makes sure all unsupported methods on Group References are never called,
but the methods are still working on all other Logical Plans by resolving all children.



Follow-up for https://github.com/crate/crate/commit/f5b2ab2787cd3dd224ed1e811a43c095a6c4ec52


## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
