### PR TITLE
Differentiate quoted idents with squared brackets from subscript expressions

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -92,6 +92,14 @@ Fixes
 - Fixed a race condition that could lead to a ``ShardNotFoundException`` when
   executing ``UPDATE`` statements.
 
+- Fixed misinterpretations of column names containing square brackets to
+  subscript expressions causing ``SQLParseExceptions``.
+  An example::
+
+    CREATE TABLE g ("""a[1]""" int);
+    SELECT """a[1]""" FROM g;
+    SQLParseException[line 1:3: mismatched input 'a' expecting ... ]
+
 - Fixed an issue that caused a ``ColumnUnknownException`` when creating a table
   with a ``generated column`` involving a subscript expression with a root
   column name containing upper cases.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/13845

Originally, subscript expression detection logic did not consider that the base column could contain square brackets.
The fix uses `SqlParser` to split the given column name into base column and subscript index.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
