### PR TITLE
Fix resume handling for pgwire protocol level fetch

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -93,6 +93,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue in the PostgreSQL wire protocol implementation that could
+  prevent protocol level fetch from working correctly with some clients. An
+  example client is `pg-cursor <https://www.npmjs.com/package/pg-cursor>`_.
+
 - Fixed an issue that a wrong HTTP response was sent, when trying to ``POST`` to
   an invalid URL, causing the HTTP client to stall.
 

--- a/server/src/main/java/io/crate/action/sql/BaseResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/BaseResultReceiver.java
@@ -21,11 +21,11 @@
 
 package io.crate.action.sql;
 
-import io.crate.data.Row;
-import io.crate.protocols.postgres.ClientInterrupted;
+import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
-import java.util.concurrent.CompletableFuture;
+
+import io.crate.data.Row;
 
 public class BaseResultReceiver implements ResultReceiver<Void> {
 
@@ -41,12 +41,8 @@ public class BaseResultReceiver implements ResultReceiver<Void> {
 
     @Override
     @OverridingMethodsMustInvokeSuper
-    public void allFinished(boolean interrupted) {
-        if (interrupted) {
-            completionFuture.completeExceptionally(new ClientInterrupted());
-        } else {
-            completionFuture.complete(null);
-        }
+    public void allFinished() {
+        completionFuture.complete(null);
     }
 
     @Override

--- a/server/src/main/java/io/crate/action/sql/CollectingResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/CollectingResultReceiver.java
@@ -60,7 +60,7 @@ public final class CollectingResultReceiver<A, R> implements ResultReceiver<R> {
     }
 
     @Override
-    public void allFinished(boolean interrupted) {
+    public void allFinished() {
         result.complete(finisher.apply(state));
     }
 

--- a/server/src/main/java/io/crate/action/sql/ResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/ResultReceiver.java
@@ -35,10 +35,8 @@ public interface ResultReceiver<T> extends CompletionListenable<T> {
 
     /**
      * Called when receiver finished.
-     * @param interrupted indicates whether the receiver finished because all results were pushed (false)
-     *                    or receiving results was prematurely interrupted (true).
      */
-    void allFinished(boolean interrupted);
+    void allFinished();
 
     void fail(Throwable t);
 }

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -499,8 +499,9 @@ public class Messages {
 
     /**
      * Send a message that just contains the msgType and the msg length
+     * @return
      */
-    private static void sendShortMsg(Channel channel, char msgType, final String traceLogMsg) {
+    private static ChannelFuture sendShortMsg(Channel channel, char msgType, final String traceLogMsg) {
         ByteBuf buffer = channel.alloc().buffer(5);
         buffer.writeByte(msgType);
         buffer.writeInt(4);
@@ -509,10 +510,11 @@ public class Messages {
         if (LOGGER.isTraceEnabled()) {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace(traceLogMsg));
         }
+        return channelFuture;
     }
 
-    static void sendPortalSuspended(Channel channel) {
-        sendShortMsg(channel, 's', "sentPortalSuspended");
+    static ChannelFuture sendPortalSuspended(Channel channel) {
+        return sendShortMsg(channel, 's', "sentPortalSuspended");
     }
 
     /**

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -266,11 +266,7 @@ public class PostgresWireProtocol {
 
         @Override
         public void accept(Object result, Throwable t) {
-            boolean clientInterrupted = t instanceof ClientInterrupted
-                                        || (t != null && t.getCause() instanceof ClientInterrupted);
-            if (!clientInterrupted) {
-                sendReadyForQuery(channel, transactionState);
-            }
+            sendReadyForQuery(channel, transactionState);
         }
     }
 

--- a/server/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
@@ -21,25 +21,26 @@
 
 package io.crate.protocols.postgres;
 
-import io.crate.Constants;
-import io.crate.action.sql.ResultReceiver;
-import io.crate.data.Row;
-import io.crate.exceptions.SQLExceptions;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
-import org.apache.logging.log4j.LogManager;
-import io.crate.common.unit.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.ConnectTransportException;
 
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
+import io.crate.Constants;
+import io.crate.action.sql.ResultReceiver;
+import io.crate.common.unit.TimeValue;
+import io.crate.data.Row;
+import io.crate.exceptions.SQLExceptions;
 
 public class RetryOnFailureResultReceiver<T> implements ResultReceiver<T> {
 
@@ -78,8 +79,8 @@ public class RetryOnFailureResultReceiver<T> implements ResultReceiver<T> {
     }
 
     @Override
-    public void allFinished(boolean interrupted) {
-        delegate.allFinished(interrupted);
+    public void allFinished() {
+        delegate.allFinished();
     }
 
     @Override

--- a/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
@@ -60,11 +60,11 @@ class RowCountReceiver extends BaseResultReceiver {
     }
 
     @Override
-    public void allFinished(boolean interrupted) {
+    public void allFinished() {
         ChannelFuture sendCommandComplete = Messages.sendCommandComplete(channel.bypassDelay(), query, rowCount);
         channel.writePendingMessages(delayedWrites);
         channel.flush();
-        sendCommandComplete.addListener(f -> super.allFinished(interrupted));
+        sendCommandComplete.addListener(f -> super.allFinished());
     }
 
     @Override

--- a/server/src/main/java/io/crate/rest/action/RestBulkRowCountReceiver.java
+++ b/server/src/main/java/io/crate/rest/action/RestBulkRowCountReceiver.java
@@ -21,12 +21,12 @@
 
 package io.crate.rest.action;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.data.Row;
 import io.crate.exceptions.SQLExceptions;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 class RestBulkRowCountReceiver extends BaseResultReceiver {
 
@@ -45,9 +45,9 @@ class RestBulkRowCountReceiver extends BaseResultReceiver {
     }
 
     @Override
-    public void allFinished(boolean interrupted) {
+    public void allFinished() {
         results[resultIdx] = new Result(null, rowCount);
-        super.allFinished(interrupted);
+        super.allFinished();
     }
 
     @Override

--- a/server/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/server/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -21,15 +21,16 @@
 
 package io.crate.rest.action;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
 import io.crate.action.sql.ResultReceiver;
 import io.crate.breaker.RowAccounting;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Symbol;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 class RestResultSetReceiver implements ResultReceiver<XContentBuilder> {
 
@@ -74,7 +75,7 @@ class RestResultSetReceiver implements ResultReceiver<XContentBuilder> {
     }
 
     @Override
-    public void allFinished(boolean interrupted) {
+    public void allFinished() {
         try {
             result.complete(finishBuilder());
         } catch (IOException e) {

--- a/server/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
+++ b/server/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
@@ -21,13 +21,14 @@
 
 package io.crate.rest.action;
 
-import io.crate.action.sql.ResultReceiver;
-import io.crate.data.Row;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import io.crate.action.sql.ResultReceiver;
+import io.crate.data.Row;
 
 class RestRowCountReceiver implements ResultReceiver<XContentBuilder> {
 
@@ -70,7 +71,7 @@ class RestRowCountReceiver implements ResultReceiver<XContentBuilder> {
     }
 
     @Override
-    public void allFinished(boolean interrupted) {
+    public void allFinished() {
         try {
             result.complete(finishBuilder());
         } catch (IOException e) {

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -86,7 +86,6 @@ import io.crate.action.sql.Session;
 import io.crate.action.sql.Sessions;
 import io.crate.auth.AccessControl;
 import io.crate.common.annotations.VisibleForTesting;
-
 import io.crate.common.unit.TimeValue;
 import io.crate.data.Row;
 import io.crate.data.Row1;
@@ -665,14 +664,14 @@ public class SQLTransportExecutor {
         }
 
         @Override
-        public void allFinished(boolean interrupted) {
+        public void allFinished() {
             try {
                 SQLResponse response = createSqlResponse();
                 listener.onResponse(response);
             } catch (Exception e) {
                 listener.onFailure(e);
             }
-            super.allFinished(interrupted);
+            super.allFinished();
         }
 
         @Override
@@ -721,7 +720,7 @@ public class SQLTransportExecutor {
         }
 
         @Override
-        public void allFinished(boolean interrupted) {
+        public void allFinished() {
             SQLResponse sqlResponse = new SQLResponse(
                 EMPTY_NAMES,
                 EMPTY_ROWS,
@@ -729,7 +728,7 @@ public class SQLTransportExecutor {
                 rowCount
             );
             listener.onResponse(sqlResponse);
-            super.allFinished(interrupted);
+            super.allFinished();
 
         }
 
@@ -761,9 +760,9 @@ public class SQLTransportExecutor {
         }
 
         @Override
-        public void allFinished(boolean interrupted) {
+        public void allFinished() {
             rowCounts[resultIdx] = rowCount;
-            super.allFinished(interrupted);
+            super.allFinished();
         }
 
         @Override


### PR DESCRIPTION
An `execute` message shouldn't result in a `sendReadyForQuery`:

https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY

> The possible responses to Execute are the same as those described
> above for queries issued via simple query protocol, except that Execute
> doesn't cause ReadyForQuery or RowDescription to be issued.

Some clients didn't expect that, others by accident followed up with a
`sync` call, which then resumed the suspended consumer/portal.

With `sendReadyForQuery` gone, we won't receive a `sync` but must resume
on `execute` already.

> Therefore, an Execute phase is always terminated by the appearance of
> exactly one of these messages: CommandComplete, EmptyQueryResponse (if
> the portal was created from an empty query string), ErrorResponse, or
> PortalSuspended.

With this change we also no longer need the `interrupted` flag for
`allFinished`.

Fixes https://github.com/crate/crate/issues/13904

Test case is in https://github.com/crate/crate-qa/pull/256