### PR TITLE
Do only one "probe" index creation when inserting into partitioned table

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -74,6 +74,10 @@ Changes
   function for improved PostgreSQL compatibility. CrateDB does not support
   comments for columns, so this function always returns ``NULL``.
 
+- Improved performance of statements that create multiple partitions at once,
+  which can occur during ``COPY FROM`` or INSERTS with multi-values into
+  partitioned tables.
+
 Fixes
 =====
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
@@ -190,8 +190,8 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
      */
     private ClusterState executeCreateIndices(ClusterState currentState, CreatePartitionsRequest request) throws Exception {
         List<String> indicesToCreate = new ArrayList<>(request.indices().size());
-        List<String> removalReasons = new ArrayList<>(request.indices().size());
-        List<Index> createdIndices = new ArrayList<>(request.indices().size());
+        String removalReason = null;
+        Index testIndex = null;
         try {
             validateAndFilterExistingIndices(currentState, indicesToCreate, request);
             if (indicesToCreate.isEmpty()) {
@@ -205,43 +205,51 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
             List<IndexTemplateMetadata> templates = findTemplates(request, currentState);
             applyTemplates(mapping, templatesAliases, templateNames, templates);
 
+            // Use only first index to validate that index can be created.
+            // All indices share same template/settings so no need to repeat validation for each index.
+            String testIndexName = indicesToCreate.get(0);
+            Settings commonIndexSettings = createCommonIndexSettings(currentState, templates);
+            shardLimitValidator.validateShardLimit(commonIndexSettings, currentState);
+            int routingNumShards = IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(commonIndexSettings);
+
+
+            IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(testIndexName)
+                .setRoutingNumShards(routingNumShards);
+
+            // Set up everything, now locally create the index to see that things are ok, and apply
+            final IndexMetadata tmpImd = tmpImdBuilder.settings(Settings.builder()
+                    .put(commonIndexSettings)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())).build();
+            ActiveShardCount waitForActiveShards = tmpImd.getWaitForActiveShards();
+            if (!waitForActiveShards.validate(tmpImd.getNumberOfReplicas())) {
+                throw new IllegalArgumentException("invalid wait_for_active_shards[" + waitForActiveShards +
+                    "]: cannot be greater than number of shard copies [" +
+                    (tmpImd.getNumberOfReplicas() + 1) + "]");
+            }
+            // create the index here (on the master) to validate it can be created, as well as adding the mapping
+            IndexService indexService = indicesService.createIndex(tmpImd, Collections.emptyList(), false);
+            testIndex = indexService.index();
+
+            // now add the mappings
+            MapperService mapperService = indexService.mapperService();
+            if (!mapping.isEmpty()) {
+                try {
+                    mapperService.merge(mapping, MapperService.MergeReason.MAPPING_UPDATE);
+                } catch (MapperParsingException mpe) {
+                    removalReason = "failed on parsing default mapping on index creation";
+                    throw mpe;
+                }
+            }
+
+            // "Probe" creation of the first index passed validation. Now add all indices to the cluster state metadata and update routing.
             Metadata.Builder newMetadataBuilder = Metadata.builder(currentState.metadata());
             for (String index : indicesToCreate) {
-                Settings indexSettings = createIndexSettings(currentState, templates);
-                shardLimitValidator.validateShardLimit(indexSettings, currentState);
-                int routingNumShards = IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(indexSettings);
-
-                String testIndex = indicesToCreate.get(0);
-                IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(testIndex)
-                    .setRoutingNumShards(routingNumShards);
-
-                // Set up everything, now locally create the index to see that things are ok, and apply
-                final IndexMetadata tmpImd = tmpImdBuilder.settings(indexSettings).build();
-                ActiveShardCount waitForActiveShards = tmpImd.getWaitForActiveShards();
-                if (!waitForActiveShards.validate(tmpImd.getNumberOfReplicas())) {
-                    throw new IllegalArgumentException("invalid wait_for_active_shards[" + waitForActiveShards +
-                                                       "]: cannot be greater than number of shard copies [" +
-                                                       (tmpImd.getNumberOfReplicas() + 1) + "]");
-                }
-                // create the index here (on the master) to validate it can be created, as well as adding the mapping
-                IndexService indexService = indicesService.createIndex(tmpImd, Collections.emptyList(), false);
-                createdIndices.add(indexService.index());
-
-                // now add the mappings
-                MapperService mapperService = indexService.mapperService();
-                if (!mapping.isEmpty()) {
-                    try {
-                        mapperService.merge(mapping, MapperService.MergeReason.MAPPING_UPDATE);
-                    } catch (MapperParsingException mpe) {
-                        removalReasons.add("failed on parsing mappings on index creation");
-                        throw mpe;
-                    }
-                }
-
-                // now, update the mappings with the actual source
                 final IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(index)
                     .setRoutingNumShards(routingNumShards)
-                    .settings(indexSettings);
+                    .settings(Settings.builder()
+                        .put(commonIndexSettings)
+                        .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                    );
 
                 DocumentMapper mapper = mapperService.documentMapper();
                 if (mapper != null) {
@@ -257,10 +265,9 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
                 try {
                     indexMetadata = indexMetadataBuilder.build();
                 } catch (Exception e) {
-                    removalReasons.add("failed to build index metadata");
+                    removalReason = "failed to build index metadata";
                     throw e;
                 }
-
 
                 logger.info("[{}] creating index, cause [bulk], templates {}, shards [{}]/[{}]",
                     index, templateNames, indexMetadata.getNumberOfShards(), indexMetadata.getNumberOfReplicas());
@@ -268,7 +275,6 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
                 indexService.getIndexEventListener().beforeIndexAddedToCluster(
                     indexMetadata.getIndex(), indexMetadata.getSettings());
                 newMetadataBuilder.put(indexMetadata, false);
-                removalReasons.add("cleaning up after validating index on master");
             }
 
             Metadata newMetadata = newMetadataBuilder.build();
@@ -281,13 +287,13 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
             return allocationService.reroute(
                 ClusterState.builder(updatedState).routingTable(routingTableBuilder.build()).build(), "bulk-index-creation");
         } finally {
-            for (int i = 0; i < createdIndices.size(); i++) {
-                // Index was already partially created - need to clean up
-                String removalReason = removalReasons.size() > i ? removalReasons.get(i) : "failed to create index";
+            if (testIndex != null) {
+                // "probe" index used for validation was partially created - need to clean up
                 indicesService.removeIndex(
-                    createdIndices.get(i),
+                    testIndex,
                     IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.NO_LONGER_ASSIGNED,
-                    removalReason);
+                    removalReason != null ? removalReason : "failed to create index"
+                );
             }
         }
     }
@@ -327,7 +333,7 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
         }
     }
 
-    private Settings createIndexSettings(ClusterState currentState, List<IndexTemplateMetadata> templates) {
+    private Settings createCommonIndexSettings(ClusterState currentState, List<IndexTemplateMetadata> templates) {
         Settings.Builder indexSettingsBuilder = Settings.builder();
         // apply templates, here, in reverse order, since first ones are better matching
         for (int i = templates.size() - 1; i >= 0; i--) {
@@ -340,8 +346,6 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
         if (indexSettingsBuilder.get(IndexMetadata.SETTING_CREATION_DATE) == null) {
             indexSettingsBuilder.put(IndexMetadata.SETTING_CREATION_DATE, new DateTime(DateTimeZone.UTC).getMillis());
         }
-        indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
-
         return indexSettingsBuilder.build();
     }
 


### PR DESCRIPTION
Already had this in https://github.com/crate/crate/commit/9e12f8142debd84b7bc299ddeda84ab19332d9d7#diff-412bbc8f646dc4a7ba56f15bb144be0cd1e672aa296e0b1451b763728b8d5ebf
(version after bug fix https://github.com/crate/crate/commit/d3c6d8dd68404ae6620eed0daf32bdc1c4066e35)

After https://github.com/crate/crate/commit/7c1133685b294dfd5108bd845242409320e31e9c
we always pick up first index in the loop (see `testIndex = indicesToCreate.get(0)`) and repeat same thing again in other iterations, which can be avoided