### PR TITLE
Add back SuppressFileSystems to NodeEnvironmentTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -50,6 +51,7 @@ import org.elasticsearch.test.IndexSettingsModule;
 import io.crate.common.collections.Sets;
 import io.crate.common.io.IOUtils;
 
+@LuceneTestCase.SuppressFileSystems("ExtrasFS") // TODO: fix test to allow extras
 public class NodeEnvironmentTests extends ESTestCase {
     private final IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("foo", Settings.EMPTY);
 


### PR DESCRIPTION
Removed this in https://github.com/crate/crate/commit/c08d8151b181ce95a26d4b0e9a8c4bed5ec34bfb
The tests passed after removing it, so I suspected it's no longer needed, but I wasn't accounting for randomization. It's still required.
