### PR TITLE
Remove redundant AnalyzedStatement param from Portal

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -356,7 +356,6 @@ public class Session implements AutoCloseable {
             portalName,
             preparedStmt,
             params,
-            preparedStmt.analyzedStatement(),
             resultFormatCodes);
         Portal oldPortal = portals.put(portalName, portal);
         if (oldPortal != null) {
@@ -384,7 +383,6 @@ public class Session implements AutoCloseable {
                     cursorName,
                     preparedQuery,
                     List.of(),
-                    preparedQuery.analyzedStatement(),
                     resultFormatCodes
                 );
                 portals.put(cursorName, queryPortal);

--- a/server/src/main/java/io/crate/protocols/postgres/Portal.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Portal.java
@@ -21,19 +21,19 @@
 
 package io.crate.protocols.postgres;
 
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import io.crate.action.sql.PreparedStmt;
 import io.crate.action.sql.RowConsumerToResultReceiver;
 import io.crate.analyze.AnalyzedStatement;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 public final class Portal {
 
     private String portalName;
     private final PreparedStmt preparedStmt;
     private final List<Object> params;
-    private final AnalyzedStatement analyzedStatement;
 
     @Nullable
     private final FormatCodes.FormatCode[] resultFormatCodes;
@@ -43,12 +43,10 @@ public final class Portal {
     public Portal(String portalName,
                   PreparedStmt preparedStmt,
                   List<Object> params,
-                  AnalyzedStatement analyzedStatement,
                   @Nullable FormatCodes.FormatCode[] resultFormatCodes) {
         this.portalName = portalName;
         this.preparedStmt = preparedStmt;
         this.params = params;
-        this.analyzedStatement = analyzedStatement;
         this.resultFormatCodes = resultFormatCodes;
     }
 
@@ -70,7 +68,7 @@ public final class Portal {
     }
 
     public AnalyzedStatement analyzedStatement() {
-        return analyzedStatement;
+        return preparedStmt.analyzedStatement();
     }
 
     public void setActiveConsumer(RowConsumerToResultReceiver consumer) {


### PR DESCRIPTION
The AnalyzedStatement is contained in the PreparedStmt parameter
