### PR TITLE
Remove undocumented index.store.preload setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -110,7 +110,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING,
         MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING,
         IndexModule.INDEX_STORE_TYPE_SETTING,
-        IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
         IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING,
         FsDirectoryFactory.INDEX_LOCK_FACTOR_SETTING,
         EngineConfig.INDEX_CODEC_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -80,13 +80,6 @@ public final class IndexModule {
     public static final Setting<String> INDEX_STORE_TYPE_SETTING =
             new Setting<>("index.store.type", "fs", Function.identity(), DataTypes.STRING, Property.IndexScope, Property.NodeScope, Property.Final);
 
-    /** On which extensions to load data into the file-system cache upon opening of files.
-     *  This only works with the mmap directory, and even in that case is still
-     *  best-effort only. */
-    public static final Setting<List<String>> INDEX_STORE_PRE_LOAD_SETTING =
-            Setting.listSetting("index.store.preload", Collections.emptyList(), Function.identity(),
-                    DataTypes.STRING_ARRAY, Property.IndexScope, Property.NodeScope);
-
     // whether to use the query cache
     public static final Setting<Boolean> INDEX_QUERY_CACHE_ENABLED_SETTING =
             Setting.boolSetting("index.queries.cache.enabled", true, Property.IndexScope);

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -19,25 +19,17 @@
 
 package org.elasticsearch.index.store;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Locale;
 
-import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NoLockFactory;
-import org.apache.lucene.store.SleepingLockWrapper;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -45,86 +37,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class FsDirectoryFactoryTests extends ESTestCase {
 
-
-    @Test
-    public void testPreload() throws IOException {
-        doTestPreload();
-        doTestPreload("nvd", "dvd", "tim");
-        doTestPreload("*");
-        Settings build = Settings.builder()
-            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.HYBRIDFS.name().toLowerCase(Locale.ROOT))
-            .putList(IndexModule.INDEX_STORE_PRE_LOAD_SETTING.getKey(), "dvd", "bar")
-            .build();
-        try (Directory directory = newDirectory(build)) {
-            assertTrue(FsDirectoryFactory.isHybridFs(directory));
-            FsDirectoryFactory.HybridDirectory hybridDirectory = (FsDirectoryFactory.HybridDirectory) directory;
-            assertTrue(hybridDirectory.useDelegate("foo.dvd"));
-            assertTrue(hybridDirectory.useDelegate("foo.nvd"));
-            assertTrue(hybridDirectory.useDelegate("foo.tim"));
-            assertTrue(hybridDirectory.useDelegate("foo.tip"));
-            assertTrue(hybridDirectory.useDelegate("foo.cfs"));
-            assertTrue(hybridDirectory.useDelegate("foo.dim"));
-            assertTrue(hybridDirectory.useDelegate("foo.kdd"));
-            assertTrue(hybridDirectory.useDelegate("foo.kdi"));
-            assertFalse(hybridDirectory.useDelegate("foo.bar"));
-            MMapDirectory delegate = hybridDirectory.getDelegate();
-            assertThat(delegate, Matchers.instanceOf(FsDirectoryFactory.PreLoadMMapDirectory.class));
-            FsDirectoryFactory.PreLoadMMapDirectory preLoadMMapDirectory = (FsDirectoryFactory.PreLoadMMapDirectory) delegate;
-            assertTrue(preLoadMMapDirectory.useDelegate("foo.dvd"));
-            assertTrue(preLoadMMapDirectory.useDelegate("foo.bar"));
-        }
-    }
-
-    private Directory newDirectory(Settings settings) throws IOException {
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("foo", settings);
-        Path tempDir = createTempDir().resolve(idxSettings.getUUID()).resolve("0");
-        Files.createDirectories(tempDir);
-        ShardPath path = new ShardPath(false, tempDir, tempDir, new ShardId(idxSettings.getIndex(), 0));
-        return new FsDirectoryFactory().newDirectory(idxSettings, path);
-     }
-
-    private void doTestPreload(String...preload) throws IOException {
-        Settings build = Settings.builder()
-            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), "mmapfs")
-            .putList(IndexModule.INDEX_STORE_PRE_LOAD_SETTING.getKey(), preload)
-            .build();
-        Directory directory = newDirectory(build);
-        try (Directory dir = directory){
-            assertSame(dir, directory); // prevent warnings
-            assertFalse(directory instanceof SleepingLockWrapper);
-            if (preload.length == 0) {
-                assertTrue(directory.toString(), directory instanceof MMapDirectory);
-                assertFalse(((MMapDirectory) directory).getPreload());
-            } else if (Arrays.asList(preload).contains("*")) {
-                assertTrue(directory.toString(), directory instanceof MMapDirectory);
-                assertTrue(((MMapDirectory) directory).getPreload());
-            } else {
-                assertTrue(directory.toString(), directory instanceof FsDirectoryFactory.PreLoadMMapDirectory);
-                FsDirectoryFactory.PreLoadMMapDirectory preLoadMMapDirectory = (FsDirectoryFactory.PreLoadMMapDirectory) directory;
-                for (String ext : preload) {
-                    assertTrue("ext: " + ext, preLoadMMapDirectory.useDelegate("foo." + ext));
-                    assertTrue("ext: " + ext, preLoadMMapDirectory.getDelegate().getPreload());
-                }
-                assertFalse(preLoadMMapDirectory.useDelegate("XXX"));
-                assertFalse(preLoadMMapDirectory.getPreload());
-                preLoadMMapDirectory.close();
-                expectThrows(
-                    AlreadyClosedException.class,
-                    () -> preLoadMMapDirectory.getDelegate().openInput("foo.bar", IOContext.DEFAULT));
-            }
-        }
-        expectThrows(AlreadyClosedException.class, () -> directory.openInput(randomBoolean() && preload.length != 0 ?
-            "foo." + preload[0] : "foo.bar", IOContext.DEFAULT));
-    }
 
     @Test
     public void testStoreDirectory() throws IOException {


### PR DESCRIPTION
`getPreload` and `setPreload(boolean)` are deprecated. There is a new
`setPreload(BiPredicate<String, IOContext> preload)` that replaces the
`boolean` version and we could adapt the code, but given that the
setting is not documented this instead removes the functionality.
