### PR TITLE
Remove VIntKeySerializer

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -51,10 +51,10 @@ public final class DiffableUtils {
     }
 
     /**
-     * Returns a map key serializer for Integer keys. Encodes as VInt.
+     * Returns a map key serializer for Integer keys.
      */
-    public static KeySerializer<Integer> getVIntKeySerializer() {
-        return VIntKeySerializer.INSTANCE;
+    public static KeySerializer<Integer> getIntKeySerializer() {
+        return IntKeySerializer.INSTANCE;
     }
 
     /**
@@ -365,6 +365,8 @@ public final class DiffableUtils {
      */
     private static final class IntKeySerializer implements KeySerializer<Integer> {
 
+        private static final IntKeySerializer INSTANCE = new IntKeySerializer();
+
         @Override
         public void writeKey(Integer key, StreamOutput out) throws IOException {
             out.writeInt(key);
@@ -373,26 +375,6 @@ public final class DiffableUtils {
         @Override
         public Integer readKey(StreamInput in) throws IOException {
             return in.readInt();
-        }
-    }
-
-    /**
-     * Serializes Integer keys of a map as a VInt. Requires keys to be positive.
-     */
-    private static final class VIntKeySerializer implements KeySerializer<Integer> {
-        public static final IntKeySerializer INSTANCE = new IntKeySerializer();
-
-        @Override
-        public void writeKey(Integer key, StreamOutput out) throws IOException {
-            if (key < 0) {
-                throw new IllegalArgumentException("Map key [" + key + "] must be positive");
-            }
-            out.writeVInt(key);
-        }
-
-        @Override
-        public Integer readKey(StreamInput in) throws IOException {
-            return in.readVInt();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -653,7 +653,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             aliases = DiffableUtils.diff(before.aliases, after.aliases, DiffableUtils.getStringKeySerializer());
             customData = DiffableUtils.diff(before.customData, after.customData, DiffableUtils.getStringKeySerializer());
             inSyncAllocationIds = DiffableUtils.diff(before.inSyncAllocationIds, after.inSyncAllocationIds,
-                DiffableUtils.getVIntKeySerializer(), DiffableUtils.StringSetValueSerializer.getInstance());
+                DiffableUtils.getIntKeySerializer(), DiffableUtils.StringSetValueSerializer.getInstance());
         }
 
         private static final DiffableUtils.DiffableValueReader<String, AliasMetadata> ALIAS_METADATA_DIFF_VALUE_READER =
@@ -675,7 +675,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             mappings = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), MAPPING_DIFF_VALUE_READER);
             aliases = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), ALIAS_METADATA_DIFF_VALUE_READER);
             customData = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_DIFF_VALUE_READER);
-            inSyncAllocationIds = DiffableUtils.readImmutableOpenIntMapDiff(in, DiffableUtils.getVIntKeySerializer(),
+            inSyncAllocationIds = DiffableUtils.readImmutableOpenIntMapDiff(in, DiffableUtils.getIntKeySerializer(),
                 DiffableUtils.StringSetValueSerializer.getInstance());
         }
 


### PR DESCRIPTION
`VIntKeySerializer.INSTANCE` was using the `IntKeySerializer` class
instead of the `VIntKeySerializer`.

Due to BWC we can't easily fix that. This instead removes the
`VIntKeySerializer` to make it clear that the `IntKeySerializer` is
used.
