### PR TITLE
Fix join using for nested joins

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,9 +81,18 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-- Fixed an issue that caused nested joins such as
-  ``SELECT * FROM t1 JOIN (t2 JOIN t3 ON t2.x = t3.x) ON t1.x = t2.x``
-  fail with an internal error.
+- Fixed an issue that caused ``JOIN`` queries to fail with an internal error,
+  when ``USING`` is used to define the join condition in combination with a
+  nested join e.g.::
+
+    SELECT * FROM t1 JOIN (t2 JOIN t3 ON t2.y = t3.y) USING(x)
+
+  Furthermore, validation of ``USING`` was added, so that a meaningful error
+  message is thrown in case it's misused.
+
+- Fixed an issue that caused nested joins to fail with an internal error e.g.::
+
+    SELECT * FROM t1 JOIN (t2 JOIN t3 ON t2.x = t3.x) ON t1.x = t2.x
 
 - Fixed an issue that could cause errors for queries with aggregations and
   ``UNION``, e.g. ::

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -25,6 +25,8 @@ import static io.crate.common.collections.Iterables.getOnlyElement;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -285,10 +287,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             if (joinCriteria instanceof JoinOn joinOn) {
                 expression = joinOn.getExpression();
             } else if (joinCriteria instanceof JoinUsing joinUsing) {
-                expression = JoinUsing.toExpression(
-                    leftRel.relationName().toQualifiedName(),
-                    rightRel.relationName().toQualifiedName(),
-                    joinUsing.getColumns());
+                expression = validateAndExtractFromUsing(leftRel.outputs(), rightRel.outputs(), joinUsing);
             } else {
                 throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "join criteria %s not supported",
                         joinCriteria.getClass().getSimpleName()));
@@ -339,7 +338,72 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         var right = relevantRelationsInOrder.get(relevantRelationsInOrder.size() - 1);
         return JoinPair.of(left, right, joinRelation.joinType(), joinCondition);
     }
-    
+
+    private static Expression validateAndExtractFromUsing(List<Symbol> leftOutputs,
+                                                          List<Symbol> rightOutputs,
+                                                          JoinUsing joinUsing) {
+        var lhsOutputs = new HashMap<String, Symbol>();
+        var rhsOutputs = new HashMap<String, Symbol>();
+
+        for (var joinColumn : joinUsing.getColumns()) {
+
+            for (var leftOutput : leftOutputs) {
+                var columnIdent = Symbols.pathFromSymbol(leftOutput);
+                if (columnIdent.name().equals(joinColumn)) {
+                    if (lhsOutputs.put(joinColumn, leftOutput) != null) {
+                        throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                                         "common column name %s appears more than once in left table", joinColumn));
+                    }
+                }
+            }
+
+            if (lhsOutputs.isEmpty()) {
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                                 "column %s specified in USING clause does not exist in left table", joinColumn));
+            }
+
+            for (Symbol rightOutput : rightOutputs) {
+                var columnIdent = Symbols.pathFromSymbol(rightOutput);
+                if (columnIdent.name().equals(joinColumn)) {
+                    if (rhsOutputs.put(joinColumn, rightOutput) != null) {
+                        throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                                         "common column name %s appears more than once in right table", joinColumn));
+                    } else {
+                        var lhsType = lhsOutputs.get(joinColumn).valueType();
+                        var rhsType = rightOutput.valueType();
+                        if (lhsType.equals(rhsType) == false) {
+                            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                                             "JOIN/USING types %s and %s varying cannot be matched", lhsType.getName(), rhsType.getName())
+                            );
+                        }
+                    }
+                }
+            }
+
+            if (rhsOutputs.isEmpty()) {
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                                                                 "column %s specified in USING clause does not exist in right table", joinColumn));
+            }
+        }
+
+        var lhsRelationNames = new HashSet<RelationName>();
+        var rhsRelationNames = new HashSet<RelationName>();
+
+        for (Symbol symbol : lhsOutputs.values()) {
+            lhsRelationNames.addAll(RelationNameCollector.collect(symbol));
+        }
+
+        for (Symbol symbol : rhsOutputs.values()) {
+            rhsRelationNames.addAll(RelationNameCollector.collect(symbol));
+        }
+
+        return JoinUsing.toExpression(
+            getOnlyElement(lhsRelationNames).toQualifiedName(),
+            getOnlyElement(rhsRelationNames).toQualifiedName(),
+            joinUsing.getColumns()
+        );
+    }
+
     @Override
     protected AnalyzedRelation visitQuerySpecification(QuerySpecification node, StatementAnalysisContext statementContext) {
         List<Relation> from = node.getFrom().isEmpty() ? EMPTY_ROW_TABLE_RELATION : node.getFrom();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix join `using` for nested joins

This extracts the relation names for lhs and rhs for the join `using`
clause from the outputs of the Join Relation. This makes the following
statement work:

```
SELECT * FROM t1 JOIN (t2 JOIN t3 ON t2.y = t3.y) USING(x)
```

It also adds additional validation to make sure the pre-conditions for join `using` are met.

Follow-up for https://github.com/crate/crate/commit/e9624a9dcd64c40e8fd26b8285e187394e289adf

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
