### PR TITLE
turn fulltext indices mapping metadata entry from Map to List

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -535,10 +535,6 @@ public class AnalyzedColumnDefinition<T> {
         return isNotNull;
     }
 
-    Map<String, Object> toMetaIndicesMapping() {
-        return Map.of();
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -123,11 +123,11 @@ public class AnalyzedTableElements<T> {
         final Map<String, Object> properties = new HashMap<>(elements.columns.size());
 
         Map<String, String> generatedColumns = new HashMap<>();
-        Map<String, Object> indicesMap = new HashMap<>();
+        List<String> indices = new ArrayList<>();
         for (AnalyzedColumnDefinition<Object> column : elements.columns) {
             properties.put(column.name(), AnalyzedColumnDefinition.toMapping(column));
             if (column.isIndexColumn()) {
-                indicesMap.put(column.name(), column.toMetaIndicesMapping());
+                indices.add(column.name());
             }
             addToGeneratedColumns("", column, generatedColumns);
         }
@@ -135,8 +135,8 @@ public class AnalyzedTableElements<T> {
         if (!elements.partitionedByColumns.isEmpty()) {
             meta.put("partitioned_by", elements.partitionedBy());
         }
-        if (!indicesMap.isEmpty()) {
-            meta.put("indices", indicesMap);
+        if (!indices.isEmpty()) {
+            meta.put("indices", indices);
         }
         if (!primaryKeys(elements).isEmpty()) {
             meta.put("primary_keys", primaryKeys(elements));

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -115,7 +115,7 @@ public class DocIndexMetadata {
     private final int numberOfShards;
     private final String numberOfReplicas;
     private final Settings tableParameters;
-    private final Map<String, Object> indicesMap;
+    private final List<String> ftIndices;
     private final List<ColumnIdent> partitionedBy;
     private final Set<Operation> supportedOperations;
     private Map<ColumnIdent, IndexReference> indices;
@@ -153,7 +153,7 @@ public class DocIndexMetadata {
         this.tableParameters = metadata.getSettings();
 
         Map<String, Object> metaMap = Maps.get(mappingMap, "_meta");
-        indicesMap = Maps.getOrDefault(metaMap, "indices", Map.of());
+        ftIndices = Maps.getOrDefault(metaMap, "indices", List.of());
         List<List<String>> partitionedByList = Maps.getOrDefault(metaMap, "partitioned_by", List.of());
         this.partitionedBy = getPartitionedBy(partitionedByList);
         generatedColumns = Maps.getOrDefault(metaMap, "generated_columns", Map.of());
@@ -514,7 +514,7 @@ public class DocIndexMetadata {
                     }
                 }
                 // is it an index?
-                if (indicesMap.containsKey(newIdent.fqn())) {
+                if (ftIndices.contains(newIdent.fqn())) {
                     IndexReference.Builder builder = getOrCreateIndexBuilder(newIdent);
                     builder.indexType(columnIndexType)
                         .analyzer((String) columnProperties.get("analyzer"));

--- a/server/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
@@ -72,6 +72,7 @@ public class IndexTemplateUpgrader implements UnaryOperator<Map<String, IndexTem
      * by {@link IndexTemplateMetadata.Builder#fromXContent} logic to prefix all settings with `index.` when applying
      * the new cluster state.
      */
+    @SuppressWarnings("unchecked")
     private HashMap<String, IndexTemplateMetadata> archiveUnknownOrInvalidSettings(Map<String, IndexTemplateMetadata> templates) {
         HashMap<String, IndexTemplateMetadata> upgradedTemplates = new HashMap<>(templates.size());
         for (Map.Entry<String, IndexTemplateMetadata> entry : templates.entrySet()) {
@@ -101,6 +102,13 @@ public class IndexTemplateUpgrader implements UnaryOperator<Map<String, IndexTem
                     // Support for `_all` was removed (in favour of `copy_to`.
                     // We never utilized this but always set `_all: {enabled: false}` if you created a table using SQL in earlier version, so we can safely drop it.
                     defaultMapping.remove("_all");
+                    updated = true;
+                }
+                Map<String, Object> meta = (Map<String, Object>) defaultMapping.get("_meta");
+                Map<String, Object> indices = meta != null ? (Map<String, Object>) meta.get("indices") : null;
+                if (indices != null) {
+                    meta.put("indices",  indices.keySet());
+                    defaultMapping.put("_meta", meta);
                     updated = true;
                 }
                 if (updated) {

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -68,6 +68,7 @@ public class MetadataIndexUpgrader implements BiFunction<IndexMetadata, IndexTem
     }
 
     @VisibleForTesting
+    @SuppressWarnings("unchecked")
     MappingMetadata createUpdatedIndexMetadata(MappingMetadata mappingMetadata, String indexName, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
         if (mappingMetadata == null) { // blobs have no mappingMetadata
             return null;
@@ -84,6 +85,15 @@ public class MetadataIndexUpgrader implements BiFunction<IndexMetadata, IndexTem
 
                 case "_all":
                     break; // `_all` is no longer supported and via CREATE TABLE we always set `_all: {enabled: false}` which is safe to remove.
+
+                case "_meta":
+                    Map<String, Object> meta = (Map<String, Object>) fieldNode;
+                    Map<String, Object> indices = (Map<String, Object>) meta.get("indices");
+                    if (indices != null) {
+                        meta.put("indices",  indices.keySet());
+                        newMapping.put(fieldName, meta);
+                    }
+                    break;
 
                 default:
                     newMapping.put(fieldName, fieldNode);

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
@@ -30,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -775,18 +775,15 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             ")");
         Map<String, Object> metaMap = (Map) analysis.mapping().get("_meta");
         assertThat(
-            metaMap.get("indices").toString(),
-            is("{ft={}}"));
+            metaMap.get("indices").toString()).isEqualTo("[ft]");
         assertThat(
             (List<String>) ((Map<String, Object>) analysis.mappingProperties()
-                .get("title")).get("copy_to"),
-            hasItem("ft")
-        );
+            .get("title"))
+            .get("copy_to")).containsExactly("ft");
         assertThat(
             (List<String>) ((Map<String, Object>) analysis.mappingProperties()
-                .get("name")).get("copy_to"),
-            hasItem("ft"));
-
+                .get("name"))
+                .get("copy_to")).containsExactly("ft");
     }
 
     @Test(expected = ColumnUnknownException.class)


### PR DESCRIPTION
Somewhat pre-requisite (optional but a bit helpful) for CREATE TABLE [refactoring](https://github.com/crate/crate/pull/13862/files#diff-1ebd2a3384d60ba10343d861738736c8f9785f44c2ef5de0aa6a56dc901f96a7R50-R62).

We can already pack `CreateTableRequest`  as `AddColumnRequest` + settings/indices/copy_to/partitionedBy/routing. 

`AddColumnRequest` supports adding multiple cols and we even have an utility method to create a request out of many `AnalyzedColumnDefinition`  after https://github.com/crate/crate/issues/7687

I was going to add `copy_to`, `indices` to the `CreateTableRequest` and noticed that `indicesMap` has always empty map as a value, we can already simplify it (to simplify streaming of "indices" and in general reduce overhead)




