### PR TITLE
Don't discard additional implicit join conditions in nested joins

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,4 +81,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue that caused nested join queries to return incorrect
+  results because a ``WHERE`` clause filter referencing a parent join was
+  discarded by the planner. Example::
+
+    SELECT * FROM t1 JOIN t2 ON t1.a = t2.b JOIN t3 ON t2.c = t3.d WHERE t1.x = t3.d
+
+  In this case, the ``WHERE`` clause filter ``t1.x = t3.d`` was discarded.

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -192,13 +192,29 @@ public class JoinPlanBuilder {
 
         JoinPair joinPair = removeMatch(joinPairs, joinNames, nextName);
         final JoinType type;
-        final Symbol condition;
+        ArrayList<Symbol> conditions = new ArrayList<>();
         if (joinPair == null) {
             type = JoinType.CROSS;
-            condition = null;
         } else {
             type = maybeInvertPair(nextName, joinPair);
-            condition = joinPair.condition();
+            if (joinPair.condition() != null) {
+                conditions.add(joinPair.condition());
+            }
+            // There could be additional joinPairs that are not directly connected to the current joinPair,
+            // when there are WHERE clauses referencing to multiple relations of a previous join which was converted
+            // into a joinPair by JoinOperations.convertImplicitJoinConditionsToJoinPairs(...)
+            // Example:
+            //  t1. JOIN t2 ON t1.x = t2.y JOIN t3 ON t1.x = t3.z WHERE t2.y = t3.z
+            //  -> JoinPair(t1, t2)     <- 1st JOIN
+            //  -> JoinPair(t1, t3)     <- 2nd JOIN
+            //  -> JoinPair(t2, t3)     <- additional joinPair condition, must be added to the 2nd JOIN
+            JoinPair additionalJoinPair;
+            while ((additionalJoinPair = removeMatch(joinPairs, joinNames, nextName)) != null) {
+                var additionalCondition = additionalJoinPair.condition();
+                if (additionalCondition != null) {
+                    conditions.add(additionalCondition);
+                }
+            }
         }
 
         LogicalPlan nextPlan = plan.apply(nextRel);
@@ -213,7 +229,7 @@ public class JoinPlanBuilder {
             source,
             nextPlan,
             type,
-            condition,
+            AndOperator.join(conditions, null),
             isFiltered,
             leftRelation,
             false);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Any JOIN clause will be split by the planner into join pairs containing only 2 relations even if on side of the join reference a parent join (because join pairs are based on relations). Any WHERE clause filter referencing to a join and such results in an additional join condition will either be added to an existing JoinPair or a new one will be created depending on the referenced relations.
This new join pair condition must be taken into account when building the join conditions.
Example:

```
t1 JOIN t2 ON t1.x = t2.y JOIN t3 ON t1.x = t3.z WHERE t2.y = t3.z
-> JoinPair(t1, t2)	<- 1st JOIN
-> JoinPair(t1, t3)     <- 2nd JOIN
-> JoinPair(t2, t3)     <- additional joinPair, condition must be added to the 2nd JOIN
```

Fixes #13808.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
