### PR TITLE
Add optimizer rule to rewrite nl-join to hash-join

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -21,8 +21,6 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.operators.EquiJoinDetector.isHashJoinPossible;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -67,8 +65,7 @@ public class JoinPlanBuilder {
                                      Symbol whereClause,
                                      List<JoinPair> joinPairs,
                                      SubQueries subQueries,
-                                     Function<AnalyzedRelation, LogicalPlan> plan,
-                                     boolean hashJoinEnabled) {
+                                     Function<AnalyzedRelation, LogicalPlan> plan) {
         if (from.size() == 1) {
             LogicalPlan source = subQueries.applyCorrelatedJoin(plan.apply(from.get(0)));
             return Filter.create(source, whereClause);
@@ -122,15 +119,17 @@ public class JoinPlanBuilder {
         AnalyzedRelation lhs = sources.get(lhsName);
         AnalyzedRelation rhs = sources.get(rhsName);
 
-        LogicalPlan joinPlan = createJoinPlan(
+        boolean isFiltered = validWhereConditions.symbolType().isValueSymbol() == false;
+
+        LogicalPlan joinPlan = new NestedLoopJoin(
             plan.apply(lhs),
             plan.apply(rhs),
             joinType,
             validJoinConditions,
+            isFiltered,
             lhs,
-            validWhereConditions,
-            hashJoinEnabled
-        );
+            false);
+
         joinPlan = Filter.create(joinPlan, validWhereConditions);
         while (it.hasNext()) {
             AnalyzedRelation nextRel = sources.get(it.next());
@@ -141,8 +140,7 @@ public class JoinPlanBuilder {
                 joinNames,
                 joinPairsByRelations,
                 queryParts,
-                lhs,
-                hashJoinEnabled
+                lhs
             );
             joinNames.add(nextRel.relationName());
         }
@@ -172,31 +170,6 @@ public class JoinPlanBuilder {
         return hasAdditionalDependencies[0];
     }
 
-    private static LogicalPlan createJoinPlan(LogicalPlan lhsPlan,
-                                              LogicalPlan rhsPlan,
-                                              JoinType joinType,
-                                              Symbol joinCondition,
-                                              AnalyzedRelation lhs,
-                                              Symbol query,
-                                              boolean hashJoinEnabled) {
-        if (hashJoinEnabled && isHashJoinPossible(joinType, joinCondition)) {
-            return new HashJoin(
-                lhsPlan,
-                rhsPlan,
-                joinCondition
-            );
-        } else {
-            return new NestedLoopJoin(
-                lhsPlan,
-                rhsPlan,
-                joinType,
-                joinCondition,
-                !query.symbolType().isValueSymbol(),
-                lhs,
-                false);
-        }
-    }
-
     private static JoinType maybeInvertPair(RelationName rhsName, JoinPair pair) {
         // A matching joinPair for two relations is retrieved using pairByQualifiedNames.remove(setOf(a, b))
         // This returns a pair for both cases: (a ⋈ b) and (b ⋈ a) -> invert joinType to execute correct join
@@ -214,8 +187,7 @@ public class JoinPlanBuilder {
                                             Set<RelationName> joinNames,
                                             Map<Set<RelationName>, JoinPair> joinPairs,
                                             Map<Set<RelationName>, Symbol> queryParts,
-                                            AnalyzedRelation leftRelation,
-                                            boolean hashJoinEnabled) {
+                                            AnalyzedRelation leftRelation) {
         RelationName nextName = nextRel.relationName();
 
         JoinPair joinPair = removeMatch(joinPairs, joinNames, nextName);
@@ -236,17 +208,16 @@ public class JoinPlanBuilder {
                 queryParts.remove(Collections.singleton(nextName)))
                 .filter(Objects::nonNull).iterator()
         );
-        return Filter.create(
-            createJoinPlan(
-                source,
-                nextPlan,
-                type,
-                condition,
-                leftRelation,
-                query,
-                hashJoinEnabled),
-            query
-        );
+        boolean isFiltered = query.symbolType().isValueSymbol() == false;
+        var joinPlan = new NestedLoopJoin(
+            source,
+            nextPlan,
+            type,
+            condition,
+            isFiltered,
+            leftRelation,
+            false);
+        return Filter.create(joinPlan, query);
     }
 
     private static Symbol removeParts(Map<Set<RelationName>, Symbol> queryParts, RelationName lhsName, RelationName rhsName) {

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -77,6 +77,7 @@ public class NestedLoopJoin implements JoinPlan {
     private boolean orderByWasPushedDown = false;
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
     private final boolean joinConditionOptimised;
+    private boolean rewriteNestedLoopJoinToHashJoinDone = false;
 
     NestedLoopJoin(LogicalPlan lhs,
                    LogicalPlan rhs,
@@ -107,10 +108,12 @@ public class NestedLoopJoin implements JoinPlan {
                           AnalyzedRelation topMostLeftRelation,
                           boolean orderByWasPushedDown,
                           boolean rewriteFilterOnOuterJoinToInnerJoinDone,
-                          boolean joinConditionOptimised) {
+                          boolean joinConditionOptimised,
+                          boolean rewriteEquiJoinToHashJoinDone) {
         this(lhs, rhs, joinType, joinCondition, isFiltered, topMostLeftRelation, joinConditionOptimised);
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
+        this.rewriteNestedLoopJoinToHashJoinDone = rewriteEquiJoinToHashJoinDone;
     }
 
     @Override
@@ -124,6 +127,10 @@ public class NestedLoopJoin implements JoinPlan {
 
     public LogicalPlan rhs() {
         return rhs;
+    }
+
+    public boolean isRewriteNestedLoopJoinToHashJoinDone() {
+        return rewriteNestedLoopJoinToHashJoinDone;
     }
 
     public boolean isJoinConditionOptimised() {
@@ -280,7 +287,8 @@ public class NestedLoopJoin implements JoinPlan {
             topMostLeftRelation,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            joinConditionOptimised
+            joinConditionOptimised,
+            rewriteNestedLoopJoinToHashJoinDone
         );
     }
 
@@ -310,7 +318,8 @@ public class NestedLoopJoin implements JoinPlan {
             topMostLeftRelation,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            joinConditionOptimised
+            joinConditionOptimised,
+            rewriteNestedLoopJoinToHashJoinDone
         );
     }
 
@@ -346,7 +355,8 @@ public class NestedLoopJoin implements JoinPlan {
                 topMostLeftRelation,
                 orderByWasPushedDown,
                 rewriteFilterOnOuterJoinToInnerJoinDone,
-                joinConditionOptimised
+                joinConditionOptimised,
+                rewriteNestedLoopJoinToHashJoinDone
             )
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -51,6 +51,7 @@ import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathRename;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathUnion;
 import io.crate.planner.optimizer.rule.OptimizeCollectWhereClauseAccess;
+import io.crate.planner.optimizer.rule.RewriteNestedLoopJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
@@ -85,7 +86,8 @@ public class LoadedRules implements SessionSettingProvider {
         OptimizeCollectWhereClauseAccess.class,
         RewriteGroupByKeysLimitToLimitDistinct.class,
         RewriteInsertFromSubQueryToInsertFromValues.class,
-        RewriteToQueryThenFetch.class
+        RewriteToQueryThenFetch.class,
+        RewriteNestedLoopJoinToHashJoin.class
     );
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -90,7 +90,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 nl.topMostLeftRelation(),
                 nl.orderByWasPushedDown(),
                 nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                true // Mark joinConditionOptimised = true
+                true, // Mark joinConditionOptimised = true
+                nl.isRewriteNestedLoopJoinToHashJoinDone()
             );
         } else {
             // Push constant join condition down to source

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -66,9 +66,10 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
         this.nlCapture = new Capture<>();
         this.pattern = typeOf(Order.class)
             .with(source(),
-                typeOf(NestedLoopJoin.class)
-                    .capturedAs(nlCapture)
-                    .with(nl -> !nl.joinType().isOuter())
+                  typeOf(NestedLoopJoin.class)
+                      .capturedAs(nlCapture)
+                      .with(nl -> !nl.joinType().isOuter() &&
+                                  nl.isRewriteNestedLoopJoinToHashJoinDone() == true)
             );
     }
 
@@ -108,7 +109,8 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.topMostLeftRelation(),
                     true,
                     nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                    false
+                    false,
+                    nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
                 );
             }
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -260,7 +260,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             nl.topMostLeftRelation(),
             nl.orderByWasPushedDown(),
             true,
-            false
+            false,
+            nl.isRewriteNestedLoopJoinToHashJoinDone()
         );
         assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";
         return splitQueries.isEmpty() ? newJoin : new Filter(newJoin, AndOperator.join(splitQueries.values()));

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import java.util.function.Function;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.EquiJoinDetector;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.statistics.TableStats;
+
+public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
+
+    private final Pattern<NestedLoopJoin> pattern = typeOf(NestedLoopJoin.class)
+        .with(nl -> nl.isRewriteNestedLoopJoinToHashJoinDone() == false &&
+                    nl.orderByWasPushedDown() == false);
+    
+    @Override
+    public Pattern<NestedLoopJoin> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(NestedLoopJoin nl,
+                             Captures captures,
+                             TableStats tableStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+
+        if (txnCtx.sessionSettings().hashJoinsEnabled() &&
+            EquiJoinDetector.isHashJoinPossible(nl.joinType(), nl.joinCondition())) {
+            return new HashJoin(
+                nl.lhs(),
+                nl.rhs(),
+                nl.joinCondition()
+            );
+        } else {
+            return new NestedLoopJoin(
+                nl.lhs(),
+                nl.rhs(),
+                nl.joinType(),
+                nl.joinCondition(),
+                nl.isFiltered(),
+                nl.topMostLeftRelation(),
+                nl.orderByWasPushedDown(),
+                nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
+                nl.isJoinConditionOptimised(),
+                true
+            );
+        }
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -44,6 +44,11 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
 
     private Properties properties;
 
+    @Override
+    protected boolean isHashJoinEnabled() {
+        return false;
+    }
+
     @Before
     public void setup() {
         properties = new Properties();

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -177,6 +177,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.| NULL| NULL",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.| NULL| NULL",
             "optimizer_rewrite_insert_from_sub_query_to_insert_from_values| true| Indicates if the optimizer rule RewriteInsertFromSubQueryToInsertFromValues is activated.| NULL| NULL",
+            "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
             "server_version| 11.0| Reports the emulated PostgreSQL version number| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -421,6 +421,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.",
             "optimizer_rewrite_insert_from_sub_query_to_insert_from_values| true| Indicates if the optimizer rule RewriteInsertFromSubQueryToInsertFromValues is activated.",
+            "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
             "search_path| doc| Sets the schema search order.",
             "server_version| 11.0| Reports the emulated PostgreSQL version number",

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -99,14 +99,14 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, plannerCtx));
-        return JoinPlanBuilder.buildJoinTree(
+        var plan = JoinPlanBuilder.buildJoinTree(
             mss.from(),
             mss.where(),
             mss.joinPairs(),
             new SubQueries(Map.of(), Map.of()),
-            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, true),
-            txnCtx.sessionSettings().hashJoinsEnabled()
+            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, true)
         );
+        return logicalPlanner.optimizer.optimize(plan, tableStats, txnCtx);
     }
 
     private Join buildJoin(LogicalPlan operator) {
@@ -260,8 +260,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             mss.where(),
             mss.joinPairs(),
             new SubQueries(Map.of(), Map.of()),
-            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, false),
-            false
+            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, false)
         );
         Join nl = (Join) operator.build(
             mock(DependencyCarrier.class), context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
@@ -596,7 +595,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_filter_on_aliased_symbol_is_moved_below_nl_if_left_join_can_be_rewritten_to_inner_join() throws Exception {
+    public void test_filter_on_aliased_symbol_is_moved_below_join_if_left_join_can_be_rewritten_to_inner_join() throws Exception {
         var executor = SQLExecutor.builder(clusterService, 2, Randomness.get(), List.of())
             .addTable("""
                 CREATE TABLE doc."metric_mini" (
@@ -623,7 +622,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             """
             Rename[start] AS doc.v1
               └ Eval[ts_production AS start]
-                └ NestedLoopJoin[INNER | (ts_production = max_ts)]
+                └ HashJoin[(ts_production = max_ts)]
                   ├ Rename[max_ts] AS last_record
                   │  └ Eval[max(ts) AS max_ts]
                   │    └ HashAggregate[max(ts)]
@@ -639,7 +638,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             """
             Rename[start] AS doc.v1
               └ Eval[ts_production AS start]
-                └ NestedLoopJoin[INNER | (ts_production = max_ts)]
+                └ HashJoin[(ts_production = max_ts)]
                   ├ Rename[max_ts] AS last_record
                   │  └ Eval[max(ts) AS max_ts]
                   │    └ HashAggregate[max(ts)]
@@ -725,7 +724,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(logicalPlan).isEqualTo(
             """
             MultiPhase
-              └ NestedLoopJoin[INNER | (i = i)]
+              └ HashJoin[(i = i)]
                 ├ Collect[doc.t1 | [a, x, i] | true]
                 └ Collect[doc.t2 | [b, y, i] | (y = ANY((SELECT z FROM (doc.t3))))]
               └ OrderBy[z ASC]

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -44,14 +44,14 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testFilterAndOuterJoinIsRewrittenToInnerJoinIfFilterEliminatesNullRow() {
+    public void testFilterAndOuterJoinIsRewrittenToHashJoinIfFilterEliminatesNullRow() {
         var plan = sqlExecutor.logicalPlan(
             "SELECT * FROM t1 LEFT JOIN t2 ON t1.x = t2.x " +
             "WHERE t2.x = '10'"
         );
         var expectedPlan =
             """
-            NestedLoopJoin[INNER | (x = x)]
+            HashJoin[(x = x)]
               ├ Collect[doc.t1 | [x] | true]
               └ Collect[doc.t2 | [x] | (x = 10)]
             """;

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -73,7 +73,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false);
+        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false, false);
         var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
         Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -2040,7 +2040,7 @@ public abstract class IntegTestCase extends ESTestCase {
      * <p>
      * Method annotations have higher priority than class annotations.
      */
-    private boolean isHashJoinEnabled() {
+    protected boolean isHashJoinEnabled() {
         UseHashJoins useHashJoins = getTestAnnotation(UseHashJoins.class);
         if (useHashJoins == null) {
             return false;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This moves the logic, if a nested-loop-join can be rewritten to a hash-join, into a rule of the query optimizer.

Fixes https://github.com/crate/crate/issues/10504


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
