### PR TITLE
Remove unused jobId property from CreatePartitionsRequest

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -163,7 +163,7 @@ public class ShardingUpsertExecutor
         createPartitionsRequestOngoing = true;
         return elasticsearchClient.execute(
             CreatePartitionsAction.INSTANCE,
-            new CreatePartitionsRequest(requests.itemsByMissingIndex.keySet(), jobId))
+            new CreatePartitionsRequest(requests.itemsByMissingIndex.keySet()))
             .thenCompose(resp -> {
                 grouper.reResolveShardLocations(requests);
                 createPartitionsRequestOngoing = false;

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -279,8 +278,7 @@ public class InsertFromValues implements LogicalPlan {
         createIndices(
             dependencies.client(),
             shardedRequests.itemsByMissingIndex().keySet(),
-            dependencies.clusterService(),
-            plannerContext.jobId()
+            dependencies.clusterService()
         ).thenCompose(acknowledgedResponse -> {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
@@ -430,7 +428,7 @@ public class InsertFromValues implements LogicalPlan {
         createIndices(
             dependencies.client(),
             shardedRequests.itemsByMissingIndex().keySet(),
-            dependencies.clusterService(), plannerContext.jobId()
+            dependencies.clusterService()
         ).thenCompose(acknowledgedResponse -> {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
@@ -752,8 +750,7 @@ public class InsertFromValues implements LogicalPlan {
 
     private static CompletableFuture<AcknowledgedResponse> createIndices(ElasticsearchClient elasticsearchClient,
                                                                          Set<String> indices,
-                                                                         ClusterService clusterService,
-                                                                         UUID jobId) {
+                                                                         ClusterService clusterService) {
         Metadata metadata = clusterService.state().metadata();
         List<String> indicesToCreate = new ArrayList<>();
         for (var index : indices) {
@@ -765,7 +762,7 @@ public class InsertFromValues implements LogicalPlan {
             return CompletableFuture.completedFuture(new AcknowledgedResponse(true));
         }
         FutureActionListener<AcknowledgedResponse, AcknowledgedResponse> listener = new FutureActionListener<>(r -> r);
-        elasticsearchClient.execute(CreatePartitionsAction.INSTANCE, new CreatePartitionsRequest(indicesToCreate, jobId))
+        elasticsearchClient.execute(CreatePartitionsAction.INSTANCE, new CreatePartitionsRequest(indicesToCreate))
             .whenComplete(listener);
         return listener;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
@@ -23,10 +23,8 @@ package org.elasticsearch.action.admin.indices.create;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
 
 import java.util.Arrays;
-import java.util.UUID;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
@@ -36,23 +34,19 @@ public class CreatePartitionsRequestTest {
 
     @Test
     public void testSerialization() throws Exception {
-        UUID jobId = UUID.randomUUID();
-        CreatePartitionsRequest request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"), jobId);
+        CreatePartitionsRequest request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"));
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
         CreatePartitionsRequest requestDeserialized = new CreatePartitionsRequest(out.bytes().streamInput());
 
         assertThat(requestDeserialized.indices(), contains("a", "b", "c"));
-        assertThat(requestDeserialized.jobId(), is(jobId));
 
-        jobId = UUID.randomUUID();
-        request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"), jobId);
+        request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"));
         out = new BytesStreamOutput();
         request.writeTo(out);
         requestDeserialized = new CreatePartitionsRequest(out.bytes().streamInput());
 
         assertThat(requestDeserialized.indices(), contains("a", "b", "c"));
-        assertThat(requestDeserialized.jobId(), is(jobId));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -73,7 +72,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
         cluster().client().execute(PutIndexTemplateAction.INSTANCE, request).get();
 
         AcknowledgedResponse response = action.execute(
-            new CreatePartitionsRequest(indices, UUID.randomUUID())
+            new CreatePartitionsRequest(indices)
         ).get();
         assertThat(response.isAcknowledged(), is(true));
 
@@ -101,8 +100,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
         ensureYellow("index_0");
 
         CreatePartitionsRequest request = new CreatePartitionsRequest(
-            Arrays.asList("index_0", "index_1"),
-            UUID.randomUUID());
+            Arrays.asList("index_0", "index_1"));
 
         CompletableFuture<ClusterStateUpdateResponse> response = new CompletableFuture<>();
 
@@ -138,7 +136,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
         cluster().client().execute(PutIndexTemplateAction.INSTANCE, templateRequest).get();
         List<String> indices = Arrays.asList("index1", "index2", "index3", "index1");
         AcknowledgedResponse response = action.execute(
-            new CreatePartitionsRequest(indices, UUID.randomUUID())
+            new CreatePartitionsRequest(indices)
         ).get();
         assertThat(response.isAcknowledged(), is(true));
         Metadata indexMetadata = cluster().clusterService().state().metadata();
@@ -146,7 +144,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
             assertThat(indexMetadata.hasIndex(index), is(true));
         }
         AcknowledgedResponse response2 = action.execute(
-            new CreatePartitionsRequest(indices, UUID.randomUUID())
+            new CreatePartitionsRequest(indices)
         ).get();
         assertThat(response2.isAcknowledged(), is(true));
     }
@@ -154,13 +152,13 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
     @Test
     public void testEmpty() throws Exception {
         AcknowledgedResponse response = action.execute(
-            new CreatePartitionsRequest(List.of(), UUID.randomUUID())).get();
+            new CreatePartitionsRequest(List.of())).get();
         assertThat(response.isAcknowledged(), is(true));
     }
 
     @Test
     public void testCreateInvalidName() throws Exception {
-        CreatePartitionsRequest createPartitionsRequest = new CreatePartitionsRequest(Arrays.asList("valid", "invalid/#haha"), UUID.randomUUID());
+        CreatePartitionsRequest createPartitionsRequest = new CreatePartitionsRequest(Arrays.asList("valid", "invalid/#haha"));
         Assertions.assertThrows(
             InvalidIndexNameException.class,
             () -> {


### PR DESCRIPTION
jobId is unused since https://github.com/crate/crate/commit/31e0f7f447eaa006e756c20bd32346b2680ebee6

