### PR TITLE
Introduce Stats for Logical Plans

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Distinct.java
+++ b/server/src/main/java/io/crate/planner/operators/Distinct.java
@@ -31,11 +31,15 @@ import static io.crate.planner.operators.GroupHashAggregate.approximateDistinctV
 
 public final class Distinct {
 
-    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, TableStats tableStats) {
+    public static LogicalPlan create(LogicalPlan source,
+                                     long numDocs,
+                                     boolean distinct,
+                                     List<Symbol> outputs,
+                                     TableStats tableStats) {
         if (!distinct) {
             return source;
         }
-        long numExpectedRows = approximateDistinctValues(source.numExpectedRows(), tableStats, outputs);
+        long numExpectedRows = approximateDistinctValues(numDocs, tableStats, outputs);
         return new GroupHashAggregate(source, outputs, Collections.emptyList(), numExpectedRows);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -34,6 +34,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
@@ -201,13 +202,19 @@ public interface LogicalPlan extends Plan {
     /**
      * Returns the total number of rows this logical operation is expected to return.
      * @return The number of expected rows if available, -1 otherwise.
+     *
+     * @deprecated Use {@link PlanStats} instead.
      */
+    @Deprecated
     long numExpectedRows();
 
     /**
      * Returns an estimation of the size (in bytes) of each row returned by the plan.
      * The estimation is based on the average size of a row of the concrete table(s) of the plan.
+     *
+     * @deprecated Use {@link PlanStats} instead.
      */
+    @Deprecated
     long estimatedRowSize();
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -25,10 +25,10 @@ import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -54,7 +54,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
     @Override
     public LogicalPlan apply(Insert plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -203,6 +203,14 @@ public class Union implements LogicalPlan {
         return new Union(sources.get(0), sources.get(1), outputs);
     }
 
+    public LogicalPlan lhs() {
+        return lhs;
+    }
+
+    public LogicalPlan rhs() {
+        return rhs;
+    }
+
     @Override
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         IntArrayList outputIndicesToKeep = new IntArrayList();

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -26,9 +26,10 @@ import java.util.function.Function;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
+
 import org.elasticsearch.Version;
 
 public interface Rule<T> {
@@ -45,7 +46,7 @@ public interface Rule<T> {
      */
     LogicalPlan apply(T plan,
                       Captures captures,
-                      TableStats tableStats,
+                      PlanStats planStats,
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
                       Function<LogicalPlan, LogicalPlan> resolvePlan);

--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.costs;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import io.crate.common.collections.Maps;
+import io.crate.expression.symbol.Literal;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.CorrelatedJoin;
+import io.crate.planner.operators.Count;
+import io.crate.planner.operators.Get;
+import io.crate.planner.operators.GroupHashAggregate;
+import io.crate.planner.operators.HashAggregate;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.Insert;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.operators.TableFunction;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.iterative.GroupReference;
+import io.crate.planner.optimizer.iterative.Memo;
+import io.crate.sql.tree.JoinType;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.types.DataTypes;
+
+public class PlanStats {
+
+    private final TableStats tableStats;
+    // Memo can be null when there are no Group References in the Logical Plans involved
+    @Nullable
+    private final Memo memo;
+
+    public PlanStats(TableStats tableStats) {
+        this(tableStats, null);
+    }
+
+    public PlanStats(TableStats tableStats, @Nullable Memo memo) {
+        this.tableStats = tableStats;
+        this.memo = memo;
+    }
+
+    public TableStats tableStats() {
+        return tableStats;
+    }
+
+    public Stats apply(LogicalPlan logicalPlan) {
+        var visitor = new StatsVisitor(tableStats, memo);
+        return logicalPlan.accept(visitor, null);
+    }
+
+    private static class StatsVisitor extends LogicalPlanVisitor<Void, Stats> {
+
+        private final TableStats tableStats;
+        @Nullable
+        private final Memo memo;
+
+        public StatsVisitor(TableStats tableStats, @Nullable Memo memo) {
+            this.tableStats = tableStats;
+            this.memo = memo;
+        }
+
+        @Override
+        public Stats visitGroupReference(GroupReference group, Void context) {
+            if (memo == null) {
+                throw new UnsupportedOperationException("Stats cannot be provided for GroupReference without a Memo");
+            }
+            var groupId = group.groupId();
+            var stats = memo.stats(groupId);
+            if (stats == null) {
+                // No stats for this group yet.
+                // Let's get the logical plan, calculate the stats
+                // and update the stats for this group
+                var logicalPlan = memo.resolve(groupId);
+                stats = logicalPlan.accept(this, context);
+                memo.addStats(groupId, stats);
+            }
+            return stats;
+        }
+
+        @Override
+        public Stats visitLimit(Limit limit, Void context) {
+            var stats = limit.source().accept(this, context);
+            if (limit.limit() instanceof Literal) {
+                var numberOfRows = DataTypes.LONG.sanitizeValue(((Literal<?>) limit.limit()).value());
+                return new Stats(numberOfRows, stats.sizeInBytes(), stats.statsByColumn());
+            }
+            return stats;
+        }
+
+        @Override
+        public Stats visitUnion(Union union, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = union.lhs().accept(this, context);
+            var rhsStats = union.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                numberOfRows = lhsStats.numDocs() + rhsStats.numDocs();
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = Math.max(lhsStats.sizeInBytes(), rhsStats.sizeInBytes());
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitNestedLoopJoin(NestedLoopJoin join, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = join.lhs().accept(this, context);
+            var rhsStats = join.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                if (join.joinType() == JoinType.CROSS) {
+                    numberOfRows = lhsStats.numDocs() * rhsStats.numDocs();
+                } else {
+                    // We don't have any cardinality estimates, so just take the bigger table
+                    numberOfRows = Math.max(lhsStats.numDocs(), rhsStats.numDocs());
+                }
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = lhsStats.sizeInBytes() + rhsStats.sizeInBytes();
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitHashJoin(HashJoin join, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = join.lhs().accept(this, context);
+            var rhsStats = join.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                // We don't have any cardinality estimates, so just take the bigger table
+                numberOfRows = Math.max(lhsStats.numDocs(), rhsStats.numDocs());
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = lhsStats.sizeInBytes() + rhsStats.sizeInBytes();
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitCollect(Collect collect, Void context) {
+            var stats = tableStats.getStats(collect.relation().relationName());
+            return new Stats(stats.numDocs(), stats.averageSizePerRowInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitCount(Count count, Void context) {
+            return new Stats(1, Long.BYTES, Map.of());
+        }
+
+        @Override
+        public Stats visitGet(Get get, Void context) {
+            return new Stats(get.numExpectedRows(), get.estimatedRowSize(), Map.of());
+        }
+
+        @Override
+        public Stats visitGroupHashAggregate(GroupHashAggregate groupHashAggregate, Void context) {
+            var stats = groupHashAggregate.source().accept(this, context);
+            return new Stats(groupHashAggregate.numExpectedRows(), stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitHashAggregate(HashAggregate hashAggregate, Void context) {
+            var stats = hashAggregate.source().accept(this, context);
+            return new Stats(1L, stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitInsert(Insert insert, Void context) {
+            var stats = insert.sources().get(0).accept(this, context);
+            return new Stats(1L, stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitCorrelatedJoin(CorrelatedJoin join, Void context) {
+            return join.sources().get(0).accept(this, context);
+        }
+
+        @Override
+        public Stats visitTableFunction(TableFunction tableFunction, Void context) {
+            // We don't have any estimates for table functions, but could go through the types of `outputs` to make a guess
+            return Stats.EMPTY;
+        }
+
+        @Override
+        public Stats visitPlan(LogicalPlan logicalPlan, Void context) {
+            // This covers all sub-classes of LogicalForwardPlan
+            if (logicalPlan.sources().size() == 1) {
+                return logicalPlan.sources().get(0).accept(this, context);
+            }
+            throw new UnsupportedOperationException("Plan stats not available");
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -36,6 +36,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Optimizer;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.statistics.TableStats;
 
 /**
@@ -70,7 +71,8 @@ public class IterativeOptimizer {
             return node;
         };
         var applicableRules = removeExcludedRules(rules, txnCtx.sessionSettings().excludedOptimizerRules());
-        exploreGroup(memo.getRootGroup(), new Context(memo, groupReferenceResolver, applicableRules, txnCtx, tableStats));
+        var planStats = new PlanStats(tableStats, memo);
+        exploreGroup(memo.getRootGroup(), new Context(memo, groupReferenceResolver, applicableRules, txnCtx, planStats));
         return memo.extract();
     }
 
@@ -120,7 +122,7 @@ public class IterativeOptimizer {
                 LogicalPlan transformed = Optimizer.tryMatchAndApply(
                     rule,
                     node,
-                    context.tableStats,
+                    context.planStats,
                     nodeCtx,
                     context.txnCtx,
                     resolvePlan,
@@ -163,6 +165,6 @@ public class IterativeOptimizer {
         Function<LogicalPlan, LogicalPlan> groupReferenceResolver,
         List<Rule<?>> rules,
         CoordinatorTxnCtx txnCtx,
-        TableStats tableStats
+        PlanStats planStats
     ) {}
 }

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
@@ -29,11 +29,14 @@ import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.carrotsearch.hppc.IntObjectHashMap;
 
 import io.crate.common.collections.Lists2;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.statistics.Stats;
 
 /**
  * Memo is used as part of an iterative Optimizer as an in-place
@@ -117,6 +120,19 @@ public class Memo {
         return resolveGroupReferences(node, GroupReferenceResolver.from(this::resolve));
     }
 
+    public void addStats(int groupId, Stats stats) {
+        Group group = group(groupId);
+        if (group.stats != null) {
+            evictStats(groupId);
+        }
+        group.stats = stats;
+    }
+
+    @Nullable
+    public Stats stats(int groupId) {
+        return group(groupId).stats;
+    }
+
     private Group group(int group) {
         if (!groups.containsKey(group)) {
             throw new IllegalStateException("Group not found");
@@ -144,7 +160,17 @@ public class Memo {
         incrementReferenceCounts(node, groupId);
         group.membership = node;
         decrementReferenceCounts(old, groupId);
+        evictStats(groupId);
         return node;
+    }
+
+    private void evictStats(int group) {
+        group(group).stats = null;
+        for (int parentGroup : group(group).incomingReferences) {
+            if (parentGroup != ROOT_GROUP_REF) {
+                evictStats(parentGroup);
+            }
+        }
     }
 
     private void incrementReferenceCounts(LogicalPlan fromNode, int fromGroup) {
@@ -217,6 +243,9 @@ public class Memo {
 
         private LogicalPlan membership;
         private final List<Integer> incomingReferences = new ArrayList<>();
+
+        @Nullable
+        private Stats stats;
 
         private Group(LogicalPlan member) {
             this.membership = requireNonNull(member, "member is null");

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
@@ -68,7 +68,7 @@ public final class DeduplicateOrder implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -27,7 +27,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Count;
 import io.crate.planner.operators.HashAggregate;
@@ -64,7 +64,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
     @Override
     public Count apply(HashAggregate aggregate,
                        Captures captures,
-                       TableStats tableStats,
+                       PlanStats planStats,
                        TransactionContext txnCtx,
                        NodeContext nodeCtx,
                        Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -38,10 +38,10 @@ import io.crate.planner.operators.HashAggregate;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate> {
 
@@ -76,7 +76,7 @@ public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate
     @Override
     public LogicalPlan apply(HashAggregate aggregate,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -28,12 +28,12 @@ import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.planner.selectivity.SelectivityFunctions;
 import io.crate.statistics.Stats;
-import io.crate.statistics.TableStats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -59,12 +59,12 @@ public class MergeFilterAndCollect implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
-        Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
+        Stats stats = planStats.apply(collect);
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(
             collect.relation(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -26,7 +26,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
@@ -72,7 +72,7 @@ public class MergeFilters implements Rule<Filter> {
     @Override
     public Filter apply(Filter plan,
                         Captures captures,
-                        TableStats tableStats,
+                        PlanStats planStats,
                         TransactionContext txnCtx,
                         NodeContext nodeCtx,
                         Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -36,6 +36,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.consumer.RelationNameCollector;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
@@ -43,7 +44,6 @@ import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedLoopJoin> {
 
@@ -64,7 +64,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
     @Override
     public LogicalPlan apply(NestedLoopJoin nl,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -36,10 +36,10 @@ import io.crate.planner.operators.CorrelatedJoin;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
 
@@ -60,7 +60,7 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathFetchOrEval.java
@@ -28,10 +28,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -60,7 +60,7 @@ public final class MoveFilterBeneathFetchOrEval implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -39,10 +39,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.GroupHashAggregate;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /**
  * Transforms queries like
@@ -76,7 +76,7 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.JoinPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
@@ -63,7 +63,7 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -81,7 +81,7 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -40,10 +40,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.ProjectSet;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
 
@@ -64,7 +64,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -28,10 +28,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -58,7 +58,7 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -25,7 +25,7 @@ import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Union;
@@ -59,7 +59,7 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -32,10 +32,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +66,7 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveLimitBeneathEval implements Rule<Limit> {
 
@@ -57,7 +57,7 @@ public class MoveLimitBeneathEval implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveLimitBeneathRename implements Rule<Limit> {
 
@@ -57,7 +57,7 @@ public class MoveLimitBeneathRename implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
@@ -28,10 +28,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -60,7 +60,7 @@ public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -44,10 +44,10 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /* Move the orderBy expression to the sub-relation if possible.
  *
@@ -81,7 +81,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order order,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -30,10 +30,10 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -79,7 +79,7 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Union;
@@ -58,7 +58,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order order,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -35,9 +35,9 @@ import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Get;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -65,7 +65,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
     @Override
     public LogicalPlan apply(Collect collect,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
@@ -87,7 +87,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
                 docKeys.get(),
                 detailedQuery.query(),
                 collect.outputs(),
-                tableStats.estimatedSizePerRow(relation.relationName())
+                planStats.apply(collect).averageSizePerRowInBytes()
             );
         } else if (!detailedQuery.clusteredBy().isEmpty() && collect.detailedQuery() == null) {
             return new Collect(collect, detailedQuery);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
@@ -54,7 +54,7 @@ public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
     @Override
     public LogicalPlan apply(Eval plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -40,6 +40,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -48,7 +49,6 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /**
  * If we can determine that a filter on an OUTER JOIN turns all NULL rows that the join could generate into a NO-MATCH
@@ -119,7 +119,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -36,10 +36,10 @@ import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LimitDistinct;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
 
@@ -79,7 +79,7 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
 
     private static boolean eagerTerminateIsLikely(Limit limit,
                                                   GroupHashAggregate groupAggregate,
-                                                  Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                                                  PlanStats planStats) {
         if (groupAggregate.outputs().size() > 1 || !groupAggregate.outputs().get(0).valueType().equals(DataTypes.STRING)) {
             // `GroupByOptimizedIterator` can only be used for single text columns.
             // If that is not the case we can always use LimitDistinct even if a eagerTerminate isn't likely
@@ -91,11 +91,12 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
             var limitVal = DataTypes.INTEGER.sanitizeValue(((Literal<?>) limitSymbol).value());
             // Would consume all source rows -> prefer default group by implementation which has other optimizations
             // which are more beneficial in this scenario
-            if (limitVal > groupAggregate.numExpectedRows()) {
+            var stats = planStats.apply(groupAggregate);
+            if (limitVal > stats.numDocs()) {
                 return false;
             }
         }
-        long sourceRows = resolvePlan.apply(groupAggregate.source()).numExpectedRows();
+        long sourceRows = planStats.apply(groupAggregate.source()).numDocs();
         if (sourceRows == 0) {
             return false;
         }
@@ -166,12 +167,12 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         GroupHashAggregate groupBy = captures.get(groupCapture);
-        if (!eagerTerminateIsLikely(limit, groupBy, resolvePlan)) {
+        if (!eagerTerminateIsLikely(limit, groupBy, planStats)) {
             return null;
         }
         return new LimitDistinct(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
@@ -32,16 +32,16 @@ import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
 
     private final Pattern<NestedLoopJoin> pattern = typeOf(NestedLoopJoin.class)
         .with(nl -> nl.isRewriteNestedLoopJoinToHashJoinDone() == false &&
                     nl.orderByWasPushedDown() == false);
-    
+
     @Override
     public Pattern<NestedLoopJoin> pattern() {
         return pattern;
@@ -50,7 +50,7 @@ public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
     @Override
     public LogicalPlan apply(NestedLoopJoin nl,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -46,6 +46,7 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -77,14 +78,14 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }
-        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(tableStats, Set.of());
+        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(planStats.tableStats(), Set.of());
         if (fetchRewrite == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -73,6 +73,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.planner.optimizer.rule.OptimizeCollectWhereClauseAccess;
@@ -184,7 +185,7 @@ public final class CopyToPlan implements Plan {
         if (match.isPresent()) {
             LogicalPlan plan = rewriteCollectToGet.apply(match.value(),
                                                          match.captures(),
-                                                         tableStats,
+                                                         new PlanStats(tableStats),
                                                          context.transactionContext(),
                                                          context.nodeContext(),
                                                          Function.identity());

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -87,6 +87,10 @@ public class Stats implements Writeable {
         return numDocs;
     }
 
+    public long sizeInBytes() {
+        return sizeInBytes;
+    }
+
     public long averageSizePerRowInBytes() {
         if (numDocs == -1) {
             return -1;

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.costs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.optimizer.iterative.GroupReference;
+import io.crate.planner.optimizer.iterative.Memo;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
+
+    public void test_collect() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 1L,
+                                 DataTypes.INTEGER.fixedSize());
+        var memo = new Memo(source);
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, 1, Map.of())));
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(source);
+        assertThat(result.numDocs()).isEqualTo(1L);
+    }
+
+    public void test_group_reference() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 1L,
+                                 DataTypes.INTEGER.fixedSize());
+        var groupReference = new GroupReference(1, source.outputs(), Set.of());
+        var memo = new Memo(source);
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, 1, Map.of())));
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(groupReference);
+        assertThat(result.numDocs()).isEqualTo(1L);
+    }
+
+    public void test_tree_of_operators() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 10L,
+                                 DataTypes.INTEGER.fixedSize());
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
+        var limit = new Limit(source, Literal.of(5), Literal.of(0));
+
+        var memo = new Memo(limit);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(limit);
+        assertThat(result.numDocs()).isEqualTo(5L);
+    }
+
+    public void test_update_table_stats() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 10L,
+                                 DataTypes.INTEGER.fixedSize());
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
+
+        var eval = Eval.create(source, List.of());
+
+        var memo = new Memo(eval);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(eval);
+        assertThat(result.numDocs()).isEqualTo(10L);
+
+        // now update the tablestats
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(100L, 1, Map.of())));
+
+        planStats = new PlanStats(tableStats, memo);
+        result = planStats.apply(eval);
+        assertThat(result.numDocs()).isEqualTo(100L);
+
+    }
+}

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -27,12 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.Test;
+
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.Collect;
-import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.optimizer.iterative.GroupReference;
 import io.crate.planner.optimizer.iterative.Memo;
@@ -44,7 +45,8 @@ import io.crate.types.DataTypes;
 
 public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
-    public void test_collect() throws Exception {
+    @Test
+    public void test_retrieve_number_of_docs_from_tablestats_in_collect_operator() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .addTable("create table a (x int)")
             .build();
@@ -58,14 +60,16 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
                                  1L,
                                  DataTypes.INTEGER.fixedSize());
         var memo = new Memo(source);
+        // set number of docs in TableStats to 10
         TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, 1, Map.of())));
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10, 1, Map.of())));
         PlanStats planStats = new PlanStats(tableStats, memo);
         var result = planStats.apply(source);
-        assertThat(result.numDocs()).isEqualTo(1L);
+        assertThat(result.numDocs()).isEqualTo(10L);
     }
 
-    public void test_group_reference() throws Exception {
+    @Test
+    public void test_retrieve_stats_for_group_reference() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .addTable("create table a (x int)")
             .build();
@@ -80,14 +84,16 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
                                  DataTypes.INTEGER.fixedSize());
         var groupReference = new GroupReference(1, source.outputs(), Set.of());
         var memo = new Memo(source);
+        // set number of docs in TableStats to 10
         TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, 1, Map.of())));
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10, 1, Map.of())));
         PlanStats planStats = new PlanStats(tableStats, memo);
         var result = planStats.apply(groupReference);
-        assertThat(result.numDocs()).isEqualTo(1L);
+        assertThat(result.numDocs()).isEqualTo(10L);
     }
 
-    public void test_tree_of_operators() throws Exception {
+    @Test
+    public void test_retrieve_stats_for_nested_operators() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .addTable("create table a (x int)")
             .build();
@@ -108,37 +114,5 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         PlanStats planStats = new PlanStats(tableStats, memo);
         var result = planStats.apply(limit);
         assertThat(result.numDocs()).isEqualTo(5L);
-    }
-
-    public void test_update_table_stats() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService)
-            .addTable("create table a (x int)")
-            .build();
-
-        DocTableInfo a = e.resolveTableInfo("a");
-
-        var x = e.asSymbol("x");
-        var source = new Collect(new DocTableRelation(a),
-                                 List.of(x),
-                                 WhereClause.MATCH_ALL,
-                                 10L,
-                                 DataTypes.INTEGER.fixedSize());
-        TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
-
-        var eval = Eval.create(source, List.of());
-
-        var memo = new Memo(eval);
-        PlanStats planStats = new PlanStats(tableStats, memo);
-        var result = planStats.apply(eval);
-        assertThat(result.numDocs()).isEqualTo(10L);
-
-        // now update the tablestats
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(100L, 1, Map.of())));
-
-        planStats = new PlanStats(tableStats, memo);
-        result = planStats.apply(eval);
-        assertThat(result.numDocs()).isEqualTo(100L);
-
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -50,6 +50,7 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanVisitor;
 import io.crate.planner.operators.PlanHint;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 
 
@@ -223,6 +224,29 @@ public class MemoTest {
             plan(newX.id(),
                  plan(y1.id(), plan(z.id())),
                  plan(y2.id(), plan(z.id()))));
+    }
+
+    @Test
+    public void test_store_and_evict_stats() {
+        var y = plan();
+        var x = plan(y);
+
+        Memo memo = new Memo(x);
+        int xGroup = memo.getRootGroup();
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        var xStats = new Stats(1, 1, Map.of());
+        var yStats = new Stats(3, 3, Map.of());
+
+        memo.addStats(yGroup, yStats);
+        memo.addStats(xGroup, xStats);
+
+        assertEquals(memo.stats(yGroup), yStats);
+        assertEquals(memo.stats(xGroup), xStats);
+
+        memo.replace(yGroup, plan());
+
+        assertThat(memo.stats(yGroup)).isNull();
+        assertThat(memo.stats(xGroup)).isNull();
     }
 
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -37,6 +37,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.statistics.TableStats;
@@ -71,7 +72,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
         Filter mergedFilter = mergeFilters.apply(match.value(),
                                                  match.captures(),
-                                                 new TableStats(),
+                                                 new PlanStats(new TableStats()),
                                                  CoordinatorTxnCtx.systemTransactionContext(),
                                                  e.nodeCtx,
                                                  Function.identity());

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -37,6 +37,7 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
@@ -82,7 +83,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
 
         HashJoin result = (HashJoin) rule.apply(match.value(),
                                                 match.captures(),
-                                                new TableStats(),
+                                                new PlanStats(new TableStats()),
                                                 CoordinatorTxnCtx.systemTransactionContext(),
                                                 sqlExpressions.nodeCtx,
                                                 Function.identity());

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -36,6 +36,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.statistics.TableStats;
@@ -73,7 +74,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -101,7 +102,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -128,7 +129,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -162,7 +163,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -197,7 +198,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This introduces `Stats` for Logical Plans:

- `PlanStats` provides `Stats`  for Logical Plans including `GroupReferences` in the scope of the Optimizers and the Rules.
- `Stats` for `GroupReferences` and `Groups` are directly stored in the `Memo`, because the `Groups` and their `Stats` are depending on each other. When the stats for one group changes the depending groups have to also change the stats.
- `PlanStats` will eventually replace `numberOfRows` and `estimatedRowSize`  in Logical Plans, but can only be removed once the table swap in Joins is moved into an Optimizer Rule, because currently `numberOfRows` and `estimatedRowSize` is used in `NestedLoop` and `HashJoin` in the `build` method.

Requirement for https://github.com/crate/crate/pull/13999




## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
