### PR TITLE
Handle empty arrays in DynamicIndexer and ObjectIndexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -157,6 +157,10 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             innerValue = type.sanitizeValue(innerValue);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
+                xContentBuilder.field(innerName);
+                if (DynamicIndexer.handleEmptyArray(type, innerValue, xContentBuilder)) {
+                    continue;
+                }
                 throw new IllegalArgumentException(
                     "Cannot create columns of type " + type.getName() + " dynamically. " +
                     "Storage is not supported for this type");


### PR DESCRIPTION
We can add them to the source without indexing or new column creation -
assuming a later document will have values and create the column with
the correct type. The empty array or null values already in the source
fit any type.
