### PR TITLE
Deprecate hamcrest based isPlan assertions

### DIFF
--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -522,6 +522,10 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         return printContext.toString();
     }
 
+    /**
+     * Deprecated use io.crate.testing.{@link io.crate.testing.Asserts} instead
+     */
+    @Deprecated()
     public static Matcher<LogicalPlan> isPlan(String expectedPlan) {
         return new FeatureMatcher<>(equalTo(expectedPlan), "same output", "output ") {
 
@@ -532,6 +536,10 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         };
     }
 
+    /**
+     * Deprecated use io.crate.testing.{@link io.crate.testing.Asserts} instead
+     */
+    @Deprecated()
     public static Matcher<LogicalPlan> isPlan(LogicalPlan expectedPlan) {
         return new FeatureMatcher<>(equalTo(printPlan(expectedPlan)), "same output", "output ") {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
