### PR TITLE
Fix field order determinism in Indexer & DocTableinfo

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnTask.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnTask.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -65,7 +66,7 @@ import io.crate.metadata.table.ColumnPolicies;
 import io.crate.types.ArrayType;
 import io.crate.types.ObjectType;
 
-final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRequest> {
+public final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRequest> {
 
     private final NodeContext nodeContext;
     private final CheckedFunction<IndexMetadata, MapperService, IOException> createMapperService;
@@ -76,7 +77,7 @@ final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRequest> 
     }
 
     @Override
-    protected ClusterState execute(ClusterState currentState, AddColumnRequest request) throws Exception {
+    public ClusterState execute(ClusterState currentState, AddColumnRequest request) throws Exception {
         Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
         DocTableInfoFactory docTableInfoFactory = new DocTableInfoFactory(nodeContext);
         DocTableInfo currentTable = docTableInfoFactory.create(request.relationName(), currentState);
@@ -182,7 +183,7 @@ final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRequest> 
         if (children == null) {
             return null;
         }
-        HashMap<String, Map<String, Object>> allColumnsMap = new HashMap<>();
+        HashMap<String, Map<String, Object>> allColumnsMap = new LinkedHashMap<>();
         for (Reference child: children) {
             allColumnsMap.put(child.column().leafName(), addColumnProperties(child, tree));
         }

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -23,6 +23,7 @@ package io.crate.execution.dml;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -73,7 +74,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
         this.column = ref.column();
         this.objectType = (ObjectType) ArrayType.unnest(ref.valueType());
         this.innerIndexers = new HashMap<>();
-        this.innerTypes = new HashMap<>(objectType.innerTypes());
+        this.innerTypes = new LinkedHashMap<>(objectType.innerTypes());
         for (var entry : objectType.innerTypes().entrySet()) {
             String innerName = entry.getKey();
             DataType<?> value = entry.getValue();

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -103,7 +104,7 @@ public interface Reference extends Symbol {
      * NULL node is a root which is an entry point for any traversing method utilizing the tree.
      */
     static HashMap<ColumnIdent, List<Reference>> buildTree(List<Reference> references) {
-        HashMap<ColumnIdent, List<Reference>> tree = new HashMap<>();
+        HashMap<ColumnIdent, List<Reference>> tree = new LinkedHashMap<>();
         for (Reference treeNode: references) {
             // To build an "adjacency list" we add each edge only once, thus we add only direct neighbor node (parent).
             // I.e if a leaf node C has path A-B we add only (B,C) edge when handling node C.

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -82,7 +82,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     public static class Builder {
 
-        Map<String, DataType<?>> innerTypesBuilder = new HashMap<>();
+        Map<String, DataType<?>> innerTypesBuilder = new LinkedHashMap<>();
 
         public Builder setInnerType(String key, DataType<?> innerType) {
             innerTypesBuilder.put(key, innerType);


### PR DESCRIPTION
The order of the fields in the source wasn't deterministic.

The `ObjectIndexer` uses the `innerTypes` of an `ObjectType` if present
but these innerTypes weren't ordered by position. This led to a
different order between indexing of dynamic values and indexing after
the mapping update.

This could trigger an assertion, causing flaky test failures:

    WARNING: Uncaught exception in thread: Thread[#915,cratedb[node_s0][generic][T#5],5,TGRP-InsertIntoIntegrationTest]
    java.lang.AssertionError: seqNo [0] was processed twice in generation [2], with different data. prvOp [Index{id='qh3x24YBsqY9ANFaFJux', seqNo=0, primaryTerm=1, version=1, autoGeneratedIdTimestamp=-1}], newOp [Index{id='qh3x24YBsqY9ANFaFJux', seqNo=0, primaryTerm=1, version=1, autoGeneratedIdTimestamp=-1}]
    	at __randomizedtesting.SeedInfo.seed([164B6F142ED3CEC8]:0)
    	at org.elasticsearch.index.translog.TranslogWriter.assertNoSeqNumberConflict(TranslogWriter.java:253)
    	at org.elasticsearch.index.translog.TranslogWriter.add(TranslogWriter.java:217)
    	at org.elasticsearch.index.translog.Translog.add(Translog.java:519)
    	at org.elasticsearch.index.engine.InternalEngine.index(InternalEngine.java:940)
    	at org.elasticsearch.index.shard.IndexShard.index(IndexShard.java:806)
    	at org.elasticsearch.index.shard.IndexShard.applyIndexOperation(IndexShard.java:752)
    	at org.elasticsearch.index.shard.IndexShard.applyTranslogOperation(IndexShard.java:1375)
    	at org.elasticsearch.index.shard.IndexShard.applyTranslogOperation(IndexShard.java:1362)
    	at org.elasticsearch.indices.recovery.RecoveryTarget.lambda$indexTranslogOperations$2(RecoveryTarget.java:379)
    [...]
    caused by: java.lang.RuntimeException: stack capture previous op
	at org.elasticsearch.index.translog.TranslogWriter.assertNoSeqNumberConflict(TranslogWriter.java:258)
	at org.elasticsearch.index.translog.TranslogWriter.add(TranslogWriter.java:217)
	at org.elasticsearch.index.translog.Translog.add(Translog.java:519)
	at org.elasticsearch.index.engine.InternalEngine.index(InternalEngine.java:940)
	at org.elasticsearch.index.shard.IndexShard.index(IndexShard.java:806)
	at org.elasticsearch.index.shard.IndexShard.index(IndexShard.java:778)
	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItemsOnReplica(TransportShardUpsertAction.java:376)
	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItemsOnReplica(TransportShardUpsertAction.java:101)
