### PR TITLE
Add relation names to Group References

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -52,12 +52,14 @@ public class GroupReference implements LogicalPlan {
 
     private final int groupId;
     private final List<Symbol> outputs;
+    private final Set<RelationName> relationNames;
     private static final String ERROR_MESSAGE =
         "Operation is not supported in GroupReference, it needs to be resolved to it's referenced LogicalPlan";
 
-    public GroupReference(int groupId, List<Symbol> outputs) {
+    public GroupReference(int groupId, List<Symbol> outputs, Collection<RelationName> relationNames) {
         this.groupId = groupId;
         this.outputs = List.copyOf(outputs);
+        this.relationNames = Set.copyOf(relationNames);
     }
 
     public int groupId() {
@@ -102,7 +104,7 @@ public class GroupReference implements LogicalPlan {
 
     @Override
     public Set<RelationName> getRelationNames() {
-        return Set.of();
+        return relationNames;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
@@ -186,7 +186,8 @@ public class Memo {
             node.sources().stream()
                 .map(child -> new GroupReference(
                     insertRecursive(child),
-                    child.outputs()))
+                    child.outputs(),
+                    child.getRelationNames()))
                 .collect(Collectors.toList()));
     }
 

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -330,7 +330,7 @@ public class MemoTest {
 
         @Override
         public Set<RelationName> getRelationNames() {
-            return null;
+            return Set.of();
         }
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
+
 import org.junit.Test;
 
 import io.crate.analyze.WhereClause;
@@ -81,7 +83,7 @@ public class PatternTest {
     @Test
     public void test_with_match_group_referenced_source() {
         var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
-        var groupReferenceSource = new GroupReference(1, source.outputs());
+        var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 
         var memo = new HashMap<Integer, LogicalPlan>();
@@ -107,7 +109,7 @@ public class PatternTest {
     @Test
     public void test_with_property_match_group_referenced_source() {
         var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
-        var groupReferenceSource = new GroupReference(1, source.outputs());
+        var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 
         var memo = new HashMap<Integer, LogicalPlan>();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds the relation names to the group references. I tried a few alternatives, moving them into joins etc. but makes everything more complicated. This also prevents any need to resolve sub-trees in the rules. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
