### PR TITLE
Update apache commons codec to 1.15

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -53,7 +53,7 @@ junit=4.13.2
 httpclient=4.5.13
 httpcore=4.4.16
 commonslogging=1.2
-commonscodec=1.14
+commonscodec=1.15
 hamcrest=2.2
 mockito=4.9.0
 carrotsearch_hppc:0.8.2

--- a/server/src/test/java/io/crate/metadata/PartitionNameTest.java
+++ b/server/src/test/java/io/crate/metadata/PartitionNameTest.java
@@ -127,10 +127,10 @@ public class PartitionNameTest extends ESTestCase {
 
     @Test
     public void testInvalidValueString() throws Exception {
-        String partitionName = IndexParts.PARTITIONED_TABLE_PART + "test.1";
+        String partitionName = IndexParts.PARTITIONED_TABLE_PART + "test.🐩";
         assertThatThrownBy(() -> PartitionName.fromIndexOrTemplate(partitionName).values())
             .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Invalid partition ident: 1");
+            .hasMessage("Invalid partition ident: 🐩");
     }
 
     @Test


### PR DESCRIPTION
A change in the library caused a test to break because a "1" input can
now be decoded with Base32.

https://commons.apache.org/proper/commons-codec/changes-report.html#a1.15

Noticed this in the maven branch where I didn't explicitly define the
dependency and it defaulted to the newer version.
