### PR TITLE
Adapt javadoc in rules regarding relation names in group references

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -39,8 +39,9 @@ public interface Rule<T> {
      *
      * @param resolvePlan resolvesPlan will resolve a {@GroupReference} to it's referenced {@LogicalPlan} instance.
      *                    It must be used on a source of {@code plan} if the rule needs to access any properties
-     *                    of the source other than the outputs. This may materialize the sub-tree for the source
-     *                    and could be expensive. If the rule doesn't access source properties, don't call it.
+     *                    of the source other than the outputs or the relation names. This may materialize
+     *                    the sub-tree for the source and could be expensive. If the rule doesn't access
+     *                    source properties, don't call it.
      */
     LogicalPlan apply(T plan,
                       Captures captures,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
