### PR TITLE
Re-use XContentBuilder in Indexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -23,6 +23,7 @@
 package io.crate.execution.dml;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -349,12 +350,16 @@ public class Indexer {
                    NodeContext nodeCtx,
                    Function<ColumnIdent, FieldType> getFieldType,
                    List<Reference> targetColumns,
-                   Symbol[] returnValues) throws IOException {
+                   Symbol[] returnValues) {
         this.symbolEval = new SymbolEvaluator(txnCtx, nodeCtx, SubQueryResults.EMPTY);
         this.columns = targetColumns;
         this.synthetics = new HashMap<>();
         this.stream = new BytesStreamOutput();
-        this.xContentBuilder = XContentFactory.jsonBuilder(stream);
+        try {
+            this.xContentBuilder = XContentFactory.jsonBuilder(stream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
 
         PartitionName partitionName = table.isPartitioned()
             ? PartitionName.fromIndexOrTemplate(indexName)

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -157,20 +157,15 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         } else {
             insertColumns = List.of(request.insertColumns());
         }
-        Indexer indexer = null;
-        try {
-            indexer = new Indexer(
-                indexName,
-                tableInfo,
-                txnCtx,
-                nodeCtx,
-                getFieldType,
-                insertColumns,
-                request.returnValues()
-            );
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        Indexer indexer = new Indexer(
+            indexName,
+            tableInfo,
+            txnCtx,
+            nodeCtx,
+            getFieldType,
+            insertColumns,
+            request.returnValues()
+        );
         if (indexer.hasUndeterministicSynthetics()) {
             request.insertColumns(indexer.insertColumns(insertColumns));
         }

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -157,15 +157,20 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         } else {
             insertColumns = List.of(request.insertColumns());
         }
-        Indexer indexer = new Indexer(
-            indexName,
-            tableInfo,
-            txnCtx,
-            nodeCtx,
-            getFieldType,
-            insertColumns,
-            request.returnValues()
-        );
+        Indexer indexer = null;
+        try {
+            indexer = new Indexer(
+                indexName,
+                tableInfo,
+                txnCtx,
+                nodeCtx,
+                getFieldType,
+                insertColumns,
+                request.returnValues()
+            );
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         if (indexer.hasUndeterministicSynthetics()) {
             request.insertColumns(indexer.insertColumns(insertColumns));
         }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -83,7 +84,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         return new IndexItem.StaticItem("dummy-id-1", List.of(), values, 0L, 0L);
     }
 
-    static Indexer getIndexer(SQLExecutor e, String tableName, FieldType fieldType, String ... columns) {
+    static Indexer getIndexer(SQLExecutor e, String tableName, FieldType fieldType, String ... columns) throws IOException {
         DocTableInfo table = e.resolveTableInfo(tableName);
         return new Indexer(
             table.ident().indexNameOrAlias(),


### PR DESCRIPTION
Inspired by https://github.com/crate/crate/pull/13790

I tried once reusing XContentBuilder in CSVParser (https://github.com/crate/crate/pull/12795) and it gave some tiny improvement. Linked PR was closed as change was dependant on other components but here lifecycle of `XContentBuilder` seems to be isolated, we pass it to other places but close in the Indexer itself.


```
Benchmark                                             Mode  Cnt     Score    Error  Units
IndexerBenchmark.measure_index_baseline               avgt   10  1129,115 ±  6,927  us/op
IndexerBenchmark.measure_index_reuse_content_builder  avgt   10   901,766 ± 26,908  us/op
```

Changes in Benchmark and `reuse` flag are of course temporal - just did it in order to run all benchmarks in a single run.