### PR TITLE
Allow PostgreSQL clients to describe cursor queries

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -93,6 +93,18 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that prevented PostgreSQL wire protocol clients from being able
+  to ``describe`` the query of a cursor created using ``DECLARE``. An example of
+  a client that uses the functionality is ``psycopg3``. A snippet like the
+  following failed::
+
+    import psycopg
+    conn = psycopg.connect("host=localhost port=5432 user=crate")
+    cur = conn.cursor(name="foo")
+    cur.execute("select 1")
+    for row in cur.fetchall():
+        print(row)
+
 - Fixed an issue in the PostgreSQL wire protocol implementation that could
   prevent protocol level fetch from working correctly with some clients. An
   example client is `pg-cursor <https://www.npmjs.com/package/pg-cursor>`_.

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -40,8 +40,10 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.UUIDs;
 
 import io.crate.analyze.AnalyzedBegin;
+import io.crate.analyze.AnalyzedClose;
 import io.crate.analyze.AnalyzedCommit;
 import io.crate.analyze.AnalyzedDeallocate;
+import io.crate.analyze.AnalyzedDeclare;
 import io.crate.analyze.AnalyzedDiscard;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.Analyzer;
@@ -80,7 +82,9 @@ import io.crate.protocols.postgres.JobsLogsUpdateListener;
 import io.crate.protocols.postgres.Portal;
 import io.crate.protocols.postgres.RetryOnFailureResultReceiver;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.sql.SqlFormatter;
 import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.Declare.Hold;
 import io.crate.sql.tree.DiscardStatement.Target;
 import io.crate.sql.tree.Statement;
@@ -361,6 +365,31 @@ public class Session implements AutoCloseable {
             // We don't comply with the spec because we allow batching of statements, see #execute
             oldPortal.closeActiveConsumer();
         }
+
+        // Clients might try to describe a declared query, need to store a portal to allow that.
+        if (preparedStmt.analyzedStatement() instanceof AnalyzedDeclare analyzedDeclare) {
+            Declare declare = analyzedDeclare.declare();
+            String cursorName = declare.cursorName();
+            if (!cursorName.equals(portalName)) {
+                var parameterTypes = parameterTypeExtractor.getParameterTypes(
+                    x -> Relations.traverseDeepSymbols(analyzedDeclare.query(), x)
+                );
+                PreparedStmt preparedQuery = new PreparedStmt(
+                    declare.query(),
+                    analyzedDeclare.query(),
+                    SqlFormatter.formatSql(declare.query()),
+                    parameterTypes
+                );
+                Portal queryPortal = new Portal(
+                    cursorName,
+                    preparedQuery,
+                    List.of(),
+                    preparedQuery.analyzedStatement(),
+                    resultFormatCodes
+                );
+                portals.put(cursorName, queryPortal);
+            }
+        }
     }
 
     public DescribeResult describe(char type, String portalOrStatement) {
@@ -498,6 +527,15 @@ public class Session implements AutoCloseable {
             );
             return resultReceiver.completionFuture();
         } else {
+            if (analyzedStmt instanceof AnalyzedClose close) {
+                String cursorName = close.cursorName();
+                if (cursorName != null) {
+                    Portal removedPortal = portals.remove(cursorName);
+                    if (removedPortal != null) {
+                        removedPortal.closeActiveConsumer();
+                    }
+                }
+            }
             if (!deferredExecutionsByStmt.isEmpty()) {
                 throw new UnsupportedOperationException(
                     "Only write operations are allowed in Batch statements");

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.action.sql;
 
+import static io.crate.testing.Asserts.assertThat;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -428,6 +429,28 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         session.close((byte) 'S', "S_1");
         assertThat(session.portals).isEmpty();
         assertThat(session.preparedStatements).isEmpty();
+    }
+
+    @Test
+    public void test_can_describe_cursor_created_using_declare() throws Exception {
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
+        Session session = sqlExecutor.createSession();
+        session.parse("", "DECLARE c1 NO SCROLL CURSOR FOR select 1", List.of());
+        session.bind("", "", List.of(), null);
+        session.execute("", 0, new BaseResultReceiver());
+
+        DescribeResult describe = session.describe('P', "c1");
+        assertThat(describe.getFields()).satisfiesExactly(
+            x -> assertThat(x).isLiteral(1, DataTypes.INTEGER)
+        );
+
+        assertThat(session.portals).containsOnlyKeys("", "c1");
+
+        session.parse("", "CLOSE c1", List.of());
+        session.bind("", "", List.of(), null);
+        session.execute("", 0, new BaseResultReceiver());
+
+        assertThat(session.portals).containsOnlyKeys("");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/13885

A client may want to `describe` the query of a cursor created with
`DECLARE`.

For example:

    import psycopg
    conn = psycopg.connect("host=localhost port=5432 user=crate")
    cur = conn.cursor(name="foo")
    cur.execute("select 1")
    for row in cur.fetchall():
        print(row)

Results in:

    method=parse stmtName= query=DECLARE "foo" CURSOR FOR select 1 paramTypes=[]
    method=bind portalName= statementName= params=[]
    method=describe type=P portalOrStatement=
    method=execute portalName= maxRows=0

    method=describe type=P portalOrStatement=foo

The `DECLARE` itself is created first (via parse, bind, describe, execute)
Then the client sends a `describe` for the cursor `foo`

To handle this the `Session` needs to special case declare & close.
