### PR TITLE
Add fields used in WHERE to toCollect

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -31,6 +31,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
+import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.OuterColumn;
 import io.crate.expression.symbol.RefVisitor;
@@ -170,7 +171,8 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
             selectSymbol.relation().visitSymbols(symbol -> symbol.accept(collectOuterColumns, null));
         }
 
-        RefVisitor.visitRefs(where, r -> toCollect.add(r));
+        RefVisitor.visitRefs(where, toCollect::add);
+        FieldsVisitor.visitFields(where, toCollect::add);
         ArrayList<Symbol> outputs = new ArrayList<>();
         for (var output : toCollect) {
             if (Symbols.containsCorrelatedSubQuery(output)) {

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -177,6 +177,10 @@ public class Asserts extends Assertions {
         return s -> assertThat(s).isReference(expectedName, expectedType);
     }
 
+    public static Consumer<Symbol> isScopedSymbol(String expectedName) {
+        return s -> assertThat(s).isScopedSymbol(expectedName);
+    }
+
     public static Consumer<Symbol> isFetchStub(String expectedName) {
         return s -> assertThat(s).isFetchStub(expectedName);
     }

--- a/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
@@ -177,6 +177,15 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
         return this;
     }
 
+    public SymbolAssert isScopedSymbol(String expectedName) {
+        isNotNull();
+        isInstanceOf(ScopedSymbol.class);
+        assertThat(((ScopedSymbol) actual).column().sqlFqn())
+            .as("sqlFqn")
+            .isEqualTo(expectedName);
+        return this;
+    }
+
     public SymbolAssert isFunction(final String expectedName) {
         return isFunction(expectedName, (List<DataType<?>>) null);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Additional to references, also add any field symbols (e.g. ScopedSymbols) to toCollect.
Follow up of #13668.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
