### PR TITLE
Implement getRelocated for IndexReference and GeoReference

### DIFF
--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import io.crate.expression.symbol.Symbol;
 import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.PackedQuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
@@ -68,6 +69,36 @@ public class GeoReference extends SimpleReference {
                         @Nullable Double distanceErrorPct) {
         super(ident, RowGranularity.DOC, type, ColumnPolicy.DYNAMIC, IndexType.PLAIN, nullable, false, position, null);
         this.geoTree = Objects.requireNonNullElse(tree, DEFAULT_TREE);
+        this.precision = precision;
+        this.treeLevels = treeLevels;
+        this.distanceErrorPct = distanceErrorPct;
+    }
+
+
+    public GeoReference(ReferenceIdent ident,
+                        RowGranularity granularity,
+                        DataType<?> type,
+                        ColumnPolicy columnPolicy,
+                        IndexType indexType,
+                        boolean nullable,
+                        boolean hasDocValues,
+                        int position,
+                        Symbol defaultExpression,
+                        String geoTree,
+                        String precision,
+                        Integer treeLevels,
+                        Double distanceErrorPct) {
+        super(ident,
+            granularity,
+            type,
+            columnPolicy,
+            indexType,
+            nullable,
+            hasDocValues,
+            position,
+            defaultExpression
+        );
+        this.geoTree = geoTree;
         this.precision = precision;
         this.treeLevels = treeLevels;
         this.distanceErrorPct = distanceErrorPct;
@@ -128,6 +159,7 @@ public class GeoReference extends SimpleReference {
         distanceErrorPct = in.readBoolean() ? null : in.readDouble();
     }
 
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -141,6 +173,25 @@ public class GeoReference extends SimpleReference {
         if (distanceErrorPct != null) {
             out.writeDouble(distanceErrorPct);
         }
+    }
+
+    @Override
+    public Reference getRelocated(ReferenceIdent newIdent) {
+        return new GeoReference(
+            newIdent,
+            granularity,
+            type,
+            columnPolicy,
+            indexType,
+            nullable,
+            hasDocValues,
+            position,
+            defaultExpression,
+            geoTree,
+            precision,
+            treeLevels,
+            distanceErrorPct
+        );
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import io.crate.expression.symbol.Symbol;
+import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -114,6 +116,31 @@ public class IndexReference extends SimpleReference {
         this.analyzer = analyzer;
     }
 
+    public IndexReference(ReferenceIdent ident,
+                          RowGranularity granularity,
+                          DataType<?> type,
+                          ColumnPolicy columnPolicy,
+                          IndexType indexType,
+                          boolean nullable,
+                          boolean hasDocValues,
+                          int position,
+                          Symbol defaultExpression,
+                          List<Reference> columns,
+                          String analyzer) {
+        super(ident,
+              granularity,
+              type,
+              columnPolicy,
+              indexType,
+              nullable,
+              hasDocValues,
+              position,
+              defaultExpression
+        );
+        this.columns = columns;
+        this.analyzer = analyzer;
+    }
+
     public List<Reference> columns() {
         return columns;
     }
@@ -157,6 +184,23 @@ public class IndexReference extends SimpleReference {
         for (Reference reference : columns) {
             Reference.toStream(reference, out);
         }
+    }
+
+    @Override
+    public Reference getRelocated(ReferenceIdent newIdent) {
+        return new IndexReference(
+            newIdent,
+            granularity,
+            type,
+            columnPolicy,
+            indexType,
+            nullable,
+            hasDocValues,
+            position,
+            defaultExpression,
+            columns,
+            analyzer
+        );
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -52,16 +52,17 @@ public class SimpleReference implements Reference {
 
     protected DataType<?> type;
 
-    private final int position;
-    private final ReferenceIdent ident;
-    private final ColumnPolicy columnPolicy;
-    private final RowGranularity granularity;
-    private final IndexType indexType;
-    private final boolean nullable;
-    private final boolean hasDocValues;
+    protected final int position;
+
+    protected final ReferenceIdent ident;
+    protected final ColumnPolicy columnPolicy;
+    protected final RowGranularity granularity;
+    protected final IndexType indexType;
+    protected final boolean nullable;
+    protected final boolean hasDocValues;
 
     @Nullable
-    private final Symbol defaultExpression;
+    protected final Symbol defaultExpression;
 
     public SimpleReference(StreamInput in) throws IOException {
         ident = new ReferenceIdent(in);


### PR DESCRIPTION
Falling to parent class implementation can lead to losing implementation specific fields on relocation. For example, losing analyzer or geoTree
