### PR TITLE
Fix parsing error when quoted subscript expressions contain quotes

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -70,3 +70,7 @@ Fixes
 - Fixed an issue that allowed creating columns with names conflicting with
   subscript pattern, such as ``"a[1]"``, a subscript expression enclosed in
   double quotes.
+
+- Fixed an issue that caused ``SQLParseException`` when quoted subscript
+  expressions contained quotes. An example would be querying an array with the
+  name containing quotes like ``SELECT "arr""[1]";``.

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -104,6 +104,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.ExpressionFormatter;
 import io.crate.sql.parser.ParsingException;
+import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.ArithmeticExpression;
 import io.crate.sql.tree.ArrayComparison;
@@ -1264,7 +1265,8 @@ public class ExpressionAnalyzer {
     private static SubscriptExpression detectAndGenerateSubscriptExpressions(String columnName) {
         var openSubscriptPos = columnName.indexOf("[");
         if (openSubscriptPos > -1) {
-            var sanitizedName = "\"" + columnName.substring(0, openSubscriptPos) + "\"" + columnName.substring(openSubscriptPos);
+            var sanitizedName = Identifiers.quote(columnName.substring(0, openSubscriptPos)) +
+                                columnName.substring(openSubscriptPos);
             try {
                 return (SubscriptExpression) SqlParser.createExpression(sanitizedName);
             } catch (ParsingException ignored) {

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -95,6 +95,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .addTable(T3.T2_DEFINITION)
             .addTable(T3.T5_DEFINITION)
             .addTable("create table tarr (xs array(integer))")
+            .addTable("create table quoted_subscript (\"a\"\"\" int[])")
             .addTable("create table nested_obj (" +
                       "o object as (a object as (b object as (c int)))," +
                       "o_arr array(object as (x int, o_arr_nested array(object as (y int))))," +
@@ -359,6 +360,15 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> expressions.asSymbol("INTERVAL '1' MONTH TO YEAR"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Startfield must be less significant than Endfield");
+    }
+
+    @Test
+    public void test_quoted_subscript_expression_with_base_column_name_containing_quotes() {
+        var symbol = executor.asSymbol("quoted_subscript.\"a\"\"[1]\"");
+        assertThat(symbol).isFunction(
+            "subscript",
+            isReference("a\""),
+            isLiteral(1));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See below example:
```
cr> create table t ("a" int[], "b""" int[]);                                                                                                        
CREATE OK, 1 row affected  (2.203 sec)
cr> select "a[1]" from t; -- a working example of quoted subscript expression                                                                                                                          
+------+
| a[1] |
+------+
+------+
SELECT 0 rows in set (0.370 sec)
cr> select "b""[1]" from t; -- but this fails with a parsing error                                                                                                                          
SQLParseException[line 1:4: mismatched input '"' expecting {<EOF>, 'AT', 'OR', 'AND', 'IN', 'NOT', 'BETWEEN', 'LIKE', 'ILIKE', 'IS', '=', NEQ, '<', '<=', '>', '>=', '<<', '~', '!~', '~*', '!~*', '+', '-', '*', '/', '%', '||', '::', '[', '&', '|', '#'}]
```

After fix:
```
cr> select "b""[1]" from t;                                                                                                                         
+----------+
| "b"""[1] |
+----------+
+----------+
SELECT 0 rows in set (1.025 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
