### PR TITLE
Expand on validateSubscriptPatternInColumnName to handle edge cases

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -63,4 +63,6 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue that allowed creating columns with names conflicting with
+  subscript pattern, such as ``"a[1]"``, a subscript expression enclosed in
+  double quotes.

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -50,7 +50,6 @@ public class ColumnIdent implements Comparable<ColumnIdent>, Accountable {
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ColumnIdent.class);
     private static final Pattern UNDERSCORE_PATTERN = Pattern.compile("^_([a-z][_a-z]*)*[a-z]$");
-    private static final Pattern SUBSCRIPT_PATTERN = Pattern.compile("^\\w+(\\[[^\\]]+\\])+");
 
     private static final Comparator<Iterable<String>> ORDERING = Ordering.<String>natural().lexicographical();
 
@@ -248,8 +247,9 @@ public class ColumnIdent implements Comparable<ColumnIdent>, Accountable {
      * @param columnName column name to check for validity
      */
     private static void validateSubscriptPatternInColumnName(String columnName) {
-        if (SUBSCRIPT_PATTERN.matcher(columnName).matches()) {
-            throw new InvalidColumnNameException(columnName, "conflicts with subscript pattern");
+        if (columnName.contains("[")) {
+            throw new InvalidColumnNameException(
+                columnName, "conflicts with subscript pattern, square brackets are not allowed");
         }
     }
 

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.types.BitStringType;
 
@@ -367,6 +368,16 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         symbol = executor.asSymbol("nested_obj.\"myObj['x']['AbC']\"");
         assertThat(symbol).isReference("myObj['x']['AbC']");
+    }
+
+    /**
+     * bug: https://github.com/crate/crate/issues/13845
+     */
+    @Test
+    public void test_invalid_quoted_subscript() {
+        assertThatThrownBy(() -> executor.asSymbol("\"\"\"a[1]\"\"\""))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column \"a[1]\" unknown");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
@@ -106,7 +105,7 @@ public class CreateTableAsIntegrationTest extends IntegTestCase {
         execute("create table tbl (col object(strict) as (nested_col text))");
         assertThatThrownBy(() -> execute("create table cpy as select col['nested_col'] from tbl"))
             .isExactlyInstanceOf(InvalidColumnNameException.class)
-            .hasMessage("\"col['nested_col']\" conflicts with subscript pattern");
+            .hasMessage("\"col['nested_col']\" conflicts with subscript pattern, square brackets are not allowed");
     }
 
     @UseJdbc(0)

--- a/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
+++ b/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
@@ -95,11 +95,8 @@ public class ColumnIdentTest {
         ColumnIdent.validateColumnName("_name_");
         ColumnIdent.validateColumnName("__name");
         ColumnIdent.validateColumnName("_name1");
-        ColumnIdent.validateColumnName("['index']");
-        ColumnIdent.validateColumnName("[0]");
-        ColumnIdent.validateColumnName("[]i");
-        ColumnIdent.validateColumnName("ident['index");
-        ColumnIdent.validateColumnName("i][[");
+        ColumnIdent.validateColumnName("'index'");
+        ColumnIdent.validateColumnName("ident'index");
         ColumnIdent.validateColumnName("1'");
     }
 
@@ -114,6 +111,9 @@ public class ColumnIdentTest {
         assertExceptionIsThrownOnValidation("ident['index']", "subscript");
         assertExceptionIsThrownOnValidation("ident['index]", "subscript");
         assertExceptionIsThrownOnValidation("ident[0]", "subscript");
+        assertExceptionIsThrownOnValidation("\"a[1]\"", "subscript");
+        assertExceptionIsThrownOnValidation("\"fda_32$@%^nf[ffDA&^\"", "subscript");
+        assertExceptionIsThrownOnValidation("[", "subscript");
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/13845

We do not expect users to use column names like `"""a[1]"""`, hence expanding on the existing logic that prevents creating column names conflicting with subscript pattern to catch such cases as well.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
