### PR TITLE
Avoid calls to dependencies in Group References

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/server/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -21,8 +21,6 @@
 
 package io.crate.planner.operators;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,6 +29,7 @@ import javax.annotation.Nullable;
 
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists2;
+import io.crate.common.collections.Maps;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
@@ -57,9 +56,7 @@ public class MultiPhase extends ForwardingLogicalPlan {
 
     private MultiPhase(LogicalPlan source, Map<LogicalPlan, SelectSymbol> subQueries) {
         super(source);
-        HashMap<LogicalPlan, SelectSymbol> allSubQueries = new HashMap<>(source.dependencies());
-        allSubQueries.putAll(subQueries);
-        this.subQueries = Collections.unmodifiableMap(allSubQueries);
+        this.subQueries = subQueries;
     }
 
     @Override
@@ -84,7 +81,7 @@ public class MultiPhase extends ForwardingLogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return subQueries;
+        return Maps.concat(source.dependencies(), subQueries);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -74,7 +74,6 @@ public class NestedLoopJoin implements LogicalPlan {
     final LogicalPlan lhs;
     final LogicalPlan rhs;
     private final List<Symbol> outputs;
-    private final Map<LogicalPlan, SelectSymbol> dependencies;
     private boolean orderByWasPushedDown = false;
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
     private final boolean joinConditionOptimised;
@@ -97,7 +96,6 @@ public class NestedLoopJoin implements LogicalPlan {
         }
         this.topMostLeftRelation = topMostLeftRelation;
         this.joinCondition = joinCondition;
-        this.dependencies = Maps.concat(lhs.dependencies(), rhs.dependencies());
         this.joinConditionOptimised = joinConditionOptimised;
     }
 
@@ -155,7 +153,7 @@ public class NestedLoopJoin implements LogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return dependencies;
+        return Maps.concat(lhs.dependencies(), rhs.dependencies());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -73,14 +73,11 @@ public class Union implements LogicalPlan {
     private final List<Symbol> outputs;
     final LogicalPlan lhs;
     final LogicalPlan rhs;
-    private final Map<LogicalPlan, SelectSymbol> dependencies;
-
 
     public Union(LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.outputs = outputs;
-        this.dependencies = Maps.concat(lhs.dependencies(), rhs.dependencies());
     }
 
     @Override
@@ -234,7 +231,7 @@ public class Union implements LogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return dependencies;
+        return Maps.concat(lhs.dependencies(), rhs.dependencies());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -81,13 +81,12 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Map.of();
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
 
     @Override
     public long numExpectedRows() {
         throw new UnsupportedOperationException(ERROR_MESSAGE);
-
     }
 
     @Override


### PR DESCRIPTION
This prevents calls to the unsupported dependency() method in Group References and ctor's of Logical Plans.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
