### PR TITLE
tests: Fix assertion in ConcurrentSnapshotsIT

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -254,17 +254,4 @@ public class Asserts extends Assertions {
     public static Function<Scalar, Consumer<Scalar>> isNotSameInstance() {
         return scalar -> s -> assertThat(s).isNotSameAs(scalar);
     }
-
-    // Exception
-    public static <T extends Throwable, E extends Throwable> void assertRootCause(T throwable,
-                                                                                  Class<E> clazz,
-                                                                                  String expectedMessage) {
-        Throwable cause = throwable;
-        while (cause.getCause() != null) {
-            cause = cause.getCause();
-        }
-        assertThat(cause)
-                .isExactlyInstanceOf(clazz)
-                .hasMessageContaining(expectedMessage);
-    }
 }


### PR DESCRIPTION
- Make the methods to check for snapshots and deletions in Progresss consistent in their usage.
- Fix assertion by extracting the `RootCause` and not just the `Cause`.

Follows: 6a6b91216e0d2957cc7073ffa4698e0219883441
