### PR TITLE
Add standard_conforming_string r/o session setting

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -54,7 +54,8 @@ None
 Changes
 =======
 
-None
+- Added the :ref:`standard_conforming_strings <conf-session-standard_conforming_strings>` 
+  read-only session setting for improved compatibility with PostgreSQL clients.
 
 Fixes
 =====

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -148,6 +148,14 @@ Supported session settings
 
   Shows the emulated ``PostgreSQL`` server version.
 
+.. _conf-session-standard_conforming_strings:
+
+**standard_conforming_strings**
+  | *Default:* ``on``
+  | *Modifiable:* ``no``
+
+  Causes ``'...'`` strings to treat backslashes literally.
+
 .. _conf-session-optimizer:
 
 **optimizer**

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -48,6 +48,7 @@ public class SessionSettingRegistry {
     static final String MAX_INDEX_KEYS = "max_index_keys";
     private static final String SERVER_VERSION_NUM = "server_version_num";
     private static final String SERVER_VERSION = "server_version";
+    static final String STANDARD_CONFORMING_STRINGS = "standard_conforming_strings";
     static final String ERROR_ON_UNKNOWN_OBJECT_KEY = "error_on_unknown_object_key";
     static final String DATE_STYLE_KEY = "datestyle";
     static final SessionSetting<String> APPLICATION_NAME = new SessionSetting<String>(
@@ -137,6 +138,20 @@ public class SessionSettingRegistry {
                      s -> String.valueOf(PostgresWireProtocol.PG_SERVER_VERSION),
                      () -> String.valueOf(PostgresWireProtocol.PG_SERVER_VERSION),
                      "Reports the emulated PostgreSQL version number",
+                     DataTypes.STRING
+                 )
+            )
+            .put(STANDARD_CONFORMING_STRINGS,
+                 new SessionSetting<>(
+                     STANDARD_CONFORMING_STRINGS,
+                     objects -> {},
+                     Function.identity(),
+                     (s, v) -> {
+                         throw new UnsupportedOperationException("\"" + STANDARD_CONFORMING_STRINGS + "\" cannot be changed.");
+                     },
+                     s -> "on",
+                     () -> "on",
+                     "Causes '...' strings to treat backslashes literally.",
                      DataTypes.STRING
                  )
             )

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -46,8 +46,8 @@ public class SessionSettingRegistry {
     private static final String SEARCH_PATH_KEY = "search_path";
     public static final String HASH_JOIN_KEY = "enable_hashjoin";
     static final String MAX_INDEX_KEYS = "max_index_keys";
-    private static final String SERVER_VERSION_NUM = "server_version_num";
-    private static final String SERVER_VERSION = "server_version";
+    static final String SERVER_VERSION_NUM = "server_version_num";
+    static final String SERVER_VERSION = "server_version";
     static final String STANDARD_CONFORMING_STRINGS = "standard_conforming_strings";
     static final String ERROR_ON_UNKNOWN_OBJECT_KEY = "error_on_unknown_object_key";
     static final String DATE_STYLE_KEY = "datestyle";

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -185,7 +185,8 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
             "server_version| 11.0| Reports the emulated PostgreSQL version number| NULL| NULL",
-            "server_version_num| 110000| Reports the emulated PostgreSQL version number| NULL| NULL"
+            "server_version_num| 110000| Reports the emulated PostgreSQL version number| NULL| NULL",
+            "standard_conforming_strings| on| Causes '...' strings to treat backslashes literally.| NULL| NULL"
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -429,7 +429,8 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
             "search_path| doc| Sets the schema search order.",
             "server_version| 11.0| Reports the emulated PostgreSQL version number",
-            "server_version_num| 110000| Reports the emulated PostgreSQL version number"
+            "server_version_num| 110000| Reports the emulated PostgreSQL version number",
+            "standard_conforming_strings| on| Causes '...' strings to treat backslashes literally."
         );
     }
 

--- a/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -55,11 +55,27 @@ public class SessionSettingRegistryTest {
     );
 
     @Test
-    public void testMaxIndexKeysSessionSettingCannotBeChanged() {
+    public void test_max_index_keys_session_setting_cannot_be_changed() {
         SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.MAX_INDEX_KEYS);
-        assertThrows(UnsupportedOperationException.class,
-                     () -> setting.apply(sessionSettings, generateInput("32"), eval),
-                     "\"max_index_keys\" cannot be changed.");
+        assertThatThrownBy(() -> setting.apply(sessionSettings, generateInput("32"), eval))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("\"max_index_keys\" cannot be changed.");
+    }
+
+    @Test
+    public void test_server_version_num_session_setting_cannot_be_changed() {
+        SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.SERVER_VERSION_NUM);
+        assertThatThrownBy(() -> setting.apply(sessionSettings, generateInput("100000"), eval))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("\"server_version_num\" cannot be changed.");
+    }
+
+    @Test
+    public void test_server_version_session_setting_cannot_be_changed() {
+        SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.SERVER_VERSION);
+        assertThatThrownBy(() -> setting.apply(sessionSettings, generateInput("10.0"), eval))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("\"server_version\" cannot be changed.");
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.metadata.settings.session;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -59,6 +60,14 @@ public class SessionSettingRegistryTest {
         assertThrows(UnsupportedOperationException.class,
                      () -> setting.apply(sessionSettings, generateInput("32"), eval),
                      "\"max_index_keys\" cannot be changed.");
+    }
+
+    @Test
+    public void test_standard_confirming_strings_session_setting_cannot_be_changed() {
+        SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.STANDARD_CONFORMING_STRINGS);
+        assertThatThrownBy(() -> setting.apply(sessionSettings, generateInput("no"), eval))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("\"standard_conforming_strings\" cannot be changed.");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adds support for the `standard_conforming_string` session setting in a read-only manner to improve compatibility with PostgreSQL clients in CrateDB. When this setting returns `on` by default as this reflect the behaviour in CrateDB that the backslash character is treated as a regular character instead of an escape character in string literals. This is consistent with default PostgreSQL behaviour.

also see https://crate.io/docs/crate/reference/en/5.2/sql/general/lexical-structure.html#escape-strings

closes https://github.com/crate/crate/issues/13884

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
