### PR TITLE
 Fix insert on conflict when column to update not in insert cols

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -498,8 +498,8 @@ public class Indexer {
 
     @SuppressWarnings("unchecked")
     public ParsedDocument index(IndexItem item) throws IOException {
-        assert item.insertValues().length == valueIndexers.size()
-            : "Number of values must match number of targetColumns/valueIndexers";
+        assert item.insertValues().length <= valueIndexers.size()
+            : "Number of values must be less than or equal the number of targetColumns/valueIndexers";
 
         Document doc = new Document();
         Consumer<? super IndexableField> addField = doc::add;

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -23,7 +23,6 @@ package io.crate.execution.dml.upsert;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -713,13 +713,23 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("create table t1 (id integer primary key, other string) clustered into 1 shards");
         execute("insert into t1 (id, other) values (1, 'test'), (2, 'test2')");
 
-        execute("insert into t1 (id, other) values (1, 'updated') ON CONFLICT (id) DO UPDATE SET other = 'updated'");
+        execute("insert into t1 (id) values (1) ON CONFLICT (id) DO UPDATE SET other = 'updated_once'");
         assertThat(response).hasRowCount(1L);
         refresh();
 
         execute("select id, other from t1 order by id");
         assertThat(response).hasRows(
-            "1| updated",
+            "1| updated_once",
+            "2| test2"
+        );
+
+        execute("insert into t1 (id, other) values (1, 'updated') ON CONFLICT (id) DO UPDATE SET other = 'updated_twice'");
+        assertThat(response).hasRowCount(1L);
+        refresh();
+
+        execute("select id, other from t1 order by id");
+        assertThat(response).hasRows(
+            "1| updated_twice",
             "2| test2"
         );
 


### PR DESCRIPTION
-  For statements like:
    ```
    INSERT INTO test (id) values (1) ON CONFLICT (id) DO UPDATE SET x = 'updated'
    ```
    where the column to update (`x`) is not included in insert cols (only `id` is),
    the operation didn't succeed, as in: `x` was not updated, since the
    `Indexer` built, was only including the `id` column (`insertColumns`).
    
    Furthermore, since we create the `Indexer` for all cases (1st attempt to
    insert, then 2nd attempt to update), asserting that the insert values
    match the `Indexer#valueIndexers.size()` is relaxed.

    Follows: #13758

- test: Migrate remaining code to assertj for InsertIntoIntegrationTest  and beautify some statement with `"""` code blocks.
