### PR TITLE
Cleanup Dead Code in Index Creation

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -26,7 +26,6 @@ import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
-import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
@@ -48,8 +47,6 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
     private String mapping = null;
 
     private final Set<Alias> aliases = new HashSet<>();
-
-    private final Set<ClusterBlock> blocks = new HashSet<>();
 
     private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
@@ -112,10 +109,6 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     public Set<Alias> aliases() {
         return aliases;
-    }
-
-    public Set<ClusterBlock> blocks() {
-        return blocks;
     }
 
     public Index recoverFrom() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -43,8 +43,6 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
     private ResizeType resizeType;
     private boolean copySettings;
 
-    private IndexMetadata.State state = IndexMetadata.State.OPEN;
-
     private Settings settings = Settings.Builder.EMPTY_SETTINGS;
 
     private String mapping = null;
@@ -102,10 +100,6 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     public String index() {
         return index;
-    }
-
-    public IndexMetadata.State state() {
-        return state;
     }
 
     public Settings settings() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -56,7 +56,6 @@ import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.ack.CreateIndexClusterStateUpdateResponse;
-import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata.State;
@@ -461,11 +460,6 @@ public class MetadataCreateIndexService {
                     indexMetadata.getNumberOfReplicas());
 
                 ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
-                if (!request.blocks().isEmpty()) {
-                    for (ClusterBlock block : request.blocks()) {
-                        blocks.addIndexBlock(request.index(), block);
-                    }
-                }
                 blocks.updateBlocks(indexMetadata);
 
                 ClusterState updatedState = ClusterState.builder(currentState).blocks(blocks).metadata(newMetadata).build();

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -384,7 +384,7 @@ public class RestoreService implements ClusterStateApplier {
                         // Index doesn't exist - create it and start recovery
                         // Make sure that the index we are about to create has a validate name
                         MetadataCreateIndexService.validateIndexName(renamedIndexName, currentState);
-                        createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), currentState, false);
+                        createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), false);
                         IndexMetadata.Builder indexMdBuilder = IndexMetadata.builder(snapshotIndexMetadata)
                             .state(IndexMetadata.State.OPEN)
                             .index(renamedIndexName);


### PR DESCRIPTION
First commit:

Partially applied https://github.com/elastic/elasticsearch/commit/383d7b77135ce1665b381ca59806e0a85618169e

Some cleanup was already done in https://github.com/crate/crate/pull/8260/commits/74e660554c38f0f71249b8583d8a23d6e7af148a#diff-6ac8b7103735b68b9305fb710311a5ade678d08dd234d0ce809d84d8fbc51dee

Second commit: blocks set is always empty, we can remove it. Setter was removed in https://github.com/crate/crate/pull/8260/commits/74e660554c38f0f71249b8583d8a23d6e7af148a#diff-6ac8b7103735b68b9305fb710311a5ade678d08dd234d0ce809d84d8fbc51dee and instance returned by the getter is never mutated,  only checked that it's `isEmpty`

