### PR TITLE
Use Indexer for inserts on primary

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
@@ -56,6 +56,7 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
         this.colsToAdd = colsToAdd;
         this.checkConstraints = checkConstraints;
         this.pKeyIndices = pKeyIndices;
+        assert colsToAdd.isEmpty() == false : "Columns to add must not be empty";
     }
 
     public AddColumnRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -32,6 +34,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;
@@ -44,9 +47,9 @@ public class DoubleIndexer implements ValueIndexer<Number> {
     private final FieldType fieldType;
     private final String name;
 
-    public DoubleIndexer(Reference ref, FieldType fieldType) {
+    public DoubleIndexer(Reference ref, @Nullable FieldType fieldType) {
         this.ref = ref;
-        this.fieldType = fieldType;
+        this.fieldType = fieldType == null ? NumberFieldMapper.FIELD_TYPE : fieldType;
         this.name = ref.column().fqn();
     }
 

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -83,6 +83,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
                 if (handleEmptyArray(type, value, xcontentBuilder)) {
+                    type = null; // guess type again with next value
                     return;
                 }
                 throw new IllegalArgumentException(

--- a/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
@@ -30,6 +30,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.locationtech.spatial4j.shape.Shape;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
@@ -70,5 +71,9 @@ public class GeoShapeIndexer implements ValueIndexer<Map<String, Object>> {
         for (var field : fields) {
             addField.accept(field);
         }
+        addField.accept(new Field(
+            FieldNamesFieldMapper.NAME,
+            name,
+            FieldNamesFieldMapper.Defaults.FIELD_TYPE));
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -518,8 +518,14 @@ public class Indexer {
             String fqn = indexColumn.name.fqn();
             for (var input : indexColumn.inputs) {
                 Object value = input.value();
+                if (value == null) {
+                    continue;
+                }
                 if (value instanceof Iterable<?> it) {
                     for (Object val : it) {
+                        if (val == null) {
+                            continue;
+                        }
                         Field field = new Field(fqn, val.toString(), indexColumn.fieldType);
                         doc.add(field);
                     }

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -27,12 +27,14 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 
 import io.crate.metadata.ColumnIdent;
@@ -62,6 +64,11 @@ public class LongIndexer implements ValueIndexer<Long> {
         addField.accept(new LongPoint(name, longValue));
         if (ref.hasDocValues()) {
             addField.accept(new SortedNumericDocValuesField(name, longValue));
+        } else {
+            addField.accept(new Field(
+                FieldNamesFieldMapper.NAME,
+                name,
+                FieldNamesFieldMapper.Defaults.FIELD_TYPE));
         }
         if (fieldType.stored()) {
             addField.accept(new StoredField(name, longValue));

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.translog.Translog;
 
 import io.crate.Streamer;
 import io.crate.common.unit.TimeValue;
+import io.crate.execution.dml.IndexItem;
 import io.crate.execution.dml.ShardRequest;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
@@ -272,7 +273,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
     /**
      * A single update item.
      */
-    public static final class Item extends ShardRequest.Item {
+    public static final class Item extends ShardRequest.Item implements IndexItem {
 
         public static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Item.class);
 

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -77,7 +77,7 @@ public class ArrayType<T> extends DataType<List<T>> {
     private final DataType<T> innerType;
     private Streamer<List<T>> streamer;
 
-    private StorageSupport<? super T> storageSupport;
+    private final StorageSupport<? super T> storageSupport;
 
     /**
      * Construct a new Collection type
@@ -137,7 +137,7 @@ public class ArrayType<T> extends DataType<List<T>> {
 
     @SuppressWarnings("unchecked")
     public ArrayType(StreamInput in) throws IOException {
-        innerType = (DataType<T>) DataTypes.fromStream(in);
+        this((DataType<T>) DataTypes.fromStream(in));
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -237,9 +237,9 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
 
     @Nullable
     public final ValueIndexer<? super T> valueIndexer(RelationName table,
-                                              Reference ref,
-                                              Function<ColumnIdent, FieldType> getFieldType,
-                                              Function<ColumnIdent, Reference> getRef) {
+                                                      Reference ref,
+                                                      Function<ColumnIdent, FieldType> getFieldType,
+                                                      Function<ColumnIdent, Reference> getRef) {
         StorageSupport<? super T> storageSupport = storageSupport();
         if (storageSupport == null) {
             throw new IllegalArgumentException(

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -118,6 +118,10 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             "{\"o\":{\"x\":10,\"y\":20}}",
             "{\"o\":{\"y\":20,\"x\":10}}"
         );
+
+        value = Map.of("x", 10, "y", 20);
+        parsedDoc = indexer.index(item(value));
+        assertThat(parsedDoc.newColumns()).isEmpty();
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -270,7 +270,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
             }))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("dynamic introduction of [middle_name] within [author.name] is not allowed");
+            .hasMessageContaining("Cannot add column `middle_name` to strict object `author['name']`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1418,6 +1418,7 @@ public class GroupByAggregateTest extends IntegTestCase {
     public void test_group_by_on_ignored_column() {
         execute("create table tbl (o object (ignored))");
         execute("insert into tbl (o) values ({x='foo'}), ({x=10})");
+        assertThat(response).hasRowCount(2);
         execute("refresh table tbl");
         execute("select o['x'], count(*) from tbl group by o['x']");
         assertThat(printedTable(response.rows())).satisfiesAnyOf(

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -161,7 +161,7 @@ public class ObjectColumnTest extends IntegTestCase {
             new Object[]{"Life, the Universe and Everything", authorMap}))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("dynamic introduction of [middle_name] within [author.name] is not allowed");
+            .hasMessageContaining("Cannot add column `middle_name` to strict object `author['name']`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -353,7 +353,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
                                     new Object[]{Map.of("another_new_col", "1970-01-01T00:00:00")}))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("mapping set to strict, dynamic introduction of [another_new_col] within [strict_field] is not allowed");
+            .hasMessageContaining("Cannot add column `another_new_col` to strict object `strict_field`");
     }
 
     @Test
@@ -470,7 +470,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
             SQLResponse res = execute(
                 "select column_name, data_type from information_schema.columns where " +
                 " table_name='arr' order by ordinal_position desc limit 1");
-            assertThat(res).hasRows("new| real_array");
+            assertThat(res).hasRows("new| double precision_array");
         });
     }
 


### PR DESCRIPTION
First step to actually use the Indexer. So far limited to the insert operation on the primary.

This also contains a couple of more fixes around the indexers which were uncovered by integration tests