### PR TITLE
tests: Replace isPlan with Asserts.isEqualTo

### DIFF
--- a/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
@@ -21,12 +21,8 @@
 
 package io.crate.planner;
 
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,7 +41,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.node.dql.Collect;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 
@@ -62,90 +57,90 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testGroupByWithScalarPlan() throws Exception {
-        Merge merge = e.plan("select id + 1 from users group by id");
+        Merge merge = e.plan("SELECT id + 1 FROM users GROUP BY id");
         Collect collect = (Collect) merge.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
 
-        assertEquals(DataTypes.LONG, collectPhase.outputTypes().get(0));
-        assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.DOC));
-        assertThat(collectPhase.projections().size(), is(2));
-        assertThat(collectPhase.projections().get(0), instanceOf(GroupProjection.class));
-        assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
-        assertThat(collectPhase.projections().get(1), instanceOf(EvalProjection.class));
-        assertThat(collectPhase.projections().get(1).outputs().get(0), instanceOf(Function.class));
-        Asserts.assertThat(collectPhase.toCollect()).satisfiesExactly(isReference("id", DataTypes.LONG));
+        assertThat(collectPhase.outputTypes().get(0)).isEqualTo(DataTypes.LONG);
+        assertThat(collectPhase.maxRowGranularity()).isEqualTo(RowGranularity.DOC);
+        assertThat(collectPhase.projections()).hasSize(2);
+        assertThat(collectPhase.projections().get(0)).isExactlyInstanceOf(GroupProjection.class);
+        assertThat(collectPhase.projections().get(0).requiredGranularity()).isEqualTo(RowGranularity.SHARD);
+        assertThat(collectPhase.projections().get(1)).isExactlyInstanceOf(EvalProjection.class);
+        assertThat(collectPhase.projections().get(1).outputs().get(0)).isExactlyInstanceOf(Function.class);
+        assertThat(collectPhase.toCollect()).satisfiesExactly(isReference("id", DataTypes.LONG));
 
         GroupProjection groupProjection = (GroupProjection) collectPhase.projections().get(0);
-        assertThat(groupProjection.keys().get(0).valueType(), is(DataTypes.LONG));
+        assertThat(groupProjection.keys().get(0).valueType()).isEqualTo(DataTypes.LONG);
 
 
-        Asserts.assertThat(collectPhase.projections().get(1).outputs())
-            .satisfiesExactly(
-                s -> Asserts.assertThat(s).isFunction("add"));
+        assertThat(collectPhase.projections().get(1).outputs())
+            .satisfiesExactly(s -> assertThat(s).isFunction("add"));
 
         MergePhase mergePhase = merge.mergePhase();
-        assertEquals(DataTypes.LONG, mergePhase.inputTypes().iterator().next());
-        assertEquals(DataTypes.LONG, mergePhase.outputTypes().get(0));
+        assertThat(mergePhase.inputTypes().iterator().next()).isEqualTo(DataTypes.LONG);
+        assertThat(mergePhase.outputTypes().get(0)).isEqualTo(DataTypes.LONG);
     }
 
     @Test
     public void testGroupByWithMultipleScalarPlan() throws Exception {
-        Merge merge = e.plan("select abs(id + 1) from users group by id");
+        Merge merge = e.plan("SELECT abs(id + 1) FROM users GROUP BY id");
         Collect collect = (Collect) merge.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
 
-        assertEquals(DataTypes.LONG, collectPhase.outputTypes().get(0));
-        assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.DOC));
-        assertThat(collectPhase.projections().size(), is(2));
-        assertThat(collectPhase.projections().get(0), instanceOf(GroupProjection.class));
-        assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
-        assertThat(collectPhase.projections().get(1), instanceOf(EvalProjection.class));
-        Asserts.assertThat(collectPhase.projections().get(1).outputs().get(0)).isFunction("abs");
-        Asserts.assertThat(collectPhase.toCollect()).satisfiesExactly(isReference("id", DataTypes.LONG));
+        assertThat(collectPhase.outputTypes().get(0)).isEqualTo(DataTypes.LONG);
+        assertThat(collectPhase.maxRowGranularity()).isEqualTo(RowGranularity.DOC);
+        assertThat(collectPhase.projections()).hasSize(2);
+        assertThat(collectPhase.projections().get(0)).isExactlyInstanceOf(GroupProjection.class);
+        assertThat(collectPhase.projections().get(0).requiredGranularity()).isEqualTo(RowGranularity.SHARD);
+        assertThat(collectPhase.projections().get(1)).isExactlyInstanceOf(EvalProjection.class);
+        assertThat(collectPhase.projections().get(1).outputs().get(0)).isFunction("abs");
+        assertThat(collectPhase.toCollect()).satisfiesExactly(isReference("id", DataTypes.LONG));
 
         GroupProjection groupProjection = (GroupProjection) collectPhase.projections().get(0);
-        assertThat(groupProjection.keys().get(0).valueType(), is(DataTypes.LONG));
+        assertThat(groupProjection.keys().get(0).valueType()).isEqualTo(DataTypes.LONG);
 
         MergePhase mergePhase = merge.mergePhase();
 
-        assertEquals(DataTypes.LONG, mergePhase.inputTypes().iterator().next());
-        assertEquals(DataTypes.LONG, mergePhase.outputTypes().get(0));
+        assertThat(mergePhase.inputTypes().iterator().next()).isEqualTo(DataTypes.LONG);
+        assertThat(mergePhase.outputTypes().get(0)).isEqualTo(DataTypes.LONG);
     }
 
     @Test
     public void testGroupByScalarWithMultipleColumnArgumentsPlan() throws Exception {
-        Merge merge = e.plan("select abs(id + other_id) from users group by id, other_id");
+        Merge merge = e.plan("SELECT abs(id + other_id) FROM users GROUP BY id, other_id");
         Merge subplan = (Merge) merge.subPlan();
         Collect collect = (Collect) subplan.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
-        assertThat(collectPhase.projections().size(), is(1));
-        assertThat(collectPhase.projections().get(0), instanceOf(GroupProjection.class));
-        assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
-        Asserts.assertThat(collectPhase.toCollect()).satisfiesExactly(
+        assertThat(collectPhase.projections()).hasSize(1);
+        assertThat(collectPhase.projections().get(0)).isExactlyInstanceOf(GroupProjection.class);
+        assertThat(collectPhase.projections().get(0).requiredGranularity()).isEqualTo(RowGranularity.SHARD);
+        assertThat(collectPhase.toCollect()).satisfiesExactly(
             isReference("id", DataTypes.LONG), isReference("other_id", DataTypes.LONG));
 
         GroupProjection groupProjection = (GroupProjection) collectPhase.projections().get(0);
-        assertThat(groupProjection.keys().size(), is(2));
-        assertThat(groupProjection.keys().get(0).valueType(), is(DataTypes.LONG));
-        assertThat(groupProjection.keys().get(1).valueType(), is(DataTypes.LONG));
+        assertThat(groupProjection.keys()).hasSize(2);
+        assertThat(groupProjection.keys().get(0).valueType()).isEqualTo(DataTypes.LONG);
+        assertThat(groupProjection.keys().get(1).valueType()).isEqualTo(DataTypes.LONG);
 
         MergePhase mergePhase = subplan.mergePhase();
-        assertThat(mergePhase.projections().size(), is(2));
-        assertThat(mergePhase.projections().get(0), instanceOf(GroupProjection.class));
-        assertThat(mergePhase.projections().get(1), instanceOf(EvalProjection.class));
+        assertThat(mergePhase.projections()).hasSize(2);
+        assertThat(mergePhase.projections().get(0)).isExactlyInstanceOf(GroupProjection.class);
+        assertThat(mergePhase.projections().get(1)).isExactlyInstanceOf(EvalProjection.class);
 
-        Asserts.assertThat(mergePhase.projections().get(1).outputs())
-            .satisfiesExactly(
-                s -> Asserts.assertThat(s).isFunction("abs"));
+        assertThat(mergePhase.projections().get(1).outputs())
+            .satisfiesExactly(s -> assertThat(s).isFunction("abs"));
     }
 
     @Test
     public void test_group_by_scalar_containing_a_table_function_results_in_project_set() {
         var logicalPlan = e.logicalPlan("SELECT regexp_matches(name, '.*')[1] FROM users GROUP BY 1");
         var expectedPlan =
-            "GroupHashAggregate[regexp_matches(name, '.*')[1]]\n" +
-            "  └ ProjectSet[regexp_matches(name, '.*'), name]\n" +
-            "    └ Collect[doc.users | [name] | true]";
-        assertThat(logicalPlan, isPlan(expectedPlan));
+            """
+            GroupHashAggregate[regexp_matches(name, '.*')[1]]
+              └ ProjectSet[regexp_matches(name, '.*'), name]
+                └ Collect[doc.users | [name] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
     }
 }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -21,23 +21,11 @@
 
 package io.crate.planner;
 
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +33,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
@@ -96,7 +83,6 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 import io.crate.types.DataTypes;
@@ -117,8 +103,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         ExecutionPlan plan = e.plan("select * from users where id in (1, 2, 3) and match(text, 'Hello')");
-        assertThat(plan, instanceOf(Merge.class));
-        assertThat(((Merge) plan).subPlan(), instanceOf(Collect.class));
+        assertThat(plan).isExactlyInstanceOf(Merge.class);
+        assertThat(((Merge) plan).subPlan()).isExactlyInstanceOf(Collect.class);
     }
 
     @Test
@@ -128,8 +114,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select name from users where id = 1");
-        assertThat(plan, isPlan(
-            "Get[doc.users | name | DocKeys{1::bigint} | (id = 1::bigint)]"));
+        assertThat(plan).isEqualTo(
+            "Get[doc.users | name | DocKeys{1::bigint} | (id = 1::bigint)]");
     }
 
     @Test
@@ -139,8 +125,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select name from users where _id = 1");
-        assertThat(plan, isPlan(
-            "Get[doc.users | name | DocKeys{1} | (_cast(_id, 'integer') = 1)]"));
+        assertThat(plan).isEqualTo(
+            "Get[doc.users | name | DocKeys{1} | (_cast(_id, 'integer') = 1)]");
     }
 
     @Test
@@ -150,8 +136,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select name from users where id = 1 and _version = 1");
-        assertThat(plan, isPlan(
-            "Get[doc.users | name | DocKeys{1::bigint, 1::bigint} | ((id = 1::bigint) AND (_version = 1::bigint))]"));
+        assertThat(plan).isEqualTo(
+            "Get[doc.users | name | DocKeys{1::bigint, 1::bigint} | ((id = 1::bigint) AND (_version = 1::bigint))]");
     }
 
     @Test
@@ -165,9 +151,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select name from bystring where name = 'one'");
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "Get[doc.bystring | name | DocKeys{'one'} | (name = 'one')]"
-        ));
+        );
     }
 
     @Test
@@ -181,9 +167,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select name, date from parted_pks where id = 1 and date = 0");
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "Get[doc.parted_pks | name, date | DocKeys{1, 0::bigint} | ((id = 1) AND (date = 0::bigint))]"
-        ));
+        );
     }
 
     @Test
@@ -193,9 +179,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select name from users where id in (1, 2)");
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "Get[doc.users | name | DocKeys{1::bigint; 2::bigint} | (id = ANY([1::bigint, 2::bigint]))]"
-        ));
+        );
     }
 
     @Test
@@ -208,16 +194,16 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Collect collect = (Collect) globalAggregate.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
 
-        assertEquals(CountAggregation.LongStateType.INSTANCE, collectPhase.outputTypes().get(0));
-        assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.DOC));
-        assertThat(collectPhase.projections().size(), is(1));
-        assertThat(collectPhase.projections().get(0), instanceOf(AggregationProjection.class));
-        assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
+        assertThat(collectPhase.outputTypes().get(0)).isEqualTo(CountAggregation.LongStateType.INSTANCE);
+        assertThat(collectPhase.maxRowGranularity()).isEqualTo(RowGranularity.DOC);
+        assertThat(collectPhase.projections()).hasSize(1);
+        assertThat(collectPhase.projections().get(0)).isExactlyInstanceOf(AggregationProjection.class);
+        assertThat(collectPhase.projections().get(0).requiredGranularity()).isEqualTo(RowGranularity.SHARD);
 
         MergePhase mergePhase = globalAggregate.mergePhase();
 
-        assertEquals(CountAggregation.LongStateType.INSTANCE, mergePhase.inputTypes().iterator().next());
-        assertEquals(DataTypes.LONG, mergePhase.outputTypes().get(0));
+        assertThat(mergePhase.inputTypes().iterator().next()).isEqualTo(CountAggregation.LongStateType.INSTANCE);
+        assertThat(mergePhase.outputTypes().get(0)).isEqualTo(DataTypes.LONG);
     }
 
     @Test
@@ -231,15 +217,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Collect collect = (Collect) merge.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
 
-        assertEquals(DataTypes.INTEGER, collectPhase.outputTypes().get(0));
-        assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.SHARD));
+        assertThat(collectPhase.outputTypes().get(0)).isEqualTo(DataTypes.INTEGER);
+        assertThat(collectPhase.maxRowGranularity()).isEqualTo(RowGranularity.SHARD);
 
-        assertThat(collectPhase.orderBy(), notNullValue());
+        assertThat(collectPhase.orderBy()).isNotNull();
 
         List<Projection> projections = collectPhase.projections();
-        assertThat(projections, contains(
-            instanceOf(LimitAndOffsetProjection.class)
-        ));
+        assertThat(projections).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(LimitAndOffsetProjection.class));
     }
 
     @Test
@@ -251,14 +236,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         QueryThenFetch qtf = e.plan("select name from users where name = 'x' order by id limit 10");
         Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
-        assertThat(collectPhase.where().toString(), is("(name = 'x')"));
+        assertThat(collectPhase.where()).hasToString("(name = 'x')");
 
         LimitAndOffsetProjection limitAndOffsetProjection = (LimitAndOffsetProjection) collectPhase.projections().get(0);
-        assertThat(limitAndOffsetProjection.limit(), is(10));
+        assertThat(limitAndOffsetProjection.limit()).isEqualTo(10);
 
         MergePhase mergePhase = merge.mergePhase();
-        assertThat(mergePhase.outputTypes().size(), is(1));
-        assertEquals(DataTypes.STRING, mergePhase.outputTypes().get(0));
+        assertThat(mergePhase.outputTypes()).hasSize(1);
+        assertThat(mergePhase.outputTypes().get(0)).isEqualTo(DataTypes.STRING);
     }
 
     @Test
@@ -272,18 +257,18 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Merge merge = e.plan("select name from users where name = 'x' order by name limit 10");
         Collect collect = (Collect) merge.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
-        assertThat(collectPhase.where().toString(), is("(name = 'x')"));
+        assertThat(collectPhase.where().toString()).isEqualTo("(name = 'x')");
 
         MergePhase mergePhase = merge.mergePhase();
-        assertThat(mergePhase.outputTypes().size(), is(1));
-        assertEquals(DataTypes.STRING, mergePhase.outputTypes().get(0));
+        assertThat(mergePhase.outputTypes()).hasSize(1);
+        assertThat(mergePhase.outputTypes().get(0)).isEqualTo(DataTypes.STRING);
 
-        assertTrue(mergePhase.finalProjection().isPresent());
+        assertThat(mergePhase.finalProjection().isPresent()).isTrue();
 
         Projection lastProjection = mergePhase.finalProjection().get();
-        assertThat(lastProjection, instanceOf(LimitAndOffsetProjection.class));
+        assertThat(lastProjection).isExactlyInstanceOf(LimitAndOffsetProjection.class);
         LimitAndOffsetProjection limitAndOffsetProjection = (LimitAndOffsetProjection) lastProjection;
-        assertThat(limitAndOffsetProjection.outputs().size(), is(1));
+        assertThat(limitAndOffsetProjection.outputs()).hasSize(1);
     }
 
     @Test
@@ -295,26 +280,26 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         QueryThenFetch qtf = e.plan("select name from users limit 100000");
         Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
-        assertThat(collectPhase.nodePageSizeHint(), is(100_000));
+        assertThat(collectPhase.nodePageSizeHint()).isEqualTo(100_000);
 
         MergePhase mergePhase = merge.mergePhase();
-        assertThat(mergePhase.projections().size(), is(2));
+        assertThat(mergePhase.projections()).hasSize(2);
         LimitAndOffsetProjection projection = (LimitAndOffsetProjection) mergePhase.projections().get(0);
-        assertThat(projection.limit(), is(100_000));
-        assertThat(projection.offset(), is(0));
+        assertThat(projection.limit()).isEqualTo(100_000);
+        assertThat(projection.offset()).isEqualTo(0);
 
         // with offset
         qtf = e.plan("select name from users limit 100000 offset 20");
         merge = ((Merge) qtf.subPlan());
 
         collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
-        assertThat(collectPhase.nodePageSizeHint(), is(100_000 + 20));
+        assertThat(collectPhase.nodePageSizeHint()).isEqualTo(100_000 + 20);
 
         mergePhase = merge.mergePhase();
-        assertThat(mergePhase.projections().size(), is(2));
+        assertThat(mergePhase.projections()).hasSize(2);
         projection = (LimitAndOffsetProjection) mergePhase.projections().get(0);
-        assertThat(projection.limit(), is(100_000));
-        assertThat(projection.offset(), is(20));
+        assertThat(projection.limit()).isEqualTo(100_000);
+        assertThat(projection.offset()).isEqualTo(20);
     }
 
 
@@ -337,14 +322,17 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         for (Map.Entry<String, Map<String, IntIndexedContainer>> entry : locations.entrySet()) {
             indices.addAll(entry.getValue().keySet());
         }
-        assertThat(indices, Matchers.containsInAnyOrder(
-            new PartitionName(new RelationName("doc", "parted_pks"), Arrays.asList("1395874800000")).asIndexName(),
-            new PartitionName(new RelationName("doc", "parted_pks"), Arrays.asList("1395961200000")).asIndexName()));
+        assertThat(indices).satisfiesExactlyInAnyOrder(
+            i -> assertThat(i).isEqualTo(
+                new PartitionName(new RelationName("doc", "parted_pks"), List.of("1395874800000")).asIndexName()),
+            i -> assertThat(i).isEqualTo(
+                new PartitionName(new RelationName("doc", "parted_pks"), List.of("1395961200000")).asIndexName())
+        );
 
-        assertThat(collectPhase.where().toString(), is("(name = 'x')"));
+        assertThat(collectPhase.where().toString()).isEqualTo("(name = 'x')");
 
         MergePhase mergePhase = merge.mergePhase();
-        assertThat(mergePhase.outputTypes().size(), is(3));
+        assertThat(mergePhase.outputTypes()).hasSize(3);
     }
 
     @Test
@@ -357,12 +345,12 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
 
-        assertThat(collectPhase.where().toString(), is("(name = 'x')"));
+        assertThat(collectPhase.where()).hasToString("(name = 'x')");
 
         MergePhase mergePhase = merge.mergePhase();
-        assertThat(mergePhase.outputTypes().size(), is(2));
-        assertEquals(DataTypes.STRING, mergePhase.outputTypes().get(0));
-        assertEquals(DataTypes.STRING, mergePhase.outputTypes().get(1));
+        assertThat(mergePhase.outputTypes()).hasSize(2);
+        assertThat(mergePhase.outputTypes().get(0)).isEqualTo(DataTypes.STRING);
+        assertThat(mergePhase.outputTypes().get(1)).isEqualTo(DataTypes.STRING);
     }
 
     @Test
@@ -376,25 +364,25 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
         Projection projection = collectPhase.projections().get(0);
-        assertThat(projection, instanceOf(AggregationProjection.class));
+        assertThat(projection).isExactlyInstanceOf(AggregationProjection.class);
         AggregationProjection aggregationProjection = (AggregationProjection) projection;
-        assertThat(aggregationProjection.aggregations().size(), is(1));
-        assertThat(aggregationProjection.mode(), is(AggregateMode.ITER_PARTIAL));
+        assertThat(aggregationProjection.aggregations()).hasSize(1);
+        assertThat(aggregationProjection.mode()).isEqualTo(AggregateMode.ITER_PARTIAL);
 
         Aggregation aggregation = aggregationProjection.aggregations().get(0);
         Symbol aggregationInput = aggregation.inputs().get(0);
-        assertThat(aggregationInput.symbolType(), is(SymbolType.INPUT_COLUMN));
+        assertThat(aggregationInput.symbolType()).isEqualTo(SymbolType.INPUT_COLUMN);
 
-        assertThat(collectPhase.toCollect().get(0), instanceOf(Reference.class));
-        assertThat(((Reference) collectPhase.toCollect().get(0)).column().name(), is("name"));
+        assertThat(collectPhase.toCollect().get(0)).isInstanceOf(Reference.class);
+        assertThat(((Reference) collectPhase.toCollect().get(0)).column().name()).isEqualTo("name");
 
         MergePhase mergePhase = globalAggregate.mergePhase();
-        assertThat(mergePhase.projections().size(), is(2));
+        assertThat(mergePhase.projections()).hasSize(2);
         Projection projection1 = mergePhase.projections().get(1);
 
-        assertThat(projection1, instanceOf(EvalProjection.class));
+        assertThat(projection1).isExactlyInstanceOf(EvalProjection.class);
         Symbol collection_count = projection1.outputs().get(0);
-        assertThat(collection_count, instanceOf(Function.class));
+        assertThat(collection_count).isExactlyInstanceOf(Function.class);
     }
 
     @Test
@@ -407,27 +395,27 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "select avg(date) from users having min(date) > '1970-01-01'");
         Collect collect = (Collect) globalAggregate.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
-        assertThat(collectPhase.projections().size(), is(1));
-        assertThat(collectPhase.projections().get(0), instanceOf(AggregationProjection.class));
+        assertThat(collectPhase.projections()).hasSize(1);
+        assertThat(collectPhase.projections().get(0)).isExactlyInstanceOf(AggregationProjection.class);
 
         MergePhase localMergeNode = globalAggregate.mergePhase();
 
-        assertThat(localMergeNode.projections(), contains(
-            instanceOf(AggregationProjection.class),
-            instanceOf(FilterProjection.class),
-            instanceOf(EvalProjection.class)));
+        assertThat(localMergeNode.projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(AggregationProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(FilterProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
 
         AggregationProjection aggregationProjection = (AggregationProjection) localMergeNode.projections().get(0);
-        assertThat(aggregationProjection.aggregations().size(), is(2));
+        assertThat(aggregationProjection.aggregations()).hasSize(2);
 
         FilterProjection filterProjection = (FilterProjection) localMergeNode.projections().get(1);
-        assertThat(filterProjection.outputs().size(), is(2));
-        assertThat(filterProjection.outputs().get(0), instanceOf(InputColumn.class));
+        assertThat(filterProjection.outputs()).hasSize(2);
+        assertThat(filterProjection.outputs().get(0)).isExactlyInstanceOf(InputColumn.class);
         InputColumn inputColumn = (InputColumn) filterProjection.outputs().get(0);
-        assertThat(inputColumn.index(), is(0));
+        assertThat(inputColumn.index()).isEqualTo(0);
 
         EvalProjection evalProjection = (EvalProjection) localMergeNode.projections().get(2);
-        assertThat(evalProjection.outputs().size(), is(1));
+        assertThat(evalProjection.outputs()).hasSize(1);
     }
 
     @Test
@@ -450,11 +438,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(
             plan.countPhase().routing().locations().entrySet().stream()
                 .flatMap(x -> x.getValue().keySet().stream())
-                .collect(Collectors.toSet()),
-            Matchers.contains(
-                is(".partitioned.parted.04732cpp6ks3ed1o60o30c1g")
-            )
-        );
+                .collect(Collectors.toSet()))
+            .containsExactly(".partitioned.parted.04732cpp6ks3ed1o60o30c1g");
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -540,10 +525,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             routing.locations().values()
                 .stream()
                 .flatMap(shardsByIndex -> shardsByIndex.keySet().stream())
-                .collect(Collectors.toSet()),
-            contains(
-                is(".partitioned.parted.04732cpp6ksjcc9i60o30c1g")
-            ));
+                .collect(Collectors.toSet()))
+            .containsExactly(".partitioned.parted.04732cpp6ksjcc9i60o30c1g");
     }
 
     @Test
@@ -553,8 +536,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         Merge merge = e.plan("select min(name) from users having 1 = 2");
-        assertThat(merge.mergePhase().projections().get(1), instanceOf(FilterProjection.class));
-        Asserts.assertThat(((FilterProjection) merge.mergePhase().projections().get(1)).query()).isSQL("false");
+        assertThat(merge.mergePhase().projections().get(1)).isExactlyInstanceOf(FilterProjection.class);
+        assertThat(((FilterProjection) merge.mergePhase().projections().get(1)).query()).isSQL("false");
     }
 
     @Test
@@ -567,7 +550,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Collect collect = (Collect) merge.subPlan();
         int shardQueueSize = ((RoutedCollectPhase) collect.collectPhase()).shardQueueSize(
             collect.collectPhase().nodeIds().iterator().next());
-        assertThat(shardQueueSize, is(375));
+        assertThat(shardQueueSize).isEqualTo(375);
     }
 
     @Test
@@ -577,10 +560,10 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         Merge plan = e.plan("select name from users order by name limit 1000000");
-        assertThat(plan.mergePhase().nodeIds().size(), is(1)); // mergePhase with executionNode = paging enabled
+        assertThat(plan.mergePhase().nodeIds()).hasSize(1); // mergePhase with executionNode = paging enabled
 
         Collect collect = (Collect) plan.subPlan();
-        assertThat(((RoutedCollectPhase) collect.collectPhase()).nodePageSizeHint(), is(750000));
+        assertThat(((RoutedCollectPhase) collect.collectPhase()).nodePageSizeHint()).isEqualTo(750000);
     }
 
     @Test
@@ -591,8 +574,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         Merge merge = e.plan("select name from users order by name limit 10 offset 1000000");
         Collect collect = (Collect) merge.subPlan();
-        assertThat(merge.mergePhase().nodeIds().size(), is(1)); // mergePhase with executionNode = paging enabled
-        assertThat(((RoutedCollectPhase) collect.collectPhase()).nodePageSizeHint(), is(750007));
+        assertThat(merge.mergePhase().nodeIds()).hasSize(1); // mergePhase with executionNode = paging enabled
+        assertThat(((RoutedCollectPhase) collect.collectPhase()).nodePageSizeHint()).isEqualTo(750007);
     }
 
     @Test
@@ -604,8 +587,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         QueryThenFetch qtf = e.plan("select name, date from users order by name limit 1000000");
         Merge merge = (Merge) qtf.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((Collect) merge.subPlan()).collectPhase());
-        assertThat(merge.mergePhase().nodeIds().size(), is(1)); // mergePhase with executionNode = paging enabled
-        assertThat(collectPhase.nodePageSizeHint(), is(750000));
+        assertThat(merge.mergePhase().nodeIds()).hasSize(1); // mergePhase with executionNode = paging enabled
+        assertThat(collectPhase.nodePageSizeHint()).isEqualTo(750000);
     }
 
     @Test
@@ -614,8 +597,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         Collect collect = e.plan("select * from unnest([1, 2], ['Arthur', 'Trillian'])");
-        assertNotNull(collect);
-        Asserts.assertThat(collect.collectPhase().toCollect()).satisfiesExactly(isReference("col1"), isReference("col2"));
+        assertThat(collect).isNotNull();
+        assertThat(collect.collectPhase().toCollect()).satisfiesExactly(isReference("col1"), isReference("col2"));
     }
 
     @Test
@@ -628,15 +611,16 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                                  "  select i + i as ii, xx from (" +
                                  "    select i, sum(x) as xx from t1 group by i) as t) as tt " +
                                  "where (ii * 2) > 4 and (xx * 2) > 120");
-        assertThat("would require merge with more than 1 nodeIds", collect.nodeIds().size(), is(1));
+        assertThat(collect.nodeIds())
+            .as("would require merge with more than 1 nodeIds")
+            .hasSize(1);
         List<Projection> projections = collect.collectPhase().projections();
-        assertThat(projections, contains(
-            instanceOf(GroupProjection.class), // parallel on shard-level
-            instanceOf(GroupProjection.class), // node-level
-            instanceOf(EvalProjection.class),
-            instanceOf(FilterProjection.class),
-            instanceOf(EvalProjection.class)
-        ));
+        assertThat(projections).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(GroupProjection.class), // parallel on shard-level
+            p -> assertThat(p).isExactlyInstanceOf(GroupProjection.class), // node-level
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(FilterProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
     }
 
     @Test
@@ -663,16 +647,15 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                                     "  and u2.name = u1.name");
         Join innerNl = (Join) outerNl.left();
 
-        Asserts.assertThat(innerNl.joinPhase().joinCondition()).isSQL("((INPUT(0) = INPUT(2)) AND (INPUT(1) = INPUT(3)))");
-        assertThat(innerNl.joinPhase().projections().size(), is(1));
-        assertThat(innerNl.joinPhase().projections().get(0), instanceOf(EvalProjection.class));
+        assertThat(innerNl.joinPhase().joinCondition()).isSQL("((INPUT(0) = INPUT(2)) AND (INPUT(1) = INPUT(3)))");
+        assertThat(innerNl.joinPhase().projections()).hasSize(1);
+        assertThat(innerNl.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
 
-        assertThat(outerNl.joinPhase().joinCondition(), nullValue());
-        assertThat(outerNl.joinPhase().projections().size(), is(2));
-        assertThat(outerNl.joinPhase().projections(), contains(
-            instanceOf(EvalProjection.class),
-            instanceOf(EvalProjection.class)
-        ));
+        assertThat(outerNl.joinPhase().joinCondition()).isNull();
+        assertThat(outerNl.joinPhase().projections()).hasSize(2);
+        assertThat(outerNl.joinPhase().projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
     }
 
     @Test
@@ -692,9 +675,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                                     "where u2.name = 'Arthur'" +
                                     "and u2.id > 1 ");
         Join nl = (Join) merge.subPlan();
-        assertThat(nl.joinPhase().joinType(), is(JoinType.INNER));
+        assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.INNER);
         Collect rightCM = (Collect) nl.right();
-        Asserts.assertThat(((RoutedCollectPhase) rightCM.collectPhase()).where())
+        assertThat(((RoutedCollectPhase) rightCM.collectPhase()).where())
             .isSQL("((doc.users.name = 'Arthur') AND (doc.users.id > 1::bigint))");
     }
 
@@ -708,7 +691,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Merge merge = e.plan("select id from sys.shards");
         Collect collect = (Collect) merge.subPlan();
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
-        assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.SHARD));
+        assertThat(collectPhase.maxRowGranularity()).isEqualTo(RowGranularity.SHARD);
     }
 
     @Test
@@ -719,10 +702,10 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         CountPlan plan = e.plan("select count(*) from users");
 
-        assertThat(plan.countPhase().where(), equalTo(Literal.BOOLEAN_TRUE));
+        assertThat(plan.countPhase().where()).isEqualTo(Literal.BOOLEAN_TRUE);
 
-        assertThat(plan.mergePhase().projections().size(), is(1));
-        assertThat(plan.mergePhase().projections().get(0), instanceOf(MergeCountProjection.class));
+        assertThat(plan.mergePhase().projections()).hasSize(1);
+        assertThat(plan.mergePhase().projections().get(0)).isExactlyInstanceOf(MergeCountProjection.class);
     }
 
     @Test
@@ -733,12 +716,12 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         QueryThenFetch qtf = e.plan("select * from users limit 2147483647 ");
         Merge merge = (Merge) qtf.subPlan();
-        assertThat(merge.mergePhase().nodeIds().size(), is(1));
+        assertThat(merge.mergePhase().nodeIds()).hasSize(1);
         String localNodeId = merge.mergePhase().nodeIds().iterator().next();
         NodeOperationTree operationTree = NodeOperationTreeGenerator.fromPlan(merge, localNodeId);
         NodeOperation nodeOperation = operationTree.nodeOperations().iterator().next();
         // paging -> must not use direct response
-        assertThat(nodeOperation.downstreamNodes(), not(contains(ExecutionPhase.DIRECT_RESPONSE)));
+        assertThat(nodeOperation.downstreamNodes()).doesNotContain(ExecutionPhase.DIRECT_RESPONSE);
 
 
         qtf = e.plan("select * from users limit 2");
@@ -747,7 +730,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         operationTree = NodeOperationTreeGenerator.fromPlan(merge, localNodeId);
         nodeOperation = operationTree.nodeOperations().iterator().next();
         // no paging -> can use direct response
-        assertThat(nodeOperation.downstreamNodes(), contains(ExecutionPhase.DIRECT_RESPONSE));
+        assertThat(nodeOperation.downstreamNodes()).containsExactly(ExecutionPhase.DIRECT_RESPONSE);
     }
 
     @Test
@@ -764,14 +747,12 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Merge merge = e.plan("select sum(profit) from gc_table");
         Collect collect = (Collect) merge.subPlan();
         List<Projection> projections = collect.collectPhase().projections();
-        assertThat(projections, contains(
-            instanceOf(AggregationProjection.class) // iter-partial on shard level
-        ));
-        assertThat(
-            merge.mergePhase().projections(),
-            contains(instanceOf(AggregationProjection.class))
+        assertThat(projections).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(AggregationProjection.class) // iter-partial on shard level
         );
-        Asserts.assertThat(((AggregationProjection)projections.get(0)).aggregations().get(0).inputs().get(0))
+        assertThat(merge.mergePhase().projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(AggregationProjection.class));
+        assertThat(((AggregationProjection)projections.get(0)).aggregations().get(0).inputs().get(0))
             .isSQL("INPUT(0)");
     }
 
@@ -783,40 +764,40 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         Merge plan = e.plan("select count(*) from users t1, users t2, users t3 " +
                             "where t1.id = t2.id and t2.id = t3.id");
-        assertThat(plan.subPlan(), instanceOf(Join.class));
+        assertThat(plan.subPlan()).isExactlyInstanceOf(Join.class);
         Join outerNL = (Join)plan.subPlan();
-        Asserts.assertThat(outerNL.joinPhase().joinCondition()).isSQL("(INPUT(1) = INPUT(2))");
-        assertThat(outerNL.joinPhase().projections().size(), is(2));
-        assertThat(outerNL.joinPhase().projections().get(0), instanceOf(EvalProjection.class));
-        assertThat(outerNL.joinPhase().projections().get(1), instanceOf(AggregationProjection.class));
-        assertThat(outerNL.joinPhase().outputTypes().size(), is(1));
-        assertThat(outerNL.joinPhase().outputTypes().get(0), is(CountAggregation.LongStateType.INSTANCE));
+        assertThat(outerNL.joinPhase().joinCondition()).isSQL("(INPUT(1) = INPUT(2))");
+        assertThat(outerNL.joinPhase().projections()).hasSize(2);
+        assertThat(outerNL.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
+        assertThat(outerNL.joinPhase().projections().get(1)).isExactlyInstanceOf(AggregationProjection.class);
+        assertThat(outerNL.joinPhase().outputTypes()).hasSize(1);
+        assertThat(outerNL.joinPhase().outputTypes().get(0)).isEqualTo(CountAggregation.LongStateType.INSTANCE);
 
         Join innerNL = (Join) outerNL.left();
-        Asserts.assertThat(innerNL.joinPhase().joinCondition()).isSQL("(INPUT(0) = INPUT(1))");
-        assertThat(innerNL.joinPhase().projections().size(), is(1));
-        assertThat(innerNL.joinPhase().projections().get(0), instanceOf(EvalProjection.class));
-        assertThat(innerNL.joinPhase().outputTypes().size(), is(2));
-        assertThat(innerNL.joinPhase().outputTypes().get(0), is(DataTypes.LONG));
+        assertThat(innerNL.joinPhase().joinCondition()).isSQL("(INPUT(0) = INPUT(1))");
+        assertThat(innerNL.joinPhase().projections()).hasSize(1);
+        assertThat(innerNL.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
+        assertThat(innerNL.joinPhase().outputTypes()).hasSize(2);
+        assertThat(innerNL.joinPhase().outputTypes().get(0)).isEqualTo(DataTypes.LONG);
 
         plan = e.plan("select count(t1.other_id) from users t1, users t2, users t3 " +
                       "where t1.id = t2.id and t2.id = t3.id");
-        assertThat(plan.subPlan(), instanceOf(Join.class));
+        assertThat(plan.subPlan()).isExactlyInstanceOf(Join.class);
         outerNL = (Join)plan.subPlan();
-        Asserts.assertThat(outerNL.joinPhase().joinCondition()).isSQL("(INPUT(2) = INPUT(3))");
-        assertThat(outerNL.joinPhase().projections().size(), is(2));
-        assertThat(outerNL.joinPhase().projections().get(0), instanceOf(EvalProjection.class));
-        assertThat(outerNL.joinPhase().projections().get(1), instanceOf(AggregationProjection.class));
-        assertThat(outerNL.joinPhase().outputTypes().size(), is(1));
-        assertThat(outerNL.joinPhase().outputTypes().get(0), is(CountAggregation.LongStateType.INSTANCE));
+        assertThat(outerNL.joinPhase().joinCondition()).isSQL("(INPUT(2) = INPUT(3))");
+        assertThat(outerNL.joinPhase().projections()).hasSize(2);
+        assertThat(outerNL.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
+        assertThat(outerNL.joinPhase().projections().get(1)).isExactlyInstanceOf(AggregationProjection.class);
+        assertThat(outerNL.joinPhase().outputTypes()).hasSize(1);
+        assertThat(outerNL.joinPhase().outputTypes().get(0)).isEqualTo(CountAggregation.LongStateType.INSTANCE);
 
         innerNL = (Join) outerNL.left();
-        Asserts.assertThat(innerNL.joinPhase().joinCondition()).isSQL("(INPUT(1) = INPUT(2))");
-        assertThat(innerNL.joinPhase().projections().size(), is(1));
-        assertThat(innerNL.joinPhase().projections().get(0), instanceOf(EvalProjection.class));
-        assertThat(innerNL.joinPhase().outputTypes().size(), is(3));
-        assertThat(innerNL.joinPhase().outputTypes().get(0), is(DataTypes.LONG));
-        assertThat(innerNL.joinPhase().outputTypes().get(1), is(DataTypes.LONG));
+        assertThat(innerNL.joinPhase().joinCondition()).isSQL("(INPUT(1) = INPUT(2))");
+        assertThat(innerNL.joinPhase().projections()).hasSize(1);
+        assertThat(innerNL.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
+        assertThat(innerNL.joinPhase().outputTypes()).hasSize(3);
+        assertThat(innerNL.joinPhase().outputTypes().get(0)).isEqualTo(DataTypes.LONG);
+        assertThat(innerNL.joinPhase().outputTypes().get(1)).isEqualTo(DataTypes.LONG);
     }
 
     @Test
@@ -826,10 +807,10 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         Join nl = e.plan("select * from users t1, users t2 WHERE 1=2");
-        assertThat(nl.left(), instanceOf(Collect.class));
-        assertThat(nl.right(), instanceOf(Collect.class));
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)nl.left()).collectPhase()).where()).isSQL("false");
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)nl.right()).collectPhase()).where()).isSQL("false");
+        assertThat(nl.left()).isExactlyInstanceOf(Collect.class);
+        assertThat(nl.right()).isExactlyInstanceOf(Collect.class);
+        assertThat(((RoutedCollectPhase)((Collect)nl.left()).collectPhase()).where()).isSQL("false");
+        assertThat(((RoutedCollectPhase)((Collect)nl.right()).collectPhase()).where()).isSQL("false");
     }
 
     @Test
@@ -839,10 +820,10 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         Join outer = e.plan("select * from users t1, users t2, users t3 WHERE 1=2");
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)outer.right()).collectPhase()).where()).isSQL("false");
+        assertThat(((RoutedCollectPhase)((Collect)outer.right()).collectPhase()).where()).isSQL("false");
         Join inner = (Join) outer.left();
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)inner.left()).collectPhase()).where()).isLiteral(false);
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)inner.right()).collectPhase()).where()).isLiteral(false);
+        assertThat(((RoutedCollectPhase)((Collect)inner.left()).collectPhase()).where()).isLiteral(false);
+        assertThat(((RoutedCollectPhase)((Collect)inner.right()).collectPhase()).where()).isLiteral(false);
     }
 
     @Test
@@ -852,10 +833,10 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         Join nl = e.plan("select count(*) from users t1, users t2 WHERE 1=2");
-        assertThat(nl.left(), instanceOf(Collect.class));
-        assertThat(nl.right(), instanceOf(Collect.class));
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)nl.left()).collectPhase()).where()).isLiteral(false);
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)nl.right()).collectPhase()).where()).isLiteral(false);
+        assertThat(nl.left()).isExactlyInstanceOf(Collect.class);
+        assertThat(nl.right()).isExactlyInstanceOf(Collect.class);
+        assertThat(((RoutedCollectPhase)((Collect)nl.left()).collectPhase()).where()).isLiteral(false);
+        assertThat(((RoutedCollectPhase)((Collect)nl.right()).collectPhase()).where()).isLiteral(false);
     }
 
     @Test
@@ -866,9 +847,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         Join outer = e.plan("select count(*) from users t1, users t2, users t3 WHERE 1=2");
         Join inner = (Join) outer.left();
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)outer.right()).collectPhase()).where()).isLiteral(false);
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)inner.left()).collectPhase()).where()).isLiteral(false);
-        Asserts.assertThat(((RoutedCollectPhase)((Collect)inner.right()).collectPhase()).where()).isLiteral(false);
+        assertThat(((RoutedCollectPhase)((Collect)outer.right()).collectPhase()).where()).isLiteral(false);
+        assertThat(((RoutedCollectPhase)((Collect)inner.left()).collectPhase()).where()).isLiteral(false);
+        assertThat(((RoutedCollectPhase)((Collect)inner.right()).collectPhase()).where()).isLiteral(false);
     }
 
     @Test
@@ -882,9 +863,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select 1 from t_pk_part_generated where ts = 0");
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "Get[doc.t_pk_part_generated | 1 | DocKeys{0::bigint, 0::bigint} | ((ts = 0::bigint) AND (p AS date_trunc('day', ts) = 0::bigint))]"
-        ));
+        );
     }
 
     @Test
@@ -897,7 +878,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         e.getSessionSettings().setHashJoinEnabled(true);
         Merge merge = e.plan("select t2.b, t1.a from t1 inner join t2 on t1.i = t2.i order by 1, 2");
         Join join = (Join) merge.subPlan();
-        assertThat(join.joinPhase().type(), is(ExecutionPhase.Type.HASH_JOIN));
+        assertThat(join.joinPhase().type()).isEqualTo(ExecutionPhase.Type.HASH_JOIN);
     }
 
     @Test
@@ -906,11 +887,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select unnest([1, 2])");
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "ProjectSet[unnest([1, 2])]\n" +
-            "  └ TableFunction[empty_row | [] | true]"));
+            "  └ TableFunction[empty_row | [] | true]");
         Symbol output = plan.outputs().get(0);
-        assertThat(output.valueType(), is(DataTypes.INTEGER));
+        assertThat(output.valueType()).isEqualTo(DataTypes.INTEGER);
     }
 
     @Test
@@ -919,10 +900,12 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select unnest([1, 2]) + 1");
-        assertThat(plan, isPlan(
-            "Eval[(unnest([1, 2]) + 1)]\n" +
-            "  └ ProjectSet[unnest([1, 2])]\n" +
-            "    └ TableFunction[empty_row | [] | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            Eval[(unnest([1, 2]) + 1)]
+              └ ProjectSet[unnest([1, 2])]
+                └ TableFunction[empty_row | [] | true]
+            """);
     }
 
     @Test
@@ -942,10 +925,13 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select count(*), generate_series(1, 2) from users");
-        assertThat(plan, isPlan(
-            "Eval[count(*), pg_catalog.generate_series(1, 2)]\n" +
-            "  └ ProjectSet[pg_catalog.generate_series(1, 2), count(*)]\n" +
-            "    └ Count[doc.users | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            Eval[count(*), pg_catalog.generate_series(1, 2)]
+              └ ProjectSet[pg_catalog.generate_series(1, 2), count(*)]
+                └ Count[doc.users | true]
+            """
+        );
     }
 
     @Test
@@ -955,11 +941,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select count(name), generate_series(1, count(name)) from users");
-        assertThat(plan, isPlan(
-            "Eval[count(name), pg_catalog.generate_series(1::bigint, count(name))]\n" +
-            "  └ ProjectSet[pg_catalog.generate_series(1::bigint, count(name)), count(name)]\n" +
-            "    └ HashAggregate[count(name)]\n" +
-            "      └ Collect[doc.users | [name] | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            Eval[count(name), pg_catalog.generate_series(1::bigint, count(name))]
+              └ ProjectSet[pg_catalog.generate_series(1::bigint, count(name)), count(name)]
+                └ HashAggregate[count(name)]
+                  └ Collect[doc.users | [name] | true]
+            """
+        );
     }
 
     @Test
@@ -968,10 +957,13 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         LogicalPlan plan = e.logicalPlan("select unnest([1, 2]) from sys.nodes order by 1");
-        assertThat(plan, isPlan(
-            "OrderBy[unnest([1, 2]) ASC]\n" +
-            "  └ ProjectSet[unnest([1, 2])]\n" +
-            "    └ Collect[sys.nodes | [] | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            OrderBy[unnest([1, 2]) ASC]
+              └ ProjectSet[unnest([1, 2])]
+                └ Collect[sys.nodes | [] | true]
+            """
+        );
     }
 
     @Test
@@ -982,13 +974,12 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         Merge localMerge = e.plan("select sum(ints) OVER (partition by awesome) from users");
         Merge distMerge = (Merge) localMerge.subPlan();
-        assertThat(distMerge.nodeIds().size(), is(2));
-        assertThat(distMerge.mergePhase().projections(), contains(
-            instanceOf(WindowAggProjection.class),
-            instanceOf(EvalProjection.class)
-        ));
+        assertThat(distMerge.nodeIds()).hasSize(2);
+        assertThat(distMerge.mergePhase().projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(WindowAggProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
         Collect collect = (Collect) distMerge.subPlan();
-        assertThat(collect.nodeIds().size(), is(2));
+        assertThat(collect.nodeIds()).hasSize(2);
     }
 
     @Test
@@ -1020,9 +1011,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         String statement = "select * from (select * from parted) t where date is null";
         LogicalPlan logicalPlan = e.logicalPlan(statement);
-        assertThat(logicalPlan, isPlan(
+        assertThat(logicalPlan).isEqualTo(
             "Rename[id, name, date, obj] AS t\n" +
-            "  └ Collect[doc.parted | [id, name, date, obj] | (date IS NULL)]"));
+            "  └ Collect[doc.parted | [id, name, date, obj] | (date IS NULL)]");
         ExecutionPlan plan = e.plan(statement);
         Collect collect = plan instanceof Collect ? (Collect) plan : ((Collect) ((Merge) plan).subPlan());
         RoutedCollectPhase routedCollectPhase = (RoutedCollectPhase) collect.collectPhase();
@@ -1031,7 +1022,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         for (String node : routedCollectPhase.routing().nodes()) {
             numShards += routedCollectPhase.routing().numShards(node);
         }
-        assertThat(numShards, is(1));
+        assertThat(numShards).isEqualTo(1);
     }
 
     @Test
@@ -1042,7 +1033,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         Merge merge = e.plan("select name from users as u where match(u.text, 'yalla') order by 1");
         Collect collect = (Collect) merge.subPlan();
-        Asserts.assertThat(((RoutedCollectPhase) collect.collectPhase()).where()).isFunction("match");
+        assertThat(((RoutedCollectPhase) collect.collectPhase()).where()).isFunction("match");
     }
 
     @Test
@@ -1057,9 +1048,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         String stmt = "select distinct name from users limit 1";
         LogicalPlan plan = e.logicalPlan(stmt);
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "LimitDistinct[1::bigint;0 | [name]]\n" +
-            "  └ Collect[doc.users | [name] | true]"));
+            "  └ Collect[doc.users | [name] | true]");
     }
 
     @Test
@@ -1070,9 +1061,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         String stmt = "select id, name from users group by id, name limit 1";
         LogicalPlan plan = e.logicalPlan(stmt);
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "LimitDistinct[1::bigint;0 | [id, name]]\n" +
-            "  └ Collect[doc.users | [id, name] | true]"));
+            "  └ Collect[doc.users | [id, name] | true]");
     }
 
     @Test
@@ -1083,26 +1074,18 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         String stmt = "select id, name from users group by id, name limit 1 offset 3";
         LogicalPlan plan = e.logicalPlan(stmt);
-        assertThat(plan, isPlan(
+        assertThat(plan).isEqualTo(
             "LimitDistinct[1::bigint;3::bigint | [id, name]]\n" +
-            "  └ Collect[doc.users | [id, name] | true]"));
+            "  └ Collect[doc.users | [id, name] | true]");
 
         Merge merge = e.plan(stmt);
         List<Projection> collectProjections = ((Collect) merge.subPlan()).collectPhase().projections();;
-        assertThat(
-            collectProjections,
-            contains(
-                instanceOf(LimitDistinctProjection.class)
-            )
-        );
+        assertThat(collectProjections).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(LimitDistinctProjection.class));
         List<Projection> mergeProjections = merge.mergePhase().projections();
-        assertThat(
-            mergeProjections,
-            contains(
-                instanceOf(LimitDistinctProjection.class),
-                instanceOf(LimitAndOffsetProjection.class)
-            )
-        );
+        assertThat(mergeProjections).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(LimitDistinctProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(LimitAndOffsetProjection.class));
     }
 
     @Test
@@ -1113,10 +1096,13 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         String stmt = "SELECT address['postcode'] FROM (SELECT address FROM users) AS u GROUP BY 1";
         LogicalPlan plan = e.logicalPlan(stmt);
-        assertThat(plan, isPlan(
-            "GroupHashAggregate[address['postcode']]\n" +
-            "  └ Rename[address] AS u\n" +
-            "    └ Collect[doc.users | [address] | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            GroupHashAggregate[address['postcode']]
+              └ Rename[address] AS u
+                └ Collect[doc.users | [address] | true]
+            """
+        );
     }
 
     @Test
@@ -1127,18 +1113,20 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         String stmt = "SELECT address['postcode'] FROM (SELECT address FROM users) AS u ORDER BY 1";
         LogicalPlan plan = e.logicalPlan(stmt);
-        assertThat(plan, isPlan(
-            "Eval[address['postcode']]\n" +
-            "  └ OrderBy[address['postcode'] ASC]\n" +
-            "    └ Rename[address] AS u\n" +
-            "      └ Collect[doc.users | [address] | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            Eval[address['postcode']]
+              └ OrderBy[address['postcode'] ASC]
+                └ Rename[address] AS u
+                  └ Collect[doc.users | [address] | true]
+            """
+        );
         Merge merge = e.plan(stmt);
         Collect collect = (Collect) merge.subPlan();
         RoutedCollectPhase collectPhase = (RoutedCollectPhase) collect.collectPhase();
-        assertThat(collectPhase.projections(), contains(
-            instanceOf(OrderedLimitAndOffsetProjection.class),
-            instanceOf(EvalProjection.class)
-        ));
+        assertThat(collectPhase.projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(OrderedLimitAndOffsetProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
     }
 
     @Test
@@ -1156,12 +1144,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                       "   AND (false)";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "NestedLoopJoin[CROSS]\n" +
-            "  ├ Rename[nspacl, nspname, nspowner, oid] AS n\n" +
-            "  │  └ Collect[pg_catalog.pg_namespace | [nspacl, nspname, nspowner, oid] | false]\n" +
-            "  └ Rename[] AS c\n" +
-            "    └ Collect[pg_catalog.pg_class | [] | false]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            NestedLoopJoin[CROSS]
+              ├ Rename[nspacl, nspname, nspowner, oid] AS n
+              │  └ Collect[pg_catalog.pg_namespace | [nspacl, nspname, nspowner, oid] | false]
+              └ Rename[] AS c
+                └ Collect[pg_catalog.pg_class | [] | false]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -1173,19 +1163,23 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         // because it is not using the InputFactory to evaluate the order by expressions
         // Injecting an Eval operator as a workaround
         String stmt =
-            "SELECT\n" +
-            "   unnest,\n" +
-            "   sum(unnest) OVER(ORDER BY power(unnest, 2) RANGE BETWEEN 3 PRECEDING and CURRENT ROW)\n" +
-            "FROM\n" +
-            "   unnest(ARRAY[2.5, 4, 5, 6, 7.5, 8.5, 10, 12]) as t(unnest)";
+            """
+            SELECT
+               unnest,
+               sum(unnest) OVER(ORDER BY power(unnest, 2) RANGE BETWEEN 3 PRECEDING and CURRENT ROW)
+            FROM
+               unnest(ARRAY[2.5, 4, 5, 6, 7.5, 8.5, 10, 12]) as t(unnest)
+            """;
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Eval[unnest, sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
-            "  └ WindowAgg[unnest, power(unnest, 2.0), sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]\n" +
-            "    └ Eval[unnest, power(unnest, 2.0)]\n" +
-            "      └ Rename[unnest] AS t\n" +
-            "        └ TableFunction[unnest | [unnest] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Eval[unnest, sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
+              └ WindowAgg[unnest, power(unnest, 2.0), sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
+                └ Eval[unnest, power(unnest, 2.0)]
+                  └ Rename[unnest] AS t
+                    └ TableFunction[unnest | [unnest] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -1200,11 +1194,13 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "ORDER BY 1";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Eval[word]\n" +
-            "  └ OrderBy[word ASC]\n" +
-            "    └ Filter[(catcode = 'R')]\n" +
-            "      └ TableFunction[pg_get_keywords | [word, catcode] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Eval[word]
+              └ OrderBy[word ASC]
+                └ Filter[(catcode = 'R')]
+                  └ TableFunction[pg_get_keywords | [word, catcode] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -1218,15 +1214,13 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String expectedPlan =
             "GroupHashAggregate[name | count(*)]\n" +
             "  └ Get[doc.users | name | DocKeys{1::bigint; 2::bigint; 3::bigint; 4::bigint; 5::bigint} | (id = ANY([1::bigint, 2::bigint, 3::bigint, 4::bigint, 5::bigint]))]";
-        assertThat(logicalPlan, isPlan(expectedPlan));
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
         Merge coordinatorMerge = e.plan(stmt);
         Merge distributedMerge = (Merge) coordinatorMerge.subPlan();
         Collect collect = (Collect) distributedMerge.subPlan();
-        assertThat(
-            collect.collectPhase().projections(),
-            contains(instanceOf(GroupProjection.class))
-        );
-        assertThat(collect.collectPhase().projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
+        assertThat(collect.collectPhase().projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(GroupProjection.class));
+        assertThat(collect.collectPhase().projections().get(0).requiredGranularity()).isEqualTo(RowGranularity.SHARD);
     }
 
     @Test
@@ -1238,11 +1232,13 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String stmt = "SELECT count(id) as cnt FROM users GROUP BY name ORDER BY count(id) DESC";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Eval[count(id) AS cnt]\n" +
-            "  └ OrderBy[count(id) DESC]\n" +
-            "    └ GroupHashAggregate[name | count(id)]\n" +
-            "      └ Collect[doc.users | [id, name] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Eval[count(id) AS cnt]
+              └ OrderBy[count(id) DESC]
+                └ GroupHashAggregate[name | count(id)]
+                  └ Collect[doc.users | [id, name] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
 
@@ -1255,13 +1251,15 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String stmt = "SELECT u1.name FROM users u1 JOIN users u2 ON (u1.name || ?) = u2.name";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Eval[name]\n" +
-            "  └ HashJoin[(name = concat(name, $1))]\n" +
-            "    ├ Rename[name] AS u1\n" +
-            "    │  └ Collect[doc.users | [name] | true]\n" +
-            "    └ Rename[name] AS u2\n" +
-            "      └ Collect[doc.users | [name] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Eval[name]
+              └ HashJoin[(name = concat(name, $1))]
+                ├ Rename[name] AS u1
+                │  └ Collect[doc.users | [name] | true]
+                └ Rename[name] AS u2
+                  └ Collect[doc.users | [name] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
 
         // this must not fail
         e.plan(stmt, UUID.randomUUID(), 0, new RowN("foo"));
@@ -1276,13 +1274,15 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String stmt = "SELECT u1.name FROM users u1 JOIN users u2 ON (u1.name || ?) != u2.name";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Eval[name]\n" +
-            "  └ NestedLoopJoin[INNER | (NOT (name = concat(name, $1)))]\n" +
-            "    ├ Rename[name] AS u1\n" +
-            "    │  └ Collect[doc.users | [name] | true]\n" +
-            "    └ Rename[name] AS u2\n" +
-            "      └ Collect[doc.users | [name] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Eval[name]
+              └ NestedLoopJoin[INNER | (NOT (name = concat(name, $1)))]
+                ├ Rename[name] AS u1
+                │  └ Collect[doc.users | [name] | true]
+                └ Rename[name] AS u2
+                  └ Collect[doc.users | [name] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
 
         // this must not fail
         e.plan(stmt, UUID.randomUUID(), 0, new RowN("foo"));
@@ -1304,14 +1304,16 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "   ON (v1.a = v2.b) ";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "HashJoin[(a = b)]\n" +
-            "  ├ Rename[a] AS v1\n" +
-            "  │  └ Rename[a] AS a1\n" +
-            "  │    └ Collect[doc.t1 | [a] | true]\n" +
-            "  └ Rename[b] AS v2\n" +
-            "    └ Rename[b] AS a2\n" +
-            "      └ Collect[doc.t2 | [b] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            HashJoin[(a = b)]
+              ├ Rename[a] AS v1
+              │  └ Rename[a] AS a1
+              │    └ Collect[doc.t1 | [a] | true]
+              └ Rename[b] AS v2
+                └ Rename[b] AS a2
+                  └ Collect[doc.t2 | [b] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -1329,14 +1331,16 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             "   ON (v1.a > v2.b) ";
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
-            "NestedLoopJoin[INNER | (a > b)]\n" +
-            "  ├ Rename[a] AS v1\n" +
-            "  │  └ Rename[a] AS a1\n" +
-            "  │    └ Collect[doc.t1 | [a] | true]\n" +
-            "  └ Rename[b] AS v2\n" +
-            "    └ Rename[b] AS a2\n" +
-            "      └ Collect[doc.t2 | [b] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            NestedLoopJoin[INNER | (a > b)]
+              ├ Rename[a] AS v1
+              │  └ Rename[a] AS a1
+              │    └ Collect[doc.t1 | [a] | true]
+              └ Rename[b] AS v2
+                └ Rename[b] AS a2
+                  └ Collect[doc.t2 | [b] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -1355,19 +1359,16 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
             "Collect[doc.parted_by_generated | [ts, p AS date_trunc('month', ts)] | (ts >= 1580515200000::bigint)]";
-        assertThat(plan, isPlan(expectedPlan));
+        assertThat(plan).isEqualTo(expectedPlan);
 
         Collect collect = (Collect) ((Merge) e.plan(stmt)).subPlan();;
         RoutedCollectPhase routedCollectPhase = (RoutedCollectPhase) collect.collectPhase();
         Symbol where = routedCollectPhase.where();
-        Asserts.assertThat(where).isSQL("(doc.parted_by_generated.ts >= 1580515200000::bigint)");
+        assertThat(where).isSQL("(doc.parted_by_generated.ts >= 1580515200000::bigint)");
         assertThat(routedCollectPhase.routing().locations().values().stream()
             .flatMap(x -> x.keySet().stream())
-            .collect(Collectors.toSet()),
-            contains(
-                ".partitioned.parted_by_generated.04732d9o60qj2d9i60o30c1g"
-            )
-        );
+            .collect(Collectors.toSet())).containsExactly(
+                ".partitioned.parted_by_generated.04732d9o60qj2d9i60o30c1g");
     }
 
     @Test
@@ -1411,13 +1412,12 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             """);
         Collect collect = (Collect) merge.subPlan();
         var pkLookup = (PKLookupPhase) collect.collectPhase();
-        assertThat(pkLookup.projections(), Matchers.contains(
-            Matchers.instanceOf(FilterProjection.class),
-            Matchers.instanceOf(EvalProjection.class),
-            Matchers.instanceOf(AggregationProjection.class)
-        ));
+        assertThat(pkLookup.projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(FilterProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(AggregationProjection.class));
         for (var projection : pkLookup.projections()) {
-            assertThat(projection.requiredGranularity(), is(RowGranularity.SHARD));
+            assertThat(projection.requiredGranularity()).isEqualTo(RowGranularity.SHARD);
         }
     }
 
@@ -1428,7 +1428,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         CountPlan plan = e.plan("select count(*) from tbl where 'a' = ANY(xs)");
-        Asserts.assertThat(plan.countPhase().where()).isSQL("(_cast('a', 'text(1)') = ANY(doc.tbl.xs))");
+        assertThat(plan.countPhase().where()).isSQL("(_cast('a', 'text(1)') = ANY(doc.tbl.xs))");
     }
 
     @Test
@@ -1444,7 +1444,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .flatMap(x -> x.values().stream())
             .mapToInt(x -> x.size())
             .sum();
-        assertThat(numShards, is(1));
+        assertThat(numShards).isEqualTo(1);
     }
 
     @Test
@@ -1457,7 +1457,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Collect collect = e.plan(stmt);
         RoutedCollectPhase routedCollectPhase = (RoutedCollectPhase) collect.collectPhase();
 
-        Asserts.assertThat(routedCollectPhase.where()).isLiteral(true);
+        assertThat(routedCollectPhase.where()).isLiteral(true);
     }
 
     @Test
@@ -1466,9 +1466,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String stmt = "SELECT UNNEST(?)";
         Collect collect = e.plan(stmt, UUID.randomUUID(), 0, new RowN(new Object[] {null}));
 
-        assertThat(collect.collectPhase().projections().get(0).projectionType(), is(ProjectionType.PROJECT_SET));
+        assertThat(collect.collectPhase().projections().get(0).projectionType()).isEqualTo(ProjectionType.PROJECT_SET);
         ProjectSetProjection projectSetProjection = (ProjectSetProjection) collect.collectPhase().projections().get(0);
-        Asserts.assertThat(((Function) projectSetProjection.tableFunctions().get(0)).arguments().get(0))
+        assertThat(((Function) projectSetProjection.tableFunctions().get(0)).arguments().get(0))
             .isLiteral(null); // used to be unbound ParameterSymbol
     }
 
@@ -1486,7 +1486,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         var subSelectPlan = e.logicalPlan(
                 "SELECT * FROM (SELECT x FROM (SELECT x FROM t1) AS r) AS s");
 
-        assertThat(withPlan, isPlan(subSelectPlan));
+        assertThat(withPlan).isEqualTo(subSelectPlan);
     }
 
     @Test
@@ -1506,6 +1506,6 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                 " (SELECT * FROM t1) AS u," +
                 " (SELECT x FROM (SELECT x FROM t2) AS u) AS v");
 
-        assertThat(withPlan, isPlan(subSelectPlan));
+        assertThat(withPlan).isEqualTo(subSelectPlan);
     }
 }

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -23,17 +23,12 @@ package io.crate.planner;
 
 import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,7 +40,6 @@ import io.crate.execution.dsl.projection.LimitAndOffsetProjection;
 import io.crate.metadata.RelationName;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.operators.LogicalPlanner;
-import io.crate.planner.operators.LogicalPlannerTest;
 import io.crate.planner.operators.Union;
 import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
@@ -68,143 +62,165 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testSimpleUnion() {
         ExecutionPlan plan = e.plan(
-            "select id from users " +
-            "union all " +
-            "select id from locations ");
-        assertThat(plan, instanceOf(UnionExecutionPlan.class));
+            """
+            SELECT id FROM users
+            UNION ALL
+            SELECT id FROM locations
+            """);
+        assertThat(plan).isExactlyInstanceOf(UnionExecutionPlan.class);
         UnionExecutionPlan unionExecutionPlan = (UnionExecutionPlan) plan;
-        assertThat(unionExecutionPlan.orderBy(), is(nullValue()));
-        assertThat(unionExecutionPlan.mergePhase().numInputs(), is(2));
-        assertThat(unionExecutionPlan.left(), instanceOf(Collect.class));
-        assertThat(unionExecutionPlan.right(), instanceOf(Collect.class));
+        assertThat(unionExecutionPlan.orderBy()).isNull();
+        assertThat(unionExecutionPlan.mergePhase().numInputs()).isEqualTo(2);
+        assertThat(unionExecutionPlan.left()).isExactlyInstanceOf(Collect.class);
+        assertThat(unionExecutionPlan.right()).isExactlyInstanceOf(Collect.class);
     }
 
     @Test
     public void testUnionWithOrderByLimit() {
         ExecutionPlan plan = e.plan(
-            "select id from users " +
-            "union all " +
-            "select id from locations " +
-            "order by id limit 2");
-        assertThat(plan, instanceOf(UnionExecutionPlan.class));
+            """
+            SELECT id FROM users
+            UNION ALL
+            SELECT id FROM locations
+            ORDER BY id
+            LIMIT 2
+            """
+        );
+        assertThat(plan).isExactlyInstanceOf(UnionExecutionPlan.class);
         UnionExecutionPlan unionExecutionPlan = (UnionExecutionPlan) plan;
-        assertThat(unionExecutionPlan.mergePhase().numInputs(), is(2));
-        assertThat(unionExecutionPlan.mergePhase().orderByPositions(), instanceOf(PositionalOrderBy.class));
-        assertThat(unionExecutionPlan.mergePhase().projections(), contains(
-            instanceOf(LimitAndOffsetProjection.class)
-        ));
-        assertThat(unionExecutionPlan.left(), instanceOf(Collect.class));
-        assertThat(unionExecutionPlan.right(), instanceOf(Collect.class));
+        assertThat(unionExecutionPlan.mergePhase().numInputs()).isEqualTo(2);
+        assertThat(unionExecutionPlan.mergePhase().orderByPositions()).isExactlyInstanceOf(PositionalOrderBy.class);
+        assertThat(unionExecutionPlan.mergePhase().projections())
+            .satisfiesExactly(p -> assertThat(p).isExactlyInstanceOf(LimitAndOffsetProjection.class));
+        assertThat(unionExecutionPlan.left()).isExactlyInstanceOf(Collect.class);
+        assertThat(unionExecutionPlan.right()).isExactlyInstanceOf(Collect.class);
     }
 
     @Test
     public void testUnionWithSubselects() {
         ExecutionPlan plan = e.plan(
-            "select * from (select id from users order by id limit 2) a " +
-            "union all " +
-            "select id from locations " +
-            "order by id limit 2");
-        assertThat(plan, instanceOf(UnionExecutionPlan.class));
+            """
+            SELECT * FROM (
+              SELECT id FROM users
+              ORDER BY id
+              LIMIT 2) a
+            UNION ALL
+            SELECT id FROM locations
+            ORDER BY id
+            LIMIT 2
+            """
+        );
+        assertThat(plan).isExactlyInstanceOf(UnionExecutionPlan.class);
         UnionExecutionPlan unionExecutionPlan = (UnionExecutionPlan) plan;
-        assertThat(unionExecutionPlan.mergePhase().numInputs(), is(2));
-        assertThat(unionExecutionPlan.orderBy(), Matchers.notNullValue());
-        assertThat(unionExecutionPlan.mergePhase().projections(), contains(
-            instanceOf(LimitAndOffsetProjection.class)
-        ));
-        assertThat(unionExecutionPlan.left(), instanceOf(Merge.class));
+        assertThat(unionExecutionPlan.mergePhase().numInputs()).isEqualTo(2);
+        assertThat(unionExecutionPlan.orderBy()).isNotNull();
+        assertThat(unionExecutionPlan.mergePhase().projections())
+            .satisfiesExactly(p -> assertThat(p).isExactlyInstanceOf(LimitAndOffsetProjection.class));
+        assertThat(unionExecutionPlan.left()).isExactlyInstanceOf(Merge.class);
         Merge merge = (Merge) unionExecutionPlan.left();
-        assertThat(merge.subPlan(), instanceOf(Collect.class));
-        assertThat(unionExecutionPlan.right(), instanceOf(Collect.class));
+        assertThat(merge.subPlan()).isExactlyInstanceOf(Collect.class);
+        assertThat(unionExecutionPlan.right()).isExactlyInstanceOf(Collect.class);
     }
 
     @Test
     public void testUnionWithOrderByLiteralConstant() {
-        String stmt = "select * from (" +
-            " select 1 as x, id from users" +
-            " union all" +
-            " select 2, id from users" +
-            ") o" +
-            " order by x";
+        String stmt =
+            """
+            SELECT * FROM (
+              SELECT 1 as x, id FROM users
+              UNION ALL
+              SELECT 2, id FROM users
+              ) o
+            ORDER BY x
+            """;
         var logicalPlan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Rename[x, id] AS o\n" +
-            "  └ Union[x, id]\n" +
-            "    ├ OrderBy[1 AS x ASC]\n" +
-            "    │  └ Collect[doc.users | [1 AS x, id] | true]\n" +
-            "    └ OrderBy[2 ASC]\n" +
-            "      └ Collect[doc.users | [2, id] | true]";
-        assertThat(logicalPlan, is(LogicalPlannerTest.isPlan(expectedPlan)));
+            """
+            Rename[x, id] AS o
+              └ Union[x, id]
+                ├ OrderBy[1 AS x ASC]
+                │  └ Collect[doc.users | [1 AS x, id] | true]
+                └ OrderBy[2 ASC]
+                  └ Collect[doc.users | [2, id] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
         ExecutionPlan plan = e.plan(stmt);
-        assertThat(plan, instanceOf(UnionExecutionPlan.class));
+        assertThat(plan).isExactlyInstanceOf(UnionExecutionPlan.class);
         UnionExecutionPlan unionExecutionPlan = (UnionExecutionPlan) plan;
-        assertThat(unionExecutionPlan.mergePhase().orderByPositions(), instanceOf(PositionalOrderBy.class));
-        assertThat(unionExecutionPlan.mergePhase().orderByPositions().indices(), is(new int[]{0}));
+        assertThat(unionExecutionPlan.mergePhase().orderByPositions()).isExactlyInstanceOf(PositionalOrderBy.class);
+        assertThat(unionExecutionPlan.mergePhase().orderByPositions().indices()).isEqualTo(new int[]{0});
     }
 
     @Test
     public void test_select_subset_of_outputs_from_union() {
-        String stmt = "select x from (" +
-                      " select 1 as x, id from users" +
-                      " union all" +
-                      " select 2, id from users" +
-                      ") o" +
-                      " order by x";
+        String stmt =
+            """
+            SELECT x FROM(
+              SELECT 1 as x, id FROM users
+              UNION ALL
+              SELECT 2, id FROM users
+              ) o
+            ORDER BY x
+             """;
         var logicalPlan = e.logicalPlan(stmt);
         String expectedPlan =
-            "Rename[x] AS o\n" +
-            "  └ Union[x]\n" +
-            "    ├ OrderBy[1 AS x ASC]\n" +
-            "    │  └ Collect[doc.users | [1 AS x] | true]\n" +
-            "    └ OrderBy[2 ASC]\n" +
-            "      └ Collect[doc.users | [2] | true]";
-        assertThat(logicalPlan, is(LogicalPlannerTest.isPlan(expectedPlan)));
+            """
+            Rename[x] AS o
+              └ Union[x]
+                ├ OrderBy[1 AS x ASC]
+                │  └ Collect[doc.users | [1 AS x] | true]
+                └ OrderBy[2 ASC]
+                  └ Collect[doc.users | [2] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void testUnionDistinct() {
         var logicalPlan = e.logicalPlan(
-            "select id from users " +
-            "union distinct " +
-            "select id from locations ");
+            """
+            SELECT id FROM users
+            UNION DISTINCT
+            SELECT id FROM locations
+            """
+        );
         String expectedPlan =
-            "GroupHashAggregate[id]\n" +
-            "  └ Union[id]\n" +
-            "    ├ Collect[doc.users | [id] | true]\n" +
-            "    └ Collect[doc.locations | [id] | true]";
-        assertThat(logicalPlan, is(LogicalPlannerTest.isPlan(expectedPlan)));
+            """
+            GroupHashAggregate[id]
+              └ Union[id]
+                ├ Collect[doc.users | [id] | true]
+                └ Collect[doc.locations | [id] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void test_union_with_different_types_in_queries_adds_casts() {
-        UnionExecutionPlan union = e.plan("select null union all select id from users");
+        UnionExecutionPlan union = e.plan("SELECT null UNION ALL SELECT id FROM users");
         Collect left = (Collect) union.left();
-        assertThat(left.collectPhase().projections(), contains(
-            instanceOf(EvalProjection.class), // returns NULL
-            instanceOf(EvalProjection.class)  // casts NULL to long to match `id`
-        ));
+        assertThat(left.collectPhase().projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class), // returns NULL
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class)  // casts NULL to long to match `id`
+        );
         Collect right = (Collect) union.right();
-        assertThat(left.streamOutputs(), is(right.streamOutputs()));
-        assertThat(left.streamOutputs(), contains(
-            is(DataTypes.LONG)
-        ));
+        assertThat(left.streamOutputs()).isEqualTo(right.streamOutputs());
+        assertThat(left.streamOutputs()).satisfiesExactly(o -> assertThat(o).isEqualTo(DataTypes.LONG));
 
 
-        union = e.plan("select id from users union all select null");
+        union = e.plan("SELECT id FROM users UNION ALL SELECT null");
         left = (Collect) union.left();
         right = (Collect) union.right();
-        assertThat(left.streamOutputs(), is(right.streamOutputs()));
-        assertThat(right.streamOutputs(), contains(
-            is(DataTypes.LONG)
-        ));
-        assertThat(right.collectPhase().projections(), contains(
-            instanceOf(EvalProjection.class), // returns NULL
-            instanceOf(EvalProjection.class)  // casts NULL to long to match `id`
-        ));
+        assertThat(left.streamOutputs()).isEqualTo(right.streamOutputs());
+        assertThat(right.streamOutputs()).satisfiesExactly(o -> assertThat(o).isEqualTo(DataTypes.LONG));
+        assertThat(right.collectPhase().projections()).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class), // returns NULL
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class)  // casts NULL to long to match `id`
+        );
     }
 
     @Test
     public void test_union_returns_unknown_expected_rows_unknown_on_one_source_plan() {
-        String stmt = "select id from users union all select id from locations";
+        String stmt = "SELECT id FROM users UNION ALL SELECT id FROM locations";
         TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(-1, 0, Map.of()));
@@ -219,13 +235,12 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
         var plan = logicalPlanner.plan(e.analyze(stmt), context);
         var union = (Union) plan.sources().get(0);
-        assertThat(union.numExpectedRows(), is(-1L));
+        assertThat(union.numExpectedRows()).isEqualTo(-1L);
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         tableStats.updateTableStats(rowCountByTable);
         plan = logicalPlanner.plan(e.analyze(stmt), context);
         union = (Union) plan.sources().get(0);
-        assertThat(union.numExpectedRows(), is(-1L));
+        assertThat(union.numExpectedRows()).isEqualTo(-1L);
     }
-
 }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -25,16 +25,10 @@ import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_DEFINIT
 import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
 import static io.crate.testing.Asserts.assertList;
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isInputColumn;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -44,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.common.Randomness;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +62,6 @@ import io.crate.planner.node.dql.join.JoinType;
 import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 
@@ -78,7 +70,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
     private ProjectionBuilder projectionBuilder;
     private PlannerContext plannerCtx;
-    private CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+    private final CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
     public void setUpExecutor() throws IOException {
@@ -136,14 +128,14 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         Join nl = plan(mss, tableStats);
-        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("locations"));
+        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
 
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10_000, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10, 0, Map.of()));
         tableStats.updateTableStats(rowCountByTable);
 
         nl = plan(mss, tableStats);
-        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("users"));
+        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
     }
 
     @Test
@@ -158,11 +150,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
-        assertThat(operator, instanceOf(NestedLoopJoin.class));
+        assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join nl = plan(mss, tableStats);
-        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("users"));
-        assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("locations"));
+        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
+        assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
     }
 
     @Test
@@ -184,11 +176,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
-        assertThat(operator, instanceOf(NestedLoopJoin.class));
+        assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join nl = plan(mss, tableStats);
-        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("users"));
-        assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("locations"));
+        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
+        assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
     }
 
     @Test
@@ -204,11 +196,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
-        assertThat(operator, instanceOf(HashJoin.class));
+        assertThat(operator).isExactlyInstanceOf(HashJoin.class);
 
         Join join = buildJoin(operator);
-        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("users"));
-        assertThat(((Reference) ((Collect) join.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is("locations"));
+        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
+        assertThat(((Reference) ((Collect) join.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
     }
 
     @Test
@@ -230,16 +222,16 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         Join nl = plan(mss, tableStats);
-        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is(leftName.name()));
-        assertThat(nl.joinPhase().joinType(), is(JoinType.LEFT));
+        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo(leftName.name());
+        assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.LEFT);
 
         rowCountByTable.put(leftName, new Stats(10_000, 0, Map.of()));
         rowCountByTable.put(rightName, new Stats(10, 0, Map.of()));
         tableStats.updateTableStats(rowCountByTable);
 
         nl = plan(mss, tableStats);
-        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name(), is(rightName.name()));
-        assertThat(nl.joinPhase().joinType(), is(JoinType.RIGHT));  // ensure that also the join type inverted
+        assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo(rightName.name());
+        assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.RIGHT);  // ensure that also the join type inverted
     }
 
     @Test
@@ -274,7 +266,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mock(DependencyCarrier.class), context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
 
         assertList(((Collect) nl.left()).collectPhase().toCollect()).isSQL("doc.users.id");
-        assertThat(nl.resultDescription().orderBy(), notNullValue());
+        assertThat(nl.resultDescription().orderBy()).isNotNull();
     }
 
     @Test
@@ -298,7 +290,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mock(DependencyCarrier.class), context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
         Join nl = (Join) merge.subPlan();
 
-        assertThat(nl.resultDescription().orderBy(), notNullValue());
+        assertThat(nl.resultDescription().orderBy()).isNotNull();
     }
 
     @Test
@@ -314,13 +306,13 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
-        assertThat(operator, instanceOf(HashJoin.class));
-        assertThat("Smaller table must be on the right-hand-side",
-                   ((HashJoin) operator).rhs().getRelationNames(),
-                   contains(TEST_DOC_LOCATIONS_TABLE_IDENT));
+        assertThat(operator).isExactlyInstanceOf(HashJoin.class);
+        assertThat(((HashJoin) operator).rhs().getRelationNames())
+            .as("Smaller table must be on the right-hand-side")
+            .containsExactly(TEST_DOC_LOCATIONS_TABLE_IDENT);
 
         Join join = buildJoin(operator);
-        Asserts.assertThat(((Collect) join.left()).collectPhase().toCollect().get(1)).isReference("other_id");
+        assertThat(((Collect) join.left()).collectPhase().toCollect().get(1)).isReference("other_id");
     }
 
     @Test
@@ -336,13 +328,13 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(rowCountByTable);
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
-        assertThat(operator, instanceOf(HashJoin.class));
-        assertThat("Smaller table must be on the right-hand-side",
-                   ((HashJoin) operator).rhs().getRelationNames(),
-                   contains(TEST_DOC_LOCATIONS_TABLE_IDENT));
+        assertThat(operator).isExactlyInstanceOf(HashJoin.class);
+        assertThat(((HashJoin) operator).rhs().getRelationNames())
+            .as("Smaller table must be on the right-hand-side")
+            .containsExactly(TEST_DOC_LOCATIONS_TABLE_IDENT);
 
         Join join = buildJoin(operator);
-        Asserts.assertThat(((Collect) join.left()).collectPhase().toCollect().get(1)).isReference("loc");
+        assertThat(((Collect) join.left()).collectPhase().toCollect().get(1)).isReference("loc");
     }
 
     @Test
@@ -352,14 +344,14 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "inner join t3 on t3.c = t2.b");
 
         LogicalPlan operator = createLogicalPlan(mss, new TableStats());
-        assertThat(operator, instanceOf(HashJoin.class));
+        assertThat(operator).isExactlyInstanceOf(HashJoin.class);
         LogicalPlan leftPlan = ((HashJoin) operator).lhs;
-        assertThat(leftPlan, instanceOf(HashJoin.class));
+        assertThat(leftPlan).isExactlyInstanceOf(HashJoin.class);
 
         Join join = buildJoin(operator);
-        assertThat(join.joinPhase(), instanceOf(HashJoinPhase.class));
-        assertThat(join.left(), instanceOf(Join.class));
-        assertThat(((Join)join.left()).joinPhase(), instanceOf(HashJoinPhase.class));
+        assertThat(join.joinPhase()).isExactlyInstanceOf(HashJoinPhase.class);
+        assertThat(join.left()).isExactlyInstanceOf(Join.class);
+        assertThat(((Join)join.left()).joinPhase()).isExactlyInstanceOf(HashJoinPhase.class);
     }
 
     @Test
@@ -369,14 +361,14 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "left join t3 on t3.c = t2.b");
 
         LogicalPlan operator = createLogicalPlan(mss, new TableStats());
-        assertThat(operator, instanceOf(NestedLoopJoin.class));
+        assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
         LogicalPlan leftPlan = ((NestedLoopJoin) operator).lhs;
-        assertThat(leftPlan, instanceOf(HashJoin.class));
+        assertThat(leftPlan).isExactlyInstanceOf(HashJoin.class);
 
         Join join = buildJoin(operator);
-        assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
-        assertThat(join.left(), instanceOf(Join.class));
-        assertThat(((Join)join.left()).joinPhase(), instanceOf(HashJoinPhase.class));
+        assertThat(join.joinPhase()).isExactlyInstanceOf(NestedLoopPhase.class);
+        assertThat(join.left()).isExactlyInstanceOf(Join.class);
+        assertThat(((Join)join.left()).joinPhase()).isExactlyInstanceOf(HashJoinPhase.class);
     }
 
     @Test
@@ -392,12 +384,12 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation mss = e.analyze("select * from t1, t4");
 
         LogicalPlan operator = createLogicalPlan(mss, new TableStats());
-        assertThat(operator, instanceOf(NestedLoopJoin.class));
+        assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
-        assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
+        assertThat(join.joinPhase()).isExactlyInstanceOf(NestedLoopPhase.class);
         NestedLoopPhase joinPhase = (NestedLoopPhase) join.joinPhase();
-        assertThat(joinPhase.blockNestedLoop, is(true));
+        assertThat(joinPhase.blockNestedLoop).isEqualTo(true);
     }
 
     @Test
@@ -420,17 +412,17 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation mss = e.analyze("select * from t1, t4");
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
-        assertThat(operator, instanceOf(NestedLoopJoin.class));
+        assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
-        assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
+        assertThat(join.joinPhase()).isExactlyInstanceOf(NestedLoopPhase.class);
         NestedLoopPhase joinPhase = (NestedLoopPhase) join.joinPhase();
-        assertThat(joinPhase.blockNestedLoop, is(true));
+        assertThat(joinPhase.blockNestedLoop).isEqualTo(true);
 
-        assertThat(join.left(), instanceOf(Collect.class));
+        assertThat(join.left()).isExactlyInstanceOf(Collect.class);
         // no table switch should have been made
-        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent(),
-            is(T3.T1));
+        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent())
+            .isEqualTo(T3.T1);
     }
 
     @Test
@@ -453,17 +445,17 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation mss = e.analyze("select * from t4, t1");
 
         LogicalPlan operator = createLogicalPlan(mss, tableStats);
-        assertThat(operator, instanceOf(NestedLoopJoin.class));
+        assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
-        assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
+        assertThat(join.joinPhase()).isExactlyInstanceOf(NestedLoopPhase.class);
         NestedLoopPhase joinPhase = (NestedLoopPhase) join.joinPhase();
-        assertThat(joinPhase.blockNestedLoop, is(true));
+        assertThat(joinPhase.blockNestedLoop).isEqualTo(true);
 
-        assertThat(join.left(), instanceOf(Collect.class));
+        assertThat(join.left()).isExactlyInstanceOf(Collect.class);
         // right side will be flipped to the left
-        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent(),
-            is(T3.T1));
+        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent())
+            .isEqualTo(T3.T1);
     }
 
     @Test
@@ -493,7 +485,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         ExecutionPlan build = operator.build(
             mock(DependencyCarrier.class), plannerCtx, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
 
-        assertThat((((NestedLoopPhase) ((Join) build).joinPhase())).blockNestedLoop, is(false));
+        assertThat((((NestedLoopPhase) ((Join) build).joinPhase())).blockNestedLoop).isEqualTo(false);
     }
 
     @Test
@@ -511,7 +503,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan join = logicalPlanner.plan(mss, plannerCtx);
 
         WindowAgg windowAggOperator = (WindowAgg) ((Eval) ((RootRelationBoundary) join).source).source;
-        assertThat(join.outputs(), hasItem(windowAggOperator.windowFunctions().get(0)));
+        assertThat(join.outputs()).contains(windowAggOperator.windowFunctions().get(0));
     }
 
     @Test
@@ -524,14 +516,16 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         String statement = "select * from (select * from t1, t2) tjoin";
         var logicalPlan = e.logicalPlan(statement);
         var expectedPlan =
-            "Rename[x, x] AS tjoin\n" +
-            "  └ NestedLoopJoin[CROSS]\n" +
-            "    ├ Collect[doc.t1 | [x] | true]\n" +
-            "    └ Collect[doc.t2 | [x] | true]";
-        assertThat(logicalPlan, isPlan(expectedPlan));
+            """
+            Rename[x, x] AS tjoin
+              └ NestedLoopJoin[CROSS]
+                ├ Collect[doc.t1 | [x] | true]
+                └ Collect[doc.t2 | [x] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
 
         Join join = e.plan(statement);
-        Asserts.assertThat(join.joinPhase().projections().get(0).outputs()).satisfiesExactly(
+        assertThat(join.joinPhase().projections().get(0).outputs()).satisfiesExactly(
             isInputColumn(0),
             isInputColumn(1));
     }
@@ -544,13 +538,16 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             limit 10
             """);
 
-        assertThat(plan, isPlan(
-            "Eval[name AS usr]\n" +
-                "  └ Limit[10::bigint;0]\n" +
-                "    └ NestedLoopJoin[CROSS]\n" +
-                "      ├ OrderBy[name ASC]\n" +
-                "      │  └ Collect[doc.users | [name] | true]\n" +
-                "      └ Collect[doc.t1 | [] | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            Eval[name AS usr]
+              └ Limit[10::bigint;0]
+                └ NestedLoopJoin[CROSS]
+                  ├ OrderBy[name ASC]
+                  │  └ Collect[doc.users | [name] | true]
+                  └ Collect[doc.t1 | [] | true]
+            """
+        );
     }
 
     @Test
@@ -574,23 +571,27 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                             " from users, t1" +
                                             " where t1.a = users.address['postcode']");
         var expectedPlan =
-            "Eval[name]\n" +
-            "  └ HashJoin[(a = address['postcode'])]\n" +
-            "    ├ Collect[doc.users | [name, address['postcode']] | true]\n" +
-            "    └ Collect[doc.t1 | [a] | true]";
-        assertThat(logicalPlan, is(isPlan(expectedPlan)));
+            """
+            Eval[name]
+              └ HashJoin[(a = address['postcode'])]
+                ├ Collect[doc.users | [name, address['postcode']] | true]
+                └ Collect[doc.t1 | [a] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
 
         // Same using an table alias (MSS -> AliasAnalyzedRelation -> AbstractTableRelation)
         logicalPlan = e.logicalPlan("select u.name" +
                                         " from users u, t1" +
                                         " where t1.a = u.address['postcode']");
         expectedPlan =
-            "Eval[name]\n" +
-            "  └ HashJoin[(a = address['postcode'])]\n" +
-            "    ├ Rename[name, address['postcode']] AS u\n" +
-            "    │  └ Collect[doc.users | [name, address['postcode']] | true]\n" +
-            "    └ Collect[doc.t1 | [a] | true]";
-        assertThat(logicalPlan, is(isPlan(expectedPlan)));
+            """
+            Eval[name]
+              └ HashJoin[(a = address['postcode'])]
+                ├ Rename[name, address['postcode']] AS u
+                │  └ Collect[doc.users | [name, address['postcode']] | true]
+                └ Collect[doc.t1 | [a] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -618,30 +619,34 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = executor.logicalPlan(
             "SELECT * FROM v1 WHERE start >= '2021-12-01' and start <= '2021-12-01 00:59:59'");
         String expectedPlan =
-            "Rename[start] AS doc.v1\n" +
-            "  └ Eval[ts_production AS start]\n" +
-            "    └ NestedLoopJoin[INNER | (ts_production = max_ts)]\n" +
-            "      ├ Rename[max_ts] AS last_record\n" +
-            "      │  └ Eval[max(ts) AS max_ts]\n" +
-            "      │    └ HashAggregate[max(ts)]\n" +
-            "      │      └ Collect[doc.metric_mini | [ts] | true]\n" +
-            "      └ Rename[ts_production] AS b\n" +
-            "        └ Collect[doc.metric_mini | [ts_production] | ((ts_production AS start >= 1638316800000::bigint) AND (ts_production AS start <= 1638320399000::bigint))]";
-        assertThat(plan, is(isPlan(expectedPlan)));
+            """
+            Rename[start] AS doc.v1
+              └ Eval[ts_production AS start]
+                └ NestedLoopJoin[INNER | (ts_production = max_ts)]
+                  ├ Rename[max_ts] AS last_record
+                  │  └ Eval[max(ts) AS max_ts]
+                  │    └ HashAggregate[max(ts)]
+                  │      └ Collect[doc.metric_mini | [ts] | true]
+                  └ Rename[ts_production] AS b
+                    └ Collect[doc.metric_mini | [ts_production] | ((ts_production AS start >= 1638316800000::bigint) AND (ts_production AS start <= 1638320399000::bigint))]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
 
         plan = executor.logicalPlan(
             "SELECT * FROM v1 WHERE start >= ? and start <= ?");
         expectedPlan =
-            "Rename[start] AS doc.v1\n" +
-            "  └ Eval[ts_production AS start]\n" +
-            "    └ NestedLoopJoin[INNER | (ts_production = max_ts)]\n" +
-            "      ├ Rename[max_ts] AS last_record\n" +
-            "      │  └ Eval[max(ts) AS max_ts]\n" +
-            "      │    └ HashAggregate[max(ts)]\n" +
-            "      │      └ Collect[doc.metric_mini | [ts] | true]\n" +
-            "      └ Rename[ts_production] AS b\n" +
-            "        └ Collect[doc.metric_mini | [ts_production] | ((ts_production AS start >= $1) AND (ts_production AS start <= $2))]";
-        assertThat(plan, is(isPlan(expectedPlan)));
+            """
+            Rename[start] AS doc.v1
+              └ Eval[ts_production AS start]
+                └ NestedLoopJoin[INNER | (ts_production = max_ts)]
+                  ├ Rename[max_ts] AS last_record
+                  │  └ Eval[max(ts) AS max_ts]
+                  │    └ HashAggregate[max(ts)]
+                  │      └ Collect[doc.metric_mini | [ts] | true]
+                  └ Rename[ts_production] AS b
+                    └ Collect[doc.metric_mini | [ts_production] | ((ts_production AS start >= $1) AND (ts_production AS start <= $2))]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -669,24 +674,26 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                 ON time_series.time = readings.time AND sensors.sensor_id = readings.sensor_id
             """;
         LogicalPlan logicalPlan = executor.logicalPlan(statement);
-        assertThat(logicalPlan, is(isPlan(
-            "Eval[time, sensor_id, battery_level]\n" +
-            "  └ NestedLoopJoin[LEFT | ((time = time) AND (sensor_id = sensor_id))]\n" +
-            "    ├ NestedLoopJoin[CROSS]\n" +
-            "    │  ├ Rename[time] AS time_series\n" +
-            "    │  │  └ TableFunction[generate_series | [generate_series] | true]\n" +
-            "    │  └ Rename[sensor_id] AS sensors\n" +
-            "    │    └ TableFunction[unnest | [unnest] | true]\n" +
-            "    └ Rename[battery_level, time, sensor_id] AS readings\n" +
-            "      └ Collect[doc.sensor_readings | [battery_level, time, sensor_id] | true]"
-        )));
+        assertThat(logicalPlan).isEqualTo(
+            """
+            Eval[time, sensor_id, battery_level]
+              └ NestedLoopJoin[LEFT | ((time = time) AND (sensor_id = sensor_id))]
+                ├ NestedLoopJoin[CROSS]
+                │  ├ Rename[time] AS time_series
+                │  │  └ TableFunction[generate_series | [generate_series] | true]
+                │  └ Rename[sensor_id] AS sensors
+                │    └ TableFunction[unnest | [unnest] | true]
+                └ Rename[battery_level, time, sensor_id] AS readings
+                  └ Collect[doc.sensor_readings | [battery_level, time, sensor_id] | true]
+            """
+        );
 
         Object plan = executor.plan(statement);
-        assertThat(plan, Matchers.instanceOf(Join.class));
+        assertThat(plan).isExactlyInstanceOf(Join.class);
     }
 
     /**
-     * https://github.com/crate/crate/issues/11404
+     * <a href=https://github.com/crate/crate/issues/11404/>
      */
     @Test
     public void test_constant_expression_in_left_join_condition_is_pushed_down_to_relation() throws Exception {
@@ -695,11 +702,13 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan logicalPlan = executor.logicalPlan(
             "select doc.t1.*, doc.t2.b from doc.t1 join doc.t2 on doc.t1.x = doc.t2.y and doc.t2.b = 'abc'");
 
-        assertThat(logicalPlan, is(isPlan(
-            "Eval[a, x, i, b]\n" +
-            "  └ HashJoin[(x = y)]\n" +
-            "    ├ Collect[doc.t1 | [a, x, i] | true]\n" +
-            "    └ Collect[doc.t2 | [b, y] | (b = 'abc')]")));
+        assertThat(logicalPlan).isEqualTo(
+            """
+            Eval[a, x, i, b]
+              └ HashJoin[(x = y)]
+                ├ Collect[doc.t1 | [a, x, i] | true]
+                └ Collect[doc.t2 | [b, y] | (b = 'abc')]
+            """);
     }
 
     @Test
@@ -712,21 +721,23 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             WHERE t2.y IN (SELECT z FROM t3);
             """;
         LogicalPlan logicalPlan = e.logicalPlan(statement);
-        assertThat(logicalPlan, is(isPlan(
-            "MultiPhase\n" +
-            "  └ NestedLoopJoin[INNER | (i = i)]\n" +
-            "    ├ Collect[doc.t1 | [a, x, i] | true]\n" +
-            "    └ Collect[doc.t2 | [b, y, i] | (y = ANY((SELECT z FROM (doc.t3))))]\n" +
-            "  └ OrderBy[z ASC]\n" +
-            "    └ Collect[doc.t3 | [z] | true]")));
+        assertThat(logicalPlan).isEqualTo(
+            """
+            MultiPhase
+              └ NestedLoopJoin[INNER | (i = i)]
+                ├ Collect[doc.t1 | [a, x, i] | true]
+                └ Collect[doc.t2 | [b, y, i] | (y = ANY((SELECT z FROM (doc.t3))))]
+              └ OrderBy[z ASC]
+                └ Collect[doc.t3 | [z] | true]
+            """);
 
         Object plan = e.plan(statement);
-        assertThat(plan, instanceOf(Merge.class));
-        assertThat(((Merge) plan).subPlan(), instanceOf(Join.class));
+        assertThat(plan).isExactlyInstanceOf(Merge.class);
+        assertThat(((Merge) plan).subPlan()).isExactlyInstanceOf(Join.class);
     }
 
     /**
-     * https://github.com/crate/crate/issues/13592
+     * <a href=https://github.com/crate/crate/issues/13592/>
      */
     public void test_correlated_subquery_can_access_all_tables_from_outer_query_that_joins_multiple_tables() throws IOException {
         var executor = SQLExecutor.builder(clusterService, 2, Randomness.get(), List.of())
@@ -738,21 +749,23 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan logicalPlan = executor.logicalPlan(
             "select (select 1 where a.x=1 and b.x=1 and c.x=1) from a,b,c,d"
         );
-        assertThat(logicalPlan, is(isPlan(
-            "Eval[(SELECT 1 FROM (empty_row))]\n" +
-            "  └ CorrelatedJoin[x, x, x, (SELECT 1 FROM (empty_row))]\n" +
-            "    └ NestedLoopJoin[CROSS]\n" +
-            "      ├ NestedLoopJoin[CROSS]\n" +
-            "      │  ├ NestedLoopJoin[CROSS]\n" +
-            "      │  │  ├ Collect[doc.a | [x] | true]\n" +
-            "      │  │  └ Collect[doc.b | [x] | true]\n" +
-            "      │  └ Collect[doc.c | [x] | true]\n" +
-            "      └ Collect[doc.d | [] | true]\n" +
-            "    └ SubPlan\n" +
-            "      └ Eval[1]\n" +
-            "        └ Limit[2::bigint;0::bigint]\n" +
-            "          └ Filter[(((x = 1) AND (x = 1)) AND (x = 1))]\n" +
-            "            └ TableFunction[empty_row | [] | true]"
-        )));
+        assertThat(logicalPlan).isEqualTo(
+            """
+            Eval[(SELECT 1 FROM (empty_row))]
+              └ CorrelatedJoin[x, x, x, (SELECT 1 FROM (empty_row))]
+                └ NestedLoopJoin[CROSS]
+                  ├ NestedLoopJoin[CROSS]
+                  │  ├ NestedLoopJoin[CROSS]
+                  │  │  ├ Collect[doc.a | [x] | true]
+                  │  │  └ Collect[doc.b | [x] | true]
+                  │  └ Collect[doc.c | [x] | true]
+                  └ Collect[doc.d | [] | true]
+                └ SubPlan
+                  └ Eval[1]
+                    └ Limit[2::bigint;0::bigint]
+                      └ Filter[(((x = 1) AND (x = 1)) AND (x = 1))]
+                        └ TableFunction[empty_row | [] | true]
+            """
+        );
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_LIMIT;
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_OFFSET;
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLimitAndOffset;
 import static org.mockito.Mockito.mock;
@@ -31,7 +30,6 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
@@ -77,10 +75,13 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
             Literal.of(20L),
             Literal.of(7L)
         );
-        Assert.assertThat(plan, isPlan(
-            "Limit[20::bigint;7::bigint]\n" +
-            "  └ Limit[10::bigint;5::bigint]\n" +
-            "    └ Collect[doc.users | [name] | true]"));
+        assertThat(plan).isEqualTo(
+            """
+            Limit[20::bigint;7::bigint]
+              └ Limit[10::bigint;5::bigint]
+                └ Collect[doc.users | [name] | true]
+            """
+        );
         PlannerContext ctx = e.getPlannerContext(clusterService.state());
         Merge merge = (Merge) plan.build(
             mock(DependencyCarrier.class),

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -1,15 +1,15 @@
 /*
  * Licensed to Crate.io GmbH ("Crate") under one or more contributor
  * license agreements.  See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.  Crate licenses
- * this file to you under the Apache License, Version 2.0 (the "License");
+ * additional informatiON regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, VersiON 2.0 (the "License");
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * distributed under the License is distributed ON an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
  * License for the specific language governing permissions and limitations
  * under the License.
@@ -21,20 +21,14 @@
 
 package io.crate.planner.operators;
 
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.hamcrest.FeatureMatcher;
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -67,8 +61,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
             .setTableStats(tableStats)
-            .addView(new RelationName("doc", "v2"), "select a, x from doc.t1")
-            .addView(new RelationName("doc", "v3"), "select a, x from doc.t1")
+            .addView(new RelationName("doc", "v2"), "SELECT a, x FROM doc.t1")
+            .addView(new RelationName("doc", "v3"), "SELECT a, x FROM doc.t1")
             .build();
     }
 
@@ -78,476 +72,501 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_collect_derives_estimated_size_per_row_from_stats_and_types() {
-        // no stats -> size derived from fixed with type
-        LogicalPlan plan = plan("select x from t1");
-        assertThat(plan.estimatedRowSize(), is((long) DataTypes.INTEGER.fixedSize()));
+        // no stats -> size derived FROM fixed with type
+        LogicalPlan plan = plan("SELECT x FROM t1");
+        assertThat(plan.estimatedRowSize()).isEqualTo((long) DataTypes.INTEGER.fixedSize());
 
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
         ColumnStats<Integer> columnStats = new ColumnStats<>(
             0.0, 50L, 2, DataTypes.INTEGER, MostCommonValues.EMPTY, List.of());
         tableStats.updateTableStats(Map.of(t1.ident(), new Stats(2L, 100L, Map.of(new ColumnIdent("x"), columnStats))));
 
-        // stats present -> size derived from them (although bogus fake stats in this case)
-        plan = plan("select x from t1");
-        assertThat(plan.estimatedRowSize(), is(50L));
+        // stats present -> size derived FROM them (although bogus fake stats in this case)
+        plan = plan("SELECT x FROM t1");
+        assertThat(plan.estimatedRowSize()).isEqualTo(50L);
     }
 
     @Test
     public void testAvgWindowFunction() {
-        LogicalPlan plan = plan("select avg(x) OVER() from t1");
-        assertThat(plan, isPlan(
-            "Eval[avg(x) OVER ()]\n" +
-            "  └ WindowAgg[x, avg(x) OVER ()]\n" +
-            "    └ Collect[doc.t1 | [x] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT avg(x) OVER() FROM t1");
+        assertThat(plan).isEqualTo(
+            """
+            Eval[avg(x) OVER ()]
+              └ WindowAgg[x, avg(x) OVER ()]
+                └ Collect[doc.t1 | [x] | true]
+            """
+        );
     }
 
     @Test
     public void testAggregationOnTableFunction() throws Exception {
-        LogicalPlan plan = plan("select max(unnest) from unnest([1, 2, 3])");
-        assertThat(plan, isPlan(
-            "HashAggregate[max(unnest)]\n" +
-            "  └ TableFunction[unnest | [unnest] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT max(unnest) FROM unnest([1, 2, 3])");
+        assertThat(plan).isEqualTo(
+            """
+            HashAggregate[max(unnest)]
+              └ TableFunction[unnest | [unnest] | true]
+            """
+        );
     }
 
     @Test
     public void testQTFWithOrderBy() throws Exception {
-        LogicalPlan plan = plan("select a, x from t1 order by a");
-        assertThat(plan, isPlan(
-            "Fetch[a, x]\n" +
-            "  └ OrderBy[a ASC]\n" +
-            "    └ Collect[doc.t1 | [_fetchid, a] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT a, x FROM t1 ORDER BY a");
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[a, x]
+              └ OrderBy[a ASC]
+                └ Collect[doc.t1 | [_fetchid, a] | true]
+            """
+        );
     }
 
     @Test
     public void testQTFWithOrderByAndAlias() throws Exception {
-        LogicalPlan plan = plan("select a, x from t1 as t order by a");
-        assertThat(plan, isPlan(
-            "Fetch[a, x]\n" +
-            "  └ Rename[t._fetchid, a] AS t\n" +
-            "    └ OrderBy[a ASC]\n" +
-            "      └ Collect[doc.t1 | [_fetchid, a] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT a, x FROM t1 as t ORDER BY a");
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[a, x]
+              └ Rename[t._fetchid, a] AS t
+                └ OrderBy[a ASC]
+                  └ Collect[doc.t1 | [_fetchid, a] | true]
+            """
+        );
     }
 
     @Test
     public void testQTFWithoutOrderBy() throws Exception {
-        LogicalPlan plan = plan("select a, x from t1");
-        assertThat(plan, isPlan("Collect[doc.t1 | [a, x] | true]"));
+        LogicalPlan plan = plan("SELECT a, x FROM t1");
+        assertThat(plan).isEqualTo("Collect[doc.t1 | [a, x] | true]");
     }
 
     @Test
     public void testSimpleSelectQAFAndLimit() throws Exception {
-        LogicalPlan plan = plan("select a from t1 order by a limit 10 offset 5");
-        assertThat(plan, isPlan(
-            "Limit[10::bigint;5::bigint]\n" +
-            "  └ OrderBy[a ASC]\n" +
-            "    └ Collect[doc.t1 | [a] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT a FROM t1 ORDER BY a LIMIT 10 offset 5");
+        assertThat(plan).isEqualTo(
+            """
+            Limit[10::bigint;5::bigint]
+              └ OrderBy[a ASC]
+                └ Collect[doc.t1 | [a] | true]
+            """
+        );
     }
 
     @Test
     public void testSelectOnVirtualTableWithOrderBy() throws Exception {
-        LogicalPlan plan = plan("select a, x from (" +
-                                "   select a, x from t1 order by a limit 3) tt " +
-                                "order by x desc limit 1");
-        assertThat(plan, isPlan(
-            "Rename[a, x] AS tt\n" +
-            "  └ Limit[1::bigint;0]\n" +
-            "    └ OrderBy[x DESC]\n" +
-            "      └ Fetch[a, x]\n" +
-            "        └ Limit[3::bigint;0]\n" +
-            "          └ OrderBy[a ASC]\n" +
-            "            └ Collect[doc.t1 | [_fetchid, a] | true]"));
+        LogicalPlan plan = plan(
+            """
+            SELECT a, x FROM (
+              SELECT a, x FROM t1 ORDER BY a LIMIT 3) tt
+            ORDER BY x DESC LIMIT 1
+            """
+        );
+        assertThat(plan).isEqualTo(
+            """
+            Rename[a, x] AS tt
+              └ Limit[1::bigint;0]
+                └ OrderBy[x DESC]
+                  └ Fetch[a, x]
+                    └ Limit[3::bigint;0]
+                      └ OrderBy[a ASC]
+                        └ Collect[doc.t1 | [_fetchid, a] | true]
+            """);
     }
 
     @Test
     public void testIntermediateFetch() throws Exception {
-        LogicalPlan plan = plan("select sum(x) from (select x from t1 limit 10) tt");
-        assertThat(plan, isPlan(
-            "HashAggregate[sum(x)]\n" +
-            "  └ Rename[x] AS tt\n" +
-            "    └ Fetch[x]\n" +
-            "      └ Limit[10::bigint;0]\n" +
-            "        └ Collect[doc.t1 | [_fetchid] | true]"));
+        LogicalPlan plan = plan("SELECT sum(x) FROM (SELECT x FROM t1 LIMIT 10) tt");
+        assertThat(plan).isEqualTo(
+            """
+            HashAggregate[sum(x)]
+              └ Rename[x] AS tt
+                └ Fetch[x]
+                  └ Limit[10::bigint;0]
+                    └ Collect[doc.t1 | [_fetchid] | true]
+            """);
     }
 
     @Test
     public void testHavingGlobalAggregation() throws Exception {
-        LogicalPlan plan = plan("select min(a), min(x) from t1 having min(x) < 33 and max(x) > 100");
-        assertThat(plan, isPlan(
-            "Eval[min(a), min(x)]\n" +
-            "  └ Filter[((min(x) < 33) AND (max(x) > 100))]\n" +
-            "    └ HashAggregate[min(a), min(x), max(x)]\n" +
-            "      └ Collect[doc.t1 | [a, x] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT min(a), min(x) FROM t1 HAVING min(x) < 33 and max(x) > 100");
+        assertThat(plan).isEqualTo(
+            """
+            Eval[min(a), min(x)]
+              └ Filter[((min(x) < 33) AND (max(x) > 100))]
+                └ HashAggregate[min(a), min(x), max(x)]
+                  └ Collect[doc.t1 | [a, x] | true]
+            """
+        );
     }
 
     @Test
     public void testHavingGlobalAggregationAndRelationAlias() throws Exception {
-        LogicalPlan plan = plan("select min(a), min(x) from t1 as tt having min(tt.x) < 33 and max(tt.x) > 100");
-        assertThat(plan, isPlan(
-            "Eval[min(a), min(x)]\n" +
-            "  └ Filter[((min(x) < 33) AND (max(x) > 100))]\n" +
-            "    └ HashAggregate[min(a), min(x), max(x)]\n" +
-            "      └ Rename[a, x] AS tt\n" +
-            "        └ Collect[doc.t1 | [a, x] | true]"));
+        LogicalPlan plan = plan("SELECT min(a), min(x) FROM t1 as tt HAVING min(tt.x) < 33 and max(tt.x) > 100");
+        assertThat(plan).isEqualTo(
+            """
+            Eval[min(a), min(x)]
+              └ Filter[((min(x) < 33) AND (max(x) > 100))]
+                └ HashAggregate[min(a), min(x), max(x)]
+                  └ Rename[a, x] AS tt
+                    └ Collect[doc.t1 | [a, x] | true]
+            """);
     }
 
     @Test
     public void testSelectCountStarIsOptimized() throws Exception {
-        LogicalPlan plan = plan("select count(*) from t1 where x > 10");
-        assertThat(plan, isPlan("Count[doc.t1 | (x > 10)]"));
+        LogicalPlan plan = plan("SELECT count(*) FROM t1 WHERE x > 10");
+        assertThat(plan).isEqualTo("Count[doc.t1 | (x > 10)]");
     }
 
     @Test
     public void test_select_count_star_on_aliased_table_is_optimized() throws Exception {
-        LogicalPlan plan = plan("select count(*) from t1 as t");
-        assertThat(plan, isPlan("Count[doc.t1 | true]"));
+        LogicalPlan plan = plan("SELECT count(*) FROM t1 as t");
+        assertThat(plan).isEqualTo("Count[doc.t1 | true]");
     }
 
     @Test
     public void test_select_count_star_is_optimized_if_there_is_a_single_agg_in_select_list() {
         LogicalPlan plan = plan("SELECT COUNT(*), COUNT(x) FROM t1 WHERE x > 10");
-        assertThat(plan, isPlan(
-            "HashAggregate[count(*), count(x)]\n" +
-            "  └ Collect[doc.t1 | [x] | (x > 10)]"));
+        assertThat(plan).isEqualTo(
+            """
+            HashAggregate[count(*), count(x)]
+              └ Collect[doc.t1 | [x] | (x > 10)]
+            """
+        );
     }
 
     @Test
     public void testSelectCountStarIsOptimizedOnNestedSubqueries() throws Exception {
-        LogicalPlan plan = plan("select * from t1 where x > (select 1 from t1 where x > (select count(*) from t2 limit 1)::integer)");
+        LogicalPlan plan = plan("SELECT * FROM t1 WHERE x > (SELECT 1 FROM t1 WHERE x > (SELECT count(*) FROM t2 LIMIT 1)::integer)");
         // instead of a Collect plan, this must result in a CountPlan through optimization
-        assertThat(plan, isPlan(
-            "MultiPhase\n" +
-            "  └ Collect[doc.t1 | [a, x, i] | (x > (SELECT 1 FROM (doc.t1)))]\n" +
-            "  └ Limit[2::bigint;0::bigint]\n" +
-            "    └ MultiPhase\n" +
-            "      └ Collect[doc.t1 | [1] | (x > cast((SELECT count(*) FROM (doc.t2)) AS integer))]\n" +
-            "      └ Limit[2::bigint;0::bigint]\n" +
-            "        └ Limit[1::bigint;0]\n" +
-            "          └ Count[doc.t2 | true]"
-        ));
+        assertThat(plan).isEqualTo(
+            """
+            MultiPhase
+              └ Collect[doc.t1 | [a, x, i] | (x > (SELECT 1 FROM (doc.t1)))]
+              └ Limit[2::bigint;0::bigint]
+                └ MultiPhase
+                  └ Collect[doc.t1 | [1] | (x > cast((SELECT count(*) FROM (doc.t2)) AS integer))]
+                  └ Limit[2::bigint;0::bigint]
+                    └ Limit[1::bigint;0]
+                      └ Count[doc.t2 | true]
+            """
+        );
     }
 
     @Test
     public void testSelectCountStarIsOptimizedInsideRelations() {
-        LogicalPlan plan = plan("select t2.i, cnt from " +
-                               " (select count(*) as cnt from t1) t1 " +
-                               "join" +
-                               " (select i from t2 limit 1) t2 " +
-                               "on t1.cnt = t2.i::long ");
-        assertThat(plan, isPlan(
-            "Eval[i, cnt]\n" +
-            "  └ HashJoin[(cnt = cast(i AS bigint))]\n" +
-            "    ├ Rename[cnt] AS t1\n" +
-            "    │  └ Eval[count(*) AS cnt]\n" +
-            "    │    └ Count[doc.t1 | true]\n" +
-            "    └ Rename[i] AS t2\n" +
-            "      └ Fetch[i]\n" +
-            "        └ Limit[1::bigint;0]\n" +
-            "          └ Collect[doc.t2 | [_fetchid] | true]"));
+        LogicalPlan plan = plan(
+            """
+            SELECT t2.i, cnt FROM
+              (SELECT count(*) as cnt FROM t1) t1
+            JOIN
+              (SELECT i FROM t2 LIMIT 1) t2
+            ON t1.cnt = t2.i::long
+            """
+        );
+        assertThat(plan).isEqualTo(
+            """
+            Eval[i, cnt]
+              └ HashJoin[(cnt = cast(i AS bigint))]
+                ├ Rename[cnt] AS t1
+                │  └ Eval[count(*) AS cnt]
+                │    └ Count[doc.t1 | true]
+                └ Rename[i] AS t2
+                  └ Fetch[i]
+                    └ Limit[1::bigint;0]
+                      └ Collect[doc.t2 | [_fetchid] | true]
+            """);
     }
 
     @Test
     public void testJoinTwoTables() {
-        LogicalPlan plan = plan("select " +
-                                "   t1.x, t1.a, t2.y " +
-                                "from " +
-                                "   t1 " +
-                                "   inner join t2 on t1.x = t2.y " +
-                                "order by t1.x " +
-                                "limit 10");
-        assertThat(plan, isPlan(
-            "Fetch[x, a, y]\n" +
-            "  └ Limit[10::bigint;0]\n" +
-            "    └ OrderBy[x ASC]\n" +
-            "      └ HashJoin[(x = y)]\n" +
-            "        ├ Collect[doc.t1 | [_fetchid, x] | true]\n" +
-            "        └ Collect[doc.t2 | [y] | true]"));
+        LogicalPlan plan = plan(
+            """
+            SELECT t1.x, t1.a, t2.y
+            FROM t1
+            INNER JOIN t2 ON t1.x = t2.y
+            ORDER BY t1.x
+            LIMIT 10
+             """);
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[x, a, y]
+              └ Limit[10::bigint;0]
+                └ OrderBy[x ASC]
+                  └ HashJoin[(x = y)]
+                    ├ Collect[doc.t1 | [_fetchid, x] | true]
+                    └ Collect[doc.t2 | [y] | true]
+            """);
     }
 
     @Test
     public void testScoreColumnIsCollectedNotFetched() throws Exception {
-        LogicalPlan plan = plan("select x, _score from t1");
-        assertThat(plan, isPlan("Collect[doc.t1 | [x, _score] | true]"));
+        LogicalPlan plan = plan("SELECT x, _score FROM t1");
+        assertThat(plan).isEqualTo("Collect[doc.t1 | [x, _score] | true]");
     }
 
     @Test
     public void testInWithSubqueryOrderImplicitlyApplied() {
-        LogicalPlan plan = plan("select x from t1 where x in (select x from t1)");
-        assertThat(plan.dependencies().entrySet().size(), is(1));
+        LogicalPlan plan = plan("SELECT x FROM t1 WHERE x in (SELECT x FROM t1)");
+        assertThat(plan.dependencies().entrySet()).hasSize(1);
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
-        assertThat(subPlan, isPlan(
-            "OrderBy[x ASC]\n" +
-            "  └ Collect[doc.t1 | [x] | true]"));
+        assertThat(subPlan).isEqualTo(
+            """
+            OrderBy[x ASC]
+              └ Collect[doc.t1 | [x] | true]
+            """);
     }
 
     @Test
     public void testInWithSubqueryOrderImplicitlyAppliedWithExistingOrderBy() {
-        LogicalPlan plan = plan("select x from t1 where x in (select x from t1 order by 1 desc limit 10)");
-        assertThat(plan.dependencies().entrySet().size(), is(1));
+        LogicalPlan plan = plan("SELECT x FROM t1 WHERE x in (SELECT x FROM t1 ORDER BY 1 DESC LIMIT 10)");
+        assertThat(plan.dependencies().entrySet()).hasSize(1);
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
-        assertThat(subPlan, isPlan(
-            "Limit[10::bigint;0]\n" +
-            "  └ OrderBy[x DESC]\n" +
-            "    └ Collect[doc.t1 | [x] | true]"));
+        assertThat(subPlan).isEqualTo(
+            """
+            Limit[10::bigint;0]
+              └ OrderBy[x DESC]
+                └ Collect[doc.t1 | [x] | true]
+            """);
     }
 
     @Test
     public void testInWithSubqueryOrderImplicitlyAppliedWithExistingOrderByOnDifferentField() {
-        LogicalPlan plan = plan("select x from t1 where x in (select x from t1 order by a desc limit 10)");
-        assertThat(plan.dependencies().entrySet().size(), is(1));
+        LogicalPlan plan = plan("SELECT x FROM t1 WHERE x in (SELECT x FROM t1 ORDER BY a DESC LIMIT 10)");
+        assertThat(plan.dependencies().entrySet()).hasSize(1);
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
-        assertThat(subPlan, isPlan(
-            "Eval[x]\n" +
-            "  └ OrderBy[x ASC]\n" +
-            "    └ Limit[10::bigint;0]\n" +
-            "      └ OrderBy[a DESC]\n" +
-            "        └ Collect[doc.t1 | [x, a] | true]"));
+        assertThat(subPlan).isEqualTo(
+            """
+            Eval[x]
+              └ OrderBy[x ASC]
+                └ Limit[10::bigint;0]
+                  └ OrderBy[a DESC]
+                    └ Collect[doc.t1 | [x, a] | true]
+            """);
     }
 
     @Test
     public void test_optimize_for_in_subquery_only_operates_on_primitive_types() {
-        LogicalPlan plan = plan("select array(select {a = x} from t1)");
-        assertThat(plan.dependencies().entrySet().size(), is(1));
+        LogicalPlan plan = plan("SELECT array(SELECT {a = x} FROM t1)");
+        assertThat(plan.dependencies().entrySet()).hasSize(1);
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
-        assertThat(subPlan, isPlan("Collect[doc.t1 | [_map('a', x)] | true]"));
+        assertThat(subPlan).isEqualTo("Collect[doc.t1 | [_map('a', x)] | true]");
     }
 
     @Test
     public void testParentQueryIsPushedDownAndMergedIntoSubRelationWhereClause() {
-        LogicalPlan plan = plan("select * from " +
-                                " (select a, i from t1 order by a limit 5) t1 " +
-                                "inner join" +
-                                " (select b, i from t2 where b > '10') t2 " +
-                                "on t1.i = t2.i where t1.a > '50' and t2.b > '100' " +
-                                "limit 10");
-        assertThat(plan, isPlan(
-            "Fetch[a, i, b, i]\n" +
-            "  └ Limit[10::bigint;0]\n" +
-            "    └ HashJoin[(i = i)]\n" +
-            "      ├ Rename[a, i] AS t1\n" +
-            "      │  └ Filter[(a > '50')]\n" +
-            "      │    └ Fetch[a, i]\n" +
-            "      │      └ Limit[5::bigint;0]\n" +
-            "      │        └ OrderBy[a ASC]\n" +
-            "      │          └ Collect[doc.t1 | [_fetchid, a] | true]\n" +
-            "      └ Rename[t2._fetchid, i] AS t2\n" +
-            "        └ Collect[doc.t2 | [_fetchid, i] | ((b > '100') AND (b > '10'))]"));
+        LogicalPlan plan = plan("SELECT * FROM " +
+                                " (SELECT a, i FROM t1 ORDER BY a LIMIT 5) t1 " +
+                                "INNER JOIN" +
+                                " (SELECT b, i FROM t2 WHERE b > '10') t2 " +
+                                "ON t1.i = t2.i WHERE t1.a > '50' and t2.b > '100' " +
+                                "LIMIT 10");
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[a, i, b, i]
+              └ Limit[10::bigint;0]
+                └ HashJoin[(i = i)]
+                  ├ Rename[a, i] AS t1
+                  │  └ Filter[(a > '50')]
+                  │    └ Fetch[a, i]
+                  │      └ Limit[5::bigint;0]
+                  │        └ OrderBy[a ASC]
+                  │          └ Collect[doc.t1 | [_fetchid, a] | true]
+                  └ Rename[t2._fetchid, i] AS t2
+                    └ Collect[doc.t2 | [_fetchid, i] | ((b > '100') AND (b > '10'))]
+            """);
     }
 
     @Test
     public void testPlanOfJoinedViewsHasBoundaryWithViewOutputs() {
-        LogicalPlan plan = plan("SELECT v2.x, v2.a, v3.x, v3.a " +
-                              "FROM v2 " +
-                              "  INNER JOIN v3 " +
-                              "  ON v2.x= v3.x");
-        assertThat(plan, isPlan(
-            "Eval[x, a, x, a]\n" +
-            "  └ HashJoin[(x = x)]\n" +
-            "    ├ Rename[a, x] AS doc.v2\n" +
-            "    │  └ Collect[doc.t1 | [a, x] | true]\n" +
-            "    └ Rename[a, x] AS doc.v3\n" +
-            "      └ Collect[doc.t1 | [a, x] | true]"));
+        LogicalPlan plan = plan(
+            """
+            SELECT v2.x, v2.a, v3.x, v3.a
+            FROM v2
+            INNER JOIN v3
+            ON v2.x= v3.x
+            """);
+        assertThat(plan).isEqualTo(
+            """
+            Eval[x, a, x, a]
+              └ HashJoin[(x = x)]
+                ├ Rename[a, x] AS doc.v2
+                │  └ Collect[doc.t1 | [a, x] | true]
+                └ Rename[a, x] AS doc.v3
+                  └ Collect[doc.t1 | [a, x] | true]
+            """);
     }
 
     @Test
     public void testAliasedPrimaryKeyLookupHasGetPlan() {
-        LogicalPlan plan = plan("select name from users u where id = 1");
-        assertThat(plan, isPlan(
+        LogicalPlan plan = plan("SELECT name FROM users u WHERE id = 1");
+        assertThat(plan).isEqualTo(
             "Rename[name] AS u\n" +
-            "  └ Get[doc.users | name | DocKeys{1::bigint} | (id = 1::bigint)]"));
+            "  └ Get[doc.users | name | DocKeys{1::bigint} | (id = 1::bigint)]");
     }
 
     @Test
     public void test_limit_distinct_limits_outputs_to_the_group_keys_if_source_has_more_outputs() {
-        String statement = "select name, other_id " +
-                           "from (select name, awesome, other_id from users) u " +
-                           "group by name, other_id limit 20";
-        LogicalPlan plan = plan(
-            statement);
-        assertThat(
-            plan,
-            isPlan(
-                "LimitDistinct[20::bigint;0 | [name, other_id]]\n" +
-                "  └ Rename[name, other_id] AS u\n" +
-                "    └ Collect[doc.users | [name, other_id] | true]"
-            )
+        String statement = """
+                            SELECT name, other_id
+                            FROM (SELECT name, awesome, other_id FROM users) u
+                            GROUP BY name, other_id LIMIT 20
+                           """;
+        LogicalPlan plan = plan(statement);
+        assertThat(plan).isEqualTo(
+            """
+            LimitDistinct[20::bigint;0 | [name, other_id]]
+              └ Rename[name, other_id] AS u
+                └ Collect[doc.users | [name, other_id] | true]
+            """
         );
         io.crate.planner.node.dql.Collect collect = sqlExecutor.plan(statement);
         List<Projection> projections = collect.collectPhase().projections();
-        assertThat(projections, contains(
-            instanceOf(LimitDistinctProjection.class),
-            instanceOf(LimitDistinctProjection.class)
-        ));
-        assertThat(projections.get(0).requiredGranularity(), is(RowGranularity.SHARD));
-        assertThat(projections.get(1).requiredGranularity(), is(RowGranularity.CLUSTER));
+        assertThat(projections).satisfiesExactly(
+            p -> assertThat(p).isExactlyInstanceOf(LimitDistinctProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(LimitDistinctProjection.class)
+        );
+        assertThat(projections.get(0).requiredGranularity()).isEqualTo(RowGranularity.SHARD);
+        assertThat(projections.get(1).requiredGranularity()).isEqualTo(RowGranularity.CLUSTER);
     }
 
     @Test
     public void test_limit_on_join_is_rewritten_to_query_then_fetch() {
-        LogicalPlan plan = plan("select * from t1, t2 limit 3");
-        assertThat(
-            plan,
-            isPlan(
-                "Fetch[a, x, i, b, y, i]\n" +
-                "  └ Limit[3::bigint;0]\n" +
-                "    └ NestedLoopJoin[CROSS]\n" +
-                "      ├ Collect[doc.t1 | [_fetchid] | true]\n" +
-                "      └ Collect[doc.t2 | [_fetchid] | true]"
-            )
+        LogicalPlan plan = plan("SELECT * FROM t1, t2 LIMIT 3");
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[a, x, i, b, y, i]
+              └ Limit[3::bigint;0]
+                └ NestedLoopJoin[CROSS]
+                  ├ Collect[doc.t1 | [_fetchid] | true]
+                  └ Collect[doc.t2 | [_fetchid] | true]
+            """
         );
     }
 
     @Test
     public void test_limit_on_hash_join_is_rewritten_to_query_then_fetch() {
-        LogicalPlan plan = plan("select * from t1 inner join t2 on t1.a = t2.b limit 3");
-        assertThat(
-            plan,
-            isPlan(
-                "Fetch[a, x, i, b, y, i]\n" +
-                "  └ Limit[3::bigint;0]\n" +
-                "    └ HashJoin[(a = b)]\n" +
-                "      ├ Collect[doc.t1 | [_fetchid, a] | true]\n" +
-                "      └ Collect[doc.t2 | [_fetchid, b] | true]"
-            )
+        LogicalPlan plan = plan("SELECT * FROM t1 INNER JOIN t2 ON t1.a = t2.b LIMIT 3");
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[a, x, i, b, y, i]
+              └ Limit[3::bigint;0]
+                └ HashJoin[(a = b)]
+                  ├ Collect[doc.t1 | [_fetchid, a] | true]
+                  └ Collect[doc.t2 | [_fetchid, b] | true]
+            """
         );
     }
 
     @Test
     public void test_unused_table_function_in_subquery_is_not_pruned() {
-        LogicalPlan plan = plan("select name from (select name, unnest(counters), text from users) u");
-        assertThat(plan, isPlan(
-            "Rename[name] AS u\n" +
-            "  └ Eval[name]\n" +
-            "    └ ProjectSet[unnest(counters), name]\n" +
-            "      └ Collect[doc.users | [counters, name] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT name FROM (SELECT name, unnest(counters), text FROM users) u");
+        assertThat(plan).isEqualTo(
+            """
+            Rename[name] AS u
+              └ Eval[name]
+                └ ProjectSet[unnest(counters), name]
+                  └ Collect[doc.users | [counters, name] | true]
+            """
+        );
     }
 
     @Test
     public void test_group_by_with_alias_and_limit_distinct_rewrite_creates_valid_plan() {
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
         tableStats.updateTableStats(Map.of(t1.ident(), new Stats(100L, 100L, Map.of())));
-        LogicalPlan plan = plan("select a as b from doc.t1 group by a limit 10");
-        assertThat(plan, isPlan(
-            "Eval[a AS b]\n" +
-            "  └ LimitDistinct[10::bigint;0 | [a]]\n" +
-            "    └ Collect[doc.t1 | [a] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT a as b FROM doc.t1 GROUP BY a LIMIT 10");
+        assertThat(plan).isEqualTo(
+            """
+            Eval[a AS b]
+              └ LimitDistinct[10::bigint;0 | [a]]
+                └ Collect[doc.t1 | [a] | true]
+            """
+        );
     }
 
     @Test
     public void test_query_uses_fetch_if_there_is_a_nested_loop_join_where_only_one_side_can_utilize_fetch() throws Exception {
         // (uses like to force NL instead of hashjoin)
         LogicalPlan plan = plan("""
-            select * from (select distinct name from users) u
-            inner join t1 on t1.a like u.name
-            limit 10
+            SELECT * FROM (SELECT distinct name FROM users) u
+            INNER JOIN t1 ON t1.a like u.name
+            LIMIT 10
             """);
-        assertThat(plan, isPlan(
-            "Fetch[name, a, x, i]\n" +
-            "  └ Limit[10::bigint;0]\n" +
-            "    └ NestedLoopJoin[INNER | (a LIKE name)]\n" +
-            "      ├ Rename[name] AS u\n" +
-            "      │  └ GroupHashAggregate[name]\n" +
-            "      │    └ Collect[doc.users | [name] | true]\n" +
-            "      └ Collect[doc.t1 | [_fetchid, a] | true]"
-        ));
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[name, a, x, i]
+              └ Limit[10::bigint;0]
+                └ NestedLoopJoin[INNER | (a LIKE name)]
+                  ├ Rename[name] AS u
+                  │  └ GroupHashAggregate[name]
+                  │    └ Collect[doc.users | [name] | true]
+                  └ Collect[doc.t1 | [_fetchid, a] | true]
+            """
+        );
     }
 
     @Test
     public void test_query_uses_fetch_if_there_is_a_hash_join_where_only_one_side_can_utilize_fetch() throws Exception {
         LogicalPlan plan = plan("""
-            select * from (select distinct name from users) u
-            inner join t1 on t1.a = u.name
-            limit 10
+            SELECT * FROM (SELECT distinct name FROM users) u
+            INNER JOIN t1 ON t1.a = u.name
+            LIMIT 10
             """);
-        assertThat(plan, isPlan(
-            "Fetch[name, a, x, i]\n" +
-            "  └ Limit[10::bigint;0]\n" +
-            "    └ HashJoin[(a = name)]\n" +
-            "      ├ Rename[name] AS u\n" +
-            "      │  └ GroupHashAggregate[name]\n" +
-            "      │    └ Collect[doc.users | [name] | true]\n" +
-            "      └ Collect[doc.t1 | [_fetchid, a] | true]"
-        ));
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[name, a, x, i]
+              └ Limit[10::bigint;0]
+                └ HashJoin[(a = name)]
+                  ├ Rename[name] AS u
+                  │  └ GroupHashAggregate[name]
+                  │    └ Collect[doc.users | [name] | true]
+                  └ Collect[doc.t1 | [_fetchid, a] | true]
+            """
+        );
     }
 
     @Test
     public void test_orderBy_not_optimized_for_array_subquery_expression() {
-        LogicalPlan plan = plan("select array(select x from t1 order by a desc limit 10)");
-        assertThat(plan.dependencies().entrySet().size(), is(1));
+        LogicalPlan plan = plan("SELECT array(SELECT x FROM t1 ORDER BY a DESC LIMIT 10)");
+        assertThat(plan.dependencies().entrySet()).hasSize(1);
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
-        assertThat(subPlan, isPlan(
-            "Eval[x]\n" +
-            "  └ Limit[10::bigint;0]\n" +
-            "    └ OrderBy[a DESC]\n" +
-            "      └ Collect[doc.t1 | [x, a] | true]"));
+        assertThat(subPlan).isEqualTo(
+            """
+            Eval[x]
+              └ Limit[10::bigint;0]
+                └ OrderBy[a DESC]
+                  └ Collect[doc.t1 | [x, a] | true]
+            """);
     }
 
     @Test
     public void test_eval_qtf_doesnt_unwrap_non_fetchable_aliases() {
         // To reproduce https://github.com/crate/crate/issues/13414  we need:
-        // 1. select at least one fetchable column (t1.i) to really kick in Query-Then-Fetch execution, just limit is not enough.
-        // 2. select used in join aliased column
+        // 1. SELECT at least one fetchable column (t1.i) to really kick in Query-Then-Fetch execution, just LIMIT is not enough.
+        // 2. SELECT used in join aliased column
         // 3. use virtual table (view or subselect)
-        // 4. use limit on the whole query
-        LogicalPlan plan = plan("""
-            select * from generate_series(1, 2)
-            cross join
-            (select t1.i, t2.y AS aliased from t1 inner join t2 on t1.x = t2.y) v
-            limit 10
-            """);
-        assertThat(plan, isPlan(
+        // 4. use LIMIT ON the whole query
+        LogicalPlan plan = plan(
             """
-                Fetch[generate_series, i, aliased]
-                  └ Limit[10::bigint;0]
-                    └ NestedLoopJoin[CROSS]
-                      ├ TableFunction[generate_series | [generate_series] | true]
-                      └ Rename[v._fetchid, aliased] AS v
-                        └ Eval[_fetchid, y AS aliased]
-                          └ HashJoin[(x = y)]
-                            ├ Collect[doc.t1 | [_fetchid, x] | true]
-                            └ Collect[doc.t2 | [y] | true]"""
-        ));
+            SELECT * FROM generate_series(1, 2)
+            CROSS JOIN
+            (SELECT t1.i, t2.y AS aliased FROM t1 INNER JOIN t2 ON t1.x = t2.y) v
+            LIMIT 10
+            """
+        );
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[generate_series, i, aliased]
+              └ Limit[10::bigint;0]
+                └ NestedLoopJoin[CROSS]
+                  ├ TableFunction[generate_series | [generate_series] | true]
+                  └ Rename[v._fetchid, aliased] AS v
+                    └ Eval[_fetchid, y AS aliased]
+                      └ HashJoin[(x = y)]
+                        ├ Collect[doc.t1 | [_fetchid, x] | true]
+                        └ Collect[doc.t2 | [y] | true]
+            """
+        );
     }
-
-    public static String printPlan(LogicalPlan logicalPlan) {
-        var printContext = new PrintContext();
-        logicalPlan.print(printContext);
-        return printContext.toString();
-    }
-
-    /**
-     * Deprecated use io.crate.testing.{@link io.crate.testing.Asserts} instead
-     */
-    @Deprecated()
-    public static Matcher<LogicalPlan> isPlan(String expectedPlan) {
-        return new FeatureMatcher<>(equalTo(expectedPlan), "same output", "output ") {
-
-            @Override
-            protected String featureValueOf(LogicalPlan actual) {
-                return printPlan(actual);
-            }
-        };
-    }
-
-    /**
-     * Deprecated use io.crate.testing.{@link io.crate.testing.Asserts} instead
-     */
-    @Deprecated()
-    public static Matcher<LogicalPlan> isPlan(LogicalPlan expectedPlan) {
-        return new FeatureMatcher<>(equalTo(printPlan(expectedPlan)), "same output", "output ") {
-
-            @Override
-            protected String featureValueOf(LogicalPlan actual) {
-                return printPlan(actual);
-            }
-        };
-    }
-
 }

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.io.IOException;
 
@@ -51,10 +50,12 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE t2.x = '10'"
         );
         var expectedPlan =
-            "NestedLoopJoin[INNER | (x = x)]\n" +
-            "  ├ Collect[doc.t1 | [x] | true]\n" +
-            "  └ Collect[doc.t2 | [x] | (x = 10)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            NestedLoopJoin[INNER | (x = x)]
+              ├ Collect[doc.t1 | [x] | true]
+              └ Collect[doc.t2 | [x] | (x = 10)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -64,11 +65,13 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t2.x, 10) = 10"
         );
         var expectedPlan =
-            "Filter[(coalesce(x, 10) = 10)]\n" +
-            "  └ NestedLoopJoin[LEFT | (x = x)]\n" +
-            "    ├ Collect[doc.t1 | [x] | true]\n" +
-            "    └ Collect[doc.t2 | [x] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Filter[(coalesce(x, 10) = 10)]
+              └ NestedLoopJoin[LEFT | (x = x)]
+                ├ Collect[doc.t1 | [x] | true]
+                └ Collect[doc.t2 | [x] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -78,11 +81,13 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t2.x, 10) = 10 AND t1.x > 5"
         );
         var expectedPlan =
-            "Filter[(coalesce(x, 10) = 10)]\n" +
-            "  └ NestedLoopJoin[LEFT | (x = x)]\n" +
-            "    ├ Collect[doc.t1 | [x] | (x > 5)]\n" +
-            "    └ Collect[doc.t2 | [x] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Filter[(coalesce(x, 10) = 10)]
+              └ NestedLoopJoin[LEFT | (x = x)]
+                ├ Collect[doc.t1 | [x] | (x > 5)]
+                └ Collect[doc.t2 | [x] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -92,11 +97,13 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t1.x, 10) = 10 AND t2.x > 5"
         );
         var expectedPlan =
-            "Filter[(coalesce(x, 10) = 10)]\n" +
-            "  └ NestedLoopJoin[RIGHT | (x = x)]\n" +
-            "    ├ Collect[doc.t1 | [x] | true]\n" +
-            "    └ Collect[doc.t2 | [x] | (x > 5)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Filter[(coalesce(x, 10) = 10)]
+              └ NestedLoopJoin[RIGHT | (x = x)]
+                ├ Collect[doc.t1 | [x] | true]
+                └ Collect[doc.t2 | [x] | (x > 5)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -106,10 +113,12 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "WHERE coalesce(t1.x, 10) = 10 AND t2.x > 5"
         );
         var expectedPlan =
-            "Filter[((coalesce(x, 10) = 10) AND (x > 5))]\n" +
-            "  └ NestedLoopJoin[FULL | (x = x)]\n" +
-            "    ├ Collect[doc.t1 | [x] | true]\n" +
-            "    └ Collect[doc.t2 | [x] | (x > 5)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Filter[((coalesce(x, 10) = 10) AND (x > 5))]
+              └ NestedLoopJoin[FULL | (x = x)]
+                ├ Collect[doc.t1 | [x] | true]
+                └ Collect[doc.t2 | [x] | (x > 5)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -9,7 +9,7 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * distributed under the License is distributed ON an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
  * License for the specific language governing permissions and limitations
  * under the License.
@@ -21,10 +21,9 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 
@@ -34,7 +33,6 @@ import org.junit.Test;
 import io.crate.analyze.TableDefinitions;
 import io.crate.planner.node.dql.CountPlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 
@@ -60,162 +58,185 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testOrderByOnUnionIsMovedBeneathUnion() {
-        LogicalPlan plan = plan("Select name from users union all select text from users order by name");
-        assertThat(plan, isPlan(
-            "Union[name]\n" +
-            "  ├ OrderBy[name ASC]\n" +
-            "  │  └ Collect[doc.users | [name] | true]\n" +
-            "  └ OrderBy[text ASC]\n" +
-            "    └ Collect[doc.users | [text] | true]"
-        ));
+        LogicalPlan plan = plan("SELECT name FROM users UNION ALL SELECT text FROM users ORDER BY name");
+        assertThat(plan).isEqualTo(
+            """
+            Union[name]
+              ├ OrderBy[name ASC]
+              │  └ Collect[doc.users | [name] | true]
+              └ OrderBy[text ASC]
+                └ Collect[doc.users | [text] | true]
+            """
+        );
     }
 
     @Test
     public void testOrderByOnUnionIsCombinedWithOrderByBeneathUnion() {
         LogicalPlan plan = plan(
-            "Select * from (select name from users order by text) a " +
-            "union all " +
-            "select text from users " +
-            "order by name");
-        assertThat(
-            plan,
-            isPlan(
-                "Union[name]\n" +
-                "  ├ Rename[name] AS a\n" +
-                "  │  └ OrderBy[name ASC]\n" +
-                "  │    └ Collect[doc.users | [name] | true]\n" +
-                "  └ OrderBy[text ASC]\n" +
-                "    └ Collect[doc.users | [text] | true]"));
+            """
+            SELECT * FROM (SELECT name FROM users ORDER BY text) a
+            UNION ALL
+            SELECT text FROM users
+            ORDER BY name
+            """);
+        assertThat(plan).isEqualTo(
+            """
+            Union[name]
+              ├ Rename[name] AS a
+              │  └ OrderBy[name ASC]
+              │    └ Collect[doc.users | [name] | true]
+              └ OrderBy[text ASC]
+                └ Collect[doc.users | [text] | true]
+            """
+        );
     }
 
     @Test
     public void testOrderByOnJoinPushedDown() {
-        LogicalPlan plan = plan("select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t1.a");
-        assertThat(
-            plan,
-            isPlan(
-                "NestedLoopJoin[INNER | (a = b)]\n" +
-                "  ├ OrderBy[a ASC]\n" +
-                "  │  └ Collect[doc.t1 | [a] | true]\n" +
-                "  └ Collect[doc.t2 | [b] | true]"
-            )
+        LogicalPlan plan = plan("SELECT t1.a, t2.b FROM t1 INNER JOIN t2 ON t1.a = t2.b ORDER BY t1.a");
+        assertThat(plan).isEqualTo(
+            """
+            NestedLoopJoin[INNER | (a = b)]
+              ├ OrderBy[a ASC]
+              │  └ Collect[doc.t1 | [a] | true]
+              └ Collect[doc.t2 | [b] | true]
+            """
         );
     }
 
     @Test
     public void testOrderByOnJoinWithMultipleRelationsPushedDown() {
-        LogicalPlan plan = plan("select t1.a, t2.b, t3.a from t1 " +
-                                "inner join t2 on t1.a = t2.b " +
-                                "inner join t1 as t3 on t3.a = t2.b " +
-                                "order by t1.a");
-        assertThat(plan, isPlan(
-                "NestedLoopJoin[INNER | (a = b)]\n" +
-                "  ├ NestedLoopJoin[INNER | (a = b)]\n" +
-                "  │  ├ OrderBy[a ASC]\n" +
-                "  │  │  └ Collect[doc.t1 | [a] | true]\n" +
-                "  │  └ Collect[doc.t2 | [b] | true]\n" +
-                "  └ Rename[a] AS t3\n" +
-                "    └ Collect[doc.t1 | [a] | true]"));
+        LogicalPlan plan = plan(
+            """
+            SELECT t1.a, t2.b, t3.a FROM t1
+            INNER JOIN t2 ON t1.a = t2.b
+            INNER JOIN t1 as t3 ON t3.a = t2.b
+            ORDER BY t1.a
+            """);
+        assertThat(plan).isEqualTo(
+            """
+            NestedLoopJoin[INNER | (a = b)]
+              ├ NestedLoopJoin[INNER | (a = b)]
+              │  ├ OrderBy[a ASC]
+              │  │  └ Collect[doc.t1 | [a] | true]
+              │  └ Collect[doc.t2 | [b] | true]
+              └ Rename[a] AS t3
+                └ Collect[doc.t1 | [a] | true]
+             """
+        );
     }
 
     @Test
     public void testOrderByOnJoinWithUncollectedColumnPushedDown() {
-        LogicalPlan plan = plan("select t2.y, t2.b, t1.i from t1 inner join t2 on t1.a = t2.b order by t1.x desc");
-        assertThat(plan, isPlan(
-            "Eval[y, b, i]\n" +
-            "  └ NestedLoopJoin[INNER | (a = b)]\n" +
-            "    ├ OrderBy[x DESC]\n" +
-            "    │  └ Collect[doc.t1 | [i, x, a] | true]\n" +
-            "    └ Collect[doc.t2 | [y, b] | true]"));
+        LogicalPlan plan = plan("SELECT t2.y, t2.b, t1.i FROM t1 INNER JOIN t2 ON t1.a = t2.b ORDER BY t1.x desc");
+        assertThat(plan).isEqualTo(
+            """
+            Eval[y, b, i]
+              └ NestedLoopJoin[INNER | (a = b)]
+                ├ OrderBy[x DESC]
+                │  └ Collect[doc.t1 | [i, x, a] | true]
+                └ Collect[doc.t2 | [y, b] | true]
+            """);
     }
 
     @Test
     public void testOrderByOnJoinOrderOnRightTableNotPushedDown() {
-        LogicalPlan plan = plan("select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t2.b");
-        assertThat(
-            plan,
-            isPlan(
-                "OrderBy[b ASC]\n" +
-                "  └ NestedLoopJoin[INNER | (a = b)]\n" +
-                "    ├ Collect[doc.t1 | [a] | true]\n" +
-                "    └ Collect[doc.t2 | [b] | true]"
-            )
+        LogicalPlan plan = plan("SELECT t1.a, t2.b FROM t1 INNER JOIN t2 ON t1.a = t2.b ORDER BY t2.b");
+        assertThat(plan).isEqualTo(
+            """
+            OrderBy[b ASC]
+              └ NestedLoopJoin[INNER | (a = b)]
+                ├ Collect[doc.t1 | [a] | true]
+                └ Collect[doc.t2 | [b] | true]
+            """
         );
     }
 
     @Test
     public void testOrderByOnJoinOrderOnMultipleTablesNotPushedDown() {
-        LogicalPlan plan = plan("select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t1.a || t2.b");
-        assertThat(
-            plan,
-            isPlan(
-                "Eval[a, b]\n" +
-                "  └ OrderBy[concat(a, b) ASC]\n" +
-                "    └ NestedLoopJoin[INNER | (a = b)]\n" +
-                "      ├ Collect[doc.t1 | [a] | true]\n" +
-                "      └ Collect[doc.t2 | [b] | true]"
-            )
+        LogicalPlan plan = plan("SELECT t1.a, t2.b FROM t1 INNER JOIN t2 ON t1.a = t2.b ORDER BY t1.a || t2.b");
+        assertThat(plan).isEqualTo(
+            """
+            Eval[a, b]
+              └ OrderBy[concat(a, b) ASC]
+                └ NestedLoopJoin[INNER | (a = b)]
+                  ├ Collect[doc.t1 | [a] | true]
+                  └ Collect[doc.t2 | [b] | true]
+            """
         );
     }
 
     @Test
     public void testFilterIsMovedBeneathOrder() {
-        LogicalPlan plan = plan("select * from (select * from t1 order by a) tt where a > '10'");
-        assertThat(plan, isPlan(
-            "Fetch[a, x, i]\n" +
-            "  └ Rename[tt._fetchid, a] AS tt\n" +
-            "    └ OrderBy[a ASC]\n" +
-            "      └ Collect[doc.t1 | [_fetchid, a] | (a > '10')]"
-        ));
+        LogicalPlan plan = plan("SELECT * FROM (SELECT * FROM t1 ORDER BY a) tt where a > '10'");
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[a, x, i]
+              └ Rename[tt._fetchid, a] AS tt
+                └ OrderBy[a ASC]
+                  └ Collect[doc.t1 | [_fetchid, a] | (a > '10')]
+            """
+        );
     }
 
     @Test
     public void testOrderByOnJoinOuterJoinInvolvedNotPushedDown() {
-        LogicalPlan plan = plan("select t1.a, t2.b, t3.a from t1 " +
-                                "inner join t2 on t1.a = t2.b " +
-                                "left join t1 as t3 on t3.a = t1.a " +
-                                "order by t1.a");
-        assertThat(plan, isPlan(
-            "OrderBy[a ASC]\n" +
-                "  └ NestedLoopJoin[LEFT | (a = a)]\n" +
-                "    ├ NestedLoopJoin[INNER | (a = b)]\n" +
-                "    │  ├ Collect[doc.t1 | [a] | true]\n" +
-                "    │  └ Collect[doc.t2 | [b] | true]\n" +
-                "    └ Rename[a] AS t3\n" +
-                "      └ Collect[doc.t1 | [a] | true]"));
+        LogicalPlan plan = plan(
+            """
+            SELECT t1.a, t2.b, t3.a FROM t1
+            INNER JOIN t2 ON t1.a = t2.b
+            LEFT JOIN t1 as t3 ON t3.a = t1.a
+            ORDER BY t1.a
+            """
+        );
+        assertThat(plan).isEqualTo(
+            """
+            OrderBy[a ASC]
+              └ NestedLoopJoin[LEFT | (a = a)]
+                ├ NestedLoopJoin[INNER | (a = b)]
+                │  ├ Collect[doc.t1 | [a] | true]
+                │  └ Collect[doc.t2 | [b] | true]
+                └ Rename[a] AS t3
+                  └ Collect[doc.t1 | [a] | true]
+            """
+        );
     }
 
     @Test
     public void testOrderByWithHashJoinNotPushedDown() {
         sqlExecutor.getSessionSettings().setHashJoinEnabled(true);
-        LogicalPlan plan = sqlExecutor.logicalPlan("select t1.a, t2.b " +
-                                                   "from t1 inner join t2 on t1.a = t2.b " +
-                                                   "order by t1.a");
+        LogicalPlan plan = sqlExecutor.logicalPlan(
+            """
+            SELECT t1.a, t2.b
+            FROM t1 INNER JOIN t2 ON t1.a = t2.b
+            ORDER BY t1.a
+            """);
         sqlExecutor.getSessionSettings().setHashJoinEnabled(false);
-        assertThat(plan, isPlan(
-            "OrderBy[a ASC]\n" +
-            "  └ HashJoin[(a = b)]\n" +
-            "    ├ Collect[doc.t1 | [a] | true]\n" +
-            "    └ Collect[doc.t2 | [b] | true]"
-        ));
+        assertThat(plan).isEqualTo(
+            """
+            OrderBy[a ASC]
+              └ HashJoin[(a = b)]
+                ├ Collect[doc.t1 | [a] | true]
+                └ Collect[doc.t2 | [b] | true]
+            """
+        );
     }
 
     @Test
     public void testOrderByIsPushedDownToLeftSide() {
         sqlExecutor.getSessionSettings().setHashJoinEnabled(false);
-        // differs from testOrderByOnJoinPushedDown in that here the ORDER BY expression is not part of the outputs
+        // differs FROM testOrderByOnJoinPushedDown in that here the ORDER BY expression is not part of the outputs
         LogicalPlan plan = sqlExecutor.logicalPlan(
             "SELECT t1.i, t2.i FROM t2 INNER JOIN t1 ON t1.x = t2.y ORDER BY lower(t2.b)");
 
-        assertThat(
-            plan,
-            LogicalPlannerTest.isPlan(
-                "Eval[i, i]\n" +
-                "  └ NestedLoopJoin[INNER | (x = y)]\n" +
-                "    ├ OrderBy[lower(b) ASC]\n" +
-                "    │  └ Collect[doc.t2 | [i, b, y] | true]\n" +
-                "    └ Collect[doc.t1 | [i, x] | true]"
-            )
+        assertThat(plan).isEqualTo(
+            """
+            Eval[i, i]
+              └ NestedLoopJoin[INNER | (x = y)]
+                ├ OrderBy[lower(b) ASC]
+                │  └ Collect[doc.t2 | [i, b, y] | true]
+                └ Collect[doc.t1 | [i, x] | true]
+            """
         );
     }
 
@@ -224,12 +245,11 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = sqlExecutor.logicalPlan(
             "SELECT name FROM (SELECT id, name FROM sys.nodes) t " +
             "WHERE id = 'nodeName'");
-        assertThat(
-            plan,
-            LogicalPlannerTest.isPlan(
-                "Rename[name] AS t\n" +
-                "  └ Collect[sys.nodes | [name] | (id = 'nodeName')]"
-            )
+        assertThat(plan).isEqualTo(
+            """
+            Rename[name] AS t
+              └ Collect[sys.nodes | [name] | (id = 'nodeName')]
+            """
         );
     }
 
@@ -237,103 +257,123 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
     public void testFilterOnSubQueryWithJoinIsPushedBeneathJoin() {
         sqlExecutor.getSessionSettings().setHashJoinEnabled(true);
         var plan = sqlExecutor.logicalPlan(
-            "SELECT * FROM " +
-            "   (SELECT * FROM t1 INNER JOIN t2 on t1.x = t2.y) tjoin " +
-            "WHERE tjoin.x = 10 "
+            """
+            SELECT * FROM
+              (SELECT * FROM t1 INNER JOIN t2 ON t1.x = t2.y) tjoin
+            WHERE tjoin.x = 10
+            """
         );
         var expectedPlan =
-            "Rename[a, x, i, b, y, i] AS tjoin\n" +
-            "  └ HashJoin[(x = y)]\n" +
-            "    ├ Collect[doc.t1 | [a, x, i] | (x = 10)]\n" +
-            "    └ Collect[doc.t2 | [b, y, i] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Rename[a, x, i, b, y, i] AS tjoin
+              └ HashJoin[(x = y)]
+                ├ Collect[doc.t1 | [a, x, i] | (x = 10)]
+                └ Collect[doc.t2 | [b, y, i] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void testFilterOnSubQueryWithJoinIsPushedBeneathNestedLoopJoin() {
         var plan = sqlExecutor.logicalPlan(
-            "SELECT * FROM " +
-            "   (SELECT * FROM t1, t2) tjoin " +
-            "WHERE tjoin.x = 10 "
+            """
+            SELECT * FROM
+              (SELECT * FROM t1, t2) tjoin
+            WHERE tjoin.x = 10
+            """
         );
         var expectedPlan =
-            "Rename[a, x, i, b, y, i] AS tjoin\n" +
-            "  └ NestedLoopJoin[CROSS]\n" +
-            "    ├ Collect[doc.t1 | [a, x, i] | (x = 10)]\n" +
-            "    └ Collect[doc.t2 | [b, y, i] | true]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Rename[a, x, i, b, y, i] AS tjoin
+              └ NestedLoopJoin[CROSS]
+                ├ Collect[doc.t1 | [a, x, i] | (x = 10)]
+                └ Collect[doc.t2 | [b, y, i] | true]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void testFilterOnSubQueryWithJoinIsSplitAndPartiallyPushedBeneathJoin() {
         sqlExecutor.getSessionSettings().setHashJoinEnabled(true);
         var plan = sqlExecutor.logicalPlan(
-            "SELECT * FROM " +
-            "   (SELECT * FROM t1 INNER JOIN t2 on t1.x = t2.y) tjoin " +
-            "WHERE tjoin.x = 10 AND tjoin.y = 20 AND (tjoin.a || tjoin.b = '')"
+            """
+            SELECT * FROM
+              (SELECT * FROM t1 INNER JOIN t2 ON t1.x = t2.y) tjoin
+            WHERE tjoin.x = 10 AND tjoin.y = 20 AND (tjoin.a || tjoin.b = '')
+            """
         );
         var expectedPlan =
-            "Rename[a, x, i, b, y, i] AS tjoin\n" +
-            "  └ Filter[(concat(a, b) = '')]\n" +
-            "    └ HashJoin[(x = y)]\n" +
-            "      ├ Collect[doc.t1 | [a, x, i] | (x = 10)]\n" +
-            "      └ Collect[doc.t2 | [b, y, i] | (y = 20)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Rename[a, x, i, b, y, i] AS tjoin
+              └ Filter[(concat(a, b) = '')]
+                └ HashJoin[(x = y)]
+                  ├ Collect[doc.t1 | [a, x, i] | (x = 10)]
+                  └ Collect[doc.t2 | [b, y, i] | (y = 20)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void testWhereClauseIsPushedDownIntoSubRelationOfUnion() {
-        LogicalPlan plan = sqlExecutor.logicalPlan("SELECT * FROM (" +
-                                                   "    SELECT name FROM sys.nodes " +
-                                                   "    WHERE name like 'b%' " +
-                                                   "    UNION ALL " +
-                                                   "    SELECT substr(name, 0, 1) as n from sys.cluster " +
-                                                   "    WHERE name like 'a%' ) u " +
-                                                   "WHERE u.name like 'c%' ");
-        assertThat(
-            plan,
-            LogicalPlannerTest.isPlan(
-                "Rename[name] AS u\n" +
-                "  └ Union[name]\n" +
-                "    ├ Collect[sys.nodes | [name] | ((name LIKE 'c%') AND (name LIKE 'b%'))]\n" +
-                "    └ Collect[sys.cluster | [substr(name, 0, 1) AS n] | ((substr(name, 0, 1) AS n LIKE 'c%') AND (name LIKE 'a%'))]"
-            )
+        LogicalPlan plan = sqlExecutor.logicalPlan(
+            """
+            SELECT * FROM (
+              SELECT name FROM sys.nodes
+              WHERE name like 'b%'
+              UNION ALL
+              SELECT substr(name, 0, 1) as n FROM sys.cluster
+              WHERE name like 'a%' ) u
+            WHERE u.name like 'c%'
+            """
+        );
+        assertThat(plan).isEqualTo(
+            """
+            Rename[name] AS u
+              └ Union[name]
+                ├ Collect[sys.nodes | [name] | ((name LIKE 'c%') AND (name LIKE 'b%'))]
+                └ Collect[sys.cluster | [substr(name, 0, 1) AS n] | ((substr(name, 0, 1) AS n LIKE 'c%') AND (name LIKE 'a%'))]
+            """
         );
     }
 
     @Test
     public void test_filters_on_project_set_are_pushed_down_for_standalone_outputs() {
         var plan = sqlExecutor.logicalPlan(
-            "SELECT" +
-            "  * " +
-            "FROM " +
-            "  (SELECT x, generate_series(1::int, x) FROM t1) tt " +
-            "WHERE x > 1"
+            """
+            SELECT * FROM
+              (SELECT x, generate_series(1::int, x) FROM t1) tt
+            WHERE x > 1
+            """
         );
         var expectedPlan =
-            "Rename[x, \"pg_catalog.generate_series(1, x)\"] AS tt\n" +
-            "  └ Eval[x, pg_catalog.generate_series(1, x)]\n" +
-            "    └ ProjectSet[pg_catalog.generate_series(1, x), x]\n" +
-            "      └ Collect[doc.t1 | [x] | (x > 1)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Rename[x, "pg_catalog.generate_series(1, x)"] AS tt
+              └ Eval[x, pg_catalog.generate_series(1, x)]
+                └ ProjectSet[pg_catalog.generate_series(1, x), x]
+                  └ Collect[doc.t1 | [x] | (x > 1)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void test_filters_on_project_set_are_pushed_down_only_for_standalone_outputs() {
         var plan = sqlExecutor.logicalPlan(
-            "SELECT" +
-            "  * " +
-            "FROM " +
-            "  (SELECT x, generate_series(1::int, x) AS y FROM t1) tt " +
-            "WHERE x > 1 AND y > 2"
+            """
+            SELECT *
+            FROM
+              (SELECT x, generate_series(1::int, x) AS y FROM t1) tt
+            WHERE x > 1 AND y > 2
+            """
         );
         var expectedPlan =
-            "Rename[x, y] AS tt\n" +
-            "  └ Eval[x, pg_catalog.generate_series(1, x) AS y]\n" +
-            "    └ Filter[(pg_catalog.generate_series(1, x) AS y > 2)]\n" +
-            "      └ ProjectSet[pg_catalog.generate_series(1, x), x]\n" +
-            "        └ Collect[doc.t1 | [x] | (x > 1)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Rename[x, y] AS tt
+              └ Eval[x, pg_catalog.generate_series(1, x) AS y]
+                └ Filter[(pg_catalog.generate_series(1, x) AS y > 2)]
+                  └ ProjectSet[pg_catalog.generate_series(1, x), x]
+                    └ Collect[doc.t1 | [x] | (x > 1)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -342,9 +382,11 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "SELECT x, count(*) FROM t1 GROUP BY 1 HAVING x > 1"
         );
         var expectedPlan =
-            "GroupHashAggregate[x | count(*)]\n" +
-            "  └ Collect[doc.t1 | [x] | (x > 1)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            GroupHashAggregate[x | count(*)]
+              └ Collect[doc.t1 | [x] | (x > 1)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -353,31 +395,37 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             "SELECT x, count(*) FROM t1 GROUP BY 1 HAVING count(*) > 10 AND x > 1"
         );
         var expectedPlan =
-            "Filter[(count(*) > 10::bigint)]\n" +
-            "  └ GroupHashAggregate[x | count(*)]\n" +
-            "    └ Collect[doc.t1 | [x] | (x > 1)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Filter[(count(*) > 10::bigint)]
+              └ GroupHashAggregate[x | count(*)]
+                └ Collect[doc.t1 | [x] | (x > 1)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void testFilterOnSubQueryPartitionKeyIsPushedBeneathPartitionedWindowAgg() {
         var plan = sqlExecutor.logicalPlan(
-            "SELECT * FROM " +
-            "   (SELECT x, sum(x) over (partition by x) FROM t1) sums " +
-            "WHERE sums.x = 10 "
+            """
+            SELECT * FROM
+              (SELECT x, sum(x) over (partition by x) FROM t1) sums
+            WHERE sums.x = 10
+            """
         );
         var expectedPlan =
-            "Rename[x, \"sum(x) OVER (PARTITION BY x)\"] AS sums\n" +
-            "  └ WindowAgg[x, sum(x) OVER (PARTITION BY x)]\n" +
-            "    └ Collect[doc.t1 | [x] | (x = 10)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Rename[x, "sum(x) OVER (PARTITION BY x)"] AS sums
+              └ WindowAgg[x, sum(x) OVER (PARTITION BY x)]
+                └ Collect[doc.t1 | [x] | (x = 10)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void test_count_start_aggregate_filter_is_pushed_down() {
         var plan = plan("SELECT COUNT(*) FILTER (WHERE x > 1) FROM t1");
         var expectedPlan = "Count[doc.t1 | (x > 1)]";
-        assertThat(plan, isPlan(expectedPlan));
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -385,32 +433,43 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         String stmt = "SELECT COUNT(*) FILTER (WHERE x > 1) FROM t1 as t";
         var plan = plan(stmt);
         var expectedPlan = "Count[doc.t1 | (x > 1)]";
-        assertThat(plan, isPlan(expectedPlan));
+        assertThat(plan).isEqualTo(expectedPlan);
 
-        CountPlan count = (CountPlan) sqlExecutor.plan(stmt);
-        Asserts.assertThat(count.countPhase().where())
+        CountPlan count = sqlExecutor.plan(stmt);
+        assertThat(count.countPhase().where())
             .isFunction("op_>", isReference("x"), isLiteral(1));
     }
 
     @Test
     public void test_count_start_aggregate_filter_is_merged_with_where_clause_query() {
         var plan = plan(
-            "SELECT COUNT(*) FILTER (WHERE x > 1) " +
-            "FROM t1 " +
-            "WHERE x > 10");
+            """
+            SELECT COUNT(*) FILTER (WHERE x > 1)
+            FROM t1
+            WHERE x > 10
+            """
+        );
         var expectedPlan = "Count[doc.t1 | ((x > 10) AND (x > 1))]";
-        assertThat(plan, isPlan(expectedPlan));
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 
     @Test
     public void test_filter_on_pk_column_on_derived_table_is_optimized_to_get() {
         // the ORDER BY id, name is here to avoid a collect-then-fetch, which would (currently) break the Get optimization
         var plan = plan(
-            "SELECT id, name FROM (SELECT id, name FROM users ORDER BY id, name) AS u WHERE id = 1 ORDER BY 1, 2");
+            """
+            SELECT id, name
+            FROM (
+              SELECT id, name FROM users ORDER BY id, name) AS u
+            WHERE id = 1 ORDER BY 1, 2
+            """
+        );
         var expectedPlan =
-            "Rename[id, name] AS u\n" +
-            "  └ OrderBy[id ASC name ASC]\n" +
-            "    └ Get[doc.users | id, name | DocKeys{1::bigint} | (id = 1::bigint)]";
-        assertThat(plan, isPlan(expectedPlan));
+            """
+            Rename[id, name] AS u
+              └ OrderBy[id ASC name ASC]
+                └ Get[doc.users | id, name | DocKeys{1::bigint} | (id = 1::bigint)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,73 +37,92 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
     @Before
     public void createExecutor() throws Exception {
         e = SQLExecutor.builder(clusterService)
-            .addTable("create table users (id int, department_id int, name string)")
-            .addTable("create table departments (id int, name string)")
+            .addTable("CREATE TABLE users (id int, department_id int, name string)")
+            .addTable("CREATE TABLE departments (id int, name string)")
             .build();
     }
 
     @Test
     public void testOrderByCanContainScalarThatIsNotInDistinctOutputs() {
         LogicalPlan logicalPlan = e.logicalPlan(
-            "select distinct id from users order by id + 10::int");
-        assertThat(logicalPlan, isPlan(
-            "Eval[id]\n" +
-            "  └ OrderBy[(id + 10) ASC]\n" +
-            "    └ GroupHashAggregate[id]\n" +
-            "      └ Collect[doc.users | [id] | true]"));
+            "SELECT DISTINCT id FROM users ORDER BY id + 10::int");
+        assertThat(logicalPlan).isEqualTo(
+            """
+            Eval[id]
+              └ OrderBy[(id + 10) ASC]
+                └ GroupHashAggregate[id]
+                  └ Collect[doc.users | [id] | true]
+            """
+        );
     }
 
     @Test
     public void testDistinctOnLiteralResultsInGroupByOnLiteral() {
-        LogicalPlan plan = e.logicalPlan("select distinct [1, 2, 3] from users");
-        assertThat(plan, isPlan(
-            "GroupHashAggregate[[1, 2, 3]]\n" +
-            "  └ Collect[doc.users | [[1, 2, 3]] | true]"));
+        LogicalPlan plan = e.logicalPlan("SELECT DISTINCT [1, 2, 3] FROM users");
+        assertThat(plan).isEqualTo(
+            """
+            GroupHashAggregate[[1, 2, 3]]
+              └ Collect[doc.users | [[1, 2, 3]] | true]
+            """
+        );
     }
 
     @Test
     public void testOrderByOnColumnNotPresentInDistinctOutputsIsNotAllowed() {
-        expectedException.expectMessage("Cannot ORDER BY `id`");
-        e.plan("select distinct name from users order by id");
+        assertThatThrownBy(() -> e.plan("SELECT DISTINCT name FROM users ORDER BY id"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Cannot ORDER BY `id`, the column does not appear in the outputs of the underlying relation");
     }
 
     @Test
     public void testDistinctMixedWithTableFunctionInOutput() {
-        LogicalPlan plan = e.logicalPlan("select distinct generate_series(1, 2), unnest from unnest([1, 1])");
-        assertThat(plan, isPlan(
-            "GroupHashAggregate[pg_catalog.generate_series(1, 2), unnest]\n" +
-            "  └ ProjectSet[pg_catalog.generate_series(1, 2), unnest]\n" +
-            "    └ TableFunction[unnest | [unnest] | true]"));
+        LogicalPlan plan = e.logicalPlan("SELECT DISTINCT generate_series(1, 2), unnest FROM unnest([1, 1])");
+        assertThat(plan).isEqualTo(
+            """
+            GroupHashAggregate[pg_catalog.generate_series(1, 2), unnest]
+              └ ProjectSet[pg_catalog.generate_series(1, 2), unnest]
+                └ TableFunction[unnest | [unnest] | true]
+            """
+        );
     }
 
     @Test
     public void testDistinctOnJoinWithGroupByAddsAnotherGroupByOperator() {
         LogicalPlan logicalPlan = e.logicalPlan(
-            "select distinct count(users.id) from users " +
-            "inner join departments on users.department_id = departments.id " +
-            "group by departments.name"
+            """
+            SELECT DISTINCT count(users.id) FROM users
+            INNER JOIN departments ON users.department_id = departments.id
+            GROUP BY departments.name
+            """
         );
-        assertThat(logicalPlan, isPlan(
-            "GroupHashAggregate[count(id)]\n" +
-            "  └ GroupHashAggregate[name | count(id)]\n" +
-            "    └ HashJoin[(department_id = id)]\n" +
-            "      ├ Collect[doc.users | [id, department_id] | true]\n" +
-            "      └ Collect[doc.departments | [name, id] | true]"
-        ));
+        assertThat(logicalPlan).isEqualTo(
+            """
+            GroupHashAggregate[count(id)]
+              └ GroupHashAggregate[name | count(id)]
+                └ HashJoin[(department_id = id)]
+                  ├ Collect[doc.users | [id, department_id] | true]
+                  └ Collect[doc.departments | [name, id] | true]
+            """
+        );
     }
 
     @Test
     public void testDistinctOnJoinWithoutGroupByAddsGroupByOperator() {
         LogicalPlan logicalPlan = e.logicalPlan(
-            "select distinct departments.name from users " +
-            "inner join departments on users.department_id = departments.id " +
-            "order by departments.name");
-        assertThat(logicalPlan, isPlan(
-            "OrderBy[name ASC]\n" +
-            "  └ GroupHashAggregate[name]\n" +
-            "    └ HashJoin[(department_id = id)]\n" +
-            "      ├ Collect[doc.users | [department_id] | true]\n" +
-            "      └ Collect[doc.departments | [name, id] | true]"
-        ));
+            """
+            SELECT DISTINCT departments.name FROM users
+            INNER JOIN departments ON users.department_id = departments.id
+            ORDER BY departments.name
+            """
+        );
+        assertThat(logicalPlan).isEqualTo(
+            """
+            OrderBy[name ASC]
+              └ GroupHashAggregate[name]
+                └ HashJoin[(department_id = id)]
+                  ├ Collect[doc.users | [department_id] | true]
+                  └ Collect[doc.departments | [name, id] | true]
+            """
+        );
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/IterativeOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/IterativeOptimizerTest.java
@@ -21,9 +21,8 @@
 
 package io.crate.planner.optimizer.iterative;
 
-import static io.crate.planner.operators.LogicalPlannerTest.printPlan;
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.createNodeContext;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -43,8 +42,8 @@ import io.crate.statistics.TableStats;
 
 public class IterativeOptimizerTest {
 
-    private NodeContext nodeCtx = createNodeContext();
-    private CoordinatorTxnCtx ctx = CoordinatorTxnCtx.systemTransactionContext();
+    private final NodeContext nodeCtx = createNodeContext();
+    private final CoordinatorTxnCtx ctx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Test
     public void test_match_single_rule_merge_filters() {
@@ -57,9 +56,8 @@ public class IterativeOptimizerTest {
                                                               List.of(new MergeFilters()));
 
         var result = optimizer.optimize(filter2, new TableStats(), ctx);
-
-        assertThat(printPlan(result)).isEqualTo("Filter[(true AND true)]\n" +
-                                                "  └ TestPlan[]");
+        assertThat(result).isEqualTo("Filter[(true AND true)]\n" +
+                                             "  └ TestPlan[]");
     }
 
     @Test
@@ -75,10 +73,13 @@ public class IterativeOptimizerTest {
                                                               List.of(new MergeFilters(), new DeduplicateOrder()));
 
         var result = optimizer.optimize(order2, new TableStats(), ctx);
-
-        assertThat(printPlan(result)).isEqualTo("OrderBy[]\n" +
-                                                "  └ Filter[(true AND true)]\n" +
-                                                "    └ TestPlan[]");
+        assertThat(result).isEqualTo(
+            """
+            OrderBy[]
+              └ Filter[(true AND true)]
+                └ TestPlan[]
+            """
+        );
     }
 
     @Test
@@ -108,9 +109,13 @@ public class IterativeOptimizerTest {
 
         var result = optimizer.optimize(order2, new TableStats(), ctx);
 
-        assertThat(printPlan(result)).isEqualTo("OrderBy[]\n" +
-                                                "  └ Filter[true]\n" +
-                                                "    └ TestPlan[]");
+        assertThat(result).isEqualTo(
+            """
+            OrderBy[]
+              └ Filter[true]
+                └ TestPlan[]
+            """
+        );
     }
 
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -22,15 +22,11 @@
 
 package io.crate.planner.optimizer.rule;
 
-import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.util.List;
 import java.util.function.Function;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -71,8 +67,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
 
-        assertThat(match.isPresent(), is(true));
-        assertThat(match.value(), Matchers.sameInstance(filter));
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
 
         LogicalPlan newPlan = rule.apply(
             match.value(),
@@ -83,7 +79,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             Function.identity()
         );
 
-        assertThat(newPlan, nullValue());
+        assertThat(newPlan).isNull();
     }
 
     @Test
@@ -99,8 +95,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
 
-        assertThat(match.isPresent(), is(true));
-        assertThat(match.value(), Matchers.sameInstance(filter));
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
 
         LogicalPlan newPlan = rule.apply(
             match.value(),
@@ -111,7 +107,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             Function.identity()
         );
 
-        assertThat(newPlan, nullValue());
+        assertThat(newPlan).isNull();
     }
 
     @Test
@@ -127,9 +123,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
 
-        assertThat(match.isPresent(), is(true));
-        assertThat(match.value(), Matchers.sameInstance(filter));
-
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
@@ -139,11 +134,13 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             Function.identity()
         );
         var expectedPlan =
-            "WindowAgg[id, row_number() OVER (PARTITION BY id)]\n" +
-            "  └ Filter[(id = 10)]\n" +
-            "    └ Collect[doc.t1 | [id] | true]";
+            """
+            WindowAgg[id, row_number() OVER (PARTITION BY id)]
+              └ Filter[(id = 10)]
+                └ Collect[doc.t1 | [id] | true]
+            """;
 
-        assertThat(newPlan, isPlan(expectedPlan));
+        assertThat(newPlan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -159,8 +156,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
 
-        assertThat(match.isPresent(), is(true));
-        assertThat(match.value(), Matchers.sameInstance(filter));
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
 
         LogicalPlan newPlan = rule.apply(
             match.value(),
@@ -171,12 +168,14 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             Function.identity()
         );
         var expectedPlan =
-            "Filter[((row_number() OVER (PARTITION BY id) = 2) AND (x = 1))]\n" +
-            "  └ WindowAgg[id, row_number() OVER (PARTITION BY id)]\n" +
-            "    └ Filter[(id = 10)]\n" +
-            "      └ Collect[doc.t1 | [id] | true]";
+            """
+            Filter[((row_number() OVER (PARTITION BY id) = 2) AND (x = 1))]
+              └ WindowAgg[id, row_number() OVER (PARTITION BY id)]
+                └ Filter[(id = 10)]
+                  └ Collect[doc.t1 | [id] | true]
+            """;
 
-        assertThat(newPlan, isPlan(expectedPlan));
+        assertThat(newPlan).isEqualTo(expectedPlan);
     }
 
     @Test
@@ -192,8 +191,8 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var rule = new MoveFilterBeneathWindowAgg();
         Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
 
-        assertThat(match.isPresent(), is(true));
-        assertThat(match.value(), Matchers.sameInstance(filter));
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
 
         LogicalPlan newPlan = rule.apply(
             match.value(),
@@ -203,6 +202,6 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             e.nodeCtx,
             Function.identity()
         );
-        assertThat(newPlan, nullValue());
+        assertThat(newPlan).isNull();
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
@@ -43,7 +43,7 @@ public class LogicalPlanAssert extends AbstractAssert<LogicalPlanAssert, Logical
     public LogicalPlanAssert isEqualTo(String expectedPlan) {
         isNotNull();
         assertThat(expectedPlan).isNotNull();
-        assertThat(printPlan(actual)).isEqualTo(expectedPlan);
+        assertThat(printPlan(actual)).isEqualTo(expectedPlan.strip());
         return this;
     }
 


### PR DESCRIPTION
- Replace old style `isPlan()` with `isEqualTo()`.
- Migrate all assertions to assertj in the relevant classes.
- Beautify statements and expected plans and use `"""..."""`
