### PR TITLE
Fixed NPE exception when querying with NOT on null object field

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -63,6 +63,12 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that led to ``NullPointerException`` when trying to query an
+  ``OBJECT`` field with no values, using the ``NOT`` operator, e.g.::
+
+     CREATE TABLE test (obj OBJECT(DYNAMIC)); -- no data
+     SELECT myobj FROM test WHERE (obj::TEXT) NOT LIKE '%value%';
+
 - Fixed an issue in the PostgreSQL wire protocol implementation that could
   lead to ``ClientInterrupted`` errors with some clients. An
   example client is `pg-cursor <https://www.npmjs.com/package/pg-cursor>`_.

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -208,8 +208,11 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
         arg.accept(INNER_VISITOR, ctx);
         for (Reference reference : ctx.references()) {
             if (reference.isNullable()) {
-                // we don't count empty arrays here as we count them below explicitly if 3Vl logic is needed.
-                builder.add(IsNullPredicate.refExistsQuery(reference, context, false), BooleanClause.Occur.MUST);
+                var refExistsQuery = IsNullPredicate.refExistsQuery(reference, context, false);
+                if (refExistsQuery != null) {
+                    // we don't count empty arrays here as we count them below explicitly if 3Vl logic is needed.
+                    builder.add(refExistsQuery, BooleanClause.Occur.MUST);
+                }
             }
         }
         if (ctx.hasStrictThreeValuedLogicFunction) {


### PR DESCRIPTION
A null check for the query returned was missing, leading to `org.apache.lucene.search.BooleanClause`'s ctor to throw and NPE for passing a `null` query.

Follows: #13106
Fixes: #13936
