### PR TITLE
Fix NoSuchFileException in BlobPathITest

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
@@ -29,6 +29,7 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_COMPRESS
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -81,6 +82,7 @@ public abstract class BlobIntegrationTestBase extends IntegTestCase {
                         Path tmpDir = blobShard.blobContainer().getTmpDirectory();
                         try (Stream<Path> files = Files.list(tmpDir)) {
                             assertThat(files.count()).isEqualTo(0L);
+                        } catch (NoSuchFileException ignored) {
                         }
                     }
                 } catch (IOException | IllegalAccessException e) {


### PR DESCRIPTION
    java.lang.RuntimeException: java.nio.file.NoSuchFileException: /tmp/io.crate.integrationtests.BlobPathITest_7A754858D6AC20B7-001/tableBlobPath-002/nodes/0/indices/1MYszJZiSAGGTPtV_wBUFQ/0/blobs/tmp
    	at __randomizedtesting.SeedInfo.seed([7A754858D6AC20B7:BCA62349D8F56702]:0)
    	at io.crate.integrationtests.BlobIntegrationTestBase.lambda$assertNoTmpFilesAndNoIndicesRemaining$0(BlobIntegrationTestBase.java:87)
    	at io.crate.integrationtests.BlobIntegrationTestBase.forEachIndicesMap(BlobIntegrationTestBase.java:101)
    	at io.crate.integrationtests.BlobIntegrationTestBase.lambda$assertNoTmpFilesAndNoIndicesRemaining$1(BlobIntegrationTestBase.java:76)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:703)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:689)
    	at io.crate.integrationtests.BlobIntegrationTestBase.assertNoTmpFilesAndNoIndicesRemaining(BlobIntegrationTestBase.java:76)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004)
    	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
    	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
    	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
    	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
    	at java.base/java.lang.Thread.run(Thread.java:1589)
    Caused by: java.nio.file.NoSuchFileException: /tmp/io.crate.integrationtests.BlobPathITest_7A754858D6AC20B7-001/tableBlobPath-002/nodes/0/indices/1MYszJZiSAGGTPtV_wBUFQ/0/blobs/tmp
    	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
    	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
    	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
    	at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
    	at org.apache.lucene.tests.mockfile.WindowsFS.getKey(WindowsFS.java:59)
    	at org.apache.lucene.tests.mockfile.WindowsFS.onOpen(WindowsFS.java:66)
    	at org.apache.lucene.tests.mockfile.HandleTrackingFS.callOpenHook(HandleTrackingFS.java:82)
    	at org.apache.lucene.tests.mockfile.HandleTrackingFS.newDirectoryStream(HandleTrackingFS.java:332)
    	at java.base/java.nio.file.Files.newDirectoryStream(Files.java:482)
    	at java.base/java.nio.file.Files.list(Files.java:3791)
    	at io.crate.integrationtests.BlobIntegrationTestBase.lambda$assertNoTmpFilesAndNoIndicesRemaining$0(BlobIntegrationTestBase.java:82)
    	... 14 more
