### PR TITLE
Use Indexer for replica operation

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -476,7 +476,8 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             }
             // Stream References
             if (insertValues != null) {
-                assert insertValueStreamers != null : "streamers are required to stream insert values";
+                assert insertValueStreamers != null && insertValueStreamers.length >= insertValues.length
+                    : "streamers are required to stream insert values and must have a streamer for each value";
                 out.writeVInt(insertValues.length);
                 for (int i = 0; i < insertValues.length; i++) {
                     insertValueStreamers[i].writeValueTo(out, insertValues[i]);

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -187,6 +187,23 @@ public class Symbols {
         return new ColumnIdent(symbol.toString(Style.UNQUALIFIED));
     }
 
+    public static boolean isDeterministic(Symbol symbol) {
+        boolean[] isDeterministic = new boolean[] { true };
+        symbol.accept(new DefaultTraversalSymbolVisitor<boolean[], Void>() {
+
+            @Override
+            public Void visitFunction(io.crate.expression.symbol.Function func,
+                                      boolean[] isDeterministic) {
+                if (!func.signature().isDeterministic()) {
+                    isDeterministic[0] = false;
+                    return null;
+                }
+                return super.visitFunction(func, isDeterministic);
+            }
+        }, isDeterministic);
+        return isDeterministic[0];
+    }
+
     /**
      * format symbols in simple style and use the formatted symbols as {@link String#format(Locale, String, Object...)} arguments
      * for the given <code>messageTmpl</code>.


### PR DESCRIPTION
Allows us to avoid setting the source on a request item - reducing
memory footprint.
The cost to re-generate the source is probably similar to what parsing
the source would be.

---

~I think this currently could lead to primary/replica divergence if there are generated columns or default clauses which are not deterministic.~
~We'll probably have to extend the targetColumns + add the generated values on the primary to the `insertValues` so that the replica can re-use them?~
