### PR TITLE
Fix `ColumnUnknownException` due to missing quotes in a subscript expression

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -83,3 +83,12 @@ Fixes
 
 - Fixed a race condition that could lead to a ``ShardNotFoundException`` when
   executing ``UPDATE`` statements.
+
+- Fixed an issue that caused a ``ColumnUnknownException`` when creating a table
+  with a ``generated column`` involving a subscript expression with a root
+  column name containing upper cases.
+  An example::
+
+    CREATE TABLE t ("OBJ" OBJECT AS (intarray int[]), firstElement AS "OBJ"['intarray'][1]);
+    ColumnUnknownException[Column obj['intarray'] unknown]
+

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -419,7 +419,7 @@ public class Function implements Symbol, Cloneable {
     private void printSubscriptFunction(StringBuilder builder, Style style) {
         Symbol base = arguments.get(0);
         if (base instanceof Reference ref && base.valueType() instanceof ArrayType && ref.column().path().size() > 0) {
-            builder.append(ref.column().name());
+            builder.append(ref.column().getRoot().quotedOutputName());
             builder.append("[");
             builder.append(arguments.get(1).toString(style));
             builder.append("]");


### PR DESCRIPTION
..where the root column contains upper cases.
Example:

```
CREATE TABLE t ("OBJ" OBJECT AS (intarray int[]), firstElement AS "OBJ"['intarray'][1]);
ColumnUnknownException[Column obj['intarray'] unknown]
```

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
