### PR TITLE
Add new column rngmultitypid to pg_range table

### DIFF
--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRangeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRangeTable.java
@@ -34,6 +34,7 @@ public final class PgRangeTable {
         return SystemTable.<Void>builder(IDENT)
             .add("rngtypid", INTEGER, ignored -> null)
             .add("rngsubtype", INTEGER, ignored -> null)
+            .add("rngmultitypid", INTEGER, ignored -> null)
             .add("rngcollation", INTEGER, ignored -> null)
             .add("rngsubopc", INTEGER, ignored -> null)
             .add("rngcanonical", REGPROC, ignored -> null)

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -562,7 +562,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(946, response.rowCount());
+        assertEquals(947, response.rowCount());
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -630,7 +630,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(509L);
+            assertThat(response).hasRowCount(510L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");


### PR DESCRIPTION
- Migrate `PrivilegesIntegrationTest` to assertj.
- Since PostgreSQL wire protocol and expected server version has been bumped to 14, the new column is required for the pg_range table.

Follows: #13420
