### PR TITLE
Prune unused outputs at the CorrelatedJoin operator and its childs

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -37,7 +37,6 @@ import io.crate.expression.symbol.OuterColumn;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.FunctionType;
@@ -180,9 +179,6 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
             } else {
                 outputs.add(output);
             }
-        }
-        if (SymbolVisitors.any(s -> s instanceof OuterColumn, where)) {
-            outputs.addAll(extractColumns(where));
         }
         return new SplitPoints(
             outputs,

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -395,8 +395,8 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
         assertThat(execute("explain " + stmt)).hasRows(
             "HashAggregate[count(*)]",
             "  └ Filter[EXISTS (SELECT 1 FROM (doc.b))]",
-            "    └ CorrelatedJoin[f1, f2, f3, (SELECT 1 FROM (doc.b))]",
-            "      └ Collect[doc.a | [f1, f2, f3] | (f3 = ANY(['a', 'b', 'c']))]",
+            "    └ CorrelatedJoin[f1, f2, (SELECT 1 FROM (doc.b))]",
+            "      └ Collect[doc.a | [f1, f2] | (f3 = ANY(['a', 'b', 'c']))]",
             "      └ SubPlan",
             "        └ Eval[1]",
             "          └ Limit[1;0]",

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -400,7 +400,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "      └ SubPlan",
             "        └ Eval[1]",
             "          └ Limit[1;0]",
-            "            └ Collect[doc.b | [1, f1, f2, f3, f1, f2, f3] | (((f1 = f1) AND (f2 = f2)) AND (f3 = 'c'))]"
+            "            └ Collect[doc.b | [1, f1, f2, f3] | (((f1 = f1) AND (f2 = f2)) AND (f3 = 'c'))]"
         );
         assertThat(execute(stmt)).hasRows(
             "1"

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -499,9 +499,9 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                     └ Collect[sys.summits | [mountain, height] | (country = 'DE')]
                   └ SubPlan
                     └ Eval[1]
-                      └ Rename[1, height, height] AS b
+                      └ Rename[1, height] AS b
                         └ Limit[1;0]
-                          └ Collect[sys.summits | [1, height, height] | (height = height)]
+                          └ Collect[sys.summits | [1, height] | (height = height)]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
     }

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -494,9 +494,9 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             """
             Eval[mountain]
               └ Filter[EXISTS (SELECT 1 FROM (b))]
-                └ CorrelatedJoin[mountain, height, country, (SELECT 1 FROM (b))]
-                  └ Rename[mountain, height, country] AS a
-                    └ Collect[sys.summits | [mountain, height, country] | (country = 'DE')]
+                └ CorrelatedJoin[mountain, height, (SELECT 1 FROM (b))]
+                  └ Rename[mountain, height] AS a
+                    └ Collect[sys.summits | [mountain, height] | (country = 'DE')]
                   └ SubPlan
                     └ Eval[1]
                       └ Rename[1, height, height] AS b


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Additionally, remove duplicated outputs of correlated join sub plans.
Duplication was introduced by https://github.com/crate/crate/commit/2ad3cefe845 and https://github.com/crate/crate/commit/c55b72d8a56.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
