### PR TITLE
Create GeoReference also for geo shape arrays

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -68,8 +68,8 @@ import io.crate.sql.tree.GenericProperties;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
 import io.crate.types.GeoShapeType;
+import io.crate.types.ObjectType;
 
 public class AnalyzedTableElements<T> {
 
@@ -475,6 +475,7 @@ public class AnalyzedTableElements<T> {
                 columnDefinition.position,
                 new ReferenceIdent(relationName, columnDefinition.ident()),
                 isNullable,
+                realType,
                 columnDefinition.geoTree(),
                 (String) geoMap.get("precision"),
                 (Integer) geoMap.get("tree_levels"),

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -33,7 +33,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.sql.tree.ColumnPolicy;
-import io.crate.types.DataTypes;
+import io.crate.types.DataType;
 
 public class GeoReference extends SimpleReference {
 
@@ -53,11 +53,12 @@ public class GeoReference extends SimpleReference {
     public GeoReference(int position,
                         ReferenceIdent ident,
                         boolean nullable,
+                        DataType<?> type,
                         @Nullable String tree,
                         @Nullable String precision,
                         @Nullable Integer treeLevels,
                         @Nullable Double distanceErrorPct) {
-        super(ident, RowGranularity.DOC, DataTypes.GEO_SHAPE, ColumnPolicy.DYNAMIC, IndexType.PLAIN, nullable, false, position, null);
+        super(ident, RowGranularity.DOC, type, ColumnPolicy.DYNAMIC, IndexType.PLAIN, nullable, false, position, null);
         this.geoTree = Objects.requireNonNullElse(tree, DEFAULT_TREE);
         this.precision = precision;
         this.treeLevels = treeLevels;

--- a/server/src/test/java/io/crate/metadata/GeoReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeoReferenceTest.java
@@ -21,13 +21,15 @@
 
 package io.crate.metadata;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+
+import static io.crate.testing.Asserts.assertThat;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
+
+import io.crate.types.DataTypes;
 
 public class GeoReferenceTest extends ESTestCase {
 
@@ -35,22 +37,40 @@ public class GeoReferenceTest extends ESTestCase {
     public void testStreaming() throws Exception {
         RelationName relationName = new RelationName("doc", "test");
         ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "geo_column");
-        GeoReference geoReferenceInfo = new GeoReference(1, referenceIdent, true, "some_tree", "1m", 3, 0.5d);
+        GeoReference geoReferenceInfo = new GeoReference(
+            1,
+            referenceIdent,
+            true,
+            DataTypes.GEO_SHAPE,
+            "some_tree",
+            "1m",
+            3,
+            0.5d
+        );
 
         BytesStreamOutput out = new BytesStreamOutput();
         Reference.toStream(geoReferenceInfo, out);
         StreamInput in = out.bytes().streamInput();
         GeoReference geoReferenceInfo2 = Reference.fromStream(in);
 
-        assertThat(geoReferenceInfo2, is(geoReferenceInfo));
+        assertThat(geoReferenceInfo2).isEqualTo(geoReferenceInfo);
 
-        GeoReference geoReferenceInfo3 = new GeoReference(2, referenceIdent, false, "some_tree", null, null, null);
+        GeoReference geoReferenceInfo3 = new GeoReference(
+            2,
+            referenceIdent,
+            false,
+            DataTypes.GEO_SHAPE,
+            "some_tree",
+            null,
+            null,
+            null
+        );
         out = new BytesStreamOutput();
         Reference.toStream(geoReferenceInfo3, out);
         in = out.bytes().streamInput();
         GeoReference geoReferenceInfo4 = Reference.fromStream(in);
 
-        assertThat(geoReferenceInfo4, is(geoReferenceInfo3));
+        assertThat(geoReferenceInfo4).isEqualTo(geoReferenceInfo3);
 
     }
 }


### PR DESCRIPTION
Currently the `GeoReference` is only used for columns of type
`geo_shape` but not for `geo_shape[]`. This is not an issue on master
but becomes a problem in the indexing branch where the indexer needs
access to a `GeoReference` to access information like the geo-tree,
tree-levels and distance.
