### PR TITLE
tests: fix flaky testEquivalentDeletesAreDeduplicated

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -22,7 +22,6 @@
 package org.elasticsearch.snapshots;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.elasticsearch.snapshots.SnapshotsService.MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING;
@@ -884,13 +883,13 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final String repoName = "test-repo";
         createRepo(repoName, "mock");
         createTableWithRecord("tbl1");
-        String[] snapshotNames = createNSnapshots(repoName, randomIntBetween(1, 5));
+        createNSnapshots(repoName, randomIntBetween(1, 5));
 
         blockMasterFromDeletingIndexNFile(repoName);
         final int deletes = randomIntBetween(2, 10);
         final List<CompletableFuture<AcknowledgedResponse>> deleteResponses = new ArrayList<>(deletes);
         for (int i = 0; i < deletes; ++i) {
-            deleteResponses.add(startDelete(repoName, snapshotNames));
+            deleteResponses.add(startDelete(repoName, "*"));
         }
         waitForBlock(masterName, repoName, TimeValue.timeValueSeconds(30L));
         awaitClusterState(masterName, state -> (hasDeletionsInProgress(state, 1)));


### PR DESCRIPTION
Use `*` instead of specific snapshot names

```
2023-03-03T12:56:24.0377349Z Caused by: org.elasticsearch.snapshots.SnapshotMissingException: [test-repo:snap-zir5wp__t_-ypjgraaaaaa-0] is missing
2023-03-03T12:56:24.0378040Z 	at org.elasticsearch.snapshots.SnapshotsService.matchingSnapshotIds(SnapshotsService.java:1342)
2023-03-03T12:56:24.0378654Z 	at org.elasticsearch.snapshots.SnapshotsService$6.execute(SnapshotsService.java:1209)
2023-03-03T12:56:24.0379291Z 	at org.elasticsearch.repositories.blobstore.BlobStoreRepository$1.execute(BlobStoreRepository.java:394)
2023-03-03T12:56:24.0379955Z 	at org.elasticsearch.cluster.ClusterStateUpdateTask.execute(ClusterStateUpdateTask.java:45)
2023-03-03T12:56:24.0380793Z 	at org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:701)
2023-03-03T12:56:24.0381456Z 	at org.elasticsearch.cluster.service.MasterService.calculateTaskOutputs(MasterService.java:318)
2023-03-03T12:56:24.0382117Z 	at org.elasticsearch.cluster.service.MasterService.runTasks(MasterService.java:213)
2023-03-03T12:56:24.0382692Z 	at org.elasticsearch.cluster.service.MasterService$Batcher.run(MasterService.java:150)
2023-03-03T12:56:24.0383302Z 	at org.elasticsearch.cluster.service.TaskBatcher.runIfNotProcessed(TaskBatcher.java:153)
2023-03-03T12:56:24.0383895Z 	at org.elasticsearch.cluster.service.TaskBatcher$BatchedTask.run(TaskBatcher.java:191)
2023-03-03T12:56:24.0384707Z 	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:259)
2023-03-03T12:56:24.0385780Z 	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:222)
2023-03-03T12:56:24.0386653Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
2023-03-03T12:56:24.0387200Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
2023-03-03T12:56:24.0387639Z 	at java.lang.Thread.run(Thread.java:1589)
```
