### PR TITLE
Refine `ColumnUnknownException` such that `MaskSensitiveExceptions` can be specialized

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,3 +81,11 @@ Fixes
   ANY(<array-literal>)`` to match on partitions where the column didn't exist or
   on records where ``<column>`` had a ``null`` value.
 
+- Fixed an issue that translated ``ColumnUnknownException`` to a misleading
+  ``SchemaUnknownException`` when users without ``DQL`` on ``doc`` schema
+  queried unknown columns from :ref:`table functions <table-functions>`.
+  An example ::
+
+    SELECT unknown_col FROM abs(1);
+    SchemaUnknownException[Schema 'doc' unknown]
+

--- a/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -188,7 +188,7 @@ class AlterTableAddColumnAnalyzer {
                         );
                     }
                 }
-                throw new ColumnUnknownException(colIdent.sqlFqn(), relationName);
+                throw new ColumnUnknownException(colIdent, relationName);
             }
         }
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -541,7 +541,7 @@ public class AnalyzedTableElements<T> {
         for (Object additionalPrimaryKey : elements.additionalPrimaryKeys) {
             ColumnIdent columnIdent = ColumnIdent.fromPath(additionalPrimaryKey.toString());
             if (!elements.columnIdents.contains(columnIdent)) {
-                throw new ColumnUnknownException(columnIdent.sqlFqn(), relationName);
+                throw new ColumnUnknownException(columnIdent, relationName);
             }
         }
         // will collect both column constraint and additional defined once and check for duplicates
@@ -552,7 +552,7 @@ public class AnalyzedTableElements<T> {
         for (Map.Entry<Object, Set<String>> entry : tableElements.copyToMap.entrySet()) {
             ColumnIdent columnIdent = ColumnIdent.fromPath(entry.getKey().toString());
             if (!tableElements.columnIdents.contains(columnIdent)) {
-                throw new ColumnUnknownException(columnIdent.sqlFqn(), relationName);
+                throw new ColumnUnknownException(columnIdent, relationName);
             }
             if (!DataTypes.STRING.equals(tableElements.columnTypes.get(columnIdent))) {
                 throw new IllegalArgumentException("INDEX definition only support 'string' typed source columns");
@@ -630,7 +630,7 @@ public class AnalyzedTableElements<T> {
             if (skipIfNotFound) {
                 return;
             }
-            throw new ColumnUnknownException(partitionedByIdent.sqlFqn(), relationName);
+            throw new ColumnUnknownException(partitionedByIdent, relationName);
         }
         DataType<?> columnType = columnDefinition.dataType();
         if (!DataTypes.isPrimitive(columnType)) {

--- a/server/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
+++ b/server/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
@@ -59,7 +59,7 @@ public class TableReferenceResolver implements FieldProvider<Reference> {
             }
         }
 
-        throw new ColumnUnknownException(columnIdent.sqlFqn(), relationName);
+        throw new ColumnUnknownException(columnIdent, relationName);
     }
 
     public List<Reference> references() {

--- a/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -133,7 +133,7 @@ public final class ValueNormalizer {
                     dynamicReference = ((DocTableInfo) tableInfo).getDynamic(nestedIdent, true, true);
                 }
                 if (dynamicReference == null) {
-                    throw new ColumnUnknownException(nestedIdent.sqlFqn(), tableInfo.ident());
+                    throw new ColumnUnknownException(nestedIdent, tableInfo.ident());
                 }
                 DataType type = DataTypes.guessType(entry.getValue());
                 if (type == null) {

--- a/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -59,7 +59,7 @@ public class NameFieldProvider implements FieldProvider<Symbol> {
 
         Symbol field = relation.getField(columnIdent, operation, errorOnUnknownObjectKey);
         if (field == null) {
-            throw new ColumnUnknownException(columnIdent.sqlFqn(), relation.relationName());
+            throw new ColumnUnknownException(columnIdent, relation.relationName());
         }
         return field;
     }

--- a/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
@@ -101,7 +101,7 @@ public class TableFunctionRelation implements AnalyzedRelation, FieldResolver {
                 return SubscriptFunctions.makeObjectSubscript(output, column);
             }
         }
-        return null;
+        throw ColumnUnknownException.ofTableFunctionRelation("Column " + column.sqlFqn() + " unknown", relationName);
     }
 
     @Override

--- a/server/src/main/java/io/crate/exceptions/CrateExceptionVisitor.java
+++ b/server/src/main/java/io/crate/exceptions/CrateExceptionVisitor.java
@@ -48,4 +48,8 @@ public class CrateExceptionVisitor<C, R> {
     protected R visitUnscopedException(UnscopedException e, C context) {
         return visitCrateException(e, context);
     }
+
+    protected R visitColumnUnknownException(ColumnUnknownException e, C context) {
+        return visitCrateException(e, context);
+    }
 }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -431,7 +431,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                 break;
             case STRICT:
                 if (forWrite) {
-                    throw new ColumnUnknownException(ident.sqlFqn(), ident());
+                    throw new ColumnUnknownException(ident, ident());
                 }
                 return null;
             case IGNORED:
@@ -460,7 +460,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         if (reference == null) {
             reference = getDynamic(columnIdent, forWrite, errorOnUnknownObjectKey);
             if (reference == null) {
-                throw new ColumnUnknownException(targetColumnName, ident);
+                throw new ColumnUnknownException(columnIdent, ident);
             }
         }
         return reference;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/13561

by making clear distinction that a `ColumnUnknownException` is originated from a table or a table function:
```
select * from my_schema.empty_row();

select * from my_schema.empty_row;
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
