### PR TITLE
bp: Fix race in testSendSnapshotSendsOps

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -258,7 +258,9 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                                                 long mappingVersion,
                                                 ActionListener<Long> listener) {
                 shippedOps.addAll(operations);
-                checkpointOnTarget.set(randomLongBetween(checkpointOnTarget.get(), Long.MAX_VALUE));
+                if (randomBoolean()) {
+                    checkpointOnTarget.addAndGet(between(1, 20));
+                }
                 listener.onResponse(checkpointOnTarget.get());
             }
         };


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/commit/0031dea9cc7b6996a7c215a87a4de023d88af040

    java.lang.AssertionError:
    Expected: <9222372812421576570L>
         but: was <9222800322437233413L>
    	at __randomizedtesting.SeedInfo.seed([FFF910B6C6F2D7A:489CD777B7764B27]:0)
    	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
    	at org.junit.Assert.assertThat(Assert.java:964)
    	at org.junit.Assert.assertThat(Assert.java:930)
    	at org.elasticsearch.indices.recovery.RecoverySourceHandlerTests.testSendSnapshotSendsOps(RecoverySourceHandlerTests.java:288)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
