### PR TITLE
Fix nested joins

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,6 +81,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused nested joins such as
+  ``SELECT * FROM t1 JOIN (t2 JOIN t3 ON t2.x = t3.x) ON t1.x = t2.x``
+  fail with an internal error.
+
 - Fixed an issue that could cause errors for queries with aggregations and
   ``UNION``, e.g. ::
 

--- a/server/src/main/java/io/crate/analyze/JoinRelation.java
+++ b/server/src/main/java/io/crate/analyze/JoinRelation.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.common.collections.Lists2;
+import io.crate.exceptions.AmbiguousColumnException;
+import io.crate.exceptions.ColumnUnknownException;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.table.Operation;
+import io.crate.sql.tree.JoinType;
+
+/**
+ * Join Relation represents a Join containing its lhs and rhs as {@link AnalyzedRelation'}.
+ * It is used inside {@link io.crate.analyze.relations.RelationAnalyzer} to
+ * determine join pairs and for internal validation.
+ * It is not possible to generate a logical plan from a JoinRelation.
+ */
+public class JoinRelation implements AnalyzedRelation {
+
+    private final AnalyzedRelation left;
+    private final AnalyzedRelation right;
+    private final List<Symbol> outputs;
+    private final JoinType joinType;
+    private final Symbol joinCondition;
+    private static final String UNSUPPORTED_OPERATION = "Joins do not support this operation";
+
+    public JoinRelation(AnalyzedRelation left,
+                        AnalyzedRelation right,
+                        JoinType joinType,
+                        @Nullable Symbol joinCondition) {
+        this.outputs = Lists2.concat(left.outputs(), right.outputs());
+        this.left = left;
+        this.right = right;
+        this.joinType = joinType;
+        this.joinCondition = joinCondition;
+    }
+
+    public AnalyzedRelation left() {
+        return left;
+    }
+
+    public AnalyzedRelation right() {
+        return right;
+    }
+
+    public JoinType joinType() {
+        return joinType;
+    }
+
+    @Nullable
+    public Symbol joinCondition() {
+        return joinCondition;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION);
+    }
+
+    @Nullable
+    @Override
+    public Symbol getField(ColumnIdent column,
+                           Operation operation,
+                           boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (Symbol output : outputs) {
+            consumer.accept(output);
+        }
+        left.visitSymbols(consumer);
+        right.visitSymbols(consumer);
+        consumer.accept(joinCondition);
+    }
+
+    @Override
+    public RelationName relationName() {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION);
+    }
+
+    @Nonnull
+    @Override
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+}

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -22,7 +22,6 @@
 package io.crate.analyze.relations;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -31,10 +30,8 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
-import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
-import io.crate.sql.tree.JoinType;
 
 public class RelationAnalysisContext {
 
@@ -64,30 +61,16 @@ public class RelationAnalysisContext {
         return sources;
     }
 
+    public List<RelationName> sourceNames() {
+        // sources is backed up by a LinkedHashMap and thus keeps insertion order.
+        return new ArrayList<>(sources().keySet());
+    }
+
     void addJoinPair(JoinPair joinType) {
         if (joinPairs == null) {
             joinPairs = new ArrayList<>();
         }
         joinPairs.add(joinType);
-    }
-
-    void addJoinType(JoinType joinType, @Nullable Symbol joinCondition) {
-        int size = sources.size();
-        assert size >= 2 : "sources must be added first, cannot add join type for only 1 source";
-        Iterator<RelationName> it = sources.keySet().iterator();
-        RelationName left = null;
-        RelationName right = null;
-        int idx = 0;
-        while (it.hasNext()) {
-            RelationName sourceName = it.next();
-            if (idx == size - 2) {
-                left = sourceName;
-            } else if (idx == size - 1) {
-                right = sourceName;
-            }
-            idx++;
-        }
-        addJoinPair(JoinPair.of(left, right, joinType, joinCondition));
     }
 
     List<JoinPair> joinPairs() {

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze.relations;
 
+import static io.crate.common.collections.Iterables.getOnlyElement;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,12 +30,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
+import io.crate.analyze.JoinRelation;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.QueriedSelectRelation;
@@ -46,7 +50,6 @@ import io.crate.analyze.validator.GroupBySymbolValidator;
 import io.crate.analyze.validator.HavingSymbolValidator;
 import io.crate.analyze.validator.SemanticSortValidator;
 import io.crate.analyze.where.WhereClauseValidator;
-import io.crate.common.collections.Iterables;
 import io.crate.common.collections.Lists2;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.RelationUnknown;
@@ -74,6 +77,7 @@ import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.metadata.view.View;
 import io.crate.metadata.view.ViewMetadata;
 import io.crate.planner.consumer.OrderByWithAggregationValidator;
+import io.crate.planner.consumer.RelationNameCollector;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.AliasedRelation;
 import io.crate.sql.tree.DefaultTraversalVisitor;
@@ -273,12 +277,24 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         AnalyzedRelation leftRel = node.getLeft().accept(this, statementContext);
         AnalyzedRelation rightRel = node.getRight().accept(this, statementContext);
 
-        RelationAnalysisContext relationContext = statementContext.currentRelationContext();
         Optional<JoinCriteria> optCriteria = node.getCriteria();
         Symbol joinCondition = null;
         if (optCriteria.isPresent()) {
             JoinCriteria joinCriteria = optCriteria.get();
-            if (joinCriteria instanceof JoinOn || joinCriteria instanceof JoinUsing) {
+            Expression expression;
+            if (joinCriteria instanceof JoinOn joinOn) {
+                expression = joinOn.getExpression();
+            } else if (joinCriteria instanceof JoinUsing joinUsing) {
+                expression = JoinUsing.toExpression(
+                    leftRel.relationName().toQualifiedName(),
+                    rightRel.relationName().toQualifiedName(),
+                    joinUsing.getColumns());
+            } else {
+                throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "join criteria %s not supported",
+                        joinCriteria.getClass().getSimpleName()));
+            }
+            try {
+                RelationAnalysisContext relationContext = statementContext.currentRelationContext();
                 final CoordinatorTxnCtx coordinatorTxnCtx = statementContext.transactionContext();
                 ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                     coordinatorTxnCtx,
@@ -289,32 +305,41 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                         relationContext.parentSources(),
                         coordinatorTxnCtx.sessionSettings().searchPath().currentSchema()),
                     new SubqueryAnalyzer(this, statementContext));
-                Expression expr;
-                if (joinCriteria instanceof JoinOn) {
-                    expr = ((JoinOn) joinCriteria).getExpression();
-                } else {
-                    expr = JoinUsing.toExpression(
-                        leftRel.relationName().toQualifiedName(),
-                        rightRel.relationName().toQualifiedName(),
-                        ((JoinUsing) joinCriteria).getColumns());
-                }
-                try {
-                    joinCondition = expressionAnalyzer.convert(expr, relationContext.expressionAnalysisContext());
-                } catch (RelationUnknown e) {
-                    throw new RelationValidationException(e.getTableIdents(),
-                        String.format(Locale.ENGLISH,
-                        "missing FROM-clause entry for relation '%s'", e.getTableIdents()));
-                }
-            } else {
-                throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "join criteria %s not supported",
-                    joinCriteria.getClass().getSimpleName()));
+                var expressionAnalysisContext = statementContext.currentRelationContext().expressionAnalysisContext();
+                joinCondition = expressionAnalyzer.convert(expression, expressionAnalysisContext);
+            } catch (RelationUnknown e) {
+                throw new RelationValidationException(
+                    e.getTableIdents(),
+                    String.format(Locale.ENGLISH, "missing FROM-clause entry for relation '%s'", e.getTableIdents())
+                );
             }
         }
-
-        relationContext.addJoinType(node.getType(), joinCondition);
-        return null;
+        JoinRelation joinRelation = new JoinRelation(leftRel, rightRel, node.getType(), joinCondition);
+        JoinPair joinPair = extractJoinPair(joinRelation, statementContext.currentRelationContext().sourceNames());
+        statementContext.currentRelationContext().addJoinPair(joinPair);
+        return joinRelation;
     }
 
+    private static JoinPair extractJoinPair(JoinRelation joinRelation, List<RelationName> relevantRelationsInOrder) {
+        assert relevantRelationsInOrder.size() >= 2 : "sources must be added first, cannot add join pair for only 1 source";
+
+        var joinCondition = joinRelation.joinCondition();
+        if (joinCondition != null) {
+            Set<RelationName> relationsInJoinConditions = RelationNameCollector.collect(joinCondition);
+            if (relationsInJoinConditions.size() > 1) {
+                // We have join conditions with two relations or more. The join conditions such as
+                // `t1.x = t2.x` determines which relations are joined together.
+                // For this reason we keep only the relations which are part of the join conditions.
+                // This makes sure we don't pick the wrong relations at the right/left assignment
+                // for the join pair but keep the original order.
+                relevantRelationsInOrder.retainAll(relationsInJoinConditions);
+            }
+        }
+        var left = relevantRelationsInOrder.get(relevantRelationsInOrder.size() - 2);
+        var right = relevantRelationsInOrder.get(relevantRelationsInOrder.size() - 1);
+        return JoinPair.of(left, right, joinRelation.joinType(), joinCondition);
+    }
+    
     @Override
     protected AnalyzedRelation visitQuerySpecification(QuerySpecification node, StatementAnalysisContext statementContext) {
         List<Relation> from = node.getFrom().isEmpty() ? EMPTY_ROW_TABLE_RELATION : node.getFrom();
@@ -519,7 +544,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     private static Symbol tryGetFromSelectList(QualifiedNameReference expression, SelectAnalysis selectAnalysis) {
         List<String> parts = expression.getName().getParts();
         if (parts.size() == 1) {
-            return SelectListFieldProvider.getOneOrAmbiguous(selectAnalysis.outputMultiMap(), Iterables.getOnlyElement(parts));
+            return SelectListFieldProvider.getOneOrAmbiguous(selectAnalysis.outputMultiMap(), getOnlyElement(parts));
         }
         return null;
     }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1396,4 +1396,47 @@ public class JoinIntegrationTest extends IntegTestCase {
                 "3| NULL"
         );
     }
+
+    /*
+     * https://github.com/crate/crate/issues/13503
+     */
+    @Test
+    @UseHashJoins(1)
+    public void test_nested_joins() {
+        execute("CREATE TABLE doc.j1 (x INT)");
+        execute("CREATE TABLE doc.j2 (x INT)");
+        execute("CREATE TABLE doc.j3 (x INT)");
+
+        execute("insert into doc.j1(x) values (1),(2),(3)");
+        execute("insert into doc.j2(x) values (1),(2),(3)");
+        execute("insert into doc.j3(x) values (1),(2),(3)");
+
+        execute("refresh table doc.j1, doc.j2, doc.j3");
+
+        var stmt = """
+            SELECT *
+              FROM doc.j1
+              JOIN (doc.j2 JOIN doc.j3 ON doc.j2.x = doc.j3.x)
+               ON doc.j1.x = doc.j2.x
+            ORDER BY doc.j1.x;
+            """;
+
+        execute("explain " + stmt);
+        assertThat(response.rows()[0][0]).isEqualTo(
+            """
+                Eval[x, x, x]
+                  └ OrderBy[x ASC]
+                    └ HashJoin[(x = x)]
+                      ├ HashJoin[(x = x)]
+                      │  ├ Collect[doc.j2 | [x] | true]
+                      │  └ Collect[doc.j3 | [x] | true]
+                      └ Collect[doc.j1 | [x] | true]"""
+        );
+
+        execute(stmt);
+        assertThat(response).hasRows("1| 1| 1",
+                                     "2| 2| 2",
+                                     "3| 3| 3");
+
+    }
 }

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.settings.Settings;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.JoinPair;
 import io.crate.analyze.where.DocKeys;
 import io.crate.data.Input;
 import io.crate.execution.dsl.projection.Projection;
@@ -99,6 +100,10 @@ public class Asserts extends Assertions {
 
     public static LogicalPlanAssert assertThat(LogicalPlan actual) {
         return new LogicalPlanAssert(actual);
+    }
+
+    public static JoinPairAssert assertThat(JoinPair actual) {
+        return new JoinPairAssert(actual);
     }
 
     // generic helper methods

--- a/server/src/testFixtures/java/io/crate/testing/JoinPairAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/JoinPairAssert.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+
+import static io.crate.testing.Asserts.assertThat;
+
+import org.assertj.core.api.AbstractAssert;
+
+import io.crate.analyze.relations.JoinPair;
+import io.crate.metadata.RelationName;
+
+public class JoinPairAssert extends AbstractAssert<JoinPairAssert, JoinPair> {
+
+    protected JoinPairAssert(JoinPair actual) {
+        super(actual, JoinPairAssert.class);
+    }
+
+    public JoinPairAssert hasPair(RelationName left, RelationName right) {
+        isNotNull();
+        assertThat(actual.left()).isEqualTo(left);
+        assertThat(actual.right()).isEqualTo(right);
+        return this;
+    }
+}


### PR DESCRIPTION
This makes nested joins work such as:

```
SELECT *
    FROM j1
    JOIN (j2 JOIN j3 ON j2.x = j3.x)
    ON j1.x = j2.x;
```

by adding a JoinRelation which is used to determine the correct JoinPairs.

fixes https://github.com/crate/crate/issues/13503

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
