### PR TITLE
Make RewriteInsertFromSubQueryToInsertFromValues Rule mandatory

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -156,7 +156,10 @@ public class LogicalPlanner {
         new RewriteToQueryThenFetch()
     );
 
-    public static final List<Rule<?>> WRITE_OPTIMIZER_RULES =
+    // This rule is private because the RewriteInsertFromSubQueryToInsertFromValues
+    // rule is mandatory to make inserts from a sub-query work correctly
+    // and should therefore not be exposed to be configurable
+    private static final List<Rule<?>> WRITE_OPTIMIZER_RULES =
         List.of(new RewriteInsertFromSubQueryToInsertFromValues());
 
     public LogicalPlanner(NodeContext nodeCtx, TableStats tableStats, Supplier<Version> minNodeVersionInCluster) {

--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -45,7 +45,6 @@ public class LoadedRules implements SessionSettingProvider {
     private static List<Class<? extends Rule<?>>> buildRules() {
         var rules = new ArrayList<Rule<?>>();
         rules.addAll(LogicalPlanner.ITERATIVE_OPTIMIZER_RULES);
-        rules.addAll(LogicalPlanner.WRITE_OPTIMIZER_RULES);
         rules.addAll(LogicalPlanner.FETCH_OPTIMIZER_RULES);
         return Lists2.map(rules, x -> (Class<? extends Rule<?>>) x.getClass());
     }

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crate.planner.operators.RewriteInsertFromSubQueryToInsertFromValues;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
@@ -52,7 +51,6 @@ import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
-@UseRandomizedOptimizerRules(alwaysKeep = RewriteInsertFromSubQueryToInsertFromValues.class)
 public class InsertIntoIntegrationTest extends IntegTestCase {
 
     private final Setup setup = new Setup(sqlExecutor);

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -182,7 +182,6 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_remove_redundant_fetch_or_eval| true| Indicates if the optimizer rule RemoveRedundantFetchOrEval is activated.| NULL| NULL",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.| NULL| NULL",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.| NULL| NULL",
-            "optimizer_rewrite_insert_from_sub_query_to_insert_from_values| true| Indicates if the optimizer rule RewriteInsertFromSubQueryToInsertFromValues is activated.| NULL| NULL",
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -427,7 +427,6 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_remove_redundant_fetch_or_eval| true| Indicates if the optimizer rule RemoveRedundantFetchOrEval is activated.",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.",
-            "optimizer_rewrite_insert_from_sub_query_to_insert_from_values| true| Indicates if the optimizer rule RewriteInsertFromSubQueryToInsertFromValues is activated.",
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
             "search_path| doc| Sets the schema search order.",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

It does not make sense to deactivate this rule or make it configurable because it's mandatory. 
See https://github.com/crate/crate/pull/13958#discussion_r1163916252

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
