### PR TITLE
Fix resource leak which can happen in non happy path scenarios

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -100,3 +100,6 @@ Fixes
     CREATE TABLE t ("OBJ" OBJECT AS (intarray int[]), firstElement AS "OBJ"['intarray'][1]);
     ColumnUnknownException[Column obj['intarray'] unknown]
 
+- Fixed a resource leak that could happen when inserting data which causes
+  constraints violation or parsing errors.
+

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -527,106 +527,107 @@ public class Indexer {
             expression.setNextRow(item);
         }
         stream.reset();
-        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder(stream);
-        xContentBuilder.startObject();
-        Object[] values = item.insertValues();
-        for (int i = 0; i < values.length; i++) {
-            Reference reference = columns.get(i);
-            Object value = reference.valueType().valueForInsert(values[i]);
-            ColumnConstraint check = columnConstraints.get(reference.column());
-            if (check != null) {
-                check.verify(value);
-            }
-            if (reference.granularity() == RowGranularity.PARTITION) {
-                continue;
-            }
-            if (value == null) {
-                continue;
-            }
-            ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
-            xContentBuilder.field(reference.column().leafName());
-            valueIndexer.indexValue(
-                value,
-                xContentBuilder,
-                addField,
-                onDynamicColumn,
-                synthetics,
-                columnConstraints
-            );
-        }
-        for (var entry : synthetics.entrySet()) {
-            ColumnIdent column = entry.getKey();
-            if (!column.isTopLevel()) {
-                continue;
-            }
-            Synthetic synthetic = entry.getValue();
-            ValueIndexer<Object> indexer = synthetic.indexer();
-            Object value = synthetic.input().value();
-            if (value == null) {
-                continue;
-            }
-            xContentBuilder.field(column.leafName());
-            indexer.indexValue(
-                value,
-                xContentBuilder,
-                addField,
-                onDynamicColumn,
-                synthetics,
-                columnConstraints
-            );
-        }
-        xContentBuilder.endObject();
-
-        for (var indexColumn : indexColumns) {
-            String fqn = indexColumn.name.fqn();
-            for (var input : indexColumn.inputs) {
-                Object value = input.value();
+        try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder(stream)) {
+            xContentBuilder.startObject();
+            Object[] values = item.insertValues();
+            for (int i = 0; i < values.length; i++) {
+                Reference reference = columns.get(i);
+                Object value = reference.valueType().valueForInsert(values[i]);
+                ColumnConstraint check = columnConstraints.get(reference.column());
+                if (check != null) {
+                    check.verify(value);
+                }
+                if (reference.granularity() == RowGranularity.PARTITION) {
+                    continue;
+                }
                 if (value == null) {
                     continue;
                 }
-                if (value instanceof Iterable<?> it) {
-                    for (Object val : it) {
-                        if (val == null) {
-                            continue;
+                ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
+                xContentBuilder.field(reference.column().leafName());
+                valueIndexer.indexValue(
+                    value,
+                    xContentBuilder,
+                    addField,
+                    onDynamicColumn,
+                    synthetics,
+                    columnConstraints
+                );
+            }
+            for (var entry : synthetics.entrySet()) {
+                ColumnIdent column = entry.getKey();
+                if (!column.isTopLevel()) {
+                    continue;
+                }
+                Synthetic synthetic = entry.getValue();
+                ValueIndexer<Object> indexer = synthetic.indexer();
+                Object value = synthetic.input().value();
+                if (value == null) {
+                    continue;
+                }
+                xContentBuilder.field(column.leafName());
+                indexer.indexValue(
+                    value,
+                    xContentBuilder,
+                    addField,
+                    onDynamicColumn,
+                    synthetics,
+                    columnConstraints
+                );
+            }
+            xContentBuilder.endObject();
+
+            for (var indexColumn : indexColumns) {
+                String fqn = indexColumn.name.fqn();
+                for (var input : indexColumn.inputs) {
+                    Object value = input.value();
+                    if (value == null) {
+                        continue;
+                    }
+                    if (value instanceof Iterable<?> it) {
+                        for (Object val : it) {
+                            if (val == null) {
+                                continue;
+                            }
+                            Field field = new Field(fqn, val.toString(), indexColumn.fieldType);
+                            doc.add(field);
                         }
-                        Field field = new Field(fqn, val.toString(), indexColumn.fieldType);
+                    } else {
+                        Field field = new Field(fqn, value.toString(), indexColumn.fieldType);
                         doc.add(field);
                     }
-                } else {
-                    Field field = new Field(fqn, value.toString(), indexColumn.fieldType);
-                    doc.add(field);
                 }
             }
+
+            for (var constraint : tableConstraints) {
+                constraint.verify(item.insertValues());
+            }
+
+            NumericDocValuesField version = new NumericDocValuesField(DocSysColumns.Names.VERSION, -1L);
+            doc.add(version);
+
+            BytesReference source = BytesReference.bytes(xContentBuilder);
+            BytesRef sourceRef = source.toBytesRef();
+            doc.add(new StoredField("_source", sourceRef.bytes, sourceRef.offset, sourceRef.length));
+
+            BytesRef idBytes = Uid.encodeId(item.id());
+            doc.add(new Field(DocSysColumns.Names.ID, idBytes, IdFieldMapper.Defaults.FIELD_TYPE));
+
+            SequenceIDFields seqID = SequenceIDFields.emptySeqID();
+            // Actual values are set via ParsedDocument.updateSeqID
+            doc.add(seqID.seqNo);
+            doc.add(seqID.seqNoDocValue);
+            doc.add(seqID.primaryTerm);
+            return new ParsedDocument(
+                version,
+                seqID,
+                item.id(),
+                doc,
+                source,
+                null,
+                newColumns
+            );
         }
-
-        for (var constraint : tableConstraints) {
-            constraint.verify(item.insertValues());
-        }
-
-        NumericDocValuesField version = new NumericDocValuesField(DocSysColumns.Names.VERSION, -1L);
-        doc.add(version);
-
-        BytesReference source = BytesReference.bytes(xContentBuilder);
-        BytesRef sourceRef = source.toBytesRef();
-        doc.add(new StoredField("_source", sourceRef.bytes, sourceRef.offset, sourceRef.length));
-
-        BytesRef idBytes = Uid.encodeId(item.id());
-        doc.add(new Field(DocSysColumns.Names.ID, idBytes, IdFieldMapper.Defaults.FIELD_TYPE));
-
-        SequenceIDFields seqID = SequenceIDFields.emptySeqID();
-        // Actual values are set via ParsedDocument.updateSeqID
-        doc.add(seqID.seqNo);
-        doc.add(seqID.seqNoDocValue);
-        doc.add(seqID.primaryTerm);
-        return new ParsedDocument(
-            version,
-            seqID,
-            item.id(),
-            doc,
-            source,
-            null,
-            newColumns
-        );
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -191,8 +191,7 @@ public class IndexWriterProjector implements Projector {
                     Maps.removeByPath(value, Arrays.asList(path));
                 }
             }
-            try (var stream = new BytesStreamOutput(lastSourceSize)) {
-                XContentBuilder xContentBuilder = new XContentBuilder(XContentType.JSON.xContent(), stream);
+            try (XContentBuilder xContentBuilder = new XContentBuilder(XContentType.JSON.xContent(), new BytesStreamOutput(lastSourceSize))) {
                 BytesReference bytes = BytesReference.bytes(xContentBuilder.map(value));
                 lastSourceSize = bytes.length();
                 return bytes.utf8ToString();


### PR DESCRIPTION
As discussed in https://github.com/crate/crate/pull/13834#discussion_r1143569772, `XContentBuilder` must be closed and is closed by `BytesReference.bytes` in case of happy path.

However, `BytesReference.bytes` might be not reached because of some error, say constraints violation in the Indexer or IOException when doing `xContentBuilder.map`

Spot this while debugging test failures in https://github.com/crate/crate/pull/13799#issuecomment-1470237454, object was dirty/not flushed because of not-null violation  == didn't reach `BytesReference.bytes`
