### PR TITLE
Remove deprecated hasRows overload

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -88,7 +88,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
 
         execute("select * from strict_table");
         assertThat(response).hasColumns("id", "name");
-        assertThat(response).hasRows("1| Ford\n");
+        assertThat(response).hasRows("1| Ford");
 
         Asserts.assertSQLError(() -> execute("insert into strict_table (id, name, boo) values (2, 'Trillian', true)"))
             .hasPGError(UNDEFINED_COLUMN)
@@ -108,7 +108,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
 
         execute("select * from strict_table");
         assertThat(response).hasColumns("id", "name");
-        assertThat(response).hasRows("1| Ford\n");
+        assertThat(response).hasRows("1| Ford");
 
         Asserts.assertSQLError(() -> execute("update strict_table set name='Trillian', boo=true where id=1"))
             .hasPGError(UNDEFINED_COLUMN)
@@ -137,7 +137,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
 
         execute("select * from dynamic_table");
         assertThat(response).hasColumns("id", "name");
-        assertThat(response).hasRows("1| Ford\n");
+        assertThat(response).hasRows("1| Ford");
 
         execute("insert into dynamic_table (id, name, boo) values (2, 'Trillian', true)");
         execute("refresh table dynamic_table");
@@ -185,7 +185,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
 
         assertThat(response).hasColumns("person['name']", "person['addresses']['city']");
         assertThat(response).hasRows(
-            "Ford| [West Country]\n"
+            "Ford| [West Country]"
         );
     }
 
@@ -286,7 +286,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("select * from dynamic_table");
         assertThat(response)
             .hasColumns("id", "name")
-            .hasRows("1| Ford\n");
+            .hasRows("1| Ford");
 
         execute("update dynamic_table set name='Trillian', boo=true where name='Ford'");
         execute("refresh table dynamic_table");
@@ -295,7 +295,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("select * from dynamic_table");
         assertThat(response)
             .hasColumns("id", "name", "boo")
-            .hasRows("1| Trillian| true\n");
+            .hasRows("1| Trillian| true");
     }
 
     @Test
@@ -311,7 +311,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("select * from dynamic_table");
         assertThat(response)
             .hasColumns("id", "score")
-            .hasRows("1| 42.24\n");
+            .hasRows("1| 42.24");
 
         execute("insert into dynamic_table (id, score, good) values (2, -0.01, false)");
         execute("refresh table dynamic_table");
@@ -338,7 +338,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("select * from dynamic_table");
         assertThat(response)
             .hasColumns("id", "score")
-            .hasRows("1| 4656234.345\n");
+            .hasRows("1| 4656234.345");
 
         execute("update dynamic_table set name='Trillian', good=true where score > 0.0");
         execute("refresh table dynamic_table");
@@ -347,7 +347,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("select * from dynamic_table");
         assertThat(response)
             .hasColumns("id", "score", "name", "good")
-            .hasRows("1| 4656234.345| Trillian| true\n");
+            .hasRows("1| 4656234.345| Trillian| true");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -391,7 +391,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "            └ Collect[doc.b | [1, f1, f2, f3, f1, f2, f3] | (((f1 = f1) AND (f2 = f2)) AND (f3 = 'c'))]"
         );
         assertThat(execute(stmt)).hasRows(
-            "1\n"
+            "1"
         );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -433,7 +433,7 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("insert into t(id) values(-1)");
         refresh();
         execute("select id from t");
-        assertThat(response).hasRows("-1\n");
+        assertThat(response).hasRows("-1");
     }
 
     @Test
@@ -456,12 +456,12 @@ public class DDLIntegrationTest extends IntegTestCase {
 
         execute("select data_type from information_schema.columns where " +
                 "table_name = 't' and column_name = 'name'");
-        assertThat(response).hasRows("text\n");
+        assertThat(response).hasRows("text");
 
         execute("alter table t add column o object as (age int)");
         execute("select data_type from information_schema.columns where " +
                 "table_name = 't' and column_name = 'o'");
-        assertThat(response).hasRows("object\n");
+        assertThat(response).hasRows("object");
     }
 
     @Test
@@ -664,7 +664,7 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("INSERT INTO t (attributes) values ([{name='Trillian', is_nice=True}])");
         refresh();
         execute("select attributes from t");
-        assertThat(response).hasRows("[{name=Trillian, is_nice=true}]\n");
+        assertThat(response).hasRows("[{name=Trillian, is_nice=true}]");
     }
 
     @Test
@@ -818,11 +818,11 @@ public class DDLIntegrationTest extends IntegTestCase {
 
         execute("select name from a.t");
         assertThat(response).hasRowCount(1);
-        assertThat(response).hasRows("Ford\n");
+        assertThat(response).hasRows("Ford");
 
         execute("select table_schema from information_schema.tables where table_name = 't'");
         assertThat(response).hasRowCount(1);
-        assertThat(response).hasRows("a\n");
+        assertThat(response).hasRows("a");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -607,16 +607,16 @@ public class GroupByAggregateTest extends IntegTestCase {
         /* count(payload) is implicitly optimized to use DocValueAggregator of payload['nested_payload']['col'],
            so below 3 executions are expected to have the same results. */
         execute("select device, count(payload) from tbl group by 1");
-        assertThat(response).hasRows("1| 3\n");
+        assertThat(response).hasRows("1| 3");
         execute("select device, count(payload['nested_payload']) from tbl group by 1");
-        assertThat(response).hasRows("1| 3\n");
+        assertThat(response).hasRows("1| 3");
         execute("select device, count(payload['nested_payload']['col']) from tbl group by 1");
-        assertThat(response).hasRows("1| 3\n");
+        assertThat(response).hasRows("1| 3");
         // below are just there to show that no other available columns are used instead of payload['nested_payload']['col']
         execute("select device, count(nullable_payload) from tbl group by 1");
-        assertThat(response).hasRows("1| 2\n");
+        assertThat(response).hasRows("1| 2");
         execute("select device, count(payload['col']) from tbl group by 1");
-        assertThat(response).hasRows("1| 2\n");
+        assertThat(response).hasRows("1| 2");
     }
 
     @Test
@@ -783,7 +783,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         execute("select avg(birthdate) from characters group by gender\n" +
                 "having avg(birthdate) = 181353600000.0");
         assertThat(response).hasRowCount(1L);
-        assertThat(response).hasRows("1.813536E11\n");
+        assertThat(response).hasRows("1.813536E11");
     }
 
     @Test
@@ -792,7 +792,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         execute("select avg(birthdate) from characters group by gender\n" +
                 "having min(birthdate) > '1970-01-01'");
         assertThat(response).hasRowCount(1L);
-        assertThat(response).hasRows("1.813536E11\n");
+        assertThat(response).hasRows("1.813536E11");
     }
 
 
@@ -822,11 +822,11 @@ public class GroupByAggregateTest extends IntegTestCase {
 
         execute("select country from foo group by country having country = 'Austria'");
         assertThat(response).hasRowCount(1L);
-        assertThat(response).hasRows("Austria\n");
+        assertThat(response).hasRows("Austria");
 
         execute("select count(*), country from foo group by country having country = 'Austria'");
         assertThat(response).hasRowCount(1L);
-        assertThat(response).hasRows("3| Austria\n");
+        assertThat(response).hasRows("3| Austria");
 
         execute("select country, min(id) from foo group by country having min(id) < 5 ");
         assertThat(response).hasRowCount(2L);
@@ -898,10 +898,10 @@ public class GroupByAggregateTest extends IntegTestCase {
 
         execute("select count(*), name from foo group by id, name order by name desc");
         assertThat(response).hasRows(
-            "1| Trillian\n" +
-            "1| Slartibardfast\n" +
-            "1| Marvin\n" +
-            "1| Arthur\n");
+            "1| Trillian",
+            "1| Slartibardfast",
+            "1| Marvin",
+            "1| Arthur");
     }
 
     @Test
@@ -977,7 +977,7 @@ public class GroupByAggregateTest extends IntegTestCase {
                 99.6d});
         refresh();
         execute("select avg(score), url, avg(score) from twice group by url limit 10");
-        assertThat(response).hasRows("99.6| https://Ä.com| 99.6\n");
+        assertThat(response).hasRows("99.6| https://Ä.com| 99.6");
     }
 
     @Test
@@ -1211,7 +1211,7 @@ public class GroupByAggregateTest extends IntegTestCase {
                 " select distinct max(col1), min(col1) from unnest([1,1,1,2,2,2,2,3,3],[1,2,3,1,2,3,4,1,2]) " +
                 " group by col2 order by 2, 1 limit 2" +
                 ") t order by 1 desc limit 1");
-        assertThat(response).hasRows("3| 1\n");
+        assertThat(response).hasRows("3| 1");
     }
 
     @Test
@@ -1230,10 +1230,10 @@ public class GroupByAggregateTest extends IntegTestCase {
     public void testGroupByOnComplexLiterals() throws Exception {
         execute("select '{coordinates=[[0.0, 0.0], [1.0, 1.0]], type=LineString}', count(*) " +
                 "from employees group by 1");
-        assertThat(response).hasRows("{coordinates=[[0.0, 0.0], [1.0, 1.0]], type=LineString}| 6\n");
+        assertThat(response).hasRows("{coordinates=[[0.0, 0.0], [1.0, 1.0]], type=LineString}| 6");
         execute("select {id1=1, id2=36}, count(*) " +
                 "from employees group by 1");
-        assertThat(response).hasRows("{id1=1, id2=36}| 6\n");
+        assertThat(response).hasRows("{id1=1, id2=36}| 6");
     }
 
     @Test
@@ -1264,7 +1264,7 @@ public class GroupByAggregateTest extends IntegTestCase {
                 });
         refresh();
         execute("select sum(i), max(s) from t1");
-        assertThat(response).hasRows("4| foobar\n");
+        assertThat(response).hasRows("4| foobar");
     }
 
     @Test
@@ -1362,7 +1362,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         execute("insert into tbl (obj) values ({x=10})");
         execute("refresh table tbl");
         execute("select obj['x'] from (select obj from tbl) as t group by obj['x']");
-        assertThat(response).hasRows("10\n");
+        assertThat(response).hasRows("10");
     }
 
     @Test
@@ -1379,7 +1379,7 @@ public class GroupByAggregateTest extends IntegTestCase {
             "    └ Collect[doc.tbl | [x, name] | true]"
         );
         execute("select name, count(x), count(x) from doc.tbl group by name");
-        assertThat(response).hasRows("Apple| 3| 3\n");
+        assertThat(response).hasRows("Apple| 3| 3");
     }
 
     @Test
@@ -1397,20 +1397,20 @@ public class GroupByAggregateTest extends IntegTestCase {
         // Ensure deterministic order for assertion → sort by id
         Arrays.sort(response.rows(), (a, b) -> ((String) a[0]).compareTo((String) b[0]));
         assertThat(response).hasRows(
-            "013440476U| Avenue de Trévoux | 013440476U| Pt(x=5.20172193646431,y=46.200959966517985)| Saint-Denis-lès-Bourg\n" +
-            "021140050C| Rue Paul Doumer | 021140050C| Pt(x=3.426927952095866,y=49.04914998449385)| Brasles\n" +
-            "122021430M| Rue Penavayre| 122021430M| Pt(x=2.573608970269561,y=44.35006999410689)| Rodez\n"
+            "013440476U| Avenue de Trévoux | 013440476U| Pt(x=5.20172193646431,y=46.200959966517985)| Saint-Denis-lès-Bourg",
+            "021140050C| Rue Paul Doumer | 021140050C| Pt(x=3.426927952095866,y=49.04914998449385)| Brasles",
+            "122021430M| Rue Penavayre| 122021430M| Pt(x=2.573608970269561,y=44.35006999410689)| Rodez"
         );
     }
 
     @Test
     public void test_group_on_null_literal() {
         execute("select null, count(*) from unnest([1, 2]) group by 1");
-        assertThat(response).hasRows("NULL| 2\n");
+        assertThat(response).hasRows("NULL| 2");
 
         execute("SELECT nn, sum(x) from (SELECT NULL as nn, x from unnest([1]) tbl (x)) t GROUP BY nn");
         assertThat(response).hasRows(
-            "NULL| 1\n"
+            "NULL| 1"
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -519,7 +519,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("SELECT table_name, partition_ident, values " +
                 "FROM information_schema.table_partitions");
         assertThat(response).hasRows(
-            "parted| 084l8sj9dhm6iobe00| {date=NULL, name=Trillian}\n");
+            "parted| 084l8sj9dhm6iobe00| {date=NULL, name=Trillian}");
     }
 
     @Test
@@ -534,7 +534,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("SELECT table_name, partition_ident, values " +
                 "FROM information_schema.table_partitions");
         assertThat(response).hasRows(
-            "parted| 084l8sj9dhm6iobe00| {date=NULL, name=Trillian}\n");
+            "parted| 084l8sj9dhm6iobe00| {date=NULL, name=Trillian}");
     }
 
     @Test
@@ -1425,7 +1425,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("insert into t (obj) (select {ts=1549966541034})");
         execute("refresh table t");
         assertThat(execute("select day, obj from t")).hasRows(
-            "1549929600000| {ts=1549966541034}\n"
+            "1549929600000| {ts=1549966541034}"
         );
     }
 
@@ -1651,7 +1651,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         String id = (String) response.rows()[0][1];
         execute("select x from tbl where id = ?", new Object[] { id });
         assertThat(response).hasRows(
-            "1\n"
+            "1"
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -139,7 +139,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
             " FROM pg_publication p" +
             " JOIN pg_publication_tables t ON p.pubname = t.pubname" +
             " ORDER BY p.pubname, schemaname, tablename");
-        assertThat(response).hasRows("-119974068| pub1| -450373579| false| doc| t1| true| true| true\n");
+        assertThat(response).hasRows("-119974068| pub1| -450373579| false| doc| t1| true| true| true");
     }
 
     @Test
@@ -485,7 +485,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
             " FROM pg_subscription s" +
             " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
             " JOIN pg_class r ON sr.srrelid = r.oid");
-        assertThat(res).hasRows("sub1| t1| r| NULL\n");
+        assertThat(res).hasRows("sub1| t1| r| NULL");
     }
 
     @Test
@@ -598,7 +598,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
                         " FROM pg_subscription s" +
                         " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
                         " JOIN pg_class r ON sr.srrelid = r.oid");
-                assertThat(res).hasRows("sub1| t1| r| NULL\n");
+                assertThat(res).hasRows("sub1| t1| r| NULL");
             });
 
             executeOnSubscriber("DROP SUBSCRIPTION sub1");
@@ -618,7 +618,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
                     " FROM pg_subscription s" +
                     " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
                     " JOIN pg_class r ON sr.srrelid = r.oid");
-            assertThat(res).hasRows("sub1| t1| r| NULL\n");
+            assertThat(res).hasRows("sub1| t1| r| NULL");
         });
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -148,11 +148,11 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
             var r = executeOnSubscriber("SELECT column_name FROM information_schema.columns" +
                                         " WHERE table_name = 't3'" +
                                         " ORDER BY ordinal_position");
-            assertThat(r).hasRows("id\n");
+            assertThat(r).hasRows("id");
             r = executeOnSubscriber("SELECT values FROM information_schema.table_partitions" +
                                         " WHERE table_name = 't2'" +
                                         " ORDER BY partition_ident");
-            assertThat(r).hasRows("{p=1}\n");
+            assertThat(r).hasRows("{p=1}");
             ensureGreenOnSubscriber();
         }, 50, TimeUnit.SECONDS);
     }
@@ -207,7 +207,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
         assertBusy(() -> {
             executeOnSubscriber("REFRESH TABLE t1");
             var r = executeOnSubscriber("SELECT id, p FROM t1 ORDER BY id");
-            assertThat(r).hasRows("2| 2\n");
+            assertThat(r).hasRows("2| 2");
         });
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -484,10 +484,10 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
             thread.join();
         }
         assertThat(execute("select distinct health from sys.health")).hasRows(
-            "GREEN\n"
+            "GREEN"
         );
         assertThat(execute("select distinct current_state from sys.allocations")).hasRows(
-            "STARTED\n"
+            "STARTED"
         );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -63,7 +63,7 @@ public class PgCatalogITest extends IntegTestCase {
     @Test
     public void test_pg_class_table_with_pg_get_expr() {
         execute("select pg_get_expr(relpartbound,0) from pg_catalog.pg_class limit 1");
-        assertThat(response).hasRows("NULL\n");
+        assertThat(response).hasRows("NULL");
     }
 
     @Test
@@ -92,13 +92,13 @@ public class PgCatalogITest extends IntegTestCase {
     @Test
     public void testPgIndexTable() {
         execute("select count(*) from pg_catalog.pg_index");
-        assertThat(response).hasRows("23\n");
+        assertThat(response).hasRows("23");
     }
 
     @Test
     public void test_pg_index_table_with_pg_get_expr() {
         execute("select pg_get_expr(indexprs,0), pg_get_expr(indpred,0) from pg_catalog.pg_index limit 1");
-        assertThat(response).hasRows("NULL| NULL\n");
+        assertThat(response).hasRows("NULL| NULL");
     }
 
     @Test
@@ -106,25 +106,27 @@ public class PgCatalogITest extends IntegTestCase {
         execute("select cn.* from pg_constraint cn, pg_class c where cn.conrelid = c.oid and c.relname = 't1'");
         assertThat(response).hasRows(
             "NULL| false| false| NULL| a| NULL| NULL| s| 0| a| 0| 0| true| [1]| t1_pk| -2048275947| true| NULL| NULL| " +
-            "728874843| NULL| p| 0| true| -874078436\n");
+            "728874843| NULL| p| 0| true| -874078436");
     }
 
     @Test
     public void testPgTablesTable() {
         execute("select * from pg_tables WHERE tablename = 't1'");
-        assertThat(response).hasRows("false| false| false| false| doc| t1| NULL| NULL\n");
+        assertThat(response).hasRows("false| false| false| false| doc| t1| NULL| NULL");
 
         execute("select count(*) from pg_tables WHERE tablename = 'v1'");
-        assertThat(response).hasRows("0\n");
+        assertThat(response).hasRows("0");
     }
 
     @Test
     public void testPgViewsTable() {
         execute("select * from pg_views WHERE viewname = 'v1'");
-        assertThat(response).hasRows("SELECT \"id\"\nFROM \"doc\".\"t1\"\n| doc| v1| crate\n");
+        assertThat(response).hasRows(
+            new Object[] { "SELECT \"id\"\nFROM \"doc\".\"t1\"\n", "doc", "v1", "crate" }
+        );
 
         execute("select count(*) from pg_views WHERE viewname = 't1'");
-        assertThat(response).hasRows("0\n");
+        assertThat(response).hasRows("0");
     }
 
     @Test
@@ -185,7 +187,7 @@ public class PgCatalogITest extends IntegTestCase {
     @Test
     public void test_primary_key_in_pg_index() {
         execute("select i.indexrelid, i.indrelid, i.indkey from pg_index i, pg_class c where c.relname = 't1' and c.oid = i.indrelid;");
-        assertThat(response).hasRows("-649073482| 728874843| [1]\n");
+        assertThat(response).hasRows("-649073482| 728874843| [1]");
     }
 
     @Test
@@ -193,7 +195,7 @@ public class PgCatalogITest extends IntegTestCase {
         execute("select ct.oid, ct.relkind, ct.relname, ct.relnamespace, ct.relnatts, ct.relpersistence, ct.relreplident, ct.reltuples" +
                 " from pg_class ct, (select * from pg_index i, pg_class c where c.relname = 't1' and c.oid = i.indrelid) i" +
                 " where ct.oid = i.indexrelid;");
-        assertThat(response).hasRows("-649073482| i| t1_pkey| -2048275947| 3| p| p| 0.0\n");
+        assertThat(response).hasRows("-649073482| i| t1_pkey| -2048275947| 3| p| p| 0.0");
     }
 
     @Test
@@ -238,7 +240,7 @@ public class PgCatalogITest extends IntegTestCase {
             "SELECT typname, typreceive, typreceive::int, typreceive::text " +
             "FROM pg_type " +
             "WHERE typname = 'bool'");
-        assertThat(response).hasRows("bool| boolrecv| 994071801| boolrecv\n");
+        assertThat(response).hasRows("bool| boolrecv| 994071801| boolrecv");
     }
 
     @Test
@@ -248,7 +250,7 @@ public class PgCatalogITest extends IntegTestCase {
             "FROM pg_type " +
             "JOIN pg_proc ON pg_proc.oid = pg_type.typreceive " +
             "WHERE pg_type.typname = 'bool'");
-        assertThat(response).hasRows("bool| boolrecv| 994071801\n");
+        assertThat(response).hasRows("bool| boolrecv| 994071801");
     }
 
     @Test
@@ -274,7 +276,7 @@ public class PgCatalogITest extends IntegTestCase {
                     inner join pg_type on typreceive = pg_proc.oid
                     where proname = 'array_recv' and typname = '_int4'
                     """);
-        assertThat(response).hasRows("556695454\n");
+        assertThat(response).hasRows("556695454");
 
         execute("""
             SELECT typ.oid, typname, typrelid, typnotnull, relkind, typelem AS elemoid,
@@ -330,6 +332,6 @@ public class PgCatalogITest extends IntegTestCase {
             " '\"persons\"'::regclass::integer oid_from_relname, " +
             " oid " +
             " FROM pg_class WHERE relname ='persons'");
-        assertThat(response).hasRows("1726373441| 1726373441\n");
+        assertThat(response).hasRows("1726373441| 1726373441");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -465,7 +465,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
             SQLResponse res = execute(
                 "select column_name, data_type from information_schema.columns where " +
                 " table_name='arr' order by ordinal_position desc limit 1");
-            assertThat(res).hasRows("new| real_array\n");
+            assertThat(res).hasRows("new| real_array");
         });
     }
 

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -472,7 +472,7 @@ public class SysShardsTest extends IntegTestCase {
         ensureGreen(); // All shards must be available before close; otherwise they're skipped
         execute("alter table doc.tbl close");
         assertBusy(() ->
-            assertThat(execute("select closed from information_schema.tables where table_name = 'tbl'")).hasRows("true\n")
+            assertThat(execute("select closed from information_schema.tables where table_name = 'tbl'")).hasRows("true")
         );
         assertThatThrownBy(() -> execute("select * from doc.tbl"))
             .satisfiesAnyOf(

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -197,7 +197,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("insert into test1 (col1) values ('abc def, ghi. jkl')");
         refresh();
         assertThat(execute("select count(col1) from test1 group by col1")).hasRows(
-            "1\n"
+            "1"
         );
     }
 
@@ -367,7 +367,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select \"id\" from test order by id limit 1 offset 1");
         assertEquals(1, response.rowCount());
         assertThat(response).hasRows(
-            "id2\n"
+            "id2"
         );
     }
 
@@ -378,7 +378,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("insert into test (id) values ('id1'), ('id2')");
         execute("select _id from test where id = 'id1'");
         assertThat(response).hasRows(
-            "id1\n"
+            "id1"
         );
     }
 
@@ -392,7 +392,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         });
         refresh();
         execute("select id from test where id != 'id1'");
-        assertThat(response).hasRows("id2\n");
+        assertThat(response).hasRows("id2");
     }
 
 
@@ -430,7 +430,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("insert into test (date) values ('2013-10-01'), ('2013-10-02')");
         execute("refresh table test");
         execute("select date from test where date = '2013-10-01'");
-        assertThat(response).hasRows("1380585600000\n");
+        assertThat(response).hasRows("1380585600000");
     }
 
     @Test
@@ -440,7 +440,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table test");
         execute(
             "select date from test where date > '2013-10-01'");
-        assertThat(response).hasRows("1380672000000\n");
+        assertThat(response).hasRows("1380672000000");
     }
 
     @Test
@@ -450,7 +450,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table test");
         execute(
             "select i from test where i > 10");
-        assertThat(response).hasRows("20\n");
+        assertThat(response).hasRows("20");
     }
 
 
@@ -467,7 +467,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         refresh();
         execute("select id, strings, integers from t1");
         assertThat(response).hasRows(
-            "1| [foo, bar]| [1, 2, 3]\n"
+            "1| [foo, bar]| [1, 2, 3]"
         );
     }
 
@@ -480,7 +480,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         refresh();
 
         assertThat(execute("select details['names'] from t1")).hasRows(
-            "[Arthur, Trillian]\n"
+            "[Arthur, Trillian]"
         );
     }
 
@@ -505,7 +505,7 @@ public class TransportSQLActionTest extends IntegTestCase {
                 "from t1 " +
                 "where ['Ford', 'Slarti', 'Ford'] = ANY (details['names'])");
         assertThat(response).hasRows(
-            "[[Arthur, Trillian], [Ford, Slarti, Ford]]| true\n"
+            "[[Arthur, Trillian], [Ford, Slarti, Ford]]| true"
         );
     }
 
@@ -542,7 +542,7 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("select id, strings from t1");
         assertThat(response).hasRows(
-            "1| [foo, null, bar]\n"
+            "1| [foo, null, bar]"
         );
     }
 
@@ -566,13 +566,13 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("select objects from t1");
         assertThat(response).hasRows(
-            "[{name=foo, age=1}, {name=bar, age=2}]\n"
+            "[{name=foo, age=1}, {name=bar, age=2}]"
         );
         execute("select objects['name'] from t1");
-        assertThat(response).hasRows("[foo, bar]\n");
+        assertThat(response).hasRows("[foo, bar]");
 
         execute("select objects['name'] from t1 where ? = ANY (objects['name'])", new Object[]{"foo"});
-        assertThat(response).hasRows("[foo, bar]\n");
+        assertThat(response).hasRows("[foo, bar]");
     }
 
     @Test
@@ -601,7 +601,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         waitNoPendingTasksOnAll(); // wait for mapping update as foo is being added
 
         execute("select pk_col, message from test where pk_col='124'");
-        assertThat(response).hasRows("124| bar1\n");
+        assertThat(response).hasRows("124| bar1");
     }
 
     @Test
@@ -634,7 +634,7 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("SELECT pk_col, message FROM test WHERE pk_col='4' OR pk_col='3'");
         assertThat(response).hasRows(
-            "3| baz\n"
+            "3| baz"
         );
 
         execute("SELECT pk_col, message FROM test WHERE pk_col='4' OR pk_col='99'");
@@ -674,10 +674,10 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRowCount(2);
 
         execute("select count(*) from characters where name like 'Jeltz'");
-        assertThat(response).hasRows("1\n");
+        assertThat(response).hasRows("1");
 
         execute("select count(*) from characters where race like '%o%'");
-        assertThat(response).hasRows("3\n");
+        assertThat(response).hasRows("3");
 
         Map<String, Object> emptyMap = new HashMap<>();
         Map<String, Object> details = new HashMap<>();
@@ -817,7 +817,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRowCount(1L);
 
         execute("select count(*) from test");
-        assertThat(response).hasRows("3\n");
+        assertThat(response).hasRows("3");
     }
 
     @Test
@@ -889,7 +889,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select \"_id\", id from quotes where id=1 and author='Ford'");
         assertEquals(1L, response.rowCount());
         assertThat(response).hasRows(
-            "AgExBEZvcmQ=| 1\n"
+            "AgExBEZvcmQ=| 1"
         );
     }
 
@@ -905,7 +905,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select \"_id\", id from quotes where id=1 and author='Ford'");
         assertEquals(1L, response.rowCount());
         assertThat(response).hasRows(
-            "AgRGb3JkATE=| 1\n"
+            "AgRGb3JkATE=| 1"
         );
     }
 
@@ -922,8 +922,8 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("select \"_id\", id from quotes where id=1 order by author");
         assertThat(response).hasRows(
-            "AgdEb3VnbGFzATE=| 1\n" +
-            "AgRGb3JkATE=| 1\n"
+            "AgdEb3VnbGFzATE=| 1",
+            "AgRGb3JkATE=| 1"
         );
     }
 
@@ -1016,7 +1016,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         refresh();
 
         execute("select count(*) from test where name like '%-updated'");
-        assertThat(response).hasRows("3\n");
+        assertThat(response).hasRows("3");
 
         // test bulk of delete-by-id
         rowCounts = execute("delete from test where id = ?", new Object[][]{
@@ -1030,7 +1030,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         refresh();
 
         execute("select count(*) from test");
-        assertThat(response).hasRows("2\n");
+        assertThat(response).hasRows("2");
 
         // test bulk of delete-by-query
         rowCounts = execute("delete from test where name = ?", new Object[][]{
@@ -1044,7 +1044,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         refresh();
 
         execute("select count(*) from test");
-        assertThat(response).hasRows("0\n");
+        assertThat(response).hasRows("0");
 
     }
 
@@ -1056,9 +1056,9 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select format('%s is a %s', name, kind) as sentence from tbl order by name");
         assertThat(response).hasColumns("sentence");
         assertThat(response).hasRows(
-            " is a Planet\n" +
-            "Aldebaran is a Star System\n" +
-            "Algol is a Star System\n"
+            " is a Planet",
+            "Aldebaran is a Star System",
+            "Algol is a Star System"
         );
 
     }
@@ -1068,43 +1068,43 @@ public class TransportSQLActionTest extends IntegTestCase {
         this.setup.setUpArrayTables();
 
         execute("select count(*) from any_table where 'Berlin' = ANY (names)");
-        assertThat(response).hasRows("2\n");
+        assertThat(response).hasRows("2");
 
         execute("select id, names from any_table where 'Berlin' = ANY (names) order by id");
         assertThat(response).hasRows(
-            "1| [Dornbirn, Berlin, St. Margrethen]\n" +
-            "3| [Hangelsberg, Berlin]\n"
+            "1| [Dornbirn, Berlin, St. Margrethen]",
+            "3| [Hangelsberg, Berlin]"
         );
 
         execute("select id from any_table where 'Berlin' != ANY (names) order by id");
         assertThat(response).hasRows(
-            "1\n" +
-            "2\n" +
-            "3\n"
+            "1",
+            "2",
+            "3"
         );
 
         execute("select count(id) from any_table where 0.0 < ANY (temps)");
-        assertThat(response).hasRows("2\n");
+        assertThat(response).hasRows("2");
 
         execute("select id, names from any_table where 0.0 < ANY (temps) order by id");
         assertThat(response).hasRows(
-            "2| [Dornbirn, Dornbirn, Dornbirn]\n" +
-            "3| [Hangelsberg, Berlin]\n"
+            "2| [Dornbirn, Dornbirn, Dornbirn]",
+            "3| [Hangelsberg, Berlin]"
         );
 
         execute("select count(*) from any_table where 0.0 > ANY (temps)");
-        assertThat(response).hasRows("2\n");
+        assertThat(response).hasRows("2");
 
         execute("select id, names from any_table where 0.0 > ANY (temps) order by id");
         assertThat(response).hasRows(
-            "2| [Dornbirn, Dornbirn, Dornbirn]\n" +
-            "3| [Hangelsberg, Berlin]\n"
+            "2| [Dornbirn, Dornbirn, Dornbirn]",
+            "3| [Hangelsberg, Berlin]"
         );
 
         execute("select id, names from any_table where 'Ber%' LIKE ANY (names) order by id");
         assertThat(response).hasRows(
-            "1| [Dornbirn, Berlin, St. Margrethen]\n" +
-            "3| [Hangelsberg, Berlin]\n"
+            "1| [Dornbirn, Berlin, St. Margrethen]",
+            "3| [Hangelsberg, Berlin]"
         );
     }
 
@@ -1114,15 +1114,15 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("select id from any_table where NOT 'Hangelsberg' = ANY (names) order by id");
         assertThat(response).hasRows(
-            "1\n" +
-            "2\n"
+            "1",
+            "2"
         );
 
         execute("select id from any_table where 'Hangelsberg' != ANY (names) order by id");
         assertThat(response).hasRows(
-            "1\n" +
-            "2\n" +
-            "3\n"
+            "1",
+            "2",
+            "3"
         );
     }
 
@@ -1132,15 +1132,15 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("select id from any_table where 'kuh%' LIKE ANY (tags) order by id");
         assertThat(response).hasRows(
-            "3\n" +
-            "4\n"
+            "3",
+            "4"
         );
 
         execute("select id from any_table where 'kuh%' NOT LIKE ANY (tags) order by id");
         assertThat(response).hasRows(
-            "1\n" +
-            "2\n" +
-            "3\n"
+            "1",
+            "2",
+            "3"
         );
     }
 
@@ -1152,7 +1152,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table ip_table");
 
         execute("select addr from ip_table where addr = '23.235.33.143'");
-        assertThat(response).hasRows("23.235.33.143\n");
+        assertThat(response).hasRows("23.235.33.143");
 
         execute("select addr from ip_table where addr > '127.0.0.1'");
         assertThat(response).hasRowCount(0);
@@ -1160,9 +1160,9 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRowCount(0);
 
         execute("select addr from ip_table where addr < '127.0.0.1'");
-        assertThat(response).hasRows("23.235.33.143\n");
+        assertThat(response).hasRows("23.235.33.143");
         execute("select addr from ip_table where addr < 2130706433"); // 2130706433 == 127.0.0.1
-        assertThat(response).hasRows("23.235.33.143\n");
+        assertThat(response).hasRows("23.235.33.143");
 
         execute("select addr from ip_table where addr <= '127.0.0.1'");
         assertThat(response).hasRowCount(2L);
@@ -1187,8 +1187,8 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select i, count(*) from t group by 1 order by count(*) desc");
 
         assertThat(response).hasRows(
-            "192.168.1.2| 2\n" +
-            "192.168.1.3| 1\n"
+            "192.168.1.2| 2",
+            "192.168.1.3| 1"
         );
     }
 
@@ -1298,7 +1298,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         refresh();
 
         execute("select within(p, 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))') from t");
-        assertThat(response).hasRows("true\n");
+        assertThat(response).hasRows("true");
 
         execute("select * from t where within(p, 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))')");
         assertThat(response).hasRowCount(1L);
@@ -1323,7 +1323,7 @@ public class TransportSQLActionTest extends IntegTestCase {
     @Test
     public void testTwoSubStrOnSameColumn() throws Exception {
         execute("select substr(name, 0, 4), substr(name, 4, 8) from sys.cluster");
-        assertThat(response).hasRows("SUIT| TE-TEST_\n");
+        assertThat(response).hasRows("SUIT| TE-TEST_");
     }
 
 
@@ -1337,11 +1337,11 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select i, i%3 from t order by i%3, l");
         assertThat(response).hasRowCount(5L);
         assertThat(response).hasRows(
-            "-1| -1\n" +
-            "1| 1\n" +
-            "10| 1\n" +
-            "193384| 1\n" +
-            "2| 2\n");
+            "-1| -1",
+            "1| 1",
+            "10| 1",
+            "193384| 1",
+            "2| 2");
     }
 
     @Test
@@ -1546,7 +1546,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table t");
 
         execute("select _doc['name'] from t");
-        assertThat(response).hasRows("Marvin\n");
+        assertThat(response).hasRows("Marvin");
     }
 
     @Test
@@ -1574,7 +1574,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("SELECT * FROM with_quote");
         assertThat(response)
             .hasColumns("\"")
-            .hasRows("'\n");
+            .hasRows("'");
     }
 
     @Test
@@ -1585,9 +1585,9 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("select b, not b, not (b > i::boolean) from t order by b");
         assertThat(response).hasRows(
-            "false| true| true\n" +
-            "true| false| true\n" +
-            "NULL| NULL| NULL\n"
+            "false| true| true",
+            "true| false| true",
+            "NULL| NULL| NULL"
         );
 
         execute("select b, i from t where not b");
@@ -1645,9 +1645,9 @@ public class TransportSQLActionTest extends IntegTestCase {
         // this causes a normalization on the map-side which used to remove the order by
         execute("select cast((select 2) as integer) * x from t order by 1");
         assertThat(response).hasRows(
-            "6\n" +
-            "10\n" +
-            "20\n");
+            "6",
+            "10",
+            "20");
     }
 
     @Test
@@ -1657,8 +1657,8 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table t");
 
         assertThat(execute("select text from t order by 1 desc")).hasRows(
-            "The End\n" +
-            "Hello World\n"
+            "The End",
+            "Hello World"
         );
     }
 
@@ -1666,9 +1666,9 @@ public class TransportSQLActionTest extends IntegTestCase {
     public void test_values_as_top_level_relation() {
         execute("VALUES (1, 'a'), (2, 'b'), (3, (SELECT 'c'))");
         assertThat(response).hasRows(
-            "1| a\n" +
-            "2| b\n" +
-            "3| c\n"
+            "1| a",
+            "2| b",
+            "3| c"
         );
     }
 
@@ -1736,8 +1736,8 @@ public class TransportSQLActionTest extends IntegTestCase {
             + "     c.relname,"
             + "     attnum");
         assertThat(response).hasRows(
-            "doc| metrics| id| 23| true| -1| 4| 1| NULL| NULL| 0| b\n" +
-            "doc| metrics| x| 23| false| -1| 4| 2| NULL| NULL| 0| b\n"
+            "doc| metrics| id| 23| true| -1| 4| 1| NULL| NULL| 0| b",
+            "doc| metrics| x| 23| false| -1| 4| 2| NULL| NULL| 0| b"
         );
     }
 
@@ -1770,11 +1770,11 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table doc.test");
         execute("explain select id from doc.test where id = '1' and region_level_1 = '2' and marker_type = '3' and is_auto = false;");
         assertThat(response).hasRows(
-            "Get[doc.test | id | DocKeys{'1', '2', '3', false} | ((((id = '1') AND (region_level_1 = '2')) AND (marker_type = '3')) AND (is_auto = false))]\n"
+            "Get[doc.test | id | DocKeys{'1', '2', '3', false} | ((((id = '1') AND (region_level_1 = '2')) AND (marker_type = '3')) AND (is_auto = false))]"
         );
         execute("select id from doc.test where id = '1' and region_level_1 = '2' and marker_type = '3' and is_auto = false;");
         assertThat(response).hasRows(
-            "1\n"
+            "1"
         );
     }
 
@@ -1785,11 +1785,11 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("select _id, path from tbl where ts = '2017-06-21' and path = 'c1'");
         assertThat(response).hasRows(
-            "Ag0xNDk4MDAzMjAwMDAwAmMx| c1\n"
+            "Ag0xNDk4MDAzMjAwMDAwAmMx| c1"
         );
         execute("select _id, path from tbl where ts = ? and path = ?", new Object[] { "2017-06-21", "c1" });
         assertThat(response).hasRows(
-            "Ag0xNDk4MDAzMjAwMDAwAmMx| c1\n"
+            "Ag0xNDk4MDAzMjAwMDAwAmMx| c1"
         );
     }
 
@@ -1892,18 +1892,18 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("SELECT _doc['xs'], xs, _raw, xs::bit(3) FROM tbl WHERE xs = B'1001'");
         assertThat(response).hasRows(
-            "B'1001'| B'1001'| {\"id\":6,\"xs\":\"CQ==\"}| B'100'\n"
+            "B'1001'| B'1001'| {\"id\":6,\"xs\":\"CQ==\"}| B'100'"
         );
         // use LIMIT 1 to hit a different execution path that should load `xs` differently
         execute("SELECT _doc['xs'], xs, _raw, xs::bit(3) FROM tbl WHERE xs = B'1001' LIMIT 1");
         assertThat(response).hasRows(
-            "B'1001'| B'1001'| {\"id\":6,\"xs\":\"CQ==\"}| B'100'\n"
+            "B'1001'| B'1001'| {\"id\":6,\"xs\":\"CQ==\"}| B'100'"
         );
 
         // primary key lookup uses different execution path to decode the value
         execute("select xs from tbl where id = 6");
         assertThat(response).hasRows(
-            "B'1001'\n"
+            "B'1001'"
         );
 
         var properties = new Properties();
@@ -2004,7 +2004,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table tbl");
         execute("select xs from tbl");
         assertThat(response).hasRows(
-            "[B'010', B'110']\n"
+            "[B'010', B'110']"
         );
     }
 
@@ -2019,12 +2019,12 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute("SELECT _doc['c'], c, _raw, c::char(1) FROM tbl WHERE c = 'two'");
         assertThat(response).hasRows(
-                "two | two | {\"c\":\"two \"}| t\n"
+                "two | two | {\"c\":\"two \"}| t"
         );
         // use LIMIT 1 to hit a different execution path that should load `c` differently
         execute("SELECT _doc['c'], c, _raw, c::char(1) FROM tbl WHERE c = 'four' LIMIT 1");
         assertThat(response).hasRows(
-            "four| four| {\"c\":\"four\"}| f\n"
+            "four| four| {\"c\":\"four\"}| f"
         );
 
         var properties = new Properties();
@@ -2052,7 +2052,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table tbl");
         execute("select c from tbl");
         assertThat(response).hasRows(
-            "[four, two ]\n"
+            "[four, two ]"
         );
     }
 
@@ -2063,9 +2063,9 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table tbl");
         execute("select _doc['x'] from tbl order by 1");
         assertThat(response).hasRows(
-            "1\n" +
-            "2\n" +
-            "3\n"
+            "1",
+            "2",
+            "3"
         );
 
     }
@@ -2079,9 +2079,9 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("INSERT INTO t1 (o) VALUES ({\"my first \"\" field\" = 'foo'})");
         refresh();
         execute("SELECT o FROM t1");
-        assertThat(response).hasRows("{my first \" field=foo}\n");
+        assertThat(response).hasRows("{my first \" field=foo}");
         execute("SELECT o['my first \" field'] FROM t1");
-        assertThat(response).hasRows("foo\n");
+        assertThat(response).hasRows("foo");
     }
 
     /**
@@ -2094,9 +2094,9 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("insert into doc.obj (obj) VALUES ('{\"(\": 1.0}');");
         refresh();
         execute("SELECT count(*) FROM doc.obj");
-        assertThat(response).hasRows("2\n");
+        assertThat(response).hasRows("2");
         execute("SELECT obj FROM doc.obj limit 1");
-        assertThat(response).hasRows("{(=1.0}\n");
+        assertThat(response).hasRows("{(=1.0}");
     }
 
 
@@ -2106,7 +2106,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("insert into doc.test VALUES ('\"\"')");
         refresh();
         execute("SELECT \"\"\"\" FROM doc.test");
-        assertThat(response).hasRows("\"\"\n");
+        assertThat(response).hasRows("\"\"");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -922,7 +922,7 @@ public class UpdateIntegrationTest extends IntegTestCase {
         execute("update test set message='msg' where id = 1 returning id");
 
         assertThat(response.cols()[0]).isEqualTo("id");
-        assertThat(response).hasRows("1\n");
+        assertThat(response).hasRows("1");
     }
 
     @Test
@@ -935,7 +935,7 @@ public class UpdateIntegrationTest extends IntegTestCase {
         execute("update test set message='msg' where id = 1 returning id as renamed");
 
         assertThat(response.cols()[0]).isEqualTo("renamed");
-        assertThat(response).hasRows("1\n");
+        assertThat(response).hasRows("1");
     }
 
     @Test
@@ -947,7 +947,7 @@ public class UpdateIntegrationTest extends IntegTestCase {
 
         execute("update test set message='updated' where id = (select 1) returning id");
 
-        assertThat(response).hasRows("1\n");
+        assertThat(response).hasRows("1");
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -672,7 +672,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         execute("CREATE SNAPSHOT " + snapshotName + " ALL WITH (wait_for_completion=true)");
 
         execute("SELECT state FROM sys.snapshots WHERE name = '" + SNAP_NAME + "'");
-        assertThat(response).hasRows("SUCCESS\n");
+        assertThat(response).hasRows("SUCCESS");
 
         execute("ALTER TABLE " + INDEX_NAME + " CLOSE");
 

--- a/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -22,6 +22,7 @@
 package org.elasticsearch.snapshots;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.elasticsearch.snapshots.SnapshotsService.MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING;
@@ -699,7 +700,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             .rootCause().hasMessageEndingWith("Snapshot was aborted by deletion");
 
         assertThat(execute("SELECT count(*) FROM sys.snapshots WHERE repository=?", new Object[]{repoName}))
-            .hasRows("0\n");
+            .hasRows("0");
         awaitClusterState(
             masterNode,
             state -> hasSnapshotsInProgress(state, 0) && hasDeletionsInProgress(state, 0)

--- a/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
@@ -46,15 +46,6 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
         return this;
     }
 
-    /**
-     * Deprecated, use io.crate.testing.{@link io.crate.testing.SQLResponseAssert#hasRows(String ... rows)} instead
-     */
-    @Deprecated
-    public SQLResponseAssert hasRows(String printedRows) {
-        assertThat(TestingHelpers.printedTable(actual.rows())).isEqualTo(printedRows);
-        return this;
-    }
-
     public SQLResponseAssert hasRows(Object[] ... rows) {
         assertThat(List.of(actual.rows())).contains(rows);
         return this;


### PR DESCRIPTION
Removes the deprecated overload because for single rows avoiding it is a
bit annoying as you'd have to explicitly use `String[]` to force the
non-deprecated `hasRows` version.
