### PR TITLE
Prune columns of scalar sub-queries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -91,6 +91,13 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed a performance regression for queries that used a scalar sub-query in the
+  ``WHERE`` which itself also filtered on columns in a ``WHERE`` without
+  selecting those columns. An example::
+
+    SELECT name FROM users
+      WHERE id IN (SELECT user_id FROM hits WHERE ts > '2023-01-01')
+
 - Fixed default behaviour for :ref:`CURSOR <sql-declare>`'s
   :ref:`SCROLL <sql-declare-scroll>`. When neither ``SCROLL`` nor ``NO SCROLL``
   is provided in the statement, ``NO SCROLL`` is now assumed.

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.DriverManager;
@@ -316,8 +317,8 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "            └ Eval[oid]\n" +
             "              └ Limit[2::bigint;0::bigint]\n" +
             "                └ NestedLoopJoin[INNER | (oid = relnamespace)]\n" +
-            "                  ├ Collect[pg_catalog.pg_class | [oid, relnamespace, relname] | (relname = table_name)]\n" +
-            "                  └ Collect[pg_catalog.pg_namespace | [oid, nspname] | (nspname = table_schema)]\n"
+            "                  ├ Collect[pg_catalog.pg_class | [oid, relnamespace] | (relname = table_name)]\n" +
+            "                  └ Collect[pg_catalog.pg_namespace | [oid] | (nspname = table_schema)]\n"
         );
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
@@ -369,8 +370,8 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "              └ Eval[oid]\n" +
             "                └ Limit[2::bigint;0::bigint]\n" +
             "                  └ NestedLoopJoin[INNER | (oid = relnamespace)]\n" +
-            "                    ├ Collect[pg_catalog.pg_class | [oid, relnamespace, relname] | (relname = table_name)]\n" +
-            "                    └ Collect[pg_catalog.pg_namespace | [oid, nspname] | (nspname = table_schema)]\n" +
+            "                    ├ Collect[pg_catalog.pg_class | [oid, relnamespace] | (relname = table_name)]\n" +
+            "                    └ Collect[pg_catalog.pg_namespace | [oid] | (nspname = table_schema)]\n" +
             "          └ SubPlan\n" +
             "            └ Eval[attrelid]\n" +
             "              └ Limit[2::bigint;0::bigint]\n" +
@@ -402,7 +403,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "      └ SubPlan",
             "        └ Eval[1]",
             "          └ Limit[1;0]",
-            "            └ Collect[doc.b | [1, f1, f2, f3] | (((f1 = f1) AND (f2 = f2)) AND (f3 = 'c'))]"
+            "            └ Collect[doc.b | [1] | (((f1 = f1) AND (f2 = f2)) AND (f3 = 'c'))]"
         );
         assertThat(execute(stmt)).hasRows(
             "1"

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -499,9 +499,9 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                     └ Collect[sys.summits | [mountain, height] | (country = 'DE')]
                   └ SubPlan
                     └ Eval[1]
-                      └ Rename[1, height] AS b
+                      └ Rename[1] AS b
                         └ Limit[1;0]
-                          └ Collect[sys.summits | [1, height] | (height = height)]
+                          └ Collect[sys.summits | [1] | (height = height)]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
     }


### PR DESCRIPTION
The PRs:

https://github.com/crate/crate/pull/13668
https://github.com/crate/crate/pull/13712

Added columns used in the where clause to the select list to make them
available for parent operators.

The idea was that they'd get pruned if not required, but we didn't
prune columns of a scalar-subquery. This led to a ~5%(?) performance
decrease on some of our benchmarks (`in_subquery.toml`).
