### PR TITLE
Add a `null_or_empty` scalar

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -77,6 +77,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Added a :ref:`null_or_empty <scalar-null-or-empty>` scalar function that can
+  be used as a faster alternative to `IS NULL` if it's acceptable to match on
+  empty objects. This makes it possible to mitigate a performance regression
+  introduced in 5.0.3 and 5.1.1
+
 - Fixed an issue that led to ``NullPointerException`` when trying to query an
   ``OBJECT`` field with no values, using the ``NOT`` operator, e.g.::
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3214,6 +3214,29 @@ objects::
         SELECT 1 row in set (... sec)
 
 
+.. _scalar-null-or-empty:
+
+
+``null_or_empty(object)``
+-------------------------
+
+The ``null_or_empty(object)`` function returns a boolean indicating if an object
+is ``NULL`` or empty (``{}``).
+
+This can serve as a faster alternative to ``IS NULL`` if matching on empty
+objects is acceptable. It makes better use of indices.
+
+::
+
+    cr> SELECT null_or_empty({}) x, null_or_empty(NULL) y, null_or_empty({x=10}) z;
+    +------+------+-------+
+    | x    | y    | z     |
+    +------+------+-------+
+    | TRUE | TRUE | FALSE |
+    +------+------+-------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-conditional-fn-exp:
 
 Conditional functions and expressions

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -413,6 +413,15 @@ does always return ``NULL`` when comparing ``NULL``.
     SELECT 1 row in set (... sec)
 
 
+.. NOTE::
+
+   On object columns using ``IS NULL`` can be slow because objects themselves
+   don't have indices. They only exist for their child columns.
+
+   You can either query on inner columns or try the :ref:`null_or_empty
+   <scalar-null-or-empty>` scalar for improved performance.
+
+
 .. _sql_dql_is_not_null:
 
 ``IS NOT NULL``
@@ -454,6 +463,14 @@ does always return ``NULL`` when comparing ``NULL``.
     |       12 |
     +----------+
     SELECT 1 row in set (... sec)
+
+.. NOTE::
+
+   On object columns using ``IS NOT NULL`` can be slow because objects
+   themselves don't have indices. They only exist for their child columns.
+
+   You can either query on inner columns or try the :ref:`null_or_empty
+   <scalar-null-or-empty>` scalar for improved performance.
 
 
 .. _sql_dql_array_comparisons:

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+
+import io.crate.data.Input;
+import io.crate.expression.predicate.IsNullPredicate;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.functions.TypeVariableConstraint;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
+import io.crate.types.TypeSignature;
+
+public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                "null_or_empty",
+                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                DataTypes.BOOLEAN.getTypeSignature()
+            ),
+            NullOrEmptyFunction::new
+        );
+        module.register(
+            Signature.scalar(
+                "null_or_empty",
+                TypeSignature.parseTypeSignature("array(E)"),
+                DataTypes.BOOLEAN.getTypeSignature()
+            ).withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("E")),
+            NullOrEmptyFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    private NullOrEmptyFunction(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    @SafeVarargs
+    public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>... args) {
+        Object value = args[0].value();
+        if (value instanceof Map<?, ?> map) {
+            return map.isEmpty();
+        }
+        if (value instanceof Collection<?> collection) {
+            return collection.isEmpty();
+        }
+        return value == null;
+    }
+
+    @Override
+    public Query toQuery(Function function, Context context) {
+        assert function.arguments().size() == 1 : "Function has a single argument";
+        Symbol arg = function.arguments().get(0);
+        if (!(arg instanceof Reference ref)) {
+            return null;
+        }
+        DataType<?> valueType = ref.valueType();
+        if (valueType instanceof ObjectType objectType) {
+            if (objectType.innerTypes().isEmpty()) {
+                return null;
+            }
+            BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder()
+                .setMinimumNumberShouldMatch(1);
+            for (var entry : objectType.innerTypes().entrySet()) {
+                String childColumn = entry.getKey();
+                Reference childRef = context.getRef(ref.column().append(childColumn));
+                if (childRef == null) {
+                    return null;
+                }
+                Query refExistsQuery = IsNullPredicate.refExistsQuery(childRef, context, true);
+                if (refExistsQuery == null) {
+                    return null;
+                }
+                booleanQuery.add(refExistsQuery, Occur.SHOULD);
+            }
+            return Queries.not(booleanQuery.build());
+        } else if (valueType instanceof ArrayType<?> && ref.hasDocValues()) {
+            return Queries.not(new FieldExistsQuery(ref.column().fqn()));
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -44,10 +44,10 @@ import io.crate.expression.scalar.bitwise.BitwiseFunctions;
 import io.crate.expression.scalar.cast.ExplicitCastFunction;
 import io.crate.expression.scalar.cast.ImplicitCastFunction;
 import io.crate.expression.scalar.cast.TryCastFunction;
+import io.crate.expression.scalar.conditional.CaseFunction;
 import io.crate.expression.scalar.conditional.CoalesceFunction;
 import io.crate.expression.scalar.conditional.GreatestFunction;
 import io.crate.expression.scalar.conditional.IfFunction;
-import io.crate.expression.scalar.conditional.CaseFunction;
 import io.crate.expression.scalar.conditional.LeastFunction;
 import io.crate.expression.scalar.conditional.NullIfFunction;
 import io.crate.expression.scalar.formatting.ToCharFunction;
@@ -207,6 +207,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         NullIfFunction.register(this);
         IfFunction.register(this);
         CaseFunction.register(this);
+        NullOrEmptyFunction.register(this);
 
         CurrentSchemaFunction.register(this);
         CurrentSchemasFunction.register(this);

--- a/server/src/test/java/io/crate/expression/scalar/NullOrEmptyFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/NullOrEmptyFunctionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.Version;
+import org.junit.Test;
+
+import io.crate.testing.QueryTester;
+
+public class NullOrEmptyFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_or_empty_on_object() throws Exception {
+        assertEvaluate("null_or_empty(null::object)", true);
+        assertEvaluate("null_or_empty({a = 10})", false);
+        assertEvaluate("null_or_empty({})", true);
+
+        QueryTester.Builder builder = new QueryTester.Builder(
+            createTempDir(),
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (obj object as (x int))"
+        );
+        builder.indexValues("obj", new Object[] { null, Map.of(), Map.of("x", 1) });
+        try (var queryTester = builder.build()) {
+            assertThat(queryTester.toQuery("null_or_empty(obj)").toString())
+                .isEqualTo("+*:* -((FieldExistsQuery [field=obj.x])~1)");
+            List<Object> results = queryTester.runQuery("obj", "null_or_empty(obj)");
+            assertThat(results).containsExactlyInAnyOrder(null, Map.of());
+
+            results = queryTester.runQuery("obj", "not null_or_empty(obj)");
+            assertThat(results).containsExactlyInAnyOrder(Map.of("x", 1));
+        }
+    }
+
+    @Test
+    public void test_null_or_empty_on_array() throws Exception {
+        assertEvaluate("null_or_empty(null::text[])", true);
+        assertEvaluate("null_or_empty(['foo', 'bar'])", false);
+        assertEvaluate("null_or_empty([])", true);
+
+        QueryTester.Builder builder = new QueryTester.Builder(
+            createTempDir(),
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (arr integer[])"
+        );
+        builder.indexValues("arr", new Object[] { null, List.of(), List.of(1, 2, 3) });
+        try (var queryTester = builder.build()) {
+            assertThat(queryTester.toQuery("null_or_empty(arr)").toString())
+                .isEqualTo("+*:* -FieldExistsQuery [field=arr]");
+            List<Object> results = queryTester.runQuery("arr", "null_or_empty(arr)");
+            assertThat(results).containsExactlyInAnyOrder(null, List.of());
+
+            results = queryTester.runQuery("arr", "not null_or_empty(arr)");
+            assertThat(results).containsExactlyInAnyOrder(List.of(1, 2, 3));
+        }
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.common.collections.Iterables;
 import io.crate.data.BatchIterators;
 import io.crate.data.Input;
 import io.crate.execution.dml.IndexItem;
@@ -58,12 +59,11 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Schemas;
-import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.SchemaInfo;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.optimizer.symbol.Optimizer;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.CreateTable;
 
 public final class QueryTester implements AutoCloseable {
 
@@ -94,8 +94,9 @@ public final class QueryTester implements AutoCloseable {
                 .build();
             plannerContext = sqlExecutor.getPlannerContext(clusterService.state());
 
-            DocSchemaInfo docSchema = findDocSchema(sqlExecutor.schemas());
-            table = (DocTableInfo) docSchema.getTables().iterator().next();
+            var createTable = (CreateTable<?>) SqlParser.createStatement(createTableStmt);
+            String tableName = Iterables.getLast(createTable.name().getName().getParts());
+            table = sqlExecutor.resolveTableInfo(tableName);
 
             indexEnv = new IndexEnv(
                 threadPool,
@@ -110,15 +111,6 @@ public final class QueryTester implements AutoCloseable {
                 Collections.singletonMap(table.ident(), docTableRelation),
                 docTableRelation
             );
-        }
-
-        private DocSchemaInfo findDocSchema(Schemas schemas) {
-            for (SchemaInfo schema : schemas) {
-                if (schema instanceof DocSchemaInfo) {
-                    return (DocSchemaInfo) schema;
-                }
-            }
-            throw new IllegalArgumentException("Create table statement must result in the creation of a user table");
         }
 
         public Builder indexValues(String column, Object ... values) throws IOException {


### PR DESCRIPTION
This can be used instead of `IS NULL` if it's okay to match on empty
objects.
Although kind of a feature this is added as a fix because it allows to
mitigate a performance regression introduced with https://github.com/crate/crate/pull/13106
We can't revert the behavior for `IS NULL` without breaking SQL
semantics.

An earlier fix (https://github.com/crate/crate/pull/13771) only helped
if the table contained no null values.

Closes https://github.com/crate/crate/issues/13769

    Statement:
      SELECT count(*) FROM many_null WHERE null_or_empty(o)
    Concurrency: 1
    Iterations: 10
    Runtime (in ms):
        mean:    1.152 ± 0.444
        min/max: 0.843 → 3.186
    Percentile:
        50:   0.924 ± 0.717 (stdev)
        95:   3.186
        99.9: 3.186

    Statement:
      SELECT count(*) FROM many_null WHERE NOT null_or_empty(o)
    Concurrency: 1
    Iterations: 10
    Runtime (in ms):
        mean:    31.275 ± 40.573
        min/max: 1.179 → 199.507
    Percentile:
        50:   1.753 ± 65.460 (stdev)
        95:   199.507
        99.9: 199.507
