### PR TITLE
Use Lucene 9.5 Long/Int/Float/Double-Field

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
@@ -27,13 +27,14 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.document.DoubleField;
 import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
@@ -62,11 +63,14 @@ public class DoubleIndexer implements ValueIndexer<Number> {
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);
         double doubleValue = value.doubleValue();
-        addField.accept(new DoublePoint(name, doubleValue));
         if (ref.hasDocValues()) {
-            addField.accept(new SortedNumericDocValuesField(
+            addField.accept(new DoubleField(name, doubleValue));
+        } else {
+            addField.accept(new DoublePoint(name, doubleValue));
+            addField.accept(new Field(
+                FieldNamesFieldMapper.NAME,
                 name,
-                NumericUtils.doubleToSortableLong(doubleValue)));
+                FieldNamesFieldMapper.Defaults.FIELD_TYPE));
         }
         if (fieldType.stored()) {
             addField.accept(new StoredField(name, doubleValue));

--- a/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
@@ -25,13 +25,14 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.FloatField;
 import org.apache.lucene.document.FloatPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;
@@ -59,11 +60,14 @@ public class FloatIndexer implements ValueIndexer<Float> {
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);
         float floatValue = value.floatValue();
-        addField.accept(new FloatPoint(name, floatValue));
         if (ref.hasDocValues()) {
-            addField.accept(new SortedNumericDocValuesField(
+            addField.accept(new FloatField(name, floatValue));
+        } else {
+            addField.accept(new FloatPoint(name, floatValue));
+            addField.accept(new Field(
+                FieldNamesFieldMapper.NAME,
                 name,
-                NumericUtils.floatToSortableInt(floatValue)));
+                FieldNamesFieldMapper.Defaults.FIELD_TYPE));
         }
         if (fieldType.stored()) {
             addField.accept(new StoredField(name, floatValue));

--- a/server/src/main/java/io/crate/execution/dml/IntIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IntIndexer.java
@@ -27,12 +27,14 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 
 import io.crate.metadata.ColumnIdent;
@@ -59,9 +61,14 @@ public class IntIndexer implements ValueIndexer<Number> {
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xContentBuilder.value(value);
         int intValue = value.intValue();
-        addField.accept(new IntPoint(name, intValue));
         if (ref.hasDocValues()) {
-            addField.accept(new SortedNumericDocValuesField(name, intValue));
+            addField.accept(new IntField(name, intValue));
+        } else {
+            addField.accept(new IntPoint(name, intValue));
+            addField.accept(new Field(
+                FieldNamesFieldMapper.NAME,
+                name,
+                FieldNamesFieldMapper.Defaults.FIELD_TYPE));
         }
         if (fieldType.stored()) {
             addField.accept(new StoredField(name, intValue));

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -29,8 +29,8 @@ import javax.annotation.Nullable;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -61,10 +61,10 @@ public class LongIndexer implements ValueIndexer<Long> {
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);
         long longValue = value.longValue();
-        addField.accept(new LongPoint(name, longValue));
         if (ref.hasDocValues()) {
-            addField.accept(new SortedNumericDocValuesField(name, longValue));
+            addField.accept(new LongField(name, longValue));
         } else {
+            addField.accept(new LongPoint(name, longValue));
             addField.accept(new Field(
                 FieldNamesFieldMapper.NAME,
                 name,

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -35,8 +35,7 @@ import java.util.stream.Stream;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.FloatPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.FloatField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
@@ -109,7 +108,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> value = Map.of("x", 10, "y", 20);
         ParsedDocument parsedDoc = indexer.index(item(value));
         assertThat(parsedDoc.doc().getFields())
-            .hasSize(10);
+            .hasSize(8);
 
         assertThat(parsedDoc.newColumns())
             .hasSize(1);
@@ -144,7 +143,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> value = Map.of("x", 10, "obj", Map.of("y", 20, "z", 30));
         ParsedDocument parsedDoc = indexer.index(item(value));
         assertThat(parsedDoc.doc().getFields())
-            .hasSize(12);
+            .hasSize(9);
 
         assertThat(parsedDoc.newColumns())
             .satisfiesExactly(
@@ -209,7 +208,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         );
 
         assertThat(parsedDoc.doc().getFields())
-            .hasSize(14);
+            .hasSize(10);
     }
 
     @Test
@@ -251,7 +250,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             "{\"x\":10,\"y\":0}"
         );
         assertThat(parsedDoc.doc().getFields())
-            .hasSize(10);
+            .hasSize(8);
     }
 
     @Test
@@ -557,7 +556,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_indexing_float_results_in_float_point() throws Exception {
+    public void test_indexing_float_results_in_float_field() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .addTable("create table tbl (x float)")
             .build();
@@ -566,9 +565,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         ParsedDocument doc = indexer.index(item(42.2f));
         IndexableField[] fields = doc.doc().getFields("x");
         assertThat(fields).satisfiesExactly(
-            x -> assertThat(x).isExactlyInstanceOf(FloatPoint.class),
             x -> assertThat(x)
-                .isExactlyInstanceOf(SortedNumericDocValuesField.class)
+                .isExactlyInstanceOf(FloatField.class)
                 .extracting("fieldsData")
                 .isEqualTo((long) NumericUtils.floatToSortableInt(42.2f))
         );


### PR DESCRIPTION
Read some comment that using the new single field variants can have a
performance benefit compared to using the `XYPoint` +
`SortedNumericDocValuesField` variants.

The behavior of the fields is the same as what we did before. From the
`LongField` javadocs:

    Field that stores a per-document <code>long</code> value for scoring, sorting or value retrieval
    and index the field for fast range filters. If you also need to store the value, you should add a
    separate {@link StoredField} instance. If you need more fine-grained control you can use {@link
    LongPoint} and {@link NumericDocValuesField} or {@link SortedNumericDocValuesField}.


Also adds some missing field-names if doc-values are disabled (which we afaik still don't allow for numbers, which is why no tests failed(?))