### PR TITLE
Fix invalid conversions of UnsupportedFeatureExceptions to MissingPrivilegeExceptions

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -105,3 +105,6 @@ Fixes
     IllegalStateException[Symbol 'io.crate.expression.symbol.Symbol' not supported]
     // r is an alias of a and is ambiguous from the perspective of the outer query
 
+ - Fixed an issue that translated ``UnsupportedOperationException`` to a
+   misleading ``MissingPrivilegeException`` when executing functions with
+   invalid names or signatures.

--- a/extensions/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.window.AbstractWindowFunctionTest;
 import io.crate.metadata.ColumnIdent;
 import io.crate.module.ExtraFunctionsModule;
@@ -163,7 +164,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
                                  new Object[] {1, 2},
                                  new Object[] {3, 2},
                                  new Object[] {2, 3}))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessage("Unknown function: first_value(doc.t1.x, NULL), no overload found for matching argument types: " +
                         "(integer, undefined). Possible candidates: first_value(E):E");
     }
@@ -178,7 +179,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
                                  new Object[] {1, 2},
                                  new Object[] {3, 2},
                                  new Object[] {2, 3}))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessage("Unknown function: last_value(doc.t1.x, NULL), no overload found for matching argument types: " +
                         "(integer, undefined). Possible candidates: last_value(E):E");
     }

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -94,6 +94,7 @@ import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.TableScopeException;
 import io.crate.exceptions.UnauthorizedException;
 import io.crate.exceptions.UnscopedException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
@@ -930,6 +931,14 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         protected Void visitSchemaScopeException(SchemaScopeException e, User context) {
             Privileges.ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, e.getSchemaName(), context);
+            return null;
+        }
+
+        @Override
+        protected Void visitUnsupportedFunctionException(UnsupportedFunctionException e, User user) {
+            if (e.getSchemaName() != null) {
+                visitSchemaScopeException(e, user);
+            }
             return null;
         }
 

--- a/server/src/main/java/io/crate/exceptions/CrateExceptionVisitor.java
+++ b/server/src/main/java/io/crate/exceptions/CrateExceptionVisitor.java
@@ -41,6 +41,10 @@ public class CrateExceptionVisitor<C, R> {
         return visitCrateException(e, context);
     }
 
+    protected R visitUnsupportedFunctionException(UnsupportedFunctionException e, C context) {
+        return visitCrateException(e, context);
+    }
+
     protected R visitClusterScopeException(ClusterScopeException e, C context) {
         return visitCrateException(e, context);
     }

--- a/server/src/main/java/io/crate/exceptions/UnsupportedFunctionException.java
+++ b/server/src/main/java/io/crate/exceptions/UnsupportedFunctionException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.exceptions;
+
+import javax.annotation.Nullable;
+
+public class UnsupportedFunctionException extends RuntimeException implements ResourceUnknownException, SchemaScopeException {
+
+    @Nullable
+    private final String schema;
+
+    public UnsupportedFunctionException(String message, @Nullable String schema) {
+        super(message);
+        this.schema = schema;
+    }
+
+    @Nullable
+    @Override
+    public String getSchemaName() {
+        return schema;
+    }
+
+    @Override
+    public <C, R> R accept(CrateExceptionVisitor<C, R> exceptionVisitor, C context) {
+        return exceptionVisitor.visitUnsupportedFunctionException(this, context);
+    }
+}

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -28,6 +28,7 @@ import io.crate.analyze.expressions.TableReferenceResolver;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
 import io.crate.exceptions.UserDefinedFunctionUnknownException;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -312,7 +313,7 @@ public class UserDefinedFunctionService {
                     Expression expression = SqlParser.createExpression(genRef.formattedGeneratedExpression());
                     try {
                         exprAnalyzer.convert(expression, new ExpressionAnalysisContext(coordinatorTxnCtx.sessionSettings()));
-                    } catch (UnsupportedOperationException e) {
+                    } catch (UnsupportedFunctionException e) {
                         throw new IllegalArgumentException(
                             "Cannot drop function '" + functionName + "', it is still in use by '" +
                                 tableInfo + "." + genRef + "'"

--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.logging.Loggers;
 
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.Style;
@@ -136,7 +137,7 @@ public class Functions {
      * }
      * </pre>
      *
-     * @throws UnsupportedOperationException if the function wasn't found
+     * @throws UnsupportedFunctionException if the function wasn't found
      */
     private FunctionImplementation get(@Nullable String suppliedSchema,
                                        String functionName,
@@ -302,11 +303,11 @@ public class Functions {
      *
      * @param signature The function signature.
      * @return The function implementation.
-     * @throws UnsupportedOperationException if no implementation is found.
+     * @throws UnsupportedFunctionException if no implementation is found.
      */
     public FunctionImplementation getQualified(Signature signature,
                                                List<DataType<?>> actualArgumentTypes,
-                                               DataType<?> actualReturnType) throws UnsupportedOperationException {
+                                               DataType<?> actualReturnType) throws UnsupportedFunctionException {
         FunctionImplementation impl = get(signature, actualArgumentTypes, actualReturnType, functionImplementations);
         if (impl == null) {
             impl = get(signature, actualArgumentTypes, actualReturnType, udfFunctionImplementations);
@@ -353,7 +354,7 @@ public class Functions {
                       ;
         }
 
-        throw new UnsupportedOperationException(message);
+        throw new UnsupportedFunctionException(message, suppliedSchema);
     }
 
     private static List<ApplicableFunction> selectMostSpecificFunctions(List<ApplicableFunction> applicableFunctions,

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -29,6 +29,7 @@ import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.exceptions.UserDefinedFunctionUnknownException;
 
 import javax.annotation.Nullable;
@@ -77,7 +78,9 @@ public class PGError {
 
     public static PGError fromThrowable(Throwable throwable) {
         var status = PGErrorStatus.INTERNAL_ERROR;
-        if (throwable instanceof IllegalArgumentException || throwable instanceof UnsupportedOperationException) {
+        if (throwable instanceof IllegalArgumentException ||
+            throwable instanceof UnsupportedOperationException ||
+            throwable instanceof UnsupportedFunctionException) {
             status = PGErrorStatus.FEATURE_NOT_SUPPORTED;
         } else if (throwable instanceof DuplicateKeyException) {
             status = PGErrorStatus.UNIQUE_VIOLATION;

--- a/server/src/main/java/io/crate/rest/action/HttpError.java
+++ b/server/src/main/java/io/crate/rest/action/HttpError.java
@@ -54,6 +54,7 @@ import io.crate.exceptions.SnapshotUnknownException;
 import io.crate.exceptions.UnauthorizedException;
 import io.crate.exceptions.UnavailableShardsException;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.exceptions.UserAlreadyExistsException;
 import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
 import io.crate.exceptions.UserDefinedFunctionUnknownException;
@@ -159,7 +160,8 @@ public class HttpError {
                 httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
             } else if (crateException instanceof SQLParseException) {
                 httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
-            } else if (crateException instanceof UnsupportedFeatureException) {
+            } else if (crateException instanceof UnsupportedFeatureException ||
+                       crateException instanceof UnsupportedFunctionException) {
                 httpErrorStatus = HttpErrorStatus.POSSIBLE_FEATURE_NOT_SUPPROTED_YET;
             } else if (crateException instanceof VersioningValidationException) {
                 httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.metadata.RowGranularity;
@@ -101,7 +102,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testWhereClauseObjectArrayField() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: (doc.users.friends['id'] = 5)," +
                                         " no overload found for matching argument types: (bigint_array, integer).");
         e.analyze("delete from users where friends['id'] = 5");

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -56,6 +56,7 @@ import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.impl.average.AverageAggregation;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.EqOperator;
@@ -799,7 +800,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .build();
 
         assertThatThrownBy(() -> executor.analyze("select id, name from parted where not date"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: (NOT doc.parted.date), " +
                                     "no overload found for matching argument types: (timestamp with time zone).");
     }
@@ -989,7 +990,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
         assertThatThrownBy(() -> executor.analyze("select * from users where 'George' = ANY (name)"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: ('George' = ANY(doc.users.name)), " +
                                     "no overload found for matching argument types: (text, text).");
     }
@@ -1048,7 +1049,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // so its fields are selected as arrays,
         // ergo simple comparison does not work here
         assertThatThrownBy(() -> executor.analyze("select * from users where 5 = friends['id']"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: (doc.users.friends['id'] = 5), " +
                                     "no overload found for matching argument types: (bigint_array, integer).");
     }
@@ -1240,7 +1241,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
         assertThatThrownBy(() -> executor.analyze("select * from users where 'awesome' LIKE ANY (name)"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: ('awesome' LIKE ANY(doc.users.name)), " +
                                     "no overload found for matching argument types: (text, text).");
     }
@@ -2148,7 +2149,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var executor = SQLExecutor.builder(clusterService)
             .build();
         assertThatThrownBy(() -> executor.analyze("select * from unnest(1, 'foo')"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: unnest(1, 'foo'), " +
                                     "no overload found for matching argument types: (integer, text).");
     }

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -55,6 +55,7 @@ import io.crate.exceptions.ColumnValidationException;
 import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.predicate.NotPredicate;
@@ -392,7 +393,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testWhereClauseObjectArrayField() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: (doc.users.friends['id'] = 5)," +
                                         " no overload found for matching argument types: (bigint_array, integer).");
         analyze("update users set awesome=true where friends['id'] = 5");

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.types.BitStringType;
 
 import org.joda.time.Period;
@@ -308,7 +309,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
         assertThatThrownBy(() -> executor.analyze("select * from tarr where xs = ANY([10, 20])"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: (doc.tarr.xs = ANY(_array(10, 20)))," +
                         " no overload found for matching argument types: (integer_array, integer_array).");
     }
@@ -316,7 +317,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testCallingUnknownFunctionWithExplicitSchemaRaisesNiceError() {
         assertThatThrownBy(() -> executor.analyze("select foo.bar(1)"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessage("Unknown function: foo.bar(1)");
     }
 

--- a/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
@@ -41,6 +41,7 @@ import io.crate.exceptions.RelationValidationException;
 import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
@@ -145,5 +146,19 @@ public class AccessControlMaySeeTest extends ESTestCase {
             new ColumnUnknownException(
                 new ColumnIdent("x"), new RelationName("doc", "empty_row")));
         assertAskedAnyForTable("doc.empty_row");
+    }
+
+    @Test
+    public void test_UnsupportedFunctionException_with_null_schema() {
+        // select * from unknown_function();
+        accessControl.ensureMaySee(new UnsupportedFunctionException("Unknown Function: unknown_function()", null));
+        assertThat(validationCallArguments).isEmpty();
+    }
+
+    @Test
+    public void test_UnsupportedFunctionException_with_non_null_schema() {
+        // select * from doc.unknown_function();
+        accessControl.ensureMaySee(new UnsupportedFunctionException("Unknown Function: doc.unknown_function()", "doc"));
+        assertAskedAnyForSchema("doc");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -122,7 +123,7 @@ public class ArbitraryAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: arbitrary(INPUT(0))," +
                                         " no overload found for matching argument types: (object).");
         executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}});

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -32,6 +32,7 @@ import org.elasticsearch.Version;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.impl.average.AverageAggregation;
 import io.crate.execution.engine.aggregation.impl.average.numeric.NumericAverageState;
@@ -137,7 +138,7 @@ public class AverageAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: avg(INPUT(0))," +
                                         " no overload found for matching argument types: (geo_point).");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
@@ -131,7 +132,7 @@ public class GeometricMeanAggregationtest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: geometric_mean(INPUT(0))," +
                                         " no overload found for matching argument types: (boolean).");
         executeAggregation(DataTypes.BOOLEAN, new Object[][]{});

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
@@ -131,10 +132,10 @@ public class MaximumAggregationTest extends AggregationTestCase {
     @Test
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.INTERVAL, new Object[][]{{new Object()}}))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: max(INPUT(0)), no overload found for matching argument types: (interval).");
         assertThatThrownBy(() -> executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}}))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: max(INPUT(0)), no overload found for matching argument types: (object).");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
@@ -110,10 +111,10 @@ public class MinimumAggregationTest extends AggregationTestCase {
     @Test
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.INTERVAL, new Object[][]{{new Object()}}))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: min(INPUT(0)), no overload found for matching argument types: (interval).");
         assertThatThrownBy(() -> executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}}))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: min(INPUT(0)), no overload found for matching argument types: (object).");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.breaker.RamAccounting;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.functions.Signature;
@@ -179,7 +180,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: percentile(INPUT(0), INPUT(0))," +
                                         " no overload found for matching argument types: (geo_point, double precision).");
         execSingleFractionPercentile(DataTypes.GEO_POINT, new Object[][]{});

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.SearchPath;
@@ -120,7 +121,7 @@ public class StdDevAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: stddev(INPUT(0))," +
                                         " no overload found for matching argument types: (geo_point).");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -32,6 +32,7 @@ import org.elasticsearch.Version;
 import org.joda.time.Period;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
@@ -192,7 +193,7 @@ public class SumAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage(
             "Unknown function: sum(NULL)," +
             " no overload found for matching argument types: (geo_point).");

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -125,7 +126,7 @@ public class VarianceAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: variance(INPUT(0))," +
                                         " no overload found for matching argument types: (geo_point).");
         executeAggregation(DataTypes.GEO_POINT, new Object[][]{});

--- a/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.operator;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 
@@ -70,7 +71,7 @@ public class CIDROperatorTest extends ScalarTestCase {
 
     @Test
     public void test_both_operands_are_of_wrong_type() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: (1.2 << _map('cidr', '192.168.0.0/24'))," +
                                         " no overload found for matching argument types: (double precision, object).");
         assertEvaluate("1.2 << { cidr = '192.168.0.0/24'}", false);

--- a/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 
@@ -100,7 +101,7 @@ public class CmpOperatorTest extends ScalarTestCase {
     public void test_comparison_for_intervals_is_not_allowed() {
         for (String op : List.of(">", ">=", "<", "<=")) {
             assertThatThrownBy(() -> assertEvaluate("INTERVAL '1' DAY " + op + " INTERVAL '2' HOUR", null))
-                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .isExactlyInstanceOf(UnsupportedFunctionException.class)
                 .hasMessageStartingWith("Unknown function: ('P1D'::interval " + op + " 'PT2H'::interval), " +
                                         "no overload found for matching argument types: (interval, interval).");
         }

--- a/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.SystemClock;
 
 public class AgeFunctionTest extends ScalarTestCase {
@@ -125,7 +126,7 @@ public class AgeFunctionTest extends ScalarTestCase {
     public void test_3_args_throws_exception() {
         assertThatThrownBy(
             () -> assertEvaluate("pg_catalog.age(null, null, null)", null))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessage("Unknown function: pg_catalog.age(NULL, NULL, NULL), no overload found for matching argument types: (undefined, undefined, undefined). " +
                 "Possible candidates: pg_catalog.age(timestamp without time zone):interval, " +
                 "pg_catalog.age(timestamp without time zone, timestamp without time zone):interval");

--- a/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
@@ -119,7 +120,7 @@ public class ArrayAvgFunctionTest extends ScalarTestCase {
     public void test_array_avg_with_array_of_undefined_inner_type_throws_exception() {
         assertThatThrownBy(
             () -> assertEvaluateNull("array_avg([])"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: array_avg([]), no overload found for matching argument types: (undefined_array).");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.types.ArrayType;
@@ -55,7 +56,7 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_cat()." +
                                         " Possible candidates: array_cat(array(E), array(E)):array(E)");
         assertEvaluateNull("array_cat()");
@@ -63,7 +64,7 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_cat(_array(1))," +
                                         " no overload found for matching argument types: (integer_array).");
         assertEvaluateNull("array_cat([1])");
@@ -71,7 +72,7 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testThreeArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_cat(_array(1), _array(2), _array(3))," +
                                         " no overload found for matching argument types: (integer_array, integer_array, integer_array).");
         assertEvaluateNull("array_cat([1], [2], [3])");

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
@@ -90,7 +91,7 @@ public class ArrayDifferenceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_difference()." +
                                         " Possible candidates: array_difference(array(E), array(E)):array(E)");
         assertNormalize("array_difference()", isNull());
@@ -98,7 +99,7 @@ public class ArrayDifferenceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_difference(_array(1))," +
                                         " no overload found for matching argument types: (integer_array).");
         assertNormalize("array_difference([1])", isNull());

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -23,6 +23,8 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
+
 public class ArrayLowerFunctionTest extends ScalarTestCase {
 
     @Test
@@ -86,7 +88,7 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_lower()." +
                                         " Possible candidates: array_lower(array(E), integer):integer");
         assertEvaluateNull("array_lower()");
@@ -94,7 +96,7 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_lower(_array(1))," +
                                         " no overload found for matching argument types: (integer_array).");
         assertEvaluateNull("array_lower([1])");
@@ -102,7 +104,7 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testThreeArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_lower(_array(1), 2, _array(3))," +
                                         " no overload found for matching argument types: (integer_array, integer, integer_array).");
         assertEvaluateNull("array_lower([1], 2, [3])");
@@ -110,7 +112,7 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSecondArgumentNotANumber() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_lower(_array(1), _array(2))," +
                                         " no overload found for matching argument types: (integer_array, integer_array).");
         assertEvaluateNull("array_lower([1], [2])");

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -82,7 +83,7 @@ public class ArrayMaxFunctionTest extends ScalarTestCase {
     @Test
     public void test_empty_array_given_directly_throws_exception() {
         Assertions.assertThatThrownBy(() -> assertEvaluate("array_max([])", null))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageContaining(
                     "Unknown function: array_max([]), no overload found for matching argument types: (undefined_array).");
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMinFunctionTest.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -82,7 +83,7 @@ public class ArrayMinFunctionTest extends ScalarTestCase {
     @Test
     public void test_empty_array_given_directly_throws_exception() {
         Assertions.assertThatThrownBy(() -> assertEvaluate("array_min([])", null))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageContaining(
                     "Unknown function: array_min([]), no overload found for matching argument types: (undefined_array).");
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
+import io.crate.exceptions.UnsupportedFunctionException;
 
 public class ArraySliceFunctionTest extends ScalarTestCase {
 
@@ -120,7 +121,7 @@ public class ArraySliceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testBaseIsNotAnArray() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_slice('not an array', 1, 3), no overload found for matching argument types");
         assertEvaluateNull("'not an array'[1:3]");
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.impl.util.KahanSummationForDouble;
 import io.crate.expression.symbol.Literal;
 import io.crate.testing.TestingHelpers;
@@ -135,7 +136,7 @@ public class ArraySumFunctionTest extends ScalarTestCase {
     @Test
     public void test_empty_array_given_directly_throws_exception() {
         Assertions.assertThatThrownBy(() -> assertEvaluate("array_sum([])", null))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageContaining(
                     "Unknown function: array_sum([]), no overload found for matching argument types: (undefined_array).");
     }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
@@ -23,18 +23,20 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
+
 public class ArrayToStringFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_to_string()");
         assertEvaluateNull("array_to_string()");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_to_string(_array(1, 2))," +
                                         " no overload found for matching argument types: (integer_array).");
         assertEvaluateNull("array_to_string([1, 2])");

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
@@ -80,7 +81,7 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_unique().");
         assertEvaluateNull("array_unique()");
     }
@@ -111,7 +112,7 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
 
     @Test
     public void testDifferentUnconvertableInnerTypes() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_unique(_array(doc.users.geopoint), _array(true))," +
                                         " no overload found for matching argument types: (geo_point_array, boolean_array).");
         assertEvaluateNull("array_unique([geopoint], [true])");

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -23,6 +23,8 @@ package io.crate.expression.scalar;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
+
 public class ArrayUpperFunctionTest extends ScalarTestCase {
 
     @Test
@@ -87,7 +89,7 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_upper()." +
                                         " Possible candidates: array_upper(array(E), integer):integer");
         assertEvaluateNull("array_upper()");
@@ -95,7 +97,7 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_upper(_array(1))," +
                                         " no overload found for matching argument types: (integer_array).");
         assertEvaluateNull("array_upper([1])");
@@ -103,7 +105,7 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
 
     @Test
     public void testThreeArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_upper(_array(1), 2, _array(3))," +
                                         " no overload found for matching argument types: (integer_array, integer, integer_array).");
         assertEvaluateNull("array_upper([1], 2, [3])");
@@ -111,7 +113,7 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSecondArgumentNotANumber() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: array_upper(_array(1), _array(2))," +
                                         " no overload found for matching argument types: (integer_array, integer_array).");
         assertEvaluateNull("array_upper([1], [2])");

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.types.DataTypes;
 
 public class ConcatFunctionTest extends ScalarTestCase {
@@ -41,7 +42,7 @@ public class ConcatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testArgumentThatHasNoStringRepr() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: concat('foo', _array(1))," +
                                         " no overload found for matching argument types: (text, integer_array).");
         assertNormalize("concat('foo', [1])", isNull());
@@ -90,7 +91,7 @@ public class ConcatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: concat(_array(1, 2), _array(_array(1, 2)))," +
                                         " no overload found for matching argument types: (integer_array, integer_array_array).");
         assertNormalize("concat([1, 2], [[1, 2]])", isNull());

--- a/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
@@ -26,6 +26,8 @@ import static io.crate.testing.Asserts.isNull;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
+
 public class ConcatWsFunctionTest extends ScalarTestCase {
 
     @Test
@@ -65,7 +67,7 @@ public class ConcatWsFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidArrayArgument() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage(
             "Unknown function: concat_ws(',', 'foo', []), " +
             "no overload found for matching argument types: (text, text, undefined_array). " +

--- a/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
 
@@ -45,7 +46,7 @@ public class ExtractFunctionsTest extends ScalarTestCase {
 
     private void assertEvaluateIntervalException(String timeUnit) {
         assertThatThrownBy(() -> assertEvaluate("extract(" + timeUnit + " from INTERVAL '10 days')", -1))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: extract(" + timeUnit.toUpperCase(Locale.ENGLISH) + " FROM");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 
 
@@ -37,14 +38,14 @@ public class StringToArrayFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: string_to_array()");
         assertEvaluateNull("string_to_array()");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: string_to_array('xyz')," +
                                         " no overload found for matching argument types: (text).");
         assertEvaluateNull("string_to_array('xyz')");

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -27,6 +27,7 @@ import org.hamcrest.Matchers;
 import org.joda.time.Period;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 
 public class IntervalFunctionTest extends ScalarTestCase {
@@ -58,7 +59,7 @@ public class IntervalFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_unsupported_arithmetic_operator_on_interval_types() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: (NULL * cast('1 second' AS interval))," +
                                         " no overload found for matching argument types: (undefined, interval).");
         assertEvaluate("null * interval '1 second'", Matchers.nullValue());
@@ -78,7 +79,7 @@ public class IntervalFunctionTest extends ScalarTestCase {
     public void test_unallowed_operations() {
         assertThatThrownBy(
             () -> assertEvaluate("interval '1 second' - '86401000'::timestamptz", 86400000L))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith("Unknown function: (cast('1 second' AS interval) - cast('86401000' AS timestamp with time zone)), ");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
@@ -27,13 +27,14 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 
 public class MapFunctionTest extends ScalarTestCase {
 
     @Test
     public void testMapWithWrongNumOfArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: _map('foo', 1, 'bar')," +
                                         " no overload found for matching argument types: (text, integer, text).");
         assertEvaluateNull("_map('foo', 1, 'bar')");

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 
@@ -41,7 +42,7 @@ public class NegateFunctionsTest extends ScalarTestCase {
 
     @Test
     public void testNegateOnStringResultsInError() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: - doc.users.name," +
                                         " no overload found for matching argument types: (text).");
         assertEvaluate("- name", nullValue(), Literal.of("foo"));

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 
@@ -63,7 +64,7 @@ public class ConditionalFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNullIfInvalidArgsLength() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: nullif(1, 2, 3)," +
                                         " no overload found for matching argument types: (integer, integer, integer).");
         assertEvaluateNull("nullif(1, 2, 3)");

--- a/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.locationtech.spatial4j.shape.Shape;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.geo.GeoJSONUtils;
@@ -76,7 +77,7 @@ public class AreaFunctionTest extends ScalarTestCase {
 
     @Test
     public void testWithTooManyArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage(
             "Unknown function: area(doc.users.geoshape, 'foo'), no overload found for matching argument types: (geo_shape, text). Possible candidates: area(geo_shape):double precision");
         assertNormalize("area(geoShape, 'foo')", isNull());
@@ -84,7 +85,7 @@ public class AreaFunctionTest extends ScalarTestCase {
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage(
             "Unknown function: area(1), no overload found for matching argument types: (integer). Possible candidates: area(geo_shape):double precision");
         assertEvaluateNull("area(1)");

--- a/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isNull;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
@@ -72,7 +73,7 @@ public class CoordinateFunctionTest extends ScalarTestCase {
 
     @Test
     public void testWithTooManyArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: latitude('POINT (10 20)', 'foo')," +
                                         " no overload found for matching argument types: (text, text).");
         assertNormalize("latitude('POINT (10 20)', 'foo')", isNull());
@@ -80,7 +81,7 @@ public class CoordinateFunctionTest extends ScalarTestCase {
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage(
             "Unknown function: longitude(1), no overload found for matching argument types: (integer)");
         assertEvaluateNull("longitude(1)");

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -29,6 +29,7 @@ import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
 import io.crate.exceptions.ConversionException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
@@ -37,7 +38,7 @@ public class DistanceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testResolveWithTooManyArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: distance('POINT (10 20)', 'POINT (11 21)', 'foo')," +
                                         " no overload found for matching argument types: (text, text, text).");
         assertNormalize("distance('POINT (10 20)', 'POINT (11 21)', 'foo')", s -> assertThat(s).isNull());
@@ -45,7 +46,7 @@ public class DistanceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: distance(1, 'POINT (11 21)')," +
                                         " no overload found for matching argument types: (integer, text).");
         assertNormalize("distance(1, 'POINT (11 21)')", s -> assertThat(s).isNull());

--- a/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isLiteral;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
@@ -55,7 +56,7 @@ public class GeoHashFunctionTest extends ScalarTestCase {
 
     @Test
     public void testWithTooManyArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: geohash('POINT (10 20)', 'foo')," +
                                         " no overload found for matching argument types: (text, text).");
         assertNormalize("geohash('POINT (10 20)', 'foo')", s -> assertThat(s).isNull());
@@ -63,7 +64,7 @@ public class GeoHashFunctionTest extends ScalarTestCase {
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage(
             "Unknown function: geohash(1), no overload found for matching argument types: (integer)");
         assertEvaluateNull("geohash(1)");

--- a/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
@@ -138,7 +139,7 @@ public class WithinFunctionTest extends ScalarTestCase {
 
     @Test
     public void testFirstArgumentWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: within(INPUT(0), INPUT(0))," +
                                         " no overload found for matching argument types: (bigint, geo_point).");
         getFunction(FNAME, List.of(DataTypes.LONG, DataTypes.GEO_POINT));
@@ -146,7 +147,7 @@ public class WithinFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSecondArgumentWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: within(INPUT(0), INPUT(0))," +
                                         " no overload found for matching argument types: (geo_point, bigint).");
         getFunction(FNAME, List.of(DataTypes.GEO_POINT, DataTypes.LONG));

--- a/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 
 public class ObjectKeysFunctionTest extends ScalarTestCase {
@@ -36,7 +37,7 @@ public class ObjectKeysFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_array_input() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: object_keys(_array(1)), no overload found for" +
                                         " matching argument types: (integer_array). Possible candidates:" +
                                         " object_keys(object):array(text)");

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isLiteral;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 
@@ -82,13 +83,13 @@ public class RegexpReplaceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbolWithInvalidNumberOfArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         assertNormalize("regexp_replace('foobar')", isLiteral(""));
     }
 
     @Test
     public void testNormalizeSymbolWithInvalidArgumentType() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: regexp_replace('foobar', '.*', _array(1, 2))," +
                                         " no overload found for matching argument types: (text, text, integer_array).");
 

--- a/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.DataTypes;
@@ -36,7 +37,7 @@ public class QuoteIdentFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: quote_ident()." +
                                         " Possible candidates: pg_catalog.quote_ident(text):text");
         assertEvaluateNull("quote_ident()");

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Function;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.types.DataTypes;
@@ -108,7 +109,7 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
 
     @Test
     public void test_function_arguments_must_have_array_types() {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: _values(200)," +
                                         " no overload found for matching argument types: (integer).");
         assertExecute("_values(200)", "");

--- a/server/src/test/java/io/crate/lucene/BitStringQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BitStringQueryTest.java
@@ -37,6 +37,7 @@ import org.elasticsearch.Version;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.sql.tree.BitString;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.DataTypeTesting;
@@ -117,7 +118,7 @@ public class BitStringQueryTest extends CrateDummyClusterServiceUnitTest {
     public void test_range_query_on_bit_type_is_not_supported() throws Exception {
         try (var tester = builder("create table tbl (bits bit(8))").build()) {
             assertThrows(
-                UnsupportedOperationException.class,
+                UnsupportedFunctionException.class,
                 () -> tester.toQuery("bits > B'01'"));
         }
     }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
@@ -390,7 +391,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void testRangeQueryOnDocThrowsException() throws Exception {
         assertThatThrownBy(() -> convert("_doc > {\"name\"='foo'}"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith(
                 "Unknown function: (doc.users._doc > _map('name', 'foo'))," +
                 " no overload found for matching argument types: (object, object).");

--- a/server/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/server/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -89,7 +90,7 @@ public class FunctionsTest extends ESTestCase {
     public void test_function_name_doesnt_exists() {
         var functions = createFunctions();
 
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(UnsupportedFunctionException.class);
         expectedException.expectMessage("Unknown function: does_not_exists()");
         functions.get(null, "does_not_exists", Collections.emptyList(), SearchPath.pathWithPGCatalogAndDoc());
     }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -41,6 +41,7 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.TableDefinitions;
 import io.crate.data.RowN;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.execution.dsl.phases.ExecutionPhase;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -442,7 +443,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .containsExactly(".partitioned.parted.04732cpp6ks3ed1o60o30c1g");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedFunctionException.class)
     public void testSelectPartitionedTableOrderByPartitionedColumnInFunction() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom(), List.of())
             .addPartitionedTable(

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -175,6 +175,7 @@ import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.dml.TransportShardAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
 import io.crate.execution.dml.upsert.TransportShardUpsertAction;
@@ -1944,7 +1945,7 @@ public abstract class IntegTestCase extends ESTestCase {
                         // function if the function was deleted.
                         assertThat(func.boundSignature().argTypes()).isNotEqualTo(Symbols.typeView(arguments));
                     }
-                } catch (UnsupportedOperationException e) {
+                } catch (UnsupportedFunctionException e) {
                     assertThat(e.getMessage()).startsWith("Unknown function");
                 }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/13750

The source of bug is that the current exception for function-does-not-exist error is `UnsupportedOperationException` which gets converted to `UnsupportedFeatureException` that implements `ClusterScopeException`. This is problematic since, when a user does not have cluster privilege, `UnsupportedFeatureException` is converted to a `MissingPrivilegesException`.

The approach to fix this is to create `UnsupportedFunctionException` implementing `SchemaScopeException` such that the conversion to `UnsupportedFeatureException` is bypassed and instead of checking cluster privilege, schema privilege is checked.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
