### PR TITLE
fix refresh_interval docs, mention correct default value

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -100,6 +100,8 @@ Fixes
     CREATE TABLE t ("OBJ" OBJECT AS (intarray int[]), firstElement AS "OBJ"['intarray'][1]);
     ColumnUnknownException[Column obj['intarray'] unknown]
 
+- Fixed a ``NullPointerException`` which occurs when using NULL as a setting value.
+
 - Fixed a resource leak that could happen when inserting data which causes
   constraints violation or parsing errors.
 

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -385,14 +385,17 @@ automatic background refresh.
 The interval of this background refresh is specified in milliseconds using this
 ``refresh_interval`` setting.
 
-The default is ``null``, which causes tables to be refreshed once every second
-(``1000ms``), but only if the table is not idle. A table can become idle if no
+By default it's not specified, which causes tables to be refreshed once every
+second but only if the table is not idle. A table can become idle if no
 query accesses it for more than 30 seconds.
 
 If a table is idle, the periodic refresh is temporarily disabled. A query
 hitting an idle table will trigger a refresh and enable the periodic refresh
 again.
 
+When ``refresh_interval`` is set explicitly, table is refreshed regardless of
+idle state. Use :ref:`ALTER TABLE RESET <sql-alter-table-set-reset>` to switch
+to default 1 second refresh and freeze-on-idle behavior.
 
 :value:
   The refresh interval in milliseconds. A value smaller or equal than 0

--- a/server/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/server/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -105,6 +105,16 @@ public class GenericPropertiesConverter {
             if (settingHolder == null) {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH, invalidMessage, entry.getKey()));
             }
+            Object value = entry.getValue();
+            if (value == null) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ENGLISH,
+                        "Cannot set NULL to property %s.",
+                        entry.getKey()
+                    )
+                );
+            }
             settingHolder.apply(builder, entry.getValue());
         }
     }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1536,4 +1536,26 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Invalid STORAGE WITH option `foobar`");
     }
+
+    @Test
+    public void test_create_table_validates_null_property() {
+        assertThatThrownBy(() -> analyze("CREATE TABLE tbl (name text) WITH (number_of_replicas = NULL)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot set NULL to property number_of_replicas.");
+    }
+
+    @Test
+    public void test_alter_table_set_mapping_validates_null_property() {
+        // column_policy on table is the only property which is handled not like a setting but like mapping, needs separate test.
+        assertThatThrownBy(() -> analyze("ALTER TABLE users SET (column_policy = null)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot set NULL to property column_policy.");
+    }
+
+    @Test
+    public void test_alter_table_set_setting_validates_null_property() {
+        assertThatThrownBy(() -> analyze("ALTER TABLE users SET (refresh_interval = null)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot set NULL to property refresh_interval.");
+    }
 }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/11742
Closes https://github.com/crate/crate/issues/13848

We cannot check `refresh_interval` via `SHOW CREATE TABLE` since 4.3 (https://github.com/crate/crate/pull/10373/)
I commented https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/analyze/TableParameters.java#L142 just to see it locally and it was   `refresh_interval = 1000` which corresponds to actual default https://github.com/crate/crate/blob/master/server/src/main/java/org/elasticsearch/index/IndexSettings.java#L103-L105






