### PR TITLE
Randomize optimizer rules in Integration Tests

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -53,6 +53,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.testing.Asserts;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(numDataNodes = 1)
 public class ColumnPolicyIntegrationTest extends IntegTestCase {
@@ -245,6 +246,7 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         assertThat(getByPath(sourceMap, "properties.my_object.properties.b.inner.type")).isEqualTo("keyword");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testAddColumnToStrictObject() throws Exception {
         execute("create table books(" +

--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -56,6 +56,7 @@ import io.crate.action.sql.Sessions;
 import io.crate.exceptions.JobKilledException;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0, supportsDedicatedMasters = false)
 public class CopyFromFailFastITest extends IntegTestCase {
@@ -95,6 +96,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
             .hasMessageContaining("ERRORS: {Cannot cast value `fail here` to type `integer`");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @TestLogging("io.crate.execution.dml.upsert:DEBUG")
     @Test
     public void test_copy_from_with_fail_fast_with_write_error_on_non_handler_node() throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
 
+import io.crate.testing.UseRandomizedOptimizerRules;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +54,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
         properties.setProperty("user", "crate");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_simple_correlated_subquery() {
         execute("EXPLAIN SELECT 1, (SELECT t.mountain) FROM sys.summits t");
@@ -104,6 +106,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             .hasMessageContaining("Subquery returned more than 1 row when it shouldn't.");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_simple_correlated_subquery_with_order_by() {
         String statement = "SELECT 1, (SELECT t.mountain) FROM sys.summits t order by 2 asc limit 5";
@@ -180,6 +183,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_correlated_subquery_used_in_virtual_table_with_union() {
         String stmt = """
@@ -214,6 +218,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_where_exists_with_correlated_subquery() {
         String stmt = "select x from generate_series(1, 2) as t (x) where exists (select t.x)";
@@ -235,6 +240,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_can_use_correlated_subquery_in_where_clause() {
         String stmt = "SELECT mountain, region FROM sys.summits t where mountain = (SELECT t.mountain) ORDER BY height desc limit 3";
@@ -278,6 +284,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_correlated_subquery_without_table_alias_within_join_condition() {
         String stmt = """
@@ -329,6 +336,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
 
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_correlated_subquery_without_table_alias_within_join_condition_and_additional_condition() {
         var stmt = """
@@ -387,6 +395,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
 
     @Test
     @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
     public void test_can_use_column_in_query_paired_with_correlation_that_is_not_selected() throws Exception {
         execute("CREATE TABLE a (f1 TEXT, f2 TEXT, f3 TEXT)");
         execute("CREATE TABLE b (f1 TEXT, f2 TEXT, f3 TEXT)");

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -42,6 +42,7 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.testing.Asserts;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class CreateTableIntegrationTest extends IntegTestCase {
 
@@ -50,6 +51,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
         executeCreateTableThreaded("create table if not exists t (name string) with (number_of_replicas = 0)");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testCreatePartitionedTableIfNotExistsConcurrently() throws Throwable {
         executeCreateTableThreaded("create table if not exists t " +
@@ -145,6 +147,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
 
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_constraint_on_generated_column() {
         execute(

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -53,9 +53,11 @@ import io.crate.metadata.Schemas;
 import io.crate.protocols.postgres.PGErrorStatus;
 import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+@UseRandomizedOptimizerRules(0)
 @IntegTestCase.ClusterScope()
 @UseRandomizedSchema(random = false)
 public class DDLIntegrationTest extends IntegTestCase {

--- a/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import io.crate.common.unit.TimeValue;
 import io.crate.execution.dsl.projection.AbstractIndexWriterProjection;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class DeleteIntegrationTest extends IntegTestCase {
 
@@ -275,6 +276,7 @@ public class DeleteIntegrationTest extends IntegTestCase {
         execute("delete from t1 as foo where foo.id = 1");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_delete_partitions_from_subquery_does_not_leave_empty_orphan_partitions() {
         execute("CREATE TABLE t (x int) PARTITIONED by (x)");

--- a/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskUsagesITest.java
@@ -68,6 +68,7 @@ import org.junit.Test;
 import io.crate.common.unit.TimeValue;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
 @IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST, numDataNodes = 0)
@@ -355,6 +356,7 @@ public class DiskUsagesITest extends IntegTestCase {
         });
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     @UseRandomizedSchema(random = false)
     @UseJdbc(0) // need execute to throw ClusterBlockException instead of PGException

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -38,6 +38,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import io.crate.testing.UseRandomizedOptimizerRules;
+
 public class DynamicMappingUpdateITest extends IntegTestCase {
 
     @Rule
@@ -212,6 +214,7 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         execute_update_stmt_results_in_dynamic_mapping_updates();
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_update_partitioned_table_results_in_dynamic_mapping_updates() {
         execute("create table t (id int primary key) partitioned by (id) with (column_policy='dynamic')");

--- a/server/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import io.crate.testing.SQLResponse;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 /**
  * In ElasticSearch a routing value of '' is treated as if there is no routing
@@ -92,6 +93,7 @@ public class EmptyStringRoutingIntegrationTest extends IntegTestCase {
         assertThat((long) response.rows()[0][1], is(2L));
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testInsertEmtpyStringRoutingIsRealtime() throws Exception {
         execute("create table t (i int primary key, c string primary key, a int)" +

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -43,6 +42,7 @@ import org.junit.jupiter.api.Assertions;
 import io.crate.data.Paging;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
 public class GroupByAggregateTest extends IntegTestCase {
@@ -1324,6 +1324,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_optimized_limit_distinct_returns_2_unique_items() throws Throwable {
         execute("create table m.tbl (id int primary key)");

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.crate.planner.operators.RewriteInsertFromSubQueryToInsertFromValues;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
@@ -50,6 +52,7 @@ import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
+@UseRandomizedOptimizerRules(alwaysKeep = RewriteInsertFromSubQueryToInsertFromValues.class)
 public class InsertIntoIntegrationTest extends IntegTestCase {
 
     private final Setup setup = new Setup(sqlExecutor);
@@ -825,6 +828,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testInsertFromSubQueryWithVersion() throws Exception {
         execute("create table users (name string) clustered into 1 shards");
@@ -1350,6 +1354,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         assertThat((String) response.rows()[0][0]).isEqualTo("{\"id\":0,\"ts\":\"2015-01-01\"}");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testInsertFromQueryWithGeneratedPrimaryKey() throws Exception {
         execute("create table t (x int, y int, z as x + y primary key)");
@@ -1359,6 +1364,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         assertThat(execute("select * from t where z = 3").rowCount()).isEqualTo(1L);
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testInsertIntoTableWithNestedPrimaryKeyFromQuery() throws Exception {
         execute("create table t (o object as (ot object as (x int primary key)))");

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -48,6 +48,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 2)
@@ -408,6 +409,7 @@ public class JoinIntegrationTest extends IntegTestCase {
             "2| 2");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_self_join_with_order_and_limit_is_executed_with_qtf() throws Exception {
         execute("create table doc.t (x int, y int)");
@@ -1128,6 +1130,7 @@ public class JoinIntegrationTest extends IntegTestCase {
     @Test
     @UseHashJoins(value = 1.0)
     @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
     public void test_nested_join_with_primary_key_lookup() throws Exception {
         // Tests for a bug where the "requires scroll" property wasn't inherited correctly.
         // This led to a primary-key lookup operation which didn't support `moveToStart`
@@ -1173,6 +1176,7 @@ public class JoinIntegrationTest extends IntegTestCase {
     @Test
     @UseHashJoins(value = 0.0)
     @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
     public void test_nested_join_with_primary_key_lookup_on_each_join() throws Exception {
         // Tests for a bug where join operations got stuck because the Paging.PAGE_SIZE was set to 0 which
         // resulted in intermediate requests for just 1 record. This causes the join operations to get stuck.
@@ -1212,9 +1216,9 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute(stmt);
     }
 
-
     @Test
     @UseHashJoins(1)
+    @UseRandomizedOptimizerRules(0)
     public void test_inner_join_on_empty_system_tables() throws Exception {
         String stmt = """
             SELECT
@@ -1248,6 +1252,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
     @Test
     @UseHashJoins(1)
+    @UseRandomizedOptimizerRules(0)
     public void test_joins_with_constant_conditions_with_unions_and_renames() {
         execute("CREATE TABLE doc.t1 (id TEXT, name TEXT, PRIMARY KEY (id))");
         execute("CREATE TABLE doc.t2 (id TEXT, name TEXT, PRIMARY KEY (id))");
@@ -1295,6 +1300,7 @@ public class JoinIntegrationTest extends IntegTestCase {
      */
     @Test
     @UseHashJoins(1)
+    @UseRandomizedOptimizerRules(0)
     public void test_alias_in_left_join_condition() {
         execute("CREATE TABLE doc.t1 (id TEXT, name TEXT, subscription_id TEXT, PRIMARY KEY (id))");
         execute("CREATE TABLE doc.t2 (kind TEXT, cluster_id TEXT, PRIMARY KEY (kind, cluster_id))");
@@ -1344,6 +1350,7 @@ public class JoinIntegrationTest extends IntegTestCase {
      * See {@url https://github.com/crate/crate/issues/13689} and {@url https://github.com/crate/crate/issues/13361}.
      */
     @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_nested_loop_join_works_as_the_left_side_of_another_join() {
         execute("CREATE TABLE t1 (x int) CLUSTERED INTO 3 SHARDS");
@@ -1402,6 +1409,7 @@ public class JoinIntegrationTest extends IntegTestCase {
      */
     @Test
     @UseHashJoins(1)
+    @UseRandomizedOptimizerRules(0)
     public void test_nested_joins() {
         execute("CREATE TABLE doc.j1 (x INT)");
         execute("CREATE TABLE doc.j2 (x INT)");
@@ -1442,6 +1450,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
     @Test
     @UseHashJoins(1)
+    @UseRandomizedOptimizerRules(0)
     public void test_join_using_on_nested_join() throws Exception {
         execute("CREATE TABLE doc.j1 (x INT)");
         execute("CREATE TABLE doc.j2 (x INT)");

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -37,6 +37,7 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.testing.DataTypeTesting;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.types.DataType;
 
 @IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST)
@@ -249,6 +250,7 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         assertThat(response).hasRowCount(2L);
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testQueriesOnColumnThatDoesNotExistInAllPartitions() throws Exception {
         // LuceneQueryBuilder uses a MappedFieldType to generate queries
@@ -303,6 +305,7 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[0][0]).isEqualTo("yalla");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testWhereNotEqualAnyWithLargeArray() throws Exception {
         // Test overriding of default value 8192 for indices.query.bool.max_clause_count

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.MetadataTracker;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
 @UseRandomizedSchema(random = false)
@@ -246,6 +247,8 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
         }, 50, TimeUnit.SECONDS);
     }
 
+    @UseRandomizedOptimizerRules(0)
+    @Test
     public void test_subscription_to_multiple_publications_should_not_stop_on_a_single_publication_drop() throws Exception {
         executeOnPublisher("CREATE TABLE t1 (id INT)");
         executeOnPublisher("INSERT INTO t1 (id) VALUES (1), (2)");

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import io.crate.testing.Asserts;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class ObjectColumnTest extends IntegTestCase {
 
@@ -142,6 +143,7 @@ public class ObjectColumnTest extends IntegTestCase {
         assertThat(response.rowCount()).isEqualTo(0);
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testAddColumnToStrictObject() throws Exception {
         Map<String, Object> authorMap = Map.of(

--- a/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.testing.Asserts;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class OpenCloseTableIntegrationTest extends IntegTestCase {
 
@@ -281,6 +282,7 @@ public class OpenCloseTableIntegrationTest extends IntegTestCase {
                                                        "as it is currently closed.", getFqn("t")));
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testSelectPartitionedTableWhilePartitionIsClosed() throws Exception {
         execute("create table partitioned_table (i int) partitioned by (i)");

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -59,6 +59,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.crate.testing.UseRandomizedOptimizerRules;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
@@ -91,6 +92,7 @@ import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseRandomizedSchema;
 
+@UseRandomizedOptimizerRules(0)
 @IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 2)
 public class PartitionedTableIntegrationTest extends IntegTestCase {
 
@@ -2361,6 +2363,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_select_partitioned_by_column_with_query_then_fetch_plan() throws Exception {
         execute("create table doc.tbl (p int, ordinal int, name text) partitioned by (p)");

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -35,6 +35,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
 public class PgCatalogITest extends IntegTestCase {
@@ -143,6 +144,7 @@ public class PgCatalogITest extends IntegTestCase {
         assertThat(response).hasColumns("classoid", "description", "objoid");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     @UseJdbc(0)
     @UseRandomizedSchema(random = false)

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -40,6 +40,7 @@ import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class SQLTypeMappingTest extends IntegTestCase {
@@ -345,6 +346,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
         assertThat(selectedObject.get("another_new_col")).isEqualTo("1970-01-01T00:00:00");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testInsertNewColumnToStrictObject() throws Exception {
         setUpObjectTable();

--- a/server/src/test/java/io/crate/integrationtests/SeqNoBasedOCCIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SeqNoBasedOCCIntegrationTest.java
@@ -26,9 +26,12 @@ import static org.junit.Assert.assertEquals;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
+import io.crate.testing.UseRandomizedOptimizerRules;
+
 
 public class SeqNoBasedOCCIntegrationTest extends IntegTestCase {
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testDeleteWhereSeqNoAndTermThatMatch() throws Exception {
         execute("create table t (x integer primary key, y string) with (number_of_replicas=0)");
@@ -68,6 +71,7 @@ public class SeqNoBasedOCCIntegrationTest extends IntegTestCase {
         assertEquals(0, response.rowCount());
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testUpdateWhereSeqNoAndPrimaryTermWithPrimaryKey() throws Exception {
         execute("create table t (x integer primary key, y string)");

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
 @UseRandomizedSchema(random = false)
@@ -389,6 +390,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             .hasMessageContaining("Unknown session setting name 'foo'.");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @UseHashJoins(1)
     @UseJdbc(1)
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -47,6 +47,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class SubSelectIntegrationTest extends IntegTestCase {
@@ -65,6 +66,7 @@ public class SubSelectIntegrationTest extends IntegTestCase {
                "1| Arthur\n"));
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_sub_select_order_by_and_limit_using_query_then_fetch() throws Exception {
         execute("create table doc.tbl (ord int, name text)");

--- a/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SwapTableITest.java
@@ -31,7 +31,9 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.testing.Asserts;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
+@UseRandomizedOptimizerRules(0)
 public class SwapTableITest extends IntegTestCase {
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -72,6 +72,7 @@ import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
 public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
@@ -492,6 +493,7 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
         assertThat((Long) resp.rows()[0][0], is(0L));
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testSysOperationsLogConcurrentAccess() throws Exception {
         new Setup(sqlExecutor).groupBySetup();

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,7 +28,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -53,6 +52,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.crate.testing.UseRandomizedOptimizerRules;
 import org.assertj.core.data.Offset;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -372,6 +372,7 @@ public class TransportSQLActionTest extends IntegTestCase {
     }
 
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testSqlRequestWithFilter() throws Exception {
         execute("create table test (id string primary key)");
@@ -604,6 +605,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRows("124| bar1");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testSelectToRoutedRequestByPlanner() throws Exception {
         this.setup.createTestTableWithPrimaryKey();
@@ -1508,6 +1510,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertEquals(response.rowCount(), 0L);
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testInsertAndCopyHaveSameIdGeneration() throws Exception {
         execute("create table t (" +
@@ -1741,6 +1744,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_subscript_on_ignored_object_does_not_raise_missing_key_error() throws Exception {
         execute("create table tbl (obj object (ignored))");
@@ -1755,6 +1759,7 @@ public class TransportSQLActionTest extends IntegTestCase {
     }
 
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_primary_key_lookup_on_multiple_columns() throws Exception {
         execute(
@@ -1778,6 +1783,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_primary_key_lookup_with_param_that_requires_cast_to_column_type() throws Exception {
         execute("create table tbl (ts timestamp with time zone primary key, path text primary key)");
@@ -1793,6 +1799,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         );
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_primary_key_lookups_returns_inserted_records() throws Exception {
         int numKeys = randomIntBetween(1, 3);

--- a/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 1)
 public class UnionIntegrationTest extends IntegTestCase {
@@ -276,6 +277,7 @@ public class UnionIntegrationTest extends IntegTestCase {
         ));
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_union_with_group_by_and_order_plus_limit_and_offset() {
         execute(

--- a/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -43,6 +43,7 @@ import io.crate.common.collections.MapBuilder;
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class UpdateIntegrationTest extends IntegTestCase {
 
@@ -1041,6 +1042,7 @@ public class UpdateIntegrationTest extends IntegTestCase {
         }
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_update_preserves_the_top_level_order_implied_by_set_clause_while_dynamically_adding_columns() {
         execute("create table t (x int) partitioned by (x) with (column_policy='dynamic')");

--- a/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.testing.Asserts;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class VersionHandlingIntegrationTest extends IntegTestCase {
 
@@ -169,6 +170,7 @@ public class VersionHandlingIntegrationTest extends IntegTestCase {
             .hasMessageContaining(VersioningValidationException.VERSION_COLUMN_USAGE_MSG);
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testSelectWhereVersionWithPrimaryKey() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)");
@@ -177,6 +179,7 @@ public class VersionHandlingIntegrationTest extends IntegTestCase {
         assertThat(printedTable(response.rows()), is("1\n"));
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testSelectGroupByVersion() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)");

--- a/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.locationtech.spatial4j.shape.Point;
 
 import io.crate.common.collections.MapBuilder;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class WherePKIntegrationTest extends IntegTestCase {
 
@@ -324,6 +325,7 @@ public class WherePKIntegrationTest extends IntegTestCase {
         assertThat(response.rowCount(), is(2L));
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void test_select_where_pk_and_additional_filter() {
         execute("create table t1 (id int primary key, x int) with (refresh_interval=0)");

--- a/server/src/test/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -38,6 +38,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.testing.UseRandomizedOptimizerRules;
+
 public class MaxDocsLimitIT extends IntegTestCase {
 
     private static final AtomicInteger maxDocs = new AtomicInteger();
@@ -105,6 +107,7 @@ public class MaxDocsLimitIT extends IntegTestCase {
             .hasMessageContaining("Number of documents in the index can't exceed [" + maxDocs.get() + "]");
     }
 
+    @UseRandomizedOptimizerRules(0)
     @Test
     public void testMaxDocsLimitConcurrently() throws Exception {
         cluster().ensureAtLeastNumDataNodes(1);

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -77,6 +77,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
+import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -272,6 +274,7 @@ import io.crate.user.UserLookup;
 @UseJdbc
 @UseHashJoins
 @UseRandomizedSchema
+@UseRandomizedOptimizerRules(alwaysKeep = {RemoveRedundantFetchOrEval.class, MergeFilterAndCollect.class})
 public abstract class IntegTestCase extends ESTestCase {
 
     private static final Logger LOGGER = LogManager.getLogger(IntegTestCase.class);


### PR DESCRIPTION
This adds randomization of optimizer rules to all Integration Tests, and excludes the tests which fail with enabled randomization.

Note: 
There is a lot of follow-up work to do, finding out why the tests don't work and why some rules are necessary. I postponed that for now and just made sure the randomization is integrated in master.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
