### PR TITLE
Fix TableIdentsExtractor to be able to extract from AliasSymbol

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -89,3 +89,12 @@ Fixes
     SELECT unknown_col FROM abs(1);
     SchemaUnknownException[Schema 'doc' unknown]
 
+- Fixed an issue that translated an ``AmbiguousColumnException`` to a
+  misleading ``IllegalStateException`` when aliased columns are queried that
+  are also ambiguous.
+  An example ::
+
+    SELECT r FROM (SELECT a AS r, a AS r FROM t) AS q
+    IllegalStateException[Symbol 'io.crate.expression.symbol.Symbol' not supported]
+    // r is an alias of a and is ambiguous from the perspective of the outer query
+

--- a/server/src/test/java/io/crate/analyze/TableIdentsExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/TableIdentsExtractorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import io.crate.expression.symbol.AliasSymbol;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.DataTypes;
+
+public class TableIdentsExtractorTest {
+
+    @Test
+    public void test_extract_table_ident_from_alias_symbol() {
+        RelationName tableIdent = new RelationName("doc", "t");
+        assertThat(
+        TableIdentsExtractor.extract(
+            new AliasSymbol("r", new SimpleReference(
+                new ReferenceIdent(tableIdent, "a"),
+                RowGranularity.DOC,
+                DataTypes.SHORT,
+                0,
+                null))
+        )).isEqualTo(Set.of(tableIdent));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes #13709

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
