### PR TITLE
Fixed default scroll behaviour of Cursors

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -81,6 +81,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed default behaviour for :ref:`CURSOR <sql-declare>`'s
+  :ref:`SCROLL <sql-declare-scroll>`. When neither ``SCROLL`` nor ``NO SCROLL``
+  is provided in the statement, ``NO SCROLL`` is now assumed.
+
 - Fixed a race condition that could lead to a ``ShardNotFoundException`` when
   executing ``UPDATE`` statements.
 

--- a/docs/sql/statements/declare.rst
+++ b/docs/sql/statements/declare.rst
@@ -71,6 +71,7 @@ Closing a connection closes all cursors created within that connection.
 This clause has no effect in CrateDB
 Cursors in CrateDB are always insensitive.
 
+.. _sql-declare-scroll:
 
 ``[ NO ] SCROLL``
 .................

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -298,7 +298,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
             getIdentText(ctx.ident()),
             hold,
             !declareCursorParams.BINARY().isEmpty(),
-            declareCursorParams.NO().isEmpty(),
+            declareCursorParams.NO().isEmpty() && !declareCursorParams.SCROLL().isEmpty(),
             query
         );
     }

--- a/server/src/test/java/io/crate/analyze/CursorTest.java
+++ b/server/src/test/java/io/crate/analyze/CursorTest.java
@@ -61,6 +61,16 @@ public class CursorTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_scroll_and_no_scroll() {
+        AnalyzedDeclare declare = executor.analyze("DECLARE c1 CURSOR FOR SELECT 1");
+        assertThat(declare.declare().scroll()).isFalse();
+        declare = executor.analyze("DECLARE c1 NO SCROLL CURSOR FOR SELECT 1");
+        assertThat(declare.declare().scroll()).isFalse();
+        declare = executor.analyze("DECLARE c1 SCROLL CURSOR FOR SELECT 1");
+        assertThat(declare.declare().scroll()).isTrue();
+    }
+
+    @Test
     public void test_explicit_binary_mode_is_not_supported() {
         // binary mode from pg-wire is possible, but not via HTTP; so we forbid it on a statement level
         assertThatThrownBy(() -> executor.analyze("declare c1 binary cursor for select 1"))

--- a/server/src/test/java/io/crate/integrationtests/CursorITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CursorITest.java
@@ -84,7 +84,7 @@ public class CursorITest extends IntegTestCase {
             Statement statement = conn.createStatement();
             conn.setAutoCommit(false);
 
-            String declare = "declare c1 cursor for select * from generate_series(1, 10)";
+            String declare = "declare c1 scroll cursor for select * from generate_series(1, 10)";
             statement.execute(declare);
             ResultSet result = statement.executeQuery("FETCH ALL FROM c1");
             int nextExpectedResult = 1;


### PR DESCRIPTION
Previously, if `SCROLL/NO SCROLL` was missing in the statement, `scroll = true` was passed in because of an incomplete check on the parsed AST node.

Fixes: #13856
