### PR TITLE
Add indexer that creates lucene doc+fields and source in one pass

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+
+public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
+
+    private final ValueIndexer<T> innerIndexer;
+
+    public ArrayIndexer(ValueIndexer<T> innerIndexer) {
+        this.innerIndexer = innerIndexer;
+    }
+
+    @Override
+    public void indexValue(List<T> values,
+                           XContentBuilder xContentBuilder,
+                           Consumer<? super IndexableField> addField,
+                           Consumer<? super Reference> onDynamicColumn,
+                           Map<ColumnIdent, Indexer.Synthetic> synthetics,
+                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
+        xContentBuilder.startArray();
+        if (values != null) {
+            for (T value : values) {
+                innerIndexer.indexValue(value, xContentBuilder, addField, onDynamicColumn, synthetics, toValidate);
+            }
+        }
+        xContentBuilder.endArray();
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/IndexItem.java
+++ b/server/src/main/java/io/crate/execution/dml/IndexItem.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.util.List;
+
+public interface IndexItem {
+
+    String id();
+
+    List<String> pkValues();
+
+    Object[] insertValues();
+
+    long seqNo();
+
+    long primaryTerm();
+
+    static record StaticItem(
+            String id,
+            List<String> pkValues,
+            Object[] insertValues,
+            long seqNo,
+            long primaryTerm) implements IndexItem {
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -457,6 +457,9 @@ public class Indexer {
             if (reference.granularity() == RowGranularity.PARTITION) {
                 continue;
             }
+            if (value == null) {
+                continue;
+            }
             ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
             xContentBuilder.field(reference.column().leafName());
             valueIndexer.indexValue(

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -1,0 +1,543 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SequenceIDFields;
+import org.elasticsearch.index.mapper.Uid;
+
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.collections.Maps;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.execution.engine.collect.NestableCollectExpression;
+import io.crate.expression.InputFactory;
+import io.crate.expression.InputFactory.Context;
+import io.crate.expression.reference.ReferenceResolver;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.tree.CheckConstraint;
+import io.crate.types.DataType;
+import io.crate.types.ObjectType;
+
+/**
+ * <p>
+ *  Component to create a {@link ParsedDocument} from a {@link IndexItem}
+ * </p>
+ *
+ * <p>Takes care of:</p>
+ * <ul>
+ *  <li>Validation of constraints (NOT NULL, CHECK)</li>
+ *  <li>Adds DEFAULT values for _missing_ columns</li>
+ *  <li>Adds GENERATED values</li>
+ *  <li>Source generation</li>
+ *  <li>Lucene {@link Document} and index field creation</li>
+ * </ul>
+ **/
+public class Indexer {
+
+    private final List<ValueIndexer<?>> valueIndexers;
+    private final List<Reference> columns;
+    private final SymbolEvaluator symbolEval;
+    private final Map<ColumnIdent, Synthetic> synthetics;
+    private final List<CollectExpression<IndexItem, Object>> expressions;
+    private final Map<ColumnIdent, ColumnConstraint> columnConstraints = new HashMap<>();
+    private final List<TableConstraint> tableConstraints;
+    private final List<IndexColumn> indexColumns;
+    private final List<Input<?>> returnValueInputs;
+
+    record IndexColumn(ColumnIdent name, FieldType fieldType, List<Input<?>> inputs) {
+    }
+
+    static class RefResolver implements ReferenceResolver<CollectExpression<IndexItem, Object>> {
+
+        private final PartitionName partitionName;
+        private final List<Reference> targetColumns;
+        private final DocTableInfo table;
+        private final SymbolEvaluator symbolEval;
+
+        private RefResolver(SymbolEvaluator symbolEval,
+                            PartitionName partitionName,
+                            List<Reference> targetColumns,
+                            DocTableInfo table) {
+            this.symbolEval = symbolEval;
+            this.partitionName = partitionName;
+            this.targetColumns = targetColumns;
+            this.table = table;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public CollectExpression<IndexItem, Object> getImplementation(Reference ref) {
+
+            // Here be dragons: A reference can refer to:
+            //
+            //  - To seqNo or primaryTerm of the IndexItem
+            //
+            //  - To a primary key that was already generated when resolving the routing.
+            //    It must be part of `pkValues()` of the IndexItem
+            //
+            //  - value in the IndexItem insertValues.
+            //    Example `INSERT INTO (x, y) VALUES (1, 2)
+            //                          │             ▲
+            //                          └─────────────┘
+            //
+            //  - Can be used in PARITITONED BY, in which case it's part of the partition name
+            //
+            //  - Can be missing from targetColumns / insertValues but have a DEFAULT clause
+            //
+            //  - Can be a child column, where the root is part of the targetColumns / insertValues
+
+            ColumnIdent column = ref.column();
+            if (column.equals(DocSysColumns.ID)) {
+                return NestableCollectExpression.forFunction(IndexItem::id);
+            } else if (column.equals(DocSysColumns.SEQ_NO)) {
+                return NestableCollectExpression.forFunction(IndexItem::seqNo);
+            } else if (column.equals(DocSysColumns.PRIMARY_TERM)) {
+                return NestableCollectExpression.forFunction(IndexItem::primaryTerm);
+            }
+            int pkIndex = table.primaryKey().indexOf(column);
+            if (pkIndex > -1) {
+                return NestableCollectExpression.forFunction(item ->
+                    ref.valueType().implicitCast(item.pkValues().get(pkIndex))
+                );
+            }
+            int index = targetColumns.indexOf(ref);
+            if (index > -1) {
+                return NestableCollectExpression.forFunction(item -> item.insertValues()[index]);
+            }
+            if (ref.granularity() == RowGranularity.PARTITION) {
+                int pIndex = table.partitionedByColumns().indexOf(ref);
+                if (pIndex > -1) {
+                    String val = partitionName.values().get(pIndex);
+                    return NestableCollectExpression.constant(val);
+                } else {
+                    return NestableCollectExpression.constant(null);
+                }
+            }
+            if (column.isTopLevel()) {
+                if (targetColumns.contains(ref)) {
+                    return NestableCollectExpression.constant(null);
+                }
+                Symbol defaultExpression = ref.defaultExpression();
+                if (defaultExpression == null) {
+                    return NestableCollectExpression.constant(null);
+                }
+                return NestableCollectExpression.constant(
+                    defaultExpression.accept(symbolEval, Row.EMPTY).value()
+                );
+            }
+            ColumnIdent root = column.getRoot();
+            int rootIdx = -1;
+            for (int i = 0; i < targetColumns.size(); i++) {
+                if (targetColumns.get(i).column().equals(root)) {
+                    rootIdx = i;
+                    break;
+                }
+            }
+            final int rootIndex = rootIdx;
+            Function<IndexItem, Object> getValue = item -> {
+                Object val = item.insertValues()[rootIndex];
+                if (val instanceof Map<?, ?> m) {
+                    List<String> path = column.path();
+                    val = Maps.getByPath((Map<String, Object>) m, path);
+                }
+                if (val == null) {
+                    Symbol defaultExpression = ref.defaultExpression();
+                    if (defaultExpression != null) {
+                        val = defaultExpression.accept(symbolEval, Row.EMPTY).value();
+                    }
+                }
+                return val;
+            };
+            return NestableCollectExpression.forFunction(getValue);
+        }
+    }
+
+    /**
+     * For DEFAULT expressions or GENERATED columns
+     **/
+    record Synthetic(Input<?> input, ValueIndexer<Object> indexer) {
+    }
+
+    interface ColumnConstraint {
+
+        void verify(Object providedValue);
+    }
+
+    interface TableConstraint {
+
+        void verify();
+    }
+
+    record NotNullTableConstraint(ColumnIdent column, Input<?> input) implements TableConstraint {
+
+        @Override
+        public void verify() {
+            Object value = input.value();
+            if (value == null) {
+                throw new IllegalArgumentException("\"" + column + "\" must not be null");
+            }
+        }
+    }
+
+    record TableCheckConstraint(
+            Input<?> input,
+            CheckConstraint<Symbol> checkConstraint) implements TableConstraint {
+
+        @Override
+        public void verify() {
+            Object value = input.value();
+            // SQL semantics: If a column is omitted from an INSERT/UPDATE statement,
+            // CHECK constraints should not fail. Same for writing explicit `null` values.
+            if (value instanceof Boolean bool) {
+                if (!bool) {
+                    throw new IllegalArgumentException(String.format(
+                        Locale.ENGLISH,
+                        "Failed CONSTRAINT %s CHECK (%s)",
+                        checkConstraint.name(),
+                        checkConstraint.expressionStr()));
+                }
+            }
+        }
+    }
+
+    record MultiCheck(List<ColumnConstraint> checks) implements ColumnConstraint {
+
+        @Override
+        public void verify(Object providedValue) {
+            for (var check : checks) {
+                check.verify(providedValue);
+            }
+        }
+
+        public static ColumnConstraint merge(ColumnConstraint check1, ColumnConstraint check2) {
+            if (check1 instanceof MultiCheck multiCheck) {
+                multiCheck.checks.add(check2);
+                return check1;
+            }
+            ArrayList<ColumnConstraint> checks = new ArrayList<>(2);
+            return new MultiCheck(checks);
+        }
+    }
+
+    record NotNull(ColumnIdent column) implements ColumnConstraint {
+
+        public void verify(Object providedValue) {
+            if (providedValue == null) {
+                throw new IllegalArgumentException("\"" + column + "\" must not be null");
+            }
+        }
+    }
+
+    record CheckGeneratedValue(Input<?> input, GeneratedReference ref) implements ColumnConstraint {
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void verify(Object providedValue) {
+            DataType<Object> valueType = (DataType<Object>) ref.valueType();
+            Object generatedValue = input.value();
+            int compare = Comparator
+                .nullsFirst(valueType)
+                .compare(
+                    valueType.sanitizeValue(generatedValue),
+                    valueType.sanitizeValue(providedValue)
+                );
+            if (compare != 0) {
+                throw new IllegalArgumentException(
+                    "Given value " + providedValue +
+                    " for generated column " + ref.column() +
+                    " does not match calculation " + ref.formattedGeneratedExpression() + " = " +
+                    generatedValue
+                );
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Indexer(String indexName,
+                   DocTableInfo table,
+                   TransactionContext txnCtx,
+                   NodeContext nodeCtx,
+                   Function<ColumnIdent, FieldType> getFieldType,
+                   List<Reference> targetColumns,
+                   Symbol[] returnValues) {
+        this.symbolEval = new SymbolEvaluator(txnCtx, nodeCtx, SubQueryResults.EMPTY);
+        this.columns = targetColumns;
+        this.synthetics = new HashMap<>();
+        PartitionName partitionName = table.isPartitioned()
+            ? PartitionName.fromIndexOrTemplate(indexName)
+            : null;
+        InputFactory inputFactory = new InputFactory(nodeCtx);
+        var referenceResolver = new RefResolver(symbolEval, partitionName, targetColumns, table);
+        Context<CollectExpression<IndexItem, Object>> ctxForRefs = inputFactory.ctxForRefs(
+            txnCtx,
+            referenceResolver
+        );
+        Function<ColumnIdent, Reference> getRef = table::getReference;
+        this.valueIndexers = new ArrayList<>(targetColumns.size());
+        for (var ref : targetColumns) {
+            this.valueIndexers.add(
+                ref.valueType().valueIndexer(table.ident(), ref, getFieldType, getRef)
+            );
+            addToValidate(table, ctxForRefs, ref);
+        }
+        this.tableConstraints = new ArrayList<>(table.checkConstraints().size());
+        for (var column : table.notNullColumns()) {
+            Reference ref = table.getReference(column);
+            assert ref != null : "Column in #notNullColumns must be available via table.getReference";
+            if (targetColumns.contains(ref)) {
+                columnConstraints.merge(ref.column(), new NotNull(column), MultiCheck::merge);
+            } else if (ref instanceof GeneratedReference generated) {
+                Input<?> input = ctxForRefs.add(generated.generatedExpression());
+                tableConstraints.add(new NotNullTableConstraint(column, input));
+            } else {
+                Input<?> input = ctxForRefs.add(ref);
+                tableConstraints.add(new NotNullTableConstraint(column, input));
+            }
+        }
+        for (var constraint : table.checkConstraints()) {
+            Symbol expression = constraint.expression();
+            Input<?> input = ctxForRefs.add(expression);
+            tableConstraints.add(new TableCheckConstraint(input, constraint));
+        }
+        for (var ref : table.defaultExpressionColumns()) {
+            if (targetColumns.contains(ref) || ref.granularity() == RowGranularity.PARTITION) {
+                continue;
+            }
+            ColumnIdent column = ref.column();
+            Input<?> input = table.primaryKey().contains(column)
+                ? ctxForRefs.add(ref)
+                : ctxForRefs.add(ref.defaultExpression());
+            ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) ref.valueType().valueIndexer(
+                table.ident(),
+                ref,
+                getFieldType,
+                getRef
+            );
+            this.synthetics.put(column, new Synthetic(input, valueIndexer));
+        }
+        for (var ref : table.generatedColumns()) {
+            if (ref.granularity() == RowGranularity.PARTITION) {
+                continue;
+            }
+            if (targetColumns.contains(ref)) {
+                continue;
+            }
+            Input<?> input = ctxForRefs.add(ref.generatedExpression());
+            ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) ref.valueType().valueIndexer(
+                table.ident(),
+                ref,
+                getFieldType,
+                getRef
+            );
+            this.synthetics.put(ref.column(), new Synthetic(input, valueIndexer));
+        }
+        this.indexColumns = new ArrayList<>(table.indexColumns().size());
+        for (var ref : table.indexColumns()) {
+            ArrayList<Input<?>> indexInputs = new ArrayList<>(ref.columns().size());
+            FieldType fieldType = getFieldType.apply(ref.column());
+
+            for (var sourceRef : ref.columns()) {
+                Reference reference = table.getReference(sourceRef.column());
+                assert reference.equals(sourceRef) : "refs must match";
+
+                Input<?> input = ctxForRefs.add(sourceRef);
+                indexInputs.add(input);
+            }
+            indexColumns.add(new IndexColumn(ref.column(), fieldType, indexInputs));
+        }
+        if (returnValues == null) {
+            this.returnValueInputs = null;
+        } else {
+            this.returnValueInputs = new ArrayList<>(returnValues.length);
+            for (Symbol returnValue : returnValues) {
+                this.returnValueInputs.add(ctxForRefs.add(returnValue));
+            }
+        }
+        this.expressions = ctxForRefs.expressions();
+    }
+
+    private void addToValidate(DocTableInfo table,
+                               Context<?> ctxForRefs,
+                               Reference ref) {
+        if (ref instanceof GeneratedReference generated && ref.granularity() == RowGranularity.DOC) {
+            Input<?> input = ctxForRefs.add(generated.generatedExpression());
+            columnConstraints.put(ref.column(), new CheckGeneratedValue(input, generated));
+        }
+        if (ref.valueType() instanceof ObjectType objectType) {
+            for (var entry : objectType.innerTypes().entrySet()) {
+                String innerName = entry.getKey();
+                ColumnIdent innerColumn = ref.column().getChild(innerName);
+                Reference reference = table.getReference(innerColumn);
+                if (reference == null) {
+                    continue;
+                }
+                addToValidate(table, ctxForRefs, reference);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public ParsedDocument index(IndexItem item) throws IOException {
+        assert item.insertValues().length == valueIndexers.size()
+            : "Number of values must match number of targetColumns/valueIndexers";
+
+        Document doc = new Document();
+        Consumer<? super IndexableField> addField = doc::add;
+        ArrayList<Reference> newColumns = new ArrayList<>();
+        Consumer<? super Reference> onDynamicColumn = newColumns::add;
+        for (var expression : expressions) {
+            expression.setNextRow(item);
+        }
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        Object[] values = item.insertValues();
+        for (int i = 0; i < values.length; i++) {
+            Reference reference = columns.get(i);
+            Object value = reference.valueType().valueForInsert(values[i]);
+            ColumnConstraint check = columnConstraints.get(reference.column());
+            if (check != null) {
+                check.verify(value);
+            }
+            if (reference.granularity() == RowGranularity.PARTITION) {
+                continue;
+            }
+            ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
+            xContentBuilder.field(reference.column().leafName());
+            valueIndexer.indexValue(
+                value,
+                xContentBuilder,
+                addField,
+                onDynamicColumn,
+                synthetics,
+                columnConstraints
+            );
+        }
+        for (var entry : synthetics.entrySet()) {
+            ColumnIdent column = entry.getKey();
+            if (!column.isTopLevel()) {
+                continue;
+            }
+            Synthetic synthetic = entry.getValue();
+            ValueIndexer<Object> indexer = synthetic.indexer();
+            Object value = synthetic.input().value();
+            xContentBuilder.field(column.leafName());
+            indexer.indexValue(
+                value,
+                xContentBuilder,
+                addField,
+                onDynamicColumn,
+                synthetics,
+                columnConstraints
+            );
+        }
+        xContentBuilder.endObject();
+
+        for (var indexColumn : indexColumns) {
+            for (var input : indexColumn.inputs) {
+                String value = (String) input.value();
+                if (indexColumn.fieldType.indexOptions() != IndexOptions.NONE) {
+                    Field field = new Field(indexColumn.name.fqn(), value, indexColumn.fieldType);
+                    doc.add(field);
+                }
+            }
+        }
+
+        for (var constraint : tableConstraints) {
+            constraint.verify();
+        }
+
+        NumericDocValuesField version = new NumericDocValuesField(DocSysColumns.Names.VERSION, -1L);
+        doc.add(version);
+
+        BytesReference source = BytesReference.bytes(xContentBuilder);
+        BytesRef sourceRef = source.toBytesRef();
+        doc.add(new StoredField("_source", sourceRef.bytes, sourceRef.offset, sourceRef.length));
+
+        BytesRef idBytes = Uid.encodeId(item.id());
+        doc.add(new Field(DocSysColumns.Names.ID, idBytes, IdFieldMapper.Defaults.FIELD_TYPE));
+
+        SequenceIDFields seqID = SequenceIDFields.emptySeqID();
+        // Actual values are set via ParsedDocument.updateSeqID
+        doc.add(seqID.seqNo);
+        doc.add(seqID.seqNoDocValue);
+        doc.add(seqID.primaryTerm);
+        return new ParsedDocument(
+            version,
+            seqID,
+            item.id(),
+            doc,
+            source,
+            null,
+            newColumns
+        );
+    }
+
+    @Nullable
+    public Object[] returnValues(IndexItem item) {
+        if (this.returnValueInputs == null) {
+            return null;
+        }
+        expressions.forEach(x -> x.setNextRow(item));
+        Object[] result = new Object[this.returnValueInputs.size()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = this.returnValueInputs.get(i).value();
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/IntIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IntIndexer.java
@@ -57,10 +57,10 @@ public class IntIndexer implements ValueIndexer<Number> {
                            Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xContentBuilder.value(value);
         if (value == null) {
             return;
         }
+        xContentBuilder.value(value);
         int intValue = value.intValue();
         addField.accept(new IntPoint(name, intValue));
         if (ref.hasDocValues()) {

--- a/server/src/main/java/io/crate/execution/dml/IntIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IntIndexer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+
+public class IntIndexer implements ValueIndexer<Number> {
+
+    private final String name;
+    private final Reference ref;
+    private final FieldType fieldType;
+
+    public IntIndexer(Reference ref, @Nullable FieldType fieldType) {
+        this.ref = ref;
+        this.name = ref.column().fqn();
+        this.fieldType = fieldType == null ? NumberFieldMapper.FIELD_TYPE : fieldType;
+    }
+
+    @Override
+    public void indexValue(Number value,
+                           XContentBuilder xContentBuilder,
+                           Consumer<? super IndexableField> addField,
+                           Consumer<? super Reference> onDynamicColumn,
+                           Map<ColumnIdent, Indexer.Synthetic> synthetics,
+                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
+        xContentBuilder.value(value);
+        if (value == null) {
+            return;
+        }
+        int intValue = value.intValue();
+        addField.accept(new IntPoint(name, intValue));
+        if (ref.hasDocValues()) {
+            addField.accept(new SortedNumericDocValuesField(name, intValue));
+        }
+        if (fieldType.stored()) {
+            addField.accept(new StoredField(name, intValue));
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -57,10 +57,10 @@ public class LongIndexer implements ValueIndexer<Long> {
                            Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
         if (value == null) {
             return;
         }
+        xcontentBuilder.value(value);
         long longValue = value.longValue();
         addField.accept(new LongPoint(name, longValue));
         if (ref.hasDocValues()) {

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+
+public class LongIndexer implements ValueIndexer<Long> {
+
+    private final Reference ref;
+    private final String name;
+    private final FieldType fieldType;
+
+    public LongIndexer(Reference ref, @Nullable FieldType fieldType) {
+        this.ref = ref;
+        this.fieldType = fieldType == null ? NumberFieldMapper.FIELD_TYPE : fieldType;
+        this.name = ref.column().fqn();
+    }
+
+    @Override
+    public void indexValue(Long value,
+                           XContentBuilder xcontentBuilder,
+                           Consumer<? super IndexableField> addField,
+                           Consumer<? super Reference> onDynamicColumn,
+                           Map<ColumnIdent, Indexer.Synthetic> synthetics,
+                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
+        xcontentBuilder.value(value);
+        if (value == null) {
+            return;
+        }
+        long longValue = value.longValue();
+        addField.accept(new LongPoint(name, longValue));
+        if (ref.hasDocValues()) {
+            addField.accept(new SortedNumericDocValuesField(name, longValue));
+        }
+        if (fieldType.stored()) {
+            addField.accept(new StoredField(name, longValue));
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import io.crate.execution.dml.Indexer.ColumnConstraint;
+import io.crate.execution.dml.Indexer.Synthetic;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.FloatType;
+import io.crate.types.IntegerType;
+import io.crate.types.ObjectType;
+import io.crate.types.ShortType;
+import io.crate.types.StorageSupport;
+
+public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
+
+    private final ObjectType objectType;
+    private final HashMap<String, ValueIndexer<Object>> innerIndexers;
+    private final ColumnIdent column;
+    private final Function<ColumnIdent, Reference> getRef;
+    private final RelationName table;
+    private final Reference ref;
+    private final Function<ColumnIdent, FieldType> getFieldType;
+
+    @SuppressWarnings("unchecked")
+    public ObjectIndexer(RelationName table,
+                         Reference ref,
+                         Function<ColumnIdent, FieldType> getFieldType,
+                         Function<ColumnIdent, Reference> getRef) {
+        this.table = table;
+        this.ref = ref;
+        this.getFieldType = getFieldType;
+        this.getRef = getRef;
+        this.column = ref.column();
+        this.objectType = (ObjectType) ArrayType.unnest(ref.valueType());
+        this.innerIndexers = new HashMap<>();
+        for (var entry : objectType.innerTypes().entrySet()) {
+            String innerName = entry.getKey();
+            DataType<?> value = entry.getValue();
+            ColumnIdent child = column.getChild(innerName);
+            Reference childRef = getRef.apply(child);
+            ValueIndexer<?> valueIndexer = value.valueIndexer(table, childRef, getFieldType, getRef);
+            innerIndexers.put(entry.getKey(), (ValueIndexer<Object>) valueIndexer);
+        }
+    }
+
+    @Override
+    public void indexValue(@Nullable Map<String, Object> value,
+                           XContentBuilder xContentBuilder,
+                           Consumer<? super IndexableField> addField,
+                           Consumer<? super Reference> onDynamicColumn,
+                           Map<ColumnIdent, Indexer.Synthetic> synthetics,
+                           Map<ColumnIdent, Indexer.ColumnConstraint> checks) throws IOException {
+        xContentBuilder.startObject();
+        if (value != null) {
+            addNewColumns(value, xContentBuilder, addField, onDynamicColumn, synthetics, checks);
+        }
+        for (var entry : objectType.innerTypes().entrySet()) {
+            String innerName = entry.getKey();
+            ColumnIdent innerColumn = column.getChild(innerName);
+            Object innerValue = value == null ? null : value.get(innerName);
+            if (innerValue == null) {
+                Synthetic synthetic = synthetics.get(innerColumn);
+                if (synthetic != null) {
+                    innerValue = synthetic.input().value();
+                }
+            }
+            ColumnConstraint check = checks.get(innerColumn);
+            if (check != null) {
+                check.verify(innerValue);
+            }
+            var valueIndexer = innerIndexers.get(innerName);
+            assert valueIndexer != null : "ValueIndexer must exist for inner column retrieved from ObjectType information";
+
+            xContentBuilder.field(innerName);
+            valueIndexer.indexValue(
+                innerValue,
+                xContentBuilder,
+                addField,
+                onDynamicColumn,
+                synthetics,
+                checks
+            );
+        }
+        xContentBuilder.endObject();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addNewColumns(Map<String, Object> value,
+                               XContentBuilder xContentBuilder,
+                               Consumer<? super IndexableField> addField,
+                               Consumer<? super Reference> onDynamicColumn,
+                               Map<ColumnIdent, Indexer.Synthetic> synthetics,
+                               Map<ColumnIdent, Indexer.ColumnConstraint> checks) throws IOException {
+        for (var entry : value.entrySet()) {
+            String innerName = entry.getKey();
+            Object innerValue = entry.getValue();
+            boolean isNewColumn = !objectType.innerTypes().containsKey(innerName);
+            if (!isNewColumn) {
+                continue;
+            }
+            if (ref.columnPolicy() == ColumnPolicy.STRICT) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ENGLISH,
+                    "Cannot add column `%s` to strict object `%s`",
+                    innerName,
+                    ref.column()
+                ));
+            }
+            var type = DataTypes.guessType(innerValue);
+            switch (type.id()) {
+                case ShortType.ID:
+                case IntegerType.ID:
+                    type = DataTypes.LONG;
+                    innerValue = type.sanitizeValue(innerValue);
+                    break;
+
+                case FloatType.ID:
+                    type = DataTypes.DOUBLE;
+                    innerValue = type.sanitizeValue(innerValue);
+                    break;
+
+                default:
+                    break;
+            }
+            StorageSupport<?> storageSupport = type.storageSupport();
+            if (storageSupport == null) {
+                throw new IllegalArgumentException(
+                    "Cannot create columns of type " + type.getName() + " dynamically. " +
+                    "Storage is not supported for this type");
+            }
+            boolean nullable = true;
+            Symbol defaultExpression = null;
+            Reference newColumn = new SimpleReference(
+                new ReferenceIdent(table, column.getChild(innerName)),
+                RowGranularity.DOC,
+                type,
+                ref.columnPolicy(),
+                IndexType.PLAIN,
+                nullable,
+                storageSupport.docValuesDefault(),
+                -1,
+                defaultExpression
+            );
+            onDynamicColumn.accept(newColumn);
+            var valueIndexer = (ValueIndexer<Object>) type.valueIndexer(
+                table,
+                newColumn,
+                getFieldType,
+                getRef
+            );
+            innerIndexers.put(innerName, valueIndexer);
+            xContentBuilder.field(innerName);
+            valueIndexer.indexValue(
+                innerValue,
+                xContentBuilder,
+                addField,
+                onDynamicColumn,
+                synthetics,
+                checks
+            );
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -111,6 +111,9 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             if (check != null) {
                 check.verify(innerValue);
             }
+            if (innerValue == null) {
+                continue;
+            }
             var valueIndexer = innerIndexers.get(innerName);
             assert valueIndexer != null : "ValueIndexer must exist for inner column retrieved from ObjectType information";
 

--- a/server/src/main/java/io/crate/execution/dml/StringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/StringIndexer.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+
+public class StringIndexer implements ValueIndexer<String> {
+
+    private final Reference ref;
+    private final FieldType fieldType;
+
+    public StringIndexer(Reference ref, FieldType fieldType) {
+        this.ref = ref;
+        this.fieldType = fieldType == null ? KeywordFieldMapper.Defaults.FIELD_TYPE : fieldType;
+    }
+
+    @Override
+    public void indexValue(String value,
+                           XContentBuilder xcontentBuilder,
+                           Consumer<? super IndexableField> addField,
+                           Consumer<? super Reference> onDynamicColumn,
+                           Map<ColumnIdent, Indexer.Synthetic> synthetics,
+                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
+        xcontentBuilder.value(value);
+        if (value == null) {
+            return;
+        }
+        String name = ref.column().fqn();
+        BytesRef binaryValue = new BytesRef(value);
+        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
+            Field field = new Field(name, binaryValue, fieldType);
+            addField.accept(field);
+            if (ref.hasDocValues() == false && fieldType.omitNorms()) {
+                addField.accept(new Field(
+                    FieldNamesFieldMapper.NAME,
+                    name,
+                    FieldNamesFieldMapper.Defaults.FIELD_TYPE));
+            }
+        }
+        if (ref.hasDocValues()) {
+            addField.accept(new SortedSetDocValuesField(name, binaryValue));
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/StringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/StringIndexer.java
@@ -55,10 +55,10 @@ public class StringIndexer implements ValueIndexer<String> {
                            Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
         if (value == null) {
             return;
         }
+        xcontentBuilder.value(value);
         String name = ref.column().fqn();
         BytesRef binaryValue = new BytesRef(value);
         if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {

--- a/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import io.crate.execution.dml.Indexer.ColumnConstraint;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+
+/**
+ * Component used to index values. An implementation must:
+ * <ul>
+ * <li>Add the value to the source using the provided `xcontentBuilder`</li>
+ * <li>Create index fields for the value and call `addField`</li>
+ * <li>Call `onDynamicColumn` for dynamically created columns</li>
+ * </ul>
+ *
+ * <p>
+ * `synthetics` and `toValidate` is for object types, where the indexer
+ * implementation must use them to generate inner columns (DEFAULT, GENERATED
+ * AS) and validate constraints. Primitive value indexers can ignore those.
+ * </p>
+ **/
+public interface ValueIndexer<T> {
+
+    void indexValue(
+        @Nullable T value,
+        XContentBuilder xcontentBuilder,
+        Consumer<? super IndexableField> addField,
+        Consumer<? super Reference> onDynamicColumn,
+        Map<ColumnIdent, Indexer.Synthetic> synthetics,
+        Map<ColumnIdent, ColumnConstraint> toValidate
+    ) throws IOException;
+}

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -157,6 +157,10 @@ public class ColumnIdent implements Comparable<ColumnIdent>, Accountable {
         return new ColumnIdent(parent.name, childPath);
     }
 
+    public ColumnIdent getChild(String name) {
+        return ColumnIdent.getChild(this, name);
+    }
+
     /**
      * Get the first non-map value from a map by traversing the name/path of the column
      */

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -48,7 +49,12 @@ import org.locationtech.spatial4j.shape.Point;
 
 import io.crate.Streamer;
 import io.crate.common.collections.Lists2;
+import io.crate.execution.dml.ArrayIndexer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.protocols.postgres.parser.PgArrayParser;
 import io.crate.protocols.postgres.parser.PgArrayParsingException;
@@ -71,12 +77,33 @@ public class ArrayType<T> extends DataType<List<T>> {
     private final DataType<T> innerType;
     private Streamer<List<T>> streamer;
 
+    private StorageSupport<? super T> storageSupport;
+
     /**
      * Construct a new Collection type
      * @param innerType The type of the elements inside the collection
      */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public ArrayType(DataType<T> innerType) {
         this.innerType = Objects.requireNonNull(innerType, "Inner type must not be null.");
+        StorageSupport innerStorage = innerType.storageSupport();
+        if (innerStorage == null) {
+            this.storageSupport = null;
+        } else {
+            this.storageSupport = new StorageSupport<T>(
+                    innerStorage.docValuesDefault(),
+                    innerStorage.hasFieldNamesIndex(),
+                    innerStorage.eqQuery()) {
+
+                @Override
+                public ValueIndexer<T> valueIndexer(RelationName table, Reference ref,
+                                                    Function<ColumnIdent, FieldType> getFieldType,
+                                                    Function<ColumnIdent, Reference> getRef) {
+                    return new ArrayIndexer<>(
+                        innerStorage.valueIndexer(table, ref, getFieldType, getRef));
+                }
+            };
+        }
     }
 
     public static DataType<?> makeArray(DataType<?> valueType, int numArrayDimensions) {
@@ -367,8 +394,9 @@ public class ArrayType<T> extends DataType<List<T>> {
     }
 
     @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public StorageSupport storageSupport() {
-        return innerType.storageSupport();
+        return storageSupport;
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -26,10 +26,12 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -40,6 +42,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import com.fasterxml.jackson.core.Base64Variants;
 
 import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.ColumnDefinition;
@@ -74,7 +80,14 @@ public final class BitStringType extends DataType<BitString> implements Streamer
                 return null;
             }
         }
-    );
+    ) {
+
+        @Override
+        public ValueIndexer<BitString> valueIndexer(RelationName table, Reference ref,
+                Function<ColumnIdent, FieldType> getFieldType, Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     public BitStringType(StreamInput in) throws IOException {
         this.length = in.readVInt();

--- a/server/src/main/java/io/crate/types/ByteType.java
+++ b/server/src/main/java/io/crate/types/ByteType.java
@@ -23,19 +23,32 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.function.Function;
 
+import org.apache.lucene.document.FieldType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWidthType {
 
     public static final ByteType INSTANCE = new ByteType();
     public static final int ID = 2;
-    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(
-        true, true, new IntEqQuery()
-    );
+    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery()) {
+
+        @Override
+        public ValueIndexer<Number> valueIndexer(RelationName table,
+                                                 Reference ref,
+                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     private ByteType() {
     }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -27,16 +27,22 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
@@ -137,6 +143,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      * @param value The value of the {@link DataType<T>}.
      * @return The prepared for insertion value of the {@link DataType<T>}.
      */
+    @SuppressWarnings("unchecked")
     public T valueForInsert(Object value) {
         return (T) value;
     }
@@ -226,6 +233,21 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
     public StorageSupport<? super T> storageSupport() {
         return null;
     }
+
+
+    @Nullable
+    public final ValueIndexer<? super T> valueIndexer(RelationName table,
+                                              Reference ref,
+                                              Function<ColumnIdent, FieldType> getFieldType,
+                                              Function<ColumnIdent, Reference> getRef) {
+        StorageSupport<? super T> storageSupport = storageSupport();
+        if (storageSupport == null) {
+            throw new IllegalArgumentException(
+                this + " has no storage support. Cannot index " + ref.column());
+        }
+        return storageSupport.valueIndexer(table, ref, getFieldType, getRef);
+    }
+
 
     public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
                                                @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -23,8 +23,10 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.function.Function;
 
 import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
@@ -34,6 +36,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class DoubleType extends DataType<Double> implements FixedWidthType, Streamer<Double> {
 
@@ -78,7 +84,16 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
                 return new IndexOrDocValuesQuery(indexQuery, dvQuery);
             }
         }
-    );
+    ) {
+
+        @Override
+        public ValueIndexer<Double> valueIndexer(RelationName table,
+                                                 Reference ref,
+                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     private DoubleType() {
     }

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -21,8 +21,11 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.function.Function;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
@@ -32,8 +35,11 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.math.BigDecimal;
+import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class FloatType extends DataType<Float> implements Streamer<Float>, FixedWidthType {
 
@@ -75,7 +81,16 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                 return new IndexOrDocValuesQuery(indexQuery, dvQuery);
             }
         }
-    );
+    ) {
+
+        @Override
+        public ValueIndexer<Float> valueIndexer(RelationName table,
+                                                Reference ref,
+                                                Function<ColumnIdent, FieldType> getFieldType,
+                                                Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     private FloatType() {
     }

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -21,7 +21,13 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.apache.lucene.document.FieldType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
@@ -30,16 +36,26 @@ import org.locationtech.spatial4j.io.WKTReader;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
-import java.io.IOException;
-import java.text.ParseException;
-import java.util.List;
-import java.util.Locale;
+import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class GeoPointType extends DataType<Point> implements Streamer<Point>, FixedWidthType {
 
     public static final int ID = 13;
     public static final GeoPointType INSTANCE = new GeoPointType();
-    private static StorageSupport<Point> STORAGE = new StorageSupport<>(true, true, null);
+    private static StorageSupport<Point> STORAGE = new StorageSupport<>(true, true, null) {
+
+        @Override
+        public ValueIndexer<Point> valueIndexer(RelationName table,
+                                                Reference ref,
+                                                Function<ColumnIdent, FieldType> getFieldType,
+                                                Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     private GeoPointType() {
     }

--- a/server/src/main/java/io/crate/types/GeoShapeType.java
+++ b/server/src/main/java/io/crate/types/GeoShapeType.java
@@ -24,7 +24,9 @@ package io.crate.types;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,13 +37,26 @@ import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
 
 import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
 import io.crate.geo.GeoJSONUtils;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class GeoShapeType extends DataType<Map<String, Object>> implements Streamer<Map<String, Object>> {
 
     public static final int ID = 14;
     public static final GeoShapeType INSTANCE = new GeoShapeType();
-    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, true, null);
+    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, true, null) {
+
+        @Override
+        public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,
+                                                              Reference ref,
+                                                              Function<ColumnIdent, FieldType> getFieldType,
+                                                              Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     private GeoShapeType() {
     }

--- a/server/src/main/java/io/crate/types/IntegerType.java
+++ b/server/src/main/java/io/crate/types/IntegerType.java
@@ -21,20 +21,37 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.function.Function;
+
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.math.BigDecimal;
+import io.crate.Streamer;
+import io.crate.execution.dml.IntIndexer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class IntegerType extends DataType<Integer> implements Streamer<Integer>, FixedWidthType {
 
     public static final IntegerType INSTANCE = new IntegerType();
     public static final int ID = 9;
     public static final int INTEGER_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Integer.class);
-    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery());
+    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery()) {
+
+        @Override
+        public ValueIndexer<Number> valueIndexer(RelationName table,
+                                                 Reference ref,
+                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<ColumnIdent, Reference> getRef) {
+            return new IntIndexer(ref, getFieldType.apply(ref.column()));
+        }
+    };
 
     private IntegerType() {
     }

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -21,8 +21,11 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.function.Function;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -30,8 +33,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.network.InetAddresses;
 
-import java.io.IOException;
-import java.net.InetAddress;
+import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class IpType extends DataType<String> implements Streamer<String> {
 
@@ -72,7 +78,16 @@ public class IpType extends DataType<String> implements Streamer<String> {
                 return InetAddressPoint.newRangeQuery(field, lower, upper);
             }
         }
-    );
+    ) {
+
+        @Override
+        public ValueIndexer<String> valueIndexer(RelationName table,
+                                                 Reference ref,
+                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     @Override
     public int id() {

--- a/server/src/main/java/io/crate/types/LongType.java
+++ b/server/src/main/java/io/crate/types/LongType.java
@@ -21,20 +21,41 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.function.Function;
+
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.math.BigDecimal;
+import io.crate.Streamer;
+import io.crate.execution.dml.LongIndexer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class LongType extends DataType<Long> implements FixedWidthType, Streamer<Long> {
 
     public static final LongType INSTANCE = new LongType();
     public static final int ID = 10;
     public static final int LONG_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Long.class);
-    private static final StorageSupport<Long> STORAGE = new StorageSupport<>(true, true, new LongEqQuery());
+    private static final StorageSupport<Long> STORAGE = new StorageSupport<>(
+        true,
+        true,
+        new LongEqQuery()
+    ) {
+
+        @Override
+        public ValueIndexer<Long> valueIndexer(RelationName table,
+                                               Reference ref,
+                                               Function<ColumnIdent, FieldType> getFieldType,
+                                               Function<ColumnIdent, Reference> getRef) {
+            return new LongIndexer(ref, getFieldType.apply(ref.column()));
+        }
+    };
 
     @Override
     public int id() {

--- a/server/src/main/java/io/crate/types/ShortType.java
+++ b/server/src/main/java/io/crate/types/ShortType.java
@@ -21,20 +21,36 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.function.Function;
+
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.math.BigDecimal;
+import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public class ShortType extends DataType<Short> implements Streamer<Short>, FixedWidthType {
 
     public static final ShortType INSTANCE = new ShortType();
     public static final int ID = 8;
     private static final int SHORT_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Short.class);
-    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery());
+    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery()) {
+
+        @Override
+        public ValueIndexer<Number> valueIndexer(RelationName table,
+                                                 Reference ref,
+                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     private ShortType() {
     }

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -22,15 +22,55 @@
 package io.crate.types;
 
 
+import java.util.function.Function;
+
 import javax.annotation.Nullable;
 
-import io.crate.metadata.IndexType;
+import org.apache.lucene.document.FieldType;
 
-public record StorageSupport<T>(boolean docValuesDefault,
-                                boolean hasFieldNamesIndex,
-                                @Nullable EqQuery<T> eqQuery) {
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+
+public abstract class StorageSupport<T> {
+
+    private final boolean docValuesDefault;
+    private final boolean hasFieldNamesIndex;
+
+    @Nullable
+    private final EqQuery<T> eqQuery;
+
+    public StorageSupport(boolean docValuesDefault,
+                          boolean hasFieldNamesIndex,
+                          EqQuery<T> eqQuery) {
+        this.docValuesDefault = docValuesDefault;
+        this.hasFieldNamesIndex = hasFieldNamesIndex;
+        this.eqQuery = eqQuery;
+    }
 
     public boolean getComputedDocValuesDefault(@Nullable IndexType indexType) {
         return docValuesDefault && indexType != IndexType.FULLTEXT;
+    }
+
+
+    public abstract ValueIndexer<T> valueIndexer(
+        RelationName table,
+        Reference ref,
+        Function<ColumnIdent, FieldType> getFieldType,
+        Function<ColumnIdent, Reference> getRef);
+
+
+    public boolean docValuesDefault() {
+        return docValuesDefault;
+    }
+
+    public boolean hasFieldNamesIndex() {
+        return hasFieldNamesIndex;
+    }
+
+    public EqQuery<T> eqQuery() {
+        return eqQuery;
     }
 }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -30,10 +30,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -49,6 +51,11 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import io.crate.Streamer;
 import io.crate.common.unit.TimeValue;
+import io.crate.execution.dml.StringIndexer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.ColumnDefinition;
@@ -88,7 +95,17 @@ public class StringType extends DataType<String> implements Streamer<String> {
                 );
             }
         }
-    );
+    ) {
+
+        @Override
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        public ValueIndexer<Object> valueIndexer(RelationName table,
+                                                 Reference ref,
+                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<ColumnIdent, Reference> getRef) {
+            return (ValueIndexer) new StringIndexer(ref, getFieldType.apply(ref.column()));
+        }
+    };
 
     private final int lengthLimit;
 

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -38,11 +38,16 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.apache.lucene.document.FieldType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.Streamer;
 import io.crate.common.StringUtils;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 public final class TimestampType extends DataType<Long>
     implements FixedWidthType, Streamer<Long> {
@@ -62,7 +67,16 @@ public final class TimestampType extends DataType<Long>
         TimestampType::parseTimestampIgnoreTimeZone,
         Precedence.TIMESTAMP);
 
-    private static final StorageSupport<Long> STORAGE = new StorageSupport<>(true, true, new LongEqQuery());
+    private static final StorageSupport<Long> STORAGE = new StorageSupport<>(true, true, new LongEqQuery()) {
+
+        @Override
+        public ValueIndexer<Long> valueIndexer(RelationName table,
+                                               Reference ref,
+                                               Function<ColumnIdent, FieldType> getFieldType,
+                                               Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     private final int id;
     private final String name;

--- a/server/src/main/java/io/crate/types/UncheckedObjectType.java
+++ b/server/src/main/java/io/crate/types/UncheckedObjectType.java
@@ -21,16 +21,22 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
-import io.crate.common.collections.MapComparator;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import io.crate.Streamer;
+import io.crate.common.collections.MapComparator;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 /**
  * Object type that makes no assumptions about neither the keys or values, treating them like generic values and lifting
@@ -42,7 +48,16 @@ public class UncheckedObjectType extends DataType<Map<Object, Object>> implement
     public static final int ID = 16;
 
     public static final String NAME = "unchecked_object";
-    private static final StorageSupport<Map<Object, Object>> STORAGE = new StorageSupport<>(false, false, null);
+    private static final StorageSupport<Map<Object, Object>> STORAGE = new StorageSupport<>(false, false, null) {
+
+        @Override
+        public ValueIndexer<Map<Object, Object>> valueIndexer(RelationName table,
+                                                              Reference ref,
+                                                              Function<ColumnIdent, FieldType> getFieldType,
+                                                              Function<ColumnIdent, Reference> getRef) {
+            throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
+        }
+    };
 
     public static UncheckedObjectType untyped() {
         return new UncheckedObjectType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -87,7 +87,8 @@ final class DocumentParser {
             context.sourceToParse().id(),
             context.doc(),
             context.sourceToParse().source(),
-            createDynamicUpdate(mapping, docMapper, context.getDynamicMappers())
+            createDynamicUpdate(mapping, docMapper, context.getDynamicMappers()),
+            List.of()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -19,9 +19,13 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.util.List;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.elasticsearch.common.bytes.BytesReference;
+
+import io.crate.metadata.Reference;
 
 /**
  * The result of parsing a document.
@@ -39,18 +43,22 @@ public class ParsedDocument {
 
     private final Mapping dynamicMappingsUpdate;
 
+    private final List<Reference> newColumns;
+
     public ParsedDocument(Field version,
                           SequenceIDFields seqID,
                           String id,
                           Document document,
                           BytesReference source,
-                          Mapping dynamicMappingsUpdate) {
+                          Mapping dynamicMappingsUpdate,
+                          List<Reference> newColumns) {
         this.version = version;
         this.seqID = seqID;
         this.id = id;
         this.document = document;
         this.source = source;
         this.dynamicMappingsUpdate = dynamicMappingsUpdate;
+        this.newColumns = newColumns;
     }
 
     public String id() {
@@ -98,4 +106,7 @@ public class ParsedDocument {
         return "Document id[" + id + "] doc [" + document + ']';
     }
 
+    public List<Reference> newColumns() {
+        return newColumns;
+    }
 }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -1,0 +1,462 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.junit.Test;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+public class IndexerTest extends CrateDummyClusterServiceUnitTest {
+
+    static IndexItem item(Object ... values) {
+        return new IndexItem.StaticItem("dummy-id-1", List.of(),values, 0L, 0L);
+    }
+
+    @Test
+    public void test_index_object_with_dynamic_column_creation() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (x int))")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference o = table.getReference(new ColumnIdent("o"));
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(o),
+            null
+        );
+
+        Map<String, Object> value = Map.of("x", 10, "y", 20);
+        ParsedDocument parsedDoc = indexer.index(item(value));
+        assertThat(parsedDoc.doc().getFields())
+            .hasSize(10);
+
+        assertThat(parsedDoc.newColumns())
+            .hasSize(1);
+
+        assertThat(parsedDoc.source().utf8ToString()).isIn(
+            "{\"o\":{\"x\":10,\"y\":20}}",
+            "{\"o\":{\"y\":20,\"x\":10}}"
+        );
+    }
+
+    @Test
+    public void test_create_dynamic_object_with_nested_columns() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (x int))")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference o = table.getReference(new ColumnIdent("o"));
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(o),
+            null
+        );
+
+        Map<String, Object> value = Map.of("x", 10, "obj", Map.of("y", 20));
+        ParsedDocument parsedDoc = indexer.index(item(value));
+        assertThat(parsedDoc.doc().getFields())
+            .hasSize(10);
+
+        assertThat(parsedDoc.newColumns())
+            .satisfiesExactly(
+                col1 -> assertThat(col1).isReference("o['obj']"),
+                col2 -> assertThat(col2).isReference("o['obj']['y']")
+            );
+    }
+
+    @Test
+    public void test_create_dynamic_array() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (x int))")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference o = table.getReference(new ColumnIdent("o"));
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(o),
+            null
+        );
+
+        Map<String, Object> value = Map.of("x", 10, "xs", List.of(2, 3, 4));
+        ParsedDocument parsedDoc = indexer.index(item(value));
+
+        assertThat(parsedDoc.newColumns())
+            .satisfiesExactly(
+                col1 -> assertThat(col1).isReference("o['xs']", new ArrayType<>(DataTypes.INTEGER))
+            );
+
+        assertThat(parsedDoc.source().utf8ToString()).isIn(
+            "{\"o\":{\"x\":10,\"xs\":[2,3,4]}}",
+            "{\"o\":{\"xs\":[2,3,4],\"x\":10}}"
+        );
+
+        assertThat(parsedDoc.doc().getFields())
+            .hasSize(14);
+    }
+
+    @Test
+    public void test_adds_default_values() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, y int default 0)")
+            .build();
+        CoordinatorTxnCtx txnCtx = new CoordinatorTxnCtx(executor.getSessionSettings());
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference x = table.getReference(new ColumnIdent("x"));
+        Reference y = table.getReference(new ColumnIdent("y"));
+        var indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            txnCtx,
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(y),
+            null
+        );
+        var parsedDoc = indexer.index(item(new Object[] { null }));
+        assertThat(parsedDoc.source().utf8ToString())
+            .as("If explicit null value is provided, the default expression is not applied")
+            .isEqualTo("{\"y\":null}");
+        assertThat(parsedDoc.doc().getFields())
+            .hasSize(6);
+
+        indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            txnCtx,
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(x),
+            null
+        );
+        parsedDoc = indexer.index(item(10));
+        assertThat(parsedDoc.source().utf8ToString()).isEqualTo(
+            "{\"x\":10,\"y\":0}"
+        );
+        assertThat(parsedDoc.doc().getFields())
+            .hasSize(10);
+    }
+
+    @Test
+    public void test_adds_generated_column() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, y int as x + 2)")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference x = table.getReference(new ColumnIdent("x"));
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(x),
+            null
+        );
+        var parsedDoc = indexer.index(item(1));
+        assertThat(parsedDoc.source().utf8ToString()).isEqualTo(
+            "{\"x\":1,\"y\":3}"
+        );
+    }
+
+    @Test
+    public void test_generated_partitioned_column_is_not_indexed_or_included_in_source() throws Exception {
+        String partition = new PartitionName(new RelationName("doc", "tbl"), List.of("3")).asIndexName();
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addPartitionedTable(
+                "create table doc.tbl (x int, p int as x + 2) partitioned by (p)",
+                partition
+            )
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference x = table.getReference(new ColumnIdent("x"));
+        Indexer indexer = new Indexer(
+            partition,
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(x),
+            null
+        );
+        var parsedDoc = indexer.index(item(1));
+        assertThat(parsedDoc.source().utf8ToString()).isEqualTo(
+            "{\"x\":1}"
+        );
+    }
+
+    @Test
+    public void test_default_and_generated_column_within_object() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (x int default 0, y int as o['x'] + 2, z int))")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference o = table.getReference(new ColumnIdent("o"));
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(o),
+            null
+        );
+
+        var parsedDoc = indexer.index(item(Map.of("z", 20)));
+        assertThat(parsedDoc.source().utf8ToString()).isEqualTo(
+            "{\"o\":{\"x\":0,\"y\":2,\"z\":20}}"
+        );
+    }
+
+    @Test
+    public void test_default_for_full_object() throws Exception {
+        var executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, o object as (x int) default {x=10})")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference x = table.getReference(new ColumnIdent("x"));
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(x),
+            null
+        );
+        var parsedDoc = indexer.index(item(42));
+        assertThat(parsedDoc.source().utf8ToString()).isEqualToIgnoringWhitespace("""
+            {
+                "x":42,
+                "o": {
+                    "x": 10
+                }
+            }
+            """);
+    }
+
+    @Test
+    public void test_validates_user_provided_value_for_generated_columns() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, y int as x + 2, o object as (z int as x + 3))")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference x = table.getReference(new ColumnIdent("x"));
+        Reference y = table.getReference(new ColumnIdent("y"));
+        Reference o = table.getReference(new ColumnIdent("o"));
+        Indexer indexer1 = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(x, y),
+            null
+        );
+        assertThatThrownBy(() -> indexer1.index(item(1, 2)))
+            .hasMessage("Given value 2 for generated column y does not match calculation (x + 2) = 3");
+
+        Indexer indexer2 = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(x, o),
+            null
+        );
+        assertThatThrownBy(() -> indexer2.index(item(1, Map.of("z", 10))))
+            .hasMessage("Given value 10 for generated column o['z'] does not match calculation (x + 3) = 4");
+    }
+
+    @Test
+    public void test_index_fails_if_not_null_column_has_null_value() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int not null, y int default 0 NOT NULL)")
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(
+                table.getReference(new ColumnIdent("x"))
+            ),
+            null
+        );
+        assertThatThrownBy(() -> indexer.index(item(new Object[] { null })))
+            .hasMessage("\"x\" must not be null");
+
+        ParsedDocument parsedDoc = indexer.index(item(10));
+        assertThat(parsedDoc.source().utf8ToString()).isEqualToIgnoringWhitespace("""
+            {"x":10, "y":0}
+            """);
+    }
+
+    @Test
+    public void test_index_fails_if_check_constraint_returns_false() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("""
+                create table tbl (
+                    x int not null constraint c1 check (x > 10),
+                    y int constraint c2 check (y < 3),
+                    z int default 0 check (z > 0)
+                )
+                """)
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(
+                table.getReference(new ColumnIdent("x")),
+                table.getReference(new ColumnIdent("z"))
+            ),
+            null
+        );
+        assertThatThrownBy(() -> indexer.index(item(8, 10)))
+            .hasMessage("Failed CONSTRAINT c1 CHECK (\"x\" > 10)");
+
+        ParsedDocument parsedDoc = indexer.index(item(20, null));
+        assertThat(parsedDoc.source().utf8ToString()).isEqualToIgnoringWhitespace("""
+            {"x":20, "z":null}
+            """);
+    }
+
+    @Test
+    public void test_does_not_allow_new_columns_in_strict_object() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("""
+                create table tbl (
+                    o object (strict) as (
+                        x int
+                    )
+                )
+                """)
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(
+                table.getReference(new ColumnIdent("o"))
+            ),
+            null
+        );
+        assertThatThrownBy(() -> indexer.index(item(Map.of("x", 10, "y", 20))))
+            .hasMessage("Cannot add column `y` to strict object `o`");
+    }
+
+    @Test
+    public void test_dynamic_int_value_results_in_long_column() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addTable("""
+                create table tbl (
+                    o object (dynamic) as (
+                        x int
+                    )
+                )
+                """)
+            .build();
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(
+                table.getReference(new ColumnIdent("o"))
+            ),
+            null
+        );
+        ParsedDocument index = indexer.index(item(Map.of("x", 10, "y", 20)));
+        assertThat(index.newColumns()).satisfiesExactly(
+            r -> assertThat(r).isReference("o['y']", DataTypes.LONG)
+        );
+    }
+
+    @Test
+    public void test_can_generate_return_values() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, y int default 20)")
+            .build();
+
+        DocTableInfo table = e.resolveTableInfo("tbl");
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            new CoordinatorTxnCtx(e.getSessionSettings()),
+            e.nodeCtx,
+            column -> NumberFieldMapper.FIELD_TYPE,
+            List.of(
+                table.getReference(new ColumnIdent("x"))
+            ),
+            new Symbol[] {
+                table.getReference(new ColumnIdent("_id")),
+                table.getReference(new ColumnIdent("x")),
+                table.getReference(new ColumnIdent("y")),
+            }
+        );
+
+        Object[] returnValues = indexer.returnValues(item(10));
+        assertThat(returnValues).containsExactly("dummy-id-1", 10, 20);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -4916,7 +4916,9 @@ public class InternalEngineTests extends EngineTestCase {
                 id,
                 document,
                 source,
-                null);
+                null,
+                List.of()
+            );
 
             final Engine.Index index = new Engine.Index(
                 new Term("_id", parsedDocument.id()),

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2975,7 +2975,7 @@ public class TranslogTests extends ESTestCase {
         document.add(seqID.seqNo);
         document.add(seqID.seqNoDocValue);
         document.add(seqID.primaryTerm);
-        ParsedDocument doc = new ParsedDocument(versionField, seqID, "1", document, B_1, null);
+        ParsedDocument doc = new ParsedDocument(versionField, seqID, "1", document, B_1, null, List.of());
 
         Engine.Index eIndex = new Engine.Index(newUid(doc), doc, randomSeqNum, randomPrimaryTerm,
             1, VersionType.INTERNAL, Origin.PRIMARY, 0, 0, false, SequenceNumbers.UNASSIGNED_SEQ_NO, 0);

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -409,7 +409,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         document.add(seqID.primaryTerm);
         final BytesReference source = new BytesArray(new byte[] { 1 });
         final ParsedDocument doc =
-            new ParsedDocument(versionField, seqID, id, document, source, null);
+            new ParsedDocument(versionField, seqID, id, document, source, null, List.of());
         return new Engine.Index(
             new Term("_id", Uid.encodeId(doc.id())), doc, UNASSIGNED_SEQ_NO, 0,
             Versions.MATCH_ANY, VersionType.INTERNAL, PRIMARY, System.nanoTime(), -1, false, UNASSIGNED_SEQ_NO, 0);

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -361,7 +361,7 @@ public abstract class EngineTestCase extends ESTestCase {
         } else {
             document.add(new StoredField(SourceFieldMapper.NAME, ref.bytes, ref.offset, ref.length));
         }
-        return new ParsedDocument(versionField, seqID, id, document, source, mappingUpdate);
+        return new ParsedDocument(versionField, seqID, id, document, source, mappingUpdate, List.of());
     }
 
     /**
@@ -383,7 +383,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 seqID.tombstoneField.setLongValue(1);
                 doc.add(seqID.tombstoneField);
                 return new ParsedDocument(
-                    versionField, seqID, id, doc, new BytesArray("{}"), null);
+                    versionField, seqID, id, doc, new BytesArray("{}"), null, List.of());
             }
 
             @Override
@@ -400,7 +400,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 BytesRef byteRef = new BytesRef(reason);
                 doc.add(new StoredField(SourceFieldMapper.NAME, byteRef.bytes, byteRef.offset, byteRef.length));
                 return new ParsedDocument(
-                    versionField, seqID, null, doc, null, null);
+                    versionField, seqID, null, doc, null, null, List.of());
             }
         };
     }


### PR DESCRIPTION
This adds a component that can be used to index documents without an
addition parse step.

This changes the insert indexing flow from:

- Create source
- Parse source to create index fields

To:

- Create source and create index fields


The overall idea is to have an `Indexer` that creates the index fields/lucene document and source using `ValueIndexers`. There is one valueIndexer per type and it's part of their `storageSupport`. 

Currently only int, long and string are implemented, the others are missing and will be added later. The integration is also missing - that's why the PR is against a feature branch.