### PR TITLE
Fix issue with aggregations and UNION

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,6 +81,15 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could cause errors for queries with aggregations and
+  ``UNION``, e.g. ::
+
+    SELECT a, avg(c), b FROM t1 GROUP BY 1, 3
+    UNION
+    SELECT x, avg(z), y FROM t2 GROUP BY 1, 3
+    UNION
+    SELECT i, avg(k), j FROM t3 GROUP BY 1, 3
+
 - Fixed an issue that could cause ``DELETE FROM`` statements which match a large
   amount of records to cause a node to crash with an out of memory error.
 
@@ -109,9 +118,9 @@ Fixes
     IllegalStateException[Symbol 'io.crate.expression.symbol.Symbol' not supported]
     // r is an alias of a and is ambiguous from the perspective of the outer query
 
- - Fixed an issue that translated ``UnsupportedOperationException`` to a
-   misleading ``MissingPrivilegeException`` when executing functions with
-   invalid names or signatures.
+- Fixed an issue that translated ``UnsupportedOperationException`` to a
+  misleading ``MissingPrivilegeException`` when executing functions with
+  invalid names or signatures.
 
 - Fixed an issue causing nested join statements using the ``NESTED LOOP`` plan
   to return incorrect results in some scenarios when issued on a multi-node

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -252,7 +252,8 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
-        HashSet<Symbol> toKeep = new HashSet<>();
+        // Keep the same order and avoid introducing an Eval
+        HashSet<Symbol> toKeep = new LinkedHashSet<>();
         // We cannot prune groupKeys, even if they are not used in the outputs, because it would change the result semantically
         for (Symbol groupKey : groupKeys) {
             SymbolVisitors.intersection(groupKey, source.outputs(), toKeep::add);


### PR DESCRIPTION
Use a LinkedHashSet to keep the order of outputs `toKeep` when pruning other unnecessary outputs. Otherwise we might end up with mixed up outputs, without an intermmediate `Eval` to re-order them:

```
GroupHashAggregate[ai, "avg(x)", "cast(i AS bigint)"]
 └ Union[ai, "cast(i AS bigint)", "avg(x)"]
 ...
```

Fixes: #13779
