### PR TITLE
Propagate BatchIterator kill to remote collector

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/phases/AbstractProjectionsPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/AbstractProjectionsPhase.java
@@ -21,30 +21,37 @@
 
 package io.crate.execution.dsl.phases;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 public abstract class AbstractProjectionsPhase implements ExecutionPhase {
 
 
-    private UUID jobId;
-    private int executionPhaseId;
-    private String name;
+    private final UUID jobId;
+    private final int executionPhaseId;
+    private final String name;
     protected final List<Projection> projections;
     protected List<DataType<?>> outputTypes = List.of();
 
-    protected AbstractProjectionsPhase(UUID jobId, int executionPhaseId, String name, List<Projection> projections) {
+    protected AbstractProjectionsPhase(UUID jobId,
+                                       int executionPhaseId,
+                                       String name,
+                                       @Nullable Collection<? extends Projection> projections) {
         this.jobId = jobId;
         this.executionPhaseId = executionPhaseId;
         this.name = name;

--- a/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
@@ -21,6 +21,20 @@
 
 package io.crate.execution.dsl.phases;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists2;
 import io.crate.data.Paging;
@@ -35,17 +49,6 @@ import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.distribution.DistributionInfo;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Function;
 
 /**
  * A plan node which collects data.
@@ -71,7 +74,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
                               Routing routing,
                               RowGranularity maxRowGranularity,
                               List<Symbol> toCollect,
-                              List<Projection> projections,
+                              Collection<? extends Projection> projections,
                               Symbol where,
                               DistributionInfo distributionInfo) {
         super(jobId, executionNodeId, name, projections);
@@ -87,7 +90,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         this.maxRowGranularity = maxRowGranularity;
         this.toCollect = toCollect;
         this.distributionInfo = distributionInfo;
-        this.outputTypes = extractOutputTypes(toCollect, projections);
+        this.outputTypes = extractOutputTypes(toCollect, this.projections);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.engine.collect;
 
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -168,7 +167,7 @@ public class RemoteCollectorFactory {
             routing,
             collectPhase.maxRowGranularity(),
             collectPhase.toCollect(),
-            new ArrayList<>(Projections.shardProjections(collectPhase.projections())),
+            Projections.shardProjections(collectPhase.projections()),
             collectPhase.where(),
             DistributionInfo.DEFAULT_BROADCAST
         );

--- a/server/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -21,25 +21,14 @@
 
 package io.crate.execution.engine.collect;
 
-import com.carrotsearch.hppc.IntArrayList;
-
-import io.crate.common.collections.Lists2;
-import io.crate.data.BatchIterator;
-import io.crate.data.Buckets;
-import io.crate.data.CollectingBatchIterator;
-import io.crate.data.CollectingRowConsumer;
-import io.crate.data.Row;
-import io.crate.exceptions.Exceptions;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
-import io.crate.execution.dsl.projection.Projections;
-import io.crate.execution.engine.collect.collectors.RemoteCollector;
-import io.crate.execution.engine.collect.collectors.ShardStateObserver;
-import io.crate.execution.engine.collect.sources.ShardCollectorProviderFactory;
-import io.crate.execution.jobs.TasksService;
-import io.crate.execution.jobs.kill.KillJobsNodeAction;
-import io.crate.execution.jobs.transport.JobAction;
-import io.crate.metadata.Routing;
-import io.crate.planner.distribution.DistributionInfo;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -52,15 +41,24 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.function.Consumer;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
+import com.carrotsearch.hppc.IntArrayList;
+
+import io.crate.common.collections.Lists2;
+import io.crate.data.BatchIterator;
+import io.crate.data.Buckets;
+import io.crate.data.CollectingBatchIterator;
+import io.crate.data.CollectingRowConsumer;
+import io.crate.data.Row;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.Projections;
+import io.crate.execution.engine.collect.collectors.RemoteCollector;
+import io.crate.execution.engine.collect.collectors.ShardStateObserver;
+import io.crate.execution.engine.collect.sources.ShardCollectorProviderFactory;
+import io.crate.execution.jobs.TasksService;
+import io.crate.execution.jobs.kill.KillJobsNodeAction;
+import io.crate.execution.jobs.transport.JobAction;
+import io.crate.metadata.Routing;
+import io.crate.planner.distribution.DistributionInfo;
 
 /**
  * Used to create RemoteCollectors
@@ -99,63 +97,71 @@ public class RemoteCollectorFactory {
     public CompletableFuture<BatchIterator<Row>> createCollector(ShardId shardId,
                                                                  RoutedCollectPhase collectPhase,
                                                                  CollectTask collectTask,
-                                                                 ShardCollectorProviderFactory shardCollectorProviderFactory) {
+                                                                 ShardCollectorProviderFactory shardCollectorProviderFactory,
+                                                                 boolean requiresScroll) {
         ShardStateObserver shardStateObserver = new ShardStateObserver(clusterService);
-        CompletableFuture<ShardRouting> shardBecameActive = shardStateObserver.waitForActiveShard(shardId);
-        Runnable onClose = () -> {};
-        Consumer<Throwable> kill = killReason -> {
-            shardBecameActive.cancel(true);
-            shardBecameActive.completeExceptionally(killReason);
-        };
-        return shardBecameActive.thenApply(activePrimaryRouting ->
-            CollectingBatchIterator.newInstance(
-                onClose,
-                kill,
-                () -> retrieveRows(activePrimaryRouting, collectPhase, collectTask, shardCollectorProviderFactory),
-                true
-            )
-        );
+        return shardStateObserver.waitForActiveShard(shardId).thenCompose(primaryRouting -> localOrRemoteCollect(
+            primaryRouting,
+            collectPhase,
+            collectTask,
+            shardCollectorProviderFactory,
+            requiresScroll
+        ));
     }
 
-    private CompletableFuture<List<Row>> retrieveRows(ShardRouting activePrimaryRouting,
-                                                      RoutedCollectPhase collectPhase,
-                                                      CollectTask collectTask,
-                                                      ShardCollectorProviderFactory shardCollectorProviderFactory) {
-        Collector<Row, ?, List<Object[]>> listCollector = Collectors.mapping(Row::materialize, Collectors.toList());
-        CollectingRowConsumer<?, List<Object[]>> consumer = new CollectingRowConsumer<>(listCollector);
-        String nodeId = activePrimaryRouting.currentNodeId();
+    private CompletableFuture<BatchIterator<Row>> localOrRemoteCollect(
+            ShardRouting primaryRouting,
+            RoutedCollectPhase collectPhase,
+            CollectTask collectTask,
+            ShardCollectorProviderFactory collectorFactory,
+            boolean requiresScroll) {
+        String nodeId = primaryRouting.currentNodeId();
         String localNodeId = clusterService.localNode().getId();
         if (localNodeId.equalsIgnoreCase(nodeId)) {
-            var indexShard = indicesService.indexServiceSafe(activePrimaryRouting.index())
-                .getShard(activePrimaryRouting.shardId().id());
-            var collectorProvider = shardCollectorProviderFactory.create(indexShard);
-            CompletableFuture<BatchIterator<Row>> it;
+            var indexShard = indicesService.indexServiceSafe(primaryRouting.index())
+                .getShard(primaryRouting.shardId().id());
+            var collectorProvider = collectorFactory.create(indexShard);
             try {
-                it = collectorProvider.getFutureIterator(collectPhase, consumer.requiresScroll(), collectTask);
-            } catch (Exception e) {
-                return Exceptions.rethrowRuntimeException(e);
+                return collectorProvider.getFutureIterator(collectPhase, requiresScroll, collectTask);
+            } catch (Throwable t) {
+                return CompletableFuture.failedFuture(t);
             }
-            it.whenComplete(consumer);
         } else {
-            UUID childJobId = UUIDs.dirtyUUID();
-            RemoteCollector remoteCollector = new RemoteCollector(
-                childJobId,
-                collectTask.txnCtx().sessionSettings(),
-                localNodeId,
-                nodeId,
-                req -> elasticsearchClient.execute(JobAction.INSTANCE, req),
-                req -> elasticsearchClient.execute(KillJobsNodeAction.INSTANCE, req),
-                searchTp,
-                tasksService,
-                collectTask.getRamAccounting(),
-                consumer,
-                createRemoteCollectPhase(childJobId, collectPhase, activePrimaryRouting.shardId(), nodeId)
-            );
-            remoteCollector.doCollect();
+            return CompletableFuture.completedFuture(
+                remoteBatchIterator(primaryRouting, collectPhase, collectTask, collectorFactory));
         }
-        return consumer
-            .completionFuture()
-            .thenApply(rows -> Lists2.mapLazy(rows, Buckets.arrayToSharedRow()));
+    }
+
+    private BatchIterator<Row> remoteBatchIterator(ShardRouting primaryRouting,
+                                                   RoutedCollectPhase collectPhase,
+                                                   CollectTask collectTask,
+                                                   ShardCollectorProviderFactory collectorFactory) {
+        Collector<Row, ?, List<Object[]>> listCollector = Collectors.mapping(Row::materialize, Collectors.toList());
+        CollectingRowConsumer<?, List<Object[]>> consumer = new CollectingRowConsumer<>(listCollector);
+        String nodeId = primaryRouting.currentNodeId();
+        String localNodeId = clusterService.localNode().getId();
+        UUID childJobId = UUIDs.dirtyUUID();
+        RemoteCollector remoteCollector = new RemoteCollector(
+            childJobId,
+            collectTask.txnCtx().sessionSettings(),
+            localNodeId,
+            nodeId,
+            req -> elasticsearchClient.execute(JobAction.INSTANCE, req),
+            req -> elasticsearchClient.execute(KillJobsNodeAction.INSTANCE, req),
+            searchTp,
+            tasksService,
+            collectTask.getRamAccounting(),
+            consumer,
+            createRemoteCollectPhase(childJobId, collectPhase, primaryRouting.shardId(), nodeId)
+        );
+        remoteCollector.doCollect();
+        Runnable onClose = () -> {};
+        return CollectingBatchIterator.newInstance(
+            onClose,
+            killReason -> remoteCollector.kill(killReason),
+            () -> consumer.completionFuture().thenApply(rows -> Lists2.mapLazy(rows, Buckets.arrayToSharedRow())),
+            true
+        );
     }
 
     private static RoutedCollectPhase createRemoteCollectPhase(UUID childJobId,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -36,7 +36,6 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
-import io.crate.common.Suppliers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -62,10 +61,11 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.hppc.cursors.IntCursor;
-import io.crate.common.collections.Iterables;
 
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RowAccountingWithEstimators;
+import io.crate.common.Suppliers;
+import io.crate.common.collections.Iterables;
 import io.crate.concurrent.CompletableFutures;
 import io.crate.data.BatchIterator;
 import io.crate.data.CompositeBatchIterator;
@@ -418,7 +418,13 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
                     if (Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.FETCHID)) {
                         throw e;
                     }
-                    iterators.add(remoteCollectorFactory.createCollector(shardId, collectPhase, collectTask, shardCollectorProviderFactory));
+                    iterators.add(remoteCollectorFactory.createCollector(
+                        shardId,
+                        collectPhase,
+                        collectTask,
+                        shardCollectorProviderFactory,
+                        requiresScroll
+                    ));
                 } catch (IndexNotFoundException e) {
                     // Prevent wrapping this to not break retry-detection
                     throw e;

--- a/server/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.integrationtests;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -35,7 +34,6 @@ import org.junit.Test;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 
 import io.crate.common.unit.TimeValue;
-import io.crate.testing.TestingHelpers;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
 public class RemoteCollectorIntegrationTest extends IntegTestCase {
@@ -79,9 +77,9 @@ public class RemoteCollectorIntegrationTest extends IntegTestCase {
         execute(plan).getResult();
 
         execute("refresh table t");
-        assertThat(TestingHelpers.printedTable(execute("select * from t order by id").rows()),
-            is("1| 20\n" +
-               "2| 40\n")
+        assertThat(execute("select * from t order by id")).hasRows(
+            "1| 20",
+            "2| 40"
         );
     }
 }


### PR DESCRIPTION
`kill` on a `BatchIterator` created with the `RemoteCollectorFactory`
didn't really have any effect. It cancelled a future that was already
completed at that point.

This changes the logic so that a kill on the `BatchIterator` forwards to
`remoteCollector.kill`.

It also optimizes the logic if the shard gets relocated to the same node
again. Previously it would copy & buffer all rows. We can by-pass that
step.


---

*Update*: Second commit also avoids the copy operation for remote collection.