### PR TITLE
Fix QuerySplitter from losing previous query parts

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -105,6 +105,13 @@ Fixes
 - Fixed a race condition that could lead to a ``ShardNotFoundException`` when
   executing ``UPDATE`` statements.
 
+- Fixed an issue that caused a subset of a ``WHERE`` clause to be lost from a
+  ``JOIN`` statement. The first trigger condition was using a column by itself
+  as a boolean expression. For example from ``WHERE NOT b AND c`` the column
+  ``c`` representing a boolean expression ``c = TRUE`` overrode ``NOT b``. The
+  second trigger condition was :ref:`MATCH predicate <predicates_match>`
+  which also overrode preceding ``WHERE`` conditions.
+
 - Fixed an issue that caused a ``ColumnUnknownException`` when creating a table
   with a ``generated column`` involving a subscript expression with a root
   column name containing upper cases.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes #13888

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
