### PR TITLE
Handle missing child Reference in ObjectIndexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -79,7 +79,11 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             DataType<?> value = entry.getValue();
             ColumnIdent child = column.getChild(innerName);
             Reference childRef = getRef.apply(child);
-            if (childRef.granularity() != RowGranularity.PARTITION) {
+            if (childRef == null) {
+                // Race, either column got deleted or stale DocTableInfo?
+                // Treat it as dynamic column if a value for the nested column is found
+                innerTypes.remove(innerName);
+            } else if (childRef.granularity() != RowGranularity.PARTITION) {
                 ValueIndexer<?> valueIndexer = value.valueIndexer(
                     table,
                     childRef,


### PR DESCRIPTION
Should fix a race condition.

`test_concurrent_statements_that_add_columns_to_partitioned_table_result_in_dynamic_mapping_updates`
could fail with:

    Caused by: org.postgresql.util.PSQLException: ERROR: Cannot invoke "io.crate.metadata.Reference.granularity()" because "childRef" is null
      Where: io.crate.execution.dml.ObjectIndexer.<init>(ObjectIndexer.java:82)
    io.crate.types.ObjectType$1.valueIndexer(ObjectType.java:79)
    io.crate.types.DataType.valueIndexer(DataType.java:248)
    io.crate.execution.dml.Indexer.<init>(Indexer.java:376)
    io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItems(TransportShardUpsertAction.java:171)
    io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItems(TransportShardUpsertAction.java:104)
    io.crate.execution.dml.TransportShardAction$1.call(TransportShardAction.java:121)
    io.crate.execution.dml.TransportShardAction$1.call(TransportShardAction.java:118)
    io.crate.execution.dml.TransportShardAction.wrapOperationInKillable(TransportShardAction.java:146)
    io.crate.execution.dml.TransportShardAction.lambda$shardOperationOnPrimary$1(TransportShardAction.java:124)
    org.elasticsearch.action.ActionListener.completeWith(ActionListener.java:230)
    io.crate.execution.dml.TransportShardAction.shardOperationOnPrimary(TransportShardAction.java:114)
    io.crate.execution.dml.TransportShardAction.shardOperationOnPrimary(TransportShardAction.java:63)
    org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryShardReference.perform(TransportReplicationAction.java:928)
    org.elasticsearch.action.support.replication.ReplicationOperation.execute(ReplicationOperation.java:126)
    org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.runWithPrimaryShardReference(TransportReplicationAction.java:429)
    org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.lambda$doRun$0(TransportReplicationAction.java:347)
    org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:75)
    org.elasticsearch.index.shard.IndexShard.lambda$wrapPrimaryOperationPermitListener$21(IndexShard.java:2721)
    org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:103)
