### PR TITLE
followup: Fix resume handling for pgwire protocol level fetch

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -63,6 +63,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue in the PostgreSQL wire protocol implementation that could
+  lead to ``ClientInterrupted`` errors with some clients. An
+  example client is `pg-cursor <https://www.npmjs.com/package/pg-cursor>`_.
+
 - Fixed an issue that allowed creating columns with names conflicting with
   subscript pattern, such as ``"a[1]"``, a subscript expression enclosed in
   double quotes.

--- a/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
@@ -30,7 +30,6 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.exceptions.SQLExceptions;
-import io.crate.protocols.postgres.ClientInterrupted;
 
 public class RowConsumerToResultReceiver implements RowConsumer {
 
@@ -136,8 +135,8 @@ public class RowConsumerToResultReceiver implements RowConsumer {
 
     public void replaceResultReceiver(ResultReceiver<?> resultReceiver, int maxRows) {
         if (!this.resultReceiver.completionFuture().isDone()) {
-            // interrupt previous resultReceiver before replacing it, to ensure future triggers
-            this.resultReceiver.fail(new ClientInterrupted());
+            // finish previous resultReceiver before replacing it, to ensure future triggers
+            this.resultReceiver.allFinished();
         }
         this.rowCount = 0;
         this.resultReceiver = resultReceiver;


### PR DESCRIPTION
Call `allFinished()` instead of `fail()` to make sure the delegate `ResultSetReceiver` writes the appropriate pgwire message to the channel.

Issue discovered with: https://github.com/crate/crate-qa/commit/af82bfb7ff9682c8996687e546e087c43678d12b
```
Error [ERR_UNHANDLED_ERROR]: Unhandled error. (error: ClientInterrupted in io.crate.action.sql.RowConsumerToResultReceiver.replaceResultReceiver(RowConsumerToResultReceiver.java:140)

      at Parser.parseErrorMessage (node_modules/pg-protocol/src/parser.ts:369:69)
      at Parser.handlePacket (node_modules/pg-protocol/src/parser.ts:188:21)
      at Parser.parse (node_modules/pg-protocol/src/parser.ts:103:30)
      at Socket.<anonymous> (node_modules/pg-protocol/src/index.ts:7:48)
      at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
        length: 2183,
        severity: 'ERROR',
        code: 'XX000',
        detail: undefined,
        hint: undefined,
        position: undefined,
        internalPosition: undefined,
        internalQuery: undefined,
        where: 'io.crate.action.sql.RowConsumerToResultReceiver.replaceResultReceiver(RowConsumerToResultReceiver.java:140)\n' +
          'io.crate.action.sql.Session.execute(Session.java:463)\n' +
          'io.crate.protocols.postgres.PostgresWireProtocol.handleExecute(PostgresWireProtocol.java:683)\n' +
          'io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.dispatchMessage(PostgresWireProtocol.java:346)\n' +
          'io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.dispatchState(PostgresWireProtocol.java:321)\n' +
          'io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.channelRead0(PostgresWireProtocol.java:289)\n' +
          'io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.channelRead0(PostgresWireProtocol.java:273)\n' +
          'io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)\n' +
          'io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)\n' +
          'io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)\n' +
          'io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)\n' +
          'io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)\n' +
          'io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)\n' +
          'io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:454)\n' +
          'io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)\n' +
          'io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)\n' +
          'io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)\n' +
          'io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)\n' +
          'io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)\n' +
          'io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)\n',
```

Follows: #13911
