### PR TITLE
Add a new grammar for parsing quoted subscript expressions

### DIFF
--- a/libs/sql-parser/src/main/antlr/QuotedSubscriptExpression.g4
+++ b/libs/sql-parser/src/main/antlr/QuotedSubscriptExpression.g4
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+grammar QuotedSubscriptExpression;
+
+quotedSubscriptExpression
+    : baseColumn subscript
+    ;
+
+subscript
+    : ARRAY_SUBSCRIPT
+    | OBJECT_SUBSCRIPT
+    ;
+
+baseColumn
+    : UNQUOTED_COLUMN
+    | QUOTED_COLUMN
+    ;
+
+ARRAY_SUBSCRIPT
+    : '[' DIGIT+ ']'
+    ;
+
+OBJECT_SUBSCRIPT
+    : '[\'' ( ~'\'' | '\'\'' )* '\']'
+    ;
+
+UNQUOTED_COLUMN
+    : (LETTER | '_') (LETTER | DIGIT | '_' | '@')*
+    ;
+
+QUOTED_COLUMN
+    : '"' ( ~'"' | '""' )* '"'
+    ;
+
+fragment DIGIT
+    : [0-9]
+    ;
+
+fragment LETTER
+    : [A-Za-z]
+    ;

--- a/libs/sql-parser/src/main/antlr/QuotedSubscriptExpression.g4
+++ b/libs/sql-parser/src/main/antlr/QuotedSubscriptExpression.g4
@@ -21,8 +21,8 @@
 
 grammar QuotedSubscriptExpression;
 
-quotedSubscriptExpression
-    : baseColumn subscript
+subscriptExpression
+    : baseColumn subscript+
     ;
 
 subscript

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1946,9 +1946,13 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
 
     @Override
     public Node visitDereference(SqlBaseParser.DereferenceContext context) {
-        return new QualifiedNameReference(
-            QualifiedName.of(identsToStrings(context.ident()))
-        );
+        List<String> identStrings = identsToStrings(context.ident());
+        String columnName = identStrings.get(identStrings.size() - 1);
+        Node subscriptExpression = detectQuotedSubscriptExpression(columnName);
+        if (subscriptExpression != null) {
+            return subscriptExpression;
+        }
+        return new QualifiedNameReference(QualifiedName.of(identStrings));
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1961,7 +1961,12 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
 
     @Override
     public Node visitColumnReference(SqlBaseParser.ColumnReferenceContext context) {
-        return new QualifiedNameReference(QualifiedName.of(getIdentText(context.ident())));
+        String processedIdent = getIdentText(context.ident());
+        Node subscriptExpression = detectQuotedSubscriptExpression(processedIdent);
+        if (subscriptExpression != null) {
+            return subscriptExpression;
+        }
+        return new QualifiedNameReference(QualifiedName.of(processedIdent));
     }
 
     @Override
@@ -2487,5 +2492,9 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
             default:
                 throw new IllegalArgumentException("Unsupported bound type: " + token.getText());
         }
+    }
+
+    private static Node detectQuotedSubscriptExpression(String expression) {
+        return QuotedSubscriptExpressionParser.detectQuotedSubscriptExpressions(expression);
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionASTBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionASTBuilder.java
@@ -34,11 +34,12 @@ import io.crate.sql.tree.SubscriptExpression;
 
 public class QuotedSubscriptExpressionASTBuilder extends QuotedSubscriptExpressionBaseVisitor<Node> {
     @Override
-    public Node visitQuotedSubscriptExpression(QuotedSubscriptExpressionParser.QuotedSubscriptExpressionContext ctx) {
-        return new SubscriptExpression(
-            new QualifiedNameReference(new QualifiedName(ctx.baseColumn().getText())),
-            (Expression) visitSubscript(ctx.subscript())
-        );
+    public Node visitSubscriptExpression(QuotedSubscriptExpressionParser.SubscriptExpressionContext ctx) {
+        Expression baseExpression = new QualifiedNameReference(new QualifiedName(ctx.baseColumn().getText()));
+        for (var subscript : ctx.subscript()) {
+            baseExpression = new SubscriptExpression(baseExpression, (Expression) visitSubscript(subscript));
+        }
+        return baseExpression;
     }
 
     @Override
@@ -59,4 +60,6 @@ public class QuotedSubscriptExpressionASTBuilder extends QuotedSubscriptExpressi
     public Node visitBaseColumn(QuotedSubscriptExpressionParser.BaseColumnContext ctx) {
         return new StringLiteral(ctx.getText());
     }
+
+
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionASTBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionASTBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.parser;
+
+import io.crate.sql.parser.antlr.v4.QuotedSubscriptExpressionBaseVisitor;
+import io.crate.sql.parser.antlr.v4.QuotedSubscriptExpressionParser;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.IntegerLiteral;
+import io.crate.sql.tree.LongLiteral;
+import io.crate.sql.tree.Node;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.StringLiteral;
+import io.crate.sql.tree.SubscriptExpression;
+
+public class QuotedSubscriptExpressionASTBuilder extends QuotedSubscriptExpressionBaseVisitor<Node> {
+    @Override
+    public Node visitQuotedSubscriptExpression(QuotedSubscriptExpressionParser.QuotedSubscriptExpressionContext ctx) {
+        return new SubscriptExpression(
+            new QualifiedNameReference(new QualifiedName(ctx.baseColumn().getText())),
+            (Expression) visitSubscript(ctx.subscript())
+        );
+    }
+
+    @Override
+    public Node visitSubscript(QuotedSubscriptExpressionParser.SubscriptContext ctx) {
+        if (ctx.ARRAY_SUBSCRIPT() == null) {
+            String objectSubscript = ctx.OBJECT_SUBSCRIPT().getText();
+            return new StringLiteral(objectSubscript.substring(2, objectSubscript.length() - 2));
+        }
+        String arraySubscript = ctx.ARRAY_SUBSCRIPT().getText();
+        long value = Long.parseLong(arraySubscript.substring(1, arraySubscript.length() - 1));
+        if (value < Integer.MAX_VALUE + 1L) {
+            return new IntegerLiteral((int) value);
+        }
+        return new LongLiteral(value);
+    }
+
+    @Override
+    public Node visitBaseColumn(QuotedSubscriptExpressionParser.BaseColumnContext ctx) {
+        return new StringLiteral(ctx.getText());
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionASTBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionASTBuilder.java
@@ -60,6 +60,4 @@ public class QuotedSubscriptExpressionASTBuilder extends QuotedSubscriptExpressi
     public Node visitBaseColumn(QuotedSubscriptExpressionParser.BaseColumnContext ctx) {
         return new StringLiteral(ctx.getText());
     }
-
-
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionParser.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionParser.java
@@ -67,14 +67,14 @@ public class QuotedSubscriptExpressionParser {
             try {
                 // first, try parsing with potentially faster SLL mode
                 parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
-                tree = parser.quotedSubscriptExpression();
+                tree = parser.subscriptExpression();
             } catch (ParseCancellationException ex) {
                 // if we fail, parse with LL mode
                 tokenStream.seek(0); // rewind input stream
                 parser.reset();
 
                 parser.getInterpreter().setPredictionMode(PredictionMode.LL);
-                tree = parser.quotedSubscriptExpression();
+                tree = parser.subscript();
             }
 
             return new QuotedSubscriptExpressionASTBuilder().visit(tree);

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionParser.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/QuotedSubscriptExpressionParser.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.parser;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+
+import io.crate.sql.parser.antlr.v4.QuotedSubscriptExpressionLexer;
+import io.crate.sql.tree.Node;
+
+public class QuotedSubscriptExpressionParser {
+    private static final BaseErrorListener ERROR_LISTENER = new BaseErrorListener() {
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line,
+                                int charPositionInLine, String message, RecognitionException e) {
+            throw new ParsingException(message, e, line, charPositionInLine);
+        }
+    };
+
+    public static Node detectQuotedSubscriptExpressions(String expression) {
+        try {
+            return invokeParser("subscript expression", expression);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Node invokeParser(String name, String expression) {
+        try {
+            var lexer = new QuotedSubscriptExpressionLexer(
+                new CaseInsensitiveStream(CharStreams.fromString(expression, name)));
+            var tokenStream = new CommonTokenStream(lexer);
+            var parser = new io.crate.sql.parser.antlr.v4.QuotedSubscriptExpressionParser(tokenStream);
+
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(ERROR_LISTENER);
+
+            parser.removeErrorListeners();
+            parser.addErrorListener(ERROR_LISTENER);
+
+            ParserRuleContext tree;
+            try {
+                // first, try parsing with potentially faster SLL mode
+                parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+                tree = parser.quotedSubscriptExpression();
+            } catch (ParseCancellationException ex) {
+                // if we fail, parse with LL mode
+                tokenStream.seek(0); // rewind input stream
+                parser.reset();
+
+                parser.getInterpreter().setPredictionMode(PredictionMode.LL);
+                tree = parser.quotedSubscriptExpression();
+            }
+
+            return new QuotedSubscriptExpressionASTBuilder().visit(tree);
+        } catch (StackOverflowError e) {
+            throw new ParsingException(name + " is too large (stack overflow while parsing)");
+        }
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/QualifiedName.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/QualifiedName.java
@@ -33,6 +33,7 @@ import java.util.stream.StreamSupport;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
+// TODO: here or some other class should also check for invalid column name: subscript pattern?
 public class QualifiedName {
 
     private final List<String> parts;

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1263,10 +1263,10 @@ public class ExpressionAnalyzer {
 
     @Nullable
     private static String detectAndSanitizeQuotedSubscript(String columnName) {
-        var openSubscriptPos = columnName.indexOf("[");
-        if (openSubscriptPos > -1) {
-            return "\"" + columnName.substring(0, openSubscriptPos) + "\"" + columnName.substring(openSubscriptPos);
-        }
+//        var openSubscriptPos = columnName.indexOf("[");
+//        if (openSubscriptPos > -1) {
+//            return "\"" + columnName.substring(0, openSubscriptPos) + "\"" + columnName.substring(openSubscriptPos);
+//        }
         return null;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
