### PR TITLE
Fix some resource leak warnings

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -188,9 +188,9 @@ public class IndexWriterProjector implements Projector {
             }
             assert value instanceof LinkedHashMap<String, Object> : "the raw source order should be preserved";
             Map<String, Object> filteredMap = XContentMapValues.filter(value, includes, excludes);
-            try {
-                BytesReference bytes = BytesReference.bytes(new XContentBuilder(XContentType.JSON.xContent(),
-                    new BytesStreamOutput(lastSourceSize)).map(filteredMap));
+            try (var stream = new BytesStreamOutput(lastSourceSize)) {
+                XContentBuilder xContentBuilder = new XContentBuilder(XContentType.JSON.xContent(), stream);
+                BytesReference bytes = BytesReference.bytes(xContentBuilder.map(filteredMap));
                 lastSourceSize = bytes.length();
                 return bytes.utf8ToString();
             } catch (IOException ex) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeToolCli.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeToolCli.java
@@ -47,6 +47,8 @@ public class NodeToolCli extends MultiCommand {
     }
 
     public static void main(String[] args) throws Exception {
-        exit(new NodeToolCli().main(args, Terminal.DEFAULT));
+        try (var nodeToolCli = new NodeToolCli()) {
+            exit(nodeToolCli.main(args, Terminal.DEFAULT));
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
@@ -19,17 +19,17 @@
 
 package org.elasticsearch.index.translog;
 
-import org.apache.lucene.util.Counter;
-import org.elasticsearch.Assertions;
-import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.index.seqno.SequenceNumbers;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.lucene.util.Counter;
+import org.elasticsearch.Assertions;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 
 public class TranslogDeletionPolicy {
 
@@ -189,7 +189,8 @@ public class TranslogDeletionPolicy {
         int totalFiles = 1; // for the current writer
         for (int i = readers.size() - 1; i >= 0 && totalFiles < maxTotalFiles; i--) {
             totalFiles++;
-            minGen = readers.get(i).generation;
+            TranslogReader translogReader = readers.get(i);
+            minGen = translogReader.generation;
         }
         return minGen;
     }


### PR DESCRIPTION
All false positives from what I can tell because `BytesStreamOutput`
doesn't have any resources to release.
