### PR TITLE
Refactor CREATE TABLE to use same mapping creation code with ADD COLUMN

### DIFF
--- a/server/src/main/java/io/crate/analyze/BoundCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/BoundCreateTable.java
@@ -27,6 +27,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
@@ -78,6 +79,7 @@ public class BoundCreateTable {
         return ifNotExists;
     }
 
+    @Nonnull
     public List<List<String>> partitionedBy() {
         return analyzedTableElements().partitionedBy();
     }
@@ -139,6 +141,11 @@ public class BoundCreateTable {
         return relationName;
     }
 
+    @Nullable
+    public String routingColumn() {
+        return routingColumn != null ? routingColumn.fqn() : null;
+    }
+
     /**
      * return true if a columnDefinition with name <code>columnIdent</code> exists
      */
@@ -147,7 +154,7 @@ public class BoundCreateTable {
                 columnIdent.name().equalsIgnoreCase("_id"));
     }
 
-    AnalyzedTableElements<Object> analyzedTableElements() {
+    public AnalyzedTableElements<Object> analyzedTableElements() {
         return analyzedTableElements;
     }
 

--- a/server/src/main/java/io/crate/analyze/BoundCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/BoundCreateTable.java
@@ -29,9 +29,7 @@ import io.crate.metadata.Schemas;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 public class BoundCreateTable {
 
@@ -41,7 +39,6 @@ public class BoundCreateTable {
     private final ColumnIdent routingColumn;
     private final boolean noOp;
     private final boolean ifNotExists;
-    private Map<String, Object> mapping;
 
     public BoundCreateTable(RelationName relationName,
                             AnalyzedTableElements<Object> tableElements,
@@ -108,33 +105,6 @@ public class BoundCreateTable {
             return PartitionName.templatePrefix(tableIdent().schema(), tableIdent().name());
         }
         return null;
-    }
-
-    @SuppressWarnings("unchecked")
-    Map<String, Object> mappingProperties() {
-        return (Map) mapping().get("properties");
-    }
-
-    public Collection<String> primaryKeys() {
-        return AnalyzedTableElements.primaryKeys(analyzedTableElements);
-    }
-
-    public Collection<String> notNullColumns() {
-        return AnalyzedTableElements.notNullColumns(analyzedTableElements);
-    }
-
-    public Map<String, Object> mapping() {
-        if (mapping == null) {
-            mapping = AnalyzedTableElements.toMapping(analyzedTableElements);
-            //noinspection unchecked
-            Map<String, Object> metaMap = (Map<String, Object>) mapping.get("_meta");
-            if (routingColumn != null) {
-                metaMap.put("routing", routingColumn.fqn());
-            }
-            // merge in user defined mapping parameter
-            mapping.putAll(tableParameter.mappings());
-        }
-        return mapping;
     }
 
     public RelationName tableIdent() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnTask.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnTask.java
@@ -21,20 +21,17 @@
 
 package io.crate.execution.ddl.tables;
 
-import static io.crate.metadata.Reference.buildTree;
+import static io.crate.execution.ddl.tables.MappingUtil.createMapping;
+import static io.crate.execution.ddl.tables.MappingUtil.mergeConstraints;
 import static io.crate.metadata.cluster.AlterTableClusterStateExecutor.resolveIndices;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -47,14 +44,11 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 
-import com.carrotsearch.hppc.IntArrayList;
-
 import io.crate.common.CheckedFunction;
 import io.crate.common.collections.Maps;
 import io.crate.execution.ddl.TransportSchemaUpdateAction;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
@@ -62,9 +56,6 @@ import io.crate.metadata.cluster.DDLClusterStateHelpers;
 import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
-import io.crate.metadata.table.ColumnPolicies;
-import io.crate.types.ArrayType;
-import io.crate.types.ObjectType;
 
 public final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRequest> {
 
@@ -77,6 +68,7 @@ public final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRe
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public ClusterState execute(ClusterState currentState, AddColumnRequest request) throws Exception {
         Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
         DocTableInfoFactory docTableInfoFactory = new DocTableInfoFactory(nodeContext);
@@ -100,21 +92,24 @@ public final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRe
         }
 
         request = addMissingParentColumns(request, currentTable);
-        HashMap<ColumnIdent, List<Reference>> tree = buildTree(request.references());
-        Map<String, Map<String, Object>> propertiesMap = buildMapping(null, tree);
-        assert propertiesMap != null : "ADD COLUMN mapping can not be null"; // Only intermediate result can be null.
+
+        Map<String, Object> mapping = createMapping(
+            request.references(),
+            request.pKeyIndices(),
+            request.checkConstraints(),
+            Map.of(),
+            List.of(),
+            null,
+            null
+        );
 
         String templateName = PartitionName.templateName(request.relationName().schema(), request.relationName().name());
         IndexTemplateMetadata indexTemplateMetadata = currentState.metadata().templates().get(templateName);
-
         if (indexTemplateMetadata != null) {
             // Partitioned table
-
-            Map<String, Object> newMapping = new HashMap<>();
-            mergeDeltaIntoExistingMapping(newMapping, request, propertiesMap);
             IndexTemplateMetadata newIndexTemplateMetadata = DDLClusterStateHelpers.updateTemplate(
                 indexTemplateMetadata,
-                newMapping,
+                mapping,
                 Collections.emptyMap(),
                 Settings.EMPTY,
                 IndexScopedSettings.DEFAULT_SCOPED_SETTINGS // Not used if new settings are empty
@@ -122,7 +117,7 @@ public final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRe
             metadataBuilder.put(newIndexTemplateMetadata);
         }
 
-        currentState = updateMapping(currentState, metadataBuilder, request, propertiesMap);
+        currentState = updateMapping(currentState, metadataBuilder, request, (Map<String, Map<String, Object>>) mapping.get("properties"));
         // ensure the new table can still be parsed into a DocTableInfo to avoid breaking the table.
         docTableInfoFactory.create(request.relationName(), currentState);
         return currentState;
@@ -155,66 +150,6 @@ public final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRe
             );
         } else {
             return request;
-        }
-    }
-
-    /**
-     * Returns properties map including all nested sub-columns if there any.
-     * Format of the top level properties field:
-     * {
-     *     col1: {
-     *        position: some_position
-     *        type: some_type
-     *        ...
-     *
-     *        * optional, only for nested objects *
-     *        properties: {
-     *            nested_col1: {...},
-     *            nested_col2: {...},
-     *        }
-     *     },
-     *     col2: {...}
-     * }
-
-     */
-    @Nullable
-    private Map<String, Map<String, Object>> buildMapping(@Nullable ColumnIdent currentNode, HashMap<ColumnIdent, List<Reference>> tree) {
-        List<Reference> children = tree.get(currentNode);
-        if (children == null) {
-            return null;
-        }
-        HashMap<String, Map<String, Object>> allColumnsMap = new LinkedHashMap<>();
-        for (Reference child: children) {
-            allColumnsMap.put(child.column().leafName(), addColumnProperties(child, tree));
-        }
-        return allColumnsMap;
-    }
-
-    /**
-     * Aligned with AnalyzedColumnDefinition.toMapping()
-     */
-    private Map<String, Object> addColumnProperties(Reference reference, HashMap<ColumnIdent, List<Reference>> tree) {
-
-        Map<String, Object> columnProperties = reference.toMapping();
-        if (reference.valueType().id() == ArrayType.ID) {
-            HashMap<String, Object> outerMapping = new HashMap<>();
-            outerMapping.put("type", "array");
-            if (ArrayType.unnest(reference.valueType()).id() == ObjectType.ID) {
-                objectMapping(columnProperties, reference, tree);
-            }
-            outerMapping.put("inner", columnProperties);
-            return outerMapping;
-        } else if (reference.valueType().id() == ObjectType.ID) {
-            objectMapping(columnProperties, reference, tree);
-        }
-        return columnProperties;
-    }
-
-    private void objectMapping(Map<String, Object> propertiesMap, Reference reference, HashMap<ColumnIdent, List<Reference>> tree) {
-        propertiesMap.put("dynamic", ColumnPolicies.encodeMappingValue(reference.columnPolicy()));
-        Map<String, Map<String, Object>> nestedObjectMap = buildMapping(reference.column(), tree);
-        if (nestedObjectMap != null) {
-            propertiesMap.put("properties", nestedObjectMap);
         }
     }
 
@@ -269,67 +204,6 @@ public final class AddColumnTask extends DDLClusterStateTaskExecutor<AddColumnRe
         );
     }
 
-    @SuppressWarnings("unchecked")
-    private static void mergeConstraints(Map<String, Object> meta,
-                                         List<Reference> references,
-                                         IntArrayList pKeyIndices,
-                                         Map<String, String> checkConstraints) {
 
-        // CHECK
-        if (checkConstraints.isEmpty() == false) {
-            Map<String, String> existingCheckConstraints = (Map<String, String>) meta.get("check_constraints");
-            if (existingCheckConstraints == null) {
-                existingCheckConstraints = new HashMap<>();
-                meta.put("check_constraints", existingCheckConstraints);
-            }
-            for (var entry : checkConstraints.entrySet()) {
-                String name = entry.getKey();
-                String expression = entry.getValue();
-                existingCheckConstraints.put(name, expression);
-            }
-        }
-
-        // PK
-        if (pKeyIndices.isEmpty() == false) {
-            List<String> primaryKeys = (List<String>) meta.get("primary_keys");
-            if (primaryKeys == null) {
-                primaryKeys = new ArrayList<>();
-                meta.put("primary_keys", primaryKeys);
-            }
-            for (int i = 0; i < pKeyIndices.size(); i ++) {
-                primaryKeys.add(references.get(pKeyIndices.get(i)).column().fqn());
-            }
-        }
-
-        // Not nulls
-        List<String> newNotNulls = references.stream().filter(ref -> !ref.isNullable()).map(ref -> ref.column().fqn()).collect(Collectors.toList());
-        if (newNotNulls.isEmpty() == false) {
-            Map<String, List<String>> constraints = (Map<String, List<String>>) meta.get("constraints");
-            List<String> notNulls = constraints != null ? constraints.get("not_null") : null;
-            if (notNulls == null) {
-                notNulls = new ArrayList<>();
-                var map = new HashMap<>();
-                map.put("not_null", notNulls);
-                meta.put("constraints", map);
-            }
-            notNulls.addAll(newNotNulls);
-        }
-
-        // Generated expressions
-        List<GeneratedReference> newGenExpressions = references.stream()
-            .filter(ref -> ref instanceof GeneratedReference)
-            .map(ref -> (GeneratedReference) ref)
-            .collect(Collectors.toList());
-        if (newGenExpressions.isEmpty() == false) {
-            Map<String, String> generatedColumns = (Map<String, String>) meta.get("generated_columns");
-            if (generatedColumns == null) {
-                generatedColumns = new HashMap<>();
-                meta.put("generated_columns", generatedColumns);
-            }
-            for (GeneratedReference genRef: newGenExpressions) {
-                generatedColumns.put(genRef.column().fqn(), genRef.formattedGeneratedExpression());
-            }
-        }
-    }
 
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
@@ -21,7 +21,12 @@
 
 package io.crate.execution.ddl.tables;
 
+import com.carrotsearch.hppc.IntArrayList;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.table.ColumnPolicies;
+import io.crate.sql.tree.ColumnPolicy;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -29,29 +34,97 @@ import org.elasticsearch.cluster.ack.AckedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import io.crate.common.unit.TimeValue;
+import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
+import static io.crate.execution.ddl.tables.AddColumnRequest.ReferencesAndConstraints;
+
+import static io.crate.execution.ddl.tables.AddColumnRequest.writeReferencesAndConstraints;
 import static org.elasticsearch.action.support.master.AcknowledgedRequest.DEFAULT_ACK_TIMEOUT;
+import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
+import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
 
 /**
  * Creates a table represented by an ES index or an ES template (partitioned table).
  * Checks for existing views in the meta data of the master node before creating the table.
- *
- * Encapsulates either a {@link CreateIndexRequest} or a {@link PutIndexTemplateRequest}.
  */
 public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> implements AckedRequest {
 
-    private final CreateIndexRequest createIndexRequest;
-    private final PutIndexTemplateRequest putIndexTemplateRequest;
+    // Fields required to add column(s), aligned with AddColumnRequest
+    private final RelationName relationName;
+    private final List<Reference> colsToAdd;
+    private final IntArrayList pKeyIndices;
+    private final Map<String, String> checkConstraints;
 
+    // Aligned with BoundCreateTable.mapping(), everything what's not covered by AddColumnRequest is added as a separate field.
+    private final Settings settings;
+    @Nullable
+    private final String routingColumn;
+    private final ColumnPolicy tableColumnPolicy; // The only setting which is set as a "mapping" change (see TableParameter.mappings()), 'strict' by default.
+    private final List<List<String>> partitionedBy;
+    private final Map<String, Object> indices;
+
+    @Deprecated
+    private CreateIndexRequest createIndexRequest;
+    @Deprecated
+    private PutIndexTemplateRequest putIndexTemplateRequest;
+
+    public CreateTableRequest(RelationName relationName,
+                              List<Reference> colsToAdd,
+                              IntArrayList pKeyIndices,
+                              Map<String, String> checkConstraints,
+                              Settings settings,
+                              @Nullable String routingColumn,
+                              ColumnPolicy tableColumnPolicy,
+                              List<List<String>> partitionedBy,
+                              Map<String, Object> indices) {
+        this.relationName = relationName;
+        this.colsToAdd = colsToAdd;
+        this.pKeyIndices = pKeyIndices;
+        this.checkConstraints = checkConstraints;
+        this.settings = settings;
+        this.routingColumn = routingColumn;
+        this.tableColumnPolicy = tableColumnPolicy;
+        this.partitionedBy = partitionedBy;
+        this.indices = indices;
+
+        this.createIndexRequest = null;
+        this.putIndexTemplateRequest = null;
+    }
+
+    @Deprecated
     public CreateTableRequest(CreateIndexRequest createIndexRequest) {
+        this(RelationName.fromIndexName(createIndexRequest.index()),
+            List.of(),
+            new IntArrayList(),
+            Map.of(),
+            Settings.EMPTY,
+            null,
+            ColumnPolicies.decodeMappingValue(ColumnPolicy.STRICT),
+            List.of(),
+            Map.of()
+        );
         this.createIndexRequest = createIndexRequest;
         this.putIndexTemplateRequest = null;
     }
 
+    @Deprecated
     public CreateTableRequest(PutIndexTemplateRequest putIndexTemplateRequest) {
+        this(RelationName.fromIndexName(putIndexTemplateRequest.aliases().iterator().next().name()),
+            List.of(),
+            new IntArrayList(),
+            Map.of(),
+            Settings.EMPTY,
+            null,
+            ColumnPolicies.decodeMappingValue(ColumnPolicy.STRICT),
+            List.of(),
+            Map.of()
+        );
         this.createIndexRequest = null;
         this.putIndexTemplateRequest = putIndexTemplateRequest;
     }
@@ -66,14 +139,9 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
         return putIndexTemplateRequest;
     }
 
+    @Nonnull
     public RelationName getTableName() {
-        if (createIndexRequest != null) {
-            return RelationName.fromIndexName(createIndexRequest.index());
-        } else if (putIndexTemplateRequest != null) {
-            return RelationName.fromIndexName(putIndexTemplateRequest.aliases().iterator().next().name());
-        } else {
-            throw new IllegalStateException("Unknown request type");
-        }
+        return relationName;
     }
 
     @Override
@@ -83,21 +151,99 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
 
     public CreateTableRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.readBoolean()) {
-            createIndexRequest = new CreateIndexRequest(in);
+        if (in.getVersion().onOrAfter(Version.V_5_4_0)) {
+
+            this.relationName = new RelationName(in);
+            ReferencesAndConstraints referencesAndConstraints = ReferencesAndConstraints.read(in);
+            this.colsToAdd = referencesAndConstraints.colsToAdd();
+            this.checkConstraints = referencesAndConstraints.checkConstraints();
+            this.pKeyIndices = referencesAndConstraints.pKeyIndices();
+
+            this.settings = readSettingsFromStream(in);
+            this.routingColumn = in.readOptionalString();
+            this.tableColumnPolicy = ColumnPolicy.VALUES.get(in.readVInt());
+            this.partitionedBy = in.readList(StreamInput::readStringList);
+            this.indices = in.readMap();
+
+            createIndexRequest = null;
             putIndexTemplateRequest = null;
         } else {
-            putIndexTemplateRequest = new PutIndexTemplateRequest(in);
-            createIndexRequest = null;
+            if (in.readBoolean()) {
+                createIndexRequest = new CreateIndexRequest(in);
+                putIndexTemplateRequest = null;
+            } else {
+                putIndexTemplateRequest = new PutIndexTemplateRequest(in);
+                createIndexRequest = null;
+            }
+            this.relationName = null;
+            this.colsToAdd = null;
+            this.pKeyIndices = null;
+            this.checkConstraints = null;
+            this.settings = null;
+            this.routingColumn = null;
+            this.tableColumnPolicy = null;
+            this.partitionedBy = null;
+            this.indices = null;
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        boolean isIndexRequest = createIndexRequest != null;
-        out.writeBoolean(isIndexRequest);
-        MasterNodeRequest request = isIndexRequest ? createIndexRequest : putIndexTemplateRequest;
-        request.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_5_4_0)) {
+            relationName.writeTo(out);
+            writeReferencesAndConstraints(out, checkConstraints, colsToAdd, pKeyIndices);
+            writeSettingsToStream(settings, out);
+            out.writeOptionalString(routingColumn);
+            out.writeVInt(tableColumnPolicy.ordinal());
+            out.writeCollection(partitionedBy, StreamOutput::writeStringCollection);
+            out.writeMap(indices);
+        } else {
+            boolean isIndexRequest = createIndexRequest != null;
+            out.writeBoolean(isIndexRequest);
+            MasterNodeRequest request = isIndexRequest ? createIndexRequest : putIndexTemplateRequest;
+            request.writeTo(out);
+        }
     }
+
+    @Nonnull
+    public Settings settings() {
+        return settings;
+    }
+
+    @Nullable
+    public String routingColumn() {
+        return routingColumn;
+    }
+
+    @Nonnull
+    public ColumnPolicy tableColumnPolicy() {
+        return tableColumnPolicy;
+    }
+
+    @Nonnull
+    public List<List<String>> partitionedBy() {
+        return partitionedBy;
+    }
+
+    @Nonnull
+    public Map<String, Object> indices() {
+        return indices;
+    }
+
+    @Nonnull
+    public Map<String, String> checkConstraints() {
+        return this.checkConstraints;
+    }
+
+    @Nonnull
+    public List<Reference> references() {
+        return this.colsToAdd;
+    }
+
+    @Nonnull
+    public IntArrayList pKeyIndices() {
+        return this.pKeyIndices;
+    }
+
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
@@ -61,7 +61,7 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
     private final IntArrayList pKeyIndices;
     private final Map<String, String> checkConstraints;
 
-    // Aligned with BoundCreateTable.mapping(), everything what's not covered by AddColumnRequest is added as a separate field.
+    // Everything what's not covered by AddColumnRequest is added as a separate field.
     private final Settings settings;
     @Nullable
     private final String routingColumn;

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -22,7 +22,6 @@
 package io.crate.execution.ddl.tables;
 
 import com.carrotsearch.hppc.IntArrayList;
-import io.crate.analyze.AnalyzedTableElements;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
@@ -48,7 +47,6 @@ public class MappingUtil {
      * This is a singe entry point to creating mapping: adding a column(s), create a table, create a partitioned table (template).
      * @param tableColumnPolicy has default value STRICT if not specified on a table creation.
      * On column addition it's NULL in order to not override an existing value.
-     * Aligned with {@link AnalyzedTableElements#toMapping(AnalyzedTableElements)}
      */
     public static Map<String, Object> createMapping(List<Reference> columns,
                                                     IntArrayList pKeyIndices,
@@ -119,9 +117,6 @@ public class MappingUtil {
         return allColumnsMap;
     }
 
-    /**
-     * Aligned with AnalyzedColumnDefinition.toMapping()
-     */
     private static Map<String, Object> addColumnProperties(Reference reference, HashMap<ColumnIdent, List<Reference>> tree) {
 
         Map<String, Object> columnProperties = reference.toMapping();

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import com.carrotsearch.hppc.IntArrayList;
+import io.crate.analyze.AnalyzedTableElements;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.Reference;
+import io.crate.metadata.table.ColumnPolicies;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.ArrayType;
+import io.crate.types.ObjectType;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.crate.metadata.Reference.buildTree;
+import static io.crate.metadata.table.ColumnPolicies.ES_MAPPING_NAME;
+
+public class MappingUtil {
+
+    /**
+     * This is a singe entry point to creating mapping: adding a column(s), create a table, create a partitioned table (template).
+     * @param tableColumnPolicy has default value STRICT if not specified on a table creation.
+     * On column addition it's NULL in order to not override an existing value.
+     * Aligned with {@link AnalyzedTableElements#toMapping(AnalyzedTableElements)}
+     */
+    public static Map<String, Object> createMapping(List<Reference> columns,
+                                                    IntArrayList pKeyIndices,
+                                                    Map<String, String> checkConstraints,
+                                                    Map<String, Object> indices,
+                                                    List<List<String>> partitionedBy,
+                                                    @Nullable ColumnPolicy tableColumnPolicy,
+                                                    @Nullable String routingColumn) {
+
+        HashMap<ColumnIdent, List<Reference>> tree = buildTree(columns);
+        Map<String, Map<String, Object>> propertiesMap = createPropertiesMap(null, tree);
+        assert propertiesMap != null : "ADD COLUMN mapping can not be null"; // Only intermediate result can be null.
+
+        Map<String, Object> mapping = new HashMap<>();
+
+        Map<String, Object> meta = new HashMap<>();
+        mergeConstraints(meta, columns, pKeyIndices, checkConstraints);
+        if (routingColumn != null) {
+            meta.put("routing", routingColumn);
+        }
+
+        if (tableColumnPolicy != null) {
+            mapping.put(ES_MAPPING_NAME, ColumnPolicies.encodeMappingValue(tableColumnPolicy));
+        }
+
+        if (indices.isEmpty() == false) {
+            meta.put("indices", indices);
+        }
+        if (partitionedBy.isEmpty() == false) {
+            meta.put("partitioned_by", partitionedBy);
+        }
+
+        mapping.put("_meta", meta);
+        mapping.put("properties", propertiesMap);
+
+        return mapping;
+    }
+
+    /**
+     * Returns properties map including all nested sub-columns if there any.
+     * Format of the top level properties field:
+     * {
+     *     col1: {
+     *        position: some_position
+     *        type: some_type
+     *        ...
+     *
+     *        * optional, only for nested objects *
+     *        properties: {
+     *            nested_col1: {...},
+     *            nested_col2: {...},
+     *        }
+     *     },
+     *     col2: {...}
+     * }
+
+     */
+    @Nullable
+    private static Map<String, Map<String, Object>> createPropertiesMap(@Nullable ColumnIdent currentNode, HashMap<ColumnIdent, List<Reference>> tree) {
+        List<Reference> children = tree.get(currentNode);
+        if (children == null) {
+            return null;
+        }
+        HashMap<String, Map<String, Object>> allColumnsMap = new LinkedHashMap<>();
+        for (Reference child: children) {
+            allColumnsMap.put(child.column().leafName(), addColumnProperties(child, tree));
+        }
+        return allColumnsMap;
+    }
+
+    /**
+     * Aligned with AnalyzedColumnDefinition.toMapping()
+     */
+    private static Map<String, Object> addColumnProperties(Reference reference, HashMap<ColumnIdent, List<Reference>> tree) {
+
+        Map<String, Object> columnProperties = reference.toMapping();
+        if (reference.valueType().id() == ArrayType.ID) {
+            HashMap<String, Object> outerMapping = new HashMap<>();
+            outerMapping.put("type", "array");
+            if (ArrayType.unnest(reference.valueType()).id() == ObjectType.ID) {
+                objectMapping(columnProperties, reference, tree);
+            }
+            outerMapping.put("inner", columnProperties);
+            return outerMapping;
+        } else if (reference.valueType().id() == ObjectType.ID) {
+            objectMapping(columnProperties, reference, tree);
+        }
+        return columnProperties;
+    }
+
+    private static void objectMapping(Map<String, Object> propertiesMap, Reference reference, HashMap<ColumnIdent, List<Reference>> tree) {
+        propertiesMap.put("dynamic", ColumnPolicies.encodeMappingValue(reference.columnPolicy()));
+        Map<String, Map<String, Object>> nestedObjectMap = createPropertiesMap(reference.column(), tree);
+        if (nestedObjectMap != null) {
+            propertiesMap.put("properties", nestedObjectMap);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void mergeConstraints(Map<String, Object> meta,
+                                         List<Reference> references,
+                                         IntArrayList pKeyIndices,
+                                         Map<String, String> checkConstraints) {
+
+        // CHECK
+        if (checkConstraints.isEmpty() == false) {
+            Map<String, String> existingCheckConstraints = (Map<String, String>) meta.get("check_constraints");
+            if (existingCheckConstraints == null) {
+                existingCheckConstraints = new LinkedHashMap<>();
+                meta.put("check_constraints", existingCheckConstraints);
+            }
+            for (var entry : checkConstraints.entrySet()) {
+                String name = entry.getKey();
+                String expression = entry.getValue();
+                existingCheckConstraints.put(name, expression);
+            }
+        }
+
+        // PK
+        if (pKeyIndices.isEmpty() == false) {
+            List<String> primaryKeys = (List<String>) meta.get("primary_keys");
+            if (primaryKeys == null) {
+                primaryKeys = new ArrayList<>();
+                meta.put("primary_keys", primaryKeys);
+            }
+            for (int i = 0; i < pKeyIndices.size(); i ++) {
+                primaryKeys.add(references.get(pKeyIndices.get(i)).column().fqn());
+            }
+        }
+
+        // Not nulls
+        List<String> newNotNulls = references.stream().filter(ref -> !ref.isNullable()).map(ref -> ref.column().fqn()).collect(Collectors.toList());
+        if (newNotNulls.isEmpty() == false) {
+            Map<String, List<String>> constraints = (Map<String, List<String>>) meta.get("constraints");
+            List<String> notNulls = constraints != null ? constraints.get("not_null") : null;
+            if (notNulls == null) {
+                notNulls = new ArrayList<>();
+                var map = new HashMap<>();
+                map.put("not_null", notNulls);
+                meta.put("constraints", map);
+            }
+            notNulls.addAll(newNotNulls);
+        }
+
+        // Generated expressions
+        List<GeneratedReference> newGenExpressions = references.stream()
+            .filter(ref -> ref instanceof GeneratedReference)
+            .map(ref -> (GeneratedReference) ref)
+            .collect(Collectors.toList());
+        if (newGenExpressions.isEmpty() == false) {
+            Map<String, String> generatedColumns = (Map<String, String>) meta.get("generated_columns");
+            if (generatedColumns == null) {
+                generatedColumns = new HashMap<>();
+                meta.put("generated_columns", generatedColumns);
+            }
+            for (GeneratedReference genRef: newGenExpressions) {
+                generatedColumns.put(genRef.column().fqn(), genRef.formattedGeneratedExpression());
+            }
+        }
+    }
+}

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -98,7 +98,7 @@ public class GeoReference extends SimpleReference {
             position,
             defaultExpression
         );
-        this.geoTree = geoTree;
+        this.geoTree = Objects.requireNonNullElse(geoTree, DEFAULT_TREE);
         this.precision = precision;
         this.treeLevels = treeLevels;
         this.distanceErrorPct = distanceErrorPct;

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -127,18 +127,6 @@ public class IndexReference extends SimpleReference {
         this.analyzer = analyzer;
     }
 
-    public IndexReference(int position,
-                          boolean nullable,
-                          boolean hasDocValues,
-                          ReferenceIdent ident,
-                          IndexType indexType,
-                          List<Reference> columns,
-                          @Nullable String analyzer) {
-        super(ident, RowGranularity.DOC, DataTypes.STRING, ColumnPolicy.DYNAMIC, indexType, nullable, hasDocValues, position, null);
-        this.columns = columns;
-        this.analyzer = analyzer;
-    }
-
     public IndexReference(ReferenceIdent ident,
                           RowGranularity granularity,
                           DataType<?> type,
@@ -231,8 +219,8 @@ public class IndexReference extends SimpleReference {
         Map<String, Object> mapping = super.toMapping();
         if (analyzer != null) {
             mapping.put("analyzer", analyzer);
-            mapping.put("type", "text");
         }
+        mapping.put("type", "text");
 
         if (columns.isEmpty() == false) {
             mapping.put("sources", columns.stream().map(ref -> ref.column().fqn()).collect(Collectors.toList()));

--- a/server/src/main/java/io/crate/planner/consumer/CreateTableAsPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/CreateTableAsPlanner.java
@@ -100,7 +100,7 @@ public final class CreateTableAsPlanner {
                 schemas,
                 dependencies.fulltextAnalyzerResolver());
 
-            tableCreator.create(boundCreateTable)
+            tableCreator.create(boundCreateTable, plannerContext.clusterState().nodes().getMinNodeVersion())
                 .thenRun(() -> postponedInsertPlan.get().execute(dependencies,
                                                                  plannerContext,
                                                                  consumer,

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
@@ -44,6 +44,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.planner.DependencyCarrier;
@@ -70,50 +71,38 @@ public class AlterTableAddColumnPlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
-        var addColumnRequest = createRequest(alterTable, dependencies.nodeContext(), plannerContext,
-                                                              params, subQueryResults, dependencies.fulltextAnalyzerResolver());
+        var tableElements = validate(
+            alterTable,
+            plannerContext.transactionContext(),
+            dependencies.nodeContext(),
+            params,
+            subQueryResults,
+            dependencies.fulltextAnalyzerResolver()
+        );
+        var addColumnRequest = createRequest(tableElements, alterTable.tableInfo().ident());
 
         dependencies.alterTableOperation().executeAlterTableAddColumn(addColumnRequest)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 
-    public static AddColumnRequest createRequest(AnalyzedAlterTableAddColumn alterTable,
-                                                 NodeContext nodeContext,
-                                                 PlannerContext plannerContext,
-                                                 Row params,
-                                                 SubQueryResults subQueryResults,
-                                                 FulltextAnalyzerResolver fulltextAnalyzerResolver) {
-        var tableElements = validate(
-            alterTable,
-            plannerContext.transactionContext(),
-            nodeContext,
-            params,
-            subQueryResults,
-            fulltextAnalyzerResolver
-        );
-
-        // We can add multiple object columns via ALTER TABLE ADD COLUMN.
-        // Those columns can have overlapping paths, for example we can add columns o['a']['b'] and o['a']['c'].
-        // For every added column AnalyzedColumnDefinition provides not only leaf but also path to the root.
-        // For o['a']['b'] and o['a']['c'] we can end up having Ref(Ident(o)) and Ref(Ident(a)) twice.
-
-        // We need a Map to compare References by FQN.
-        // Regular Set cannot be used as it would use Reference.position along with other fields when calling equals() and
-        // position is resolved to -1 and -2 for all parts of the path in the case above so overlapping parts will be "different".
-
-        // pKeyIndices is constructed based on insertion order, so we need a LinkedHashMap.
+    /**
+     * @param tableElements has to be finalized and validated before passing to this method.
+     * collectReferences is called with bound = true meaning that it expects analyzer, geo properties to be resolved at this point.
+     */
+    public static AddColumnRequest createRequest(AnalyzedTableElements<Object> tableElements, RelationName relationName) {
 
         LinkedHashMap<ColumnIdent, Reference> references = new LinkedHashMap<>();
         IntArrayList pKeysIndices = new IntArrayList();
-        tableElements.collectReferences(alterTable.tableInfo().ident(), references, pKeysIndices, true);
+        tableElements.collectReferences(relationName, references, pKeysIndices, true);
 
         return new AddColumnRequest(
-            alterTable.tableInfo().ident(),
+            relationName,
             new ArrayList<>(references.values()), // We don't use Map in the request itself since we need directly indexed structure referred by pKeysIndices.
             tableElements.getCheckConstraints(),
             pKeysIndices
         );
     }
+
 
     /**
      * Validates statement, resolves generated and default expressions.

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateTablePlan.java
@@ -108,7 +108,7 @@ public class CreateTablePlan implements Plan {
             return;
         }
 
-        tableCreator.create(boundCreateTable)
+        tableCreator.create(boundCreateTable, plannerContext.clusterState().nodes().getMinNodeVersion())
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -155,15 +155,16 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
 
         PlannerContext plannerContext = e.getPlannerContext(clusterService.state());
 
-        var request = AlterTableAddColumnPlan.createRequest(
+        var tableElements = validate(
             analyzedAlterTableAddColumn,
+            plannerContext.transactionContext(),
             plannerContext.nodeContext(),
-            plannerContext,
             Row.EMPTY,
             SubQueryResults.EMPTY,
             e.fulltextAnalyzerResolver()
         );
 
+        var request = AlterTableAddColumnPlan.createRequest(tableElements, analyzedAlterTableAddColumn.tableInfo().ident());
 
         assertThat(request.pKeyIndices()).hasSize(2);
         assertThat(request.references()).hasSize(4); // 2 leaves (b, c) and their common parents (o, a).

--- a/server/src/test/java/io/crate/execution/ddl/tables/CreateTableRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/CreateTableRequestTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static io.crate.analyze.AnalyzedColumnDefinition.typeNameForESMapping;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.carrotsearch.hppc.IntArrayList;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.SimpleReference;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class CreateTableRequestTest {
+
+    @Test
+    public void test_streaming() throws Exception {
+        RelationName rel = RelationName.of(QualifiedName.of("t1"), Schemas.DOC_SCHEMA_NAME);
+
+        Reference ref1 = new SimpleReference(
+            new ReferenceIdent(rel, "part_col_1"),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            1,
+            null
+        );
+        Reference ref2 = new SimpleReference(
+            new ReferenceIdent(rel, "part_col_2"),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            2,
+            null
+        );
+        Reference ref3 = new SimpleReference(
+            new ReferenceIdent(rel, "just_col"),
+            RowGranularity.DOC,
+            DataTypes.BYTE,
+            3,
+            null
+        );
+        Reference ref4 = new SimpleReference(
+            new ReferenceIdent(rel, "some_routing_col"),
+            RowGranularity.DOC,
+            DataTypes.LONG,
+            4,
+            null
+        );
+        List<Reference> refs = List.of(ref1, ref2, ref3, ref4);
+        List<String> partCol1 = List.of("part_col_1", typeNameForESMapping(DataTypes.STRING, null, false));
+        List<String> partCol2 = List.of("part_col_2", typeNameForESMapping(DataTypes.INTEGER, null, false));
+        List<List<String>> partitionedBy = List.of(partCol1, partCol2);
+
+        CreateTableRequest request = new CreateTableRequest(
+            rel,
+            refs,
+            IntArrayList.from(3),
+            Map.of("check1", "just_col > 0"),
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_5_4_0).build(),
+            "some_routing_col",
+            ColumnPolicy.DYNAMIC,
+            partitionedBy,
+            Map.of("fulltext_index_name", Map.of())
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+        CreateTableRequest fromStream = new CreateTableRequest(out.bytes().streamInput());
+
+        assertThat(fromStream.getTableName()).isEqualTo(request.getTableName());
+        assertThat(fromStream.references()).isEqualTo(request.references());
+        assertThat(fromStream.checkConstraints()).isEqualTo(request.checkConstraints());
+        assertThat(fromStream.pKeyIndices()).isEqualTo(request.pKeyIndices());
+
+        assertThat(fromStream.settings()).isEqualTo(request.settings());
+        assertThat(fromStream.routingColumn()).isEqualTo(request.routingColumn());
+        assertThat(fromStream.tableColumnPolicy()).isEqualTo(request.tableColumnPolicy());
+        assertThat(fromStream.partitionedBy()).containsExactlyElementsOf(request.partitionedBy());
+        assertThat(fromStream.indices()).isEqualTo(request.indices());
+    }
+
+}

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -30,7 +30,6 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -321,6 +320,15 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("create table novels (title string, description string, " +
                 "index title_desc_fulltext using fulltext(title, description) " +
                 "with(analyzer='stop')) with (number_of_replicas = 0)");
+
+        String expectedMapping = "{\"default\":{" +
+            "\"dynamic\":\"strict\",\"" +
+            "_meta\":{\"indices\":{\"title_desc_fulltext\":{}}}," +
+            "\"properties\":{" +
+            "\"description\":{\"type\":\"keyword\",\"position\":2}," +
+            "\"title\":{\"type\":\"keyword\",\"position\":1}," +
+            "\"title_desc_fulltext\":{\"type\":\"text\",\"position\":3,\"analyzer\":\"stop\",\"sources\":[\"title\",\"description\"]}}}}";
+        assertEquals(expectedMapping, getIndexMapping("novels"));
 
         String title = "So Long, and Thanks for All the Fish";
         String description = "Many were increasingly of the opinion that they'd all made a big " +
@@ -1105,8 +1113,8 @@ public class DDLIntegrationTest extends IntegTestCase {
                       analyzer = 'simple'
                    ),
                    PRIMARY KEY ("id", "int_col"),
-                   CONSTRAINT int_check CHECK("int_col" > 20),
-                   CONSTRAINT leaf_check CHECK("o1"['a1']['c1'] > 10)
+                   CONSTRAINT leaf_check CHECK("o1"['a1']['c1'] > 10),
+                   CONSTRAINT int_check CHECK("int_col" > 20)
                 )""".stripIndent()
         );
 

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import io.crate.testing.TestingHelpers;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -1197,7 +1198,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
 
         IndexMetadata indexMetadata = IndexMetadata.builder(analyzedStatement.tableIdent().name())
             .settings(settingsBuilder)
-            .putMapping(new MappingMetadata(analyzedStatement.mapping()))
+            .putMapping(new MappingMetadata(TestingHelpers.toMapping(analyzedStatement)))
             .build();
 
         return newMeta(indexMetadata, analyzedStatement.tableIdent().name());

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -468,7 +468,7 @@ public class SQLExecutor {
                 .put(customSettings)
                 .build();
 
-            XContentBuilder mappingBuilder = JsonXContent.builder().map(analyzedStmt.mapping());
+            XContentBuilder mappingBuilder = JsonXContent.builder().map(TestingHelpers.toMapping(analyzedStmt));
             CompressedXContent mapping = new CompressedXContent(BytesReference.bytes(mappingBuilder));
             AliasMetadata alias = new AliasMetadata(analyzedStmt.tableIdent().indexNameOrAlias());
             IndexTemplateMetadata.Builder template = IndexTemplateMetadata.builder(analyzedStmt.templateName())
@@ -485,7 +485,7 @@ public class SQLExecutor {
                 IndexMetadata indexMetadata = getIndexMetadata(
                     partition,
                     combinedSettings,
-                    analyzedStmt.mapping(),
+                    TestingHelpers.toMapping(analyzedStmt),
                     prevState.nodes().getSmallestNonClientNodeVersion())
                     .putAlias(alias)
                     .build();
@@ -538,7 +538,7 @@ public class SQLExecutor {
             IndexMetadata indexMetadata = getIndexMetadata(
                 relationName.indexNameOrAlias(),
                 combinedSettings,
-                analyzedStmt.mapping(),
+                TestingHelpers.toMapping(analyzedStmt),
                 prevState.nodes().getSmallestNonClientNodeVersion()
             ).build();
 


### PR DESCRIPTION
One of the pre-requisites for https://github.com/crate/crate/issues/4457

`Dynamic mapping updates`, `ADD COLUMN(s)`,` CREATE TABLE AS`, `CREATE TABLE`, `CREATE TABLE ... PARTITIONED BY` all have in common that they update columns mapping. 

`ALTER TABLE ADD COLUMN(s)` uses new `AddColumnTask` from 5.2
`Dynamic mapping updates` uses `AddColumnTask` from 5.3 via Indexers.

If we migrate CREATE... statements to re-use `AddColumnTask` as well, we would have a single entry point for adding columns which can be useful, for example, when assigning column OID-s.

Technical details: `AddColumnTask` requires `AddColumnRequest` which is CrateDB specific structure (Reference).

CREATE TABLE is superset of adding column(s), thus we can express `CreateTableRequest` as `AddColumnRequest` + settings/indices/copy_to/partitionedBy/routing., see [commit](https://github.com/crate/crate/pull/13934/commits/8ac24dbb0f9c6be421647f7fd1e9567c74c31e71)


`AddColumnRequest` supports adding multiple cols and we even have an utility method to create a request out of many `AnalyzedColumnDefinition` after https://github.com/crate/crate/issues/7687. [Commit](https://github.com/crate/crate/pull/13934/commits/f28fa678eaaf38430142313a4217f3b4c00c5d87) to make it re-usable for CREATE TABLE case.

Another goal of migrating `CreateTableRequest` to CrateDB specific structures in making one step towards https://github.com/crate/crate/issues/11939. We don't use mapping and ES specific requests in our DDL requests and in planner. 

If we decide to store tables in a cluster state in a custom format, we would just change how we serialize `Reference` 


