### PR TITLE
Use seqNo as indicator for skip on replica

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
@@ -37,6 +37,8 @@ public class SequenceNumbers {
      */
     public static final long NO_OPS_PERFORMED = -1L;
 
+    public static final long SKIP_ON_REPLICA = -3L;
+
     /**
      * Represents an unassigned primary term (e.g., when a primary shard was not yet allocated)
      */


### PR DESCRIPTION
Once indexers (https://github.com/crate/crate/pull/13696) are integrated
we'll generate the source on the replica too and can no longer use the
presence of source to skip items.
