### PR TITLE
Use DataType#compare in array/row comparators

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -120,7 +120,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
     public void measureLoadAndConsumeOrderedLuceneBatchIterator(Blackhole blackhole) throws Exception {
         BatchIterator<Row> it = OrderedLuceneBatchIteratorFactory.newInstance(
             Collections.singletonList(createOrderedCollector(indexSearcher, columnName)),
-            OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
+            OrderingByPosition.rowOrdering(List.of(DataTypes.INTEGER), new int[]{0}, reverseFlags, nullsFirst),
             ROW_ACCOUNTING,
             EsExecutors.directExecutor(),
             () -> 1,

--- a/benchmarks/src/main/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorBenchmark.java
@@ -21,18 +21,6 @@
 
 package io.crate.execution.engine.distribution.merge;
 
-import io.crate.data.Row;
-import io.crate.data.Row1;
-import io.crate.execution.engine.sort.OrderingByPosition;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,6 +30,20 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.execution.engine.sort.OrderingByPosition;
+import io.crate.types.DataTypes;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -58,7 +60,7 @@ public class SortedPagingIteratorBenchmark {
     @Setup
     public void prepareData() {
         rnd = new Random(42);
-        compareOnFirstColumn = OrderingByPosition.rowOrdering(0, false, false);
+        compareOnFirstColumn = OrderingByPosition.rowOrdering(DataTypes.INTEGER, 0, false, false);
 
         unsortedFirst = IntStream.range(0, 1_000_000).mapToObj(Row1::new).collect(Collectors.toList());
         unsortedSecond = IntStream.range(500_000, 1_500_00).mapToObj(Row1::new).collect(Collectors.toList());

--- a/server/src/main/java/io/crate/execution/dsl/phases/MergePhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/MergePhase.java
@@ -21,16 +21,6 @@
 
 package io.crate.execution.dsl.phases;
 
-import io.crate.execution.dsl.projection.Projection;
-import io.crate.expression.symbol.Symbols;
-import io.crate.planner.PositionalOrderBy;
-import io.crate.planner.distribution.DistributionInfo;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,6 +29,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.expression.symbol.Symbols;
+import io.crate.planner.PositionalOrderBy;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 /**
  * A plan node which merges results from upstreams

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -103,7 +103,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.shard.unassigned.UnassignedShard;
 import io.crate.metadata.sys.SysShardsTableInfo;
-import io.crate.planner.consumer.OrderByPositionVisitor;
 import io.crate.types.DataType;
 
 /**
@@ -361,11 +360,7 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
 
         return CompletableFutures.allAsList(orderedDocCollectors).thenApply(collectors -> OrderedLuceneBatchIteratorFactory.newInstance(
             collectors,
-            OrderingByPosition.rowOrdering(
-                OrderByPositionVisitor.orderByPositions(orderBy.orderBySymbols(), collectPhase.toCollect()),
-                orderBy.reverseFlags(),
-                orderBy.nullsFirst()
-            ),
+            OrderingByPosition.rowOrdering(orderBy, collectPhase.toCollect()),
             new RowAccountingWithEstimators(columnTypes, collectTask.getRamAccounting()),
             executor,
             availableThreads,

--- a/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -127,12 +127,17 @@ public class WindowProjector {
         Supplier<InputFactory.Context<CollectExpression<Row, ?>>> createInputFactoryContext =
             () -> inputFactory.ctxForInputColumns(txnCtx);
         int arrayListElementOverHead = 32;
+        List<DataType<?>> rowTypes = Symbols.typeView(projection.standalone());
         RowAccountingWithEstimators accounting = new RowAccountingWithEstimators(
-            Symbols.typeView(projection.standalone()), ramAccounting, arrayListElementOverHead);
+            rowTypes, ramAccounting, arrayListElementOverHead);
         Comparator<Object[]> cmpPartitionBy = partitions.isEmpty()
             ? null
-            : createComparator(createInputFactoryContext, new OrderBy(windowDefinition.partitions()));
-        Comparator<Object[]> cmpOrderBy = createComparator(createInputFactoryContext, windowDefinition.orderBy());
+            : createComparator(createInputFactoryContext, rowTypes, new OrderBy(windowDefinition.partitions()));
+        Comparator<Object[]> cmpOrderBy = createComparator(
+            createInputFactoryContext,
+            rowTypes,
+            windowDefinition.orderBy()
+        );
         int numCellsInSourceRow = projection.standalone().size();
         ComputeFrameBoundary<Object[]> computeFrameStart = createComputeStartFrameBoundary(
             numCellsInSourceRow,

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -715,6 +715,7 @@ public class JobSetup {
                     projectingRowConsumer,
                     PagingIterator.create(
                         phase.numUpstreams(),
+                        phase.inputTypes(),
                         projectingRowConsumer.requiresScroll(),
                         phase.orderByPositions(),
                         () -> new RowAccountingWithEstimators(
@@ -1007,6 +1008,7 @@ public class JobSetup {
                 rowConsumer,
                 PagingIterator.create(
                     mergePhase.numUpstreams(),
+                    mergePhase.inputTypes(),
                     rowConsumer.requiresScroll(),
                     mergePhase.orderByPositions(),
                     () -> new RowAccountingWithEstimators(

--- a/server/src/test/java/io/crate/action/sql/CursorTest.java
+++ b/server/src/test/java/io/crate/action/sql/CursorTest.java
@@ -133,6 +133,7 @@ public class CursorTest extends ESTestCase {
         );
         PagingIterator<Integer, Row> pi = PagingIterator.create(
             1,
+            List.of(DataTypes.INTEGER, DataTypes.INTEGER),
             true,
             null,
             () -> rowAccounting);

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -135,7 +135,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
                 LuceneOrderedDocCollector collector2 = createOrderedCollector(searcher2, 2);
                 return OrderedLuceneBatchIteratorFactory.newInstance(
                     Arrays.asList(collector1, collector2),
-                    OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
+                    OrderingByPosition.rowOrdering(List.of(DataTypes.LONG), new int[]{0}, reverseFlags, nullsFirst),
                     ROW_ACCOUNTING,
                     Runnable::run,
                     () -> 1,
@@ -154,7 +154,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
 
         BatchIterator<Row> rowBatchIterator = OrderedLuceneBatchIteratorFactory.newInstance(
             Arrays.asList(createOrderedCollector(searcher1, 1)),
-            OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
+            OrderingByPosition.rowOrdering(List.of(DataTypes.INTEGER), new int[]{0}, reverseFlags, nullsFirst),
             rowAccounting,
             Runnable::run,
             () -> 2,
@@ -174,7 +174,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
         LuceneOrderedDocCollector collector2 = createOrderedCollector(searcher2, 2);
         BatchIterator<Row> rowBatchIterator = OrderedLuceneBatchIteratorFactory.newInstance(
             Arrays.asList(collector1, collector2),
-            OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
+            OrderingByPosition.rowOrdering(List.of(DataTypes.INTEGER), new int[]{0}, reverseFlags, nullsFirst),
             rowAccounting,
             Runnable::run,
             () -> 1,
@@ -194,7 +194,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
         CountDownLatch triggerRunnable = new CountDownLatch(1);
         BatchIterator<Row> rowBatchIterator = OrderedLuceneBatchIteratorFactory.newInstance(
             Collections.singletonList(luceneOrderedDocCollector),
-            OrderingByPosition.rowOrdering(new int[]{0}, reverseFlags, nullsFirst),
+            OrderingByPosition.rowOrdering(List.of(DataTypes.INTEGER), new int[]{0}, reverseFlags, nullsFirst),
             rowAccounting,
             runnable -> {
                 var t = new Thread(() -> {

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/SortedPagingIteratorTest.java
@@ -37,11 +37,12 @@ import io.crate.data.Bucket;
 import io.crate.data.Row;
 import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
+import io.crate.types.DataTypes;
 
 public class SortedPagingIteratorTest extends ESTestCase {
 
     public static final Comparator<Row> ORDERING =
-        OrderingByPosition.rowOrdering(new int[]{0}, new boolean[]{false}, new boolean[]{false});
+        OrderingByPosition.rowOrdering(List.of(DataTypes.STRING), new int[]{0}, new boolean[]{false}, new boolean[]{false});
 
     @Test
     public void testTwoBucketsAndTwoPagesAreSortedCorrectly() throws Exception {

--- a/server/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
@@ -21,73 +21,81 @@
 
 package io.crate.execution.engine.sort;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 
 import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import io.crate.common.collections.Ordering;
+import io.crate.types.DataTypes;
 
 public class OrderingByPositionTest extends ESTestCase {
 
     @Test
     public void testOrderByAscNullsFirst() throws Exception {
-        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, true);
+        Comparator<Object[]> ordering =
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, true);
 
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(1));
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{null})).isEqualTo(1);
     }
 
     @Test
     public void testOrderByAscNullsLast() throws Exception {
-        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, false);
+        Comparator<Object[]> ordering =
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false);
 
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(-1));
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{null})).isEqualTo(-1);
     }
 
     @Test
     public void testOrderByDescNullsLast() throws Exception {
-        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, true, false);
+        Comparator<Object[]> ordering =
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, true, false);
 
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(-1));
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{2}), is(1));
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{null})).isEqualTo(-1);
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{2})).isEqualTo(1);
     }
 
     @Test
     public void testOrderByDescNullsFirst() throws Exception {
-        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, true, true);
+        Comparator<Object[]> ordering =
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, true, true);
 
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{null}), is(1));
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{null})).isEqualTo(1);
     }
 
     @Test
     public void testOrderByAsc() throws Exception {
-        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(0, false, true);
+        Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, true);
 
-        assertThat(ordering.compare(new Object[]{1}, new Object[]{2}), is(-1));
+        assertThat(ordering.compare(new Object[]{1}, new Object[]{2})).isEqualTo(-1);
     }
 
     @Test
     public void testMultipleOrderBy() throws Exception {
         Comparator<Object[]> ordering = Ordering.compound(Arrays.asList(
-            OrderingByPosition.arrayOrdering(1, false, false),
-            OrderingByPosition.arrayOrdering(0, false, false)
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 1, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false)
         ));
 
-        assertThat(ordering.compare(new Object[]{0, 0}, new Object[]{4, 0}), is(-1));
-        assertThat(ordering.compare(new Object[]{4, 0}, new Object[]{1, 1}), is(-1));
-        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2}), is(-1));
-        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2}), is(-1));
+        assertThat(ordering.compare(new Object[]{0, 0}, new Object[]{4, 0})).isEqualTo(-1);
+        assertThat(ordering.compare(new Object[]{4, 0}, new Object[]{1, 1})).isEqualTo(-1);
+        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2})).isEqualTo(-1);
+        assertThat(ordering.compare(new Object[]{5, 1}, new Object[]{2, 2})).isEqualTo(-1);
     }
 
     @Test
     public void testSingleOrderByPositionResultsInNonCompoundOrdering() throws Exception {
         Comparator<Object[]> ordering = OrderingByPosition.arrayOrdering(
-            new int[]{0}, new boolean[]{false}, new boolean[]{false});
-        assertThat(ordering, Matchers.instanceOf(NullAwareComparator.class));
+            List.of(DataTypes.INTEGER),
+            new int[]{0},
+            new boolean[]{false},
+            new boolean[]{false}
+        );
+        assertThat(ordering).isExactlyInstanceOf(NullAwareComparator.class);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingLimitAndOffsetProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingLimitAndOffsetProjectorTest.java
@@ -58,7 +58,7 @@ public class SortingLimitAndOffsetProjectorTest extends ESTestCase {
     private static final Literal<Boolean> TRUE_LITERAL = Literal.of(true);
     private static final List<Input<?>> INPUT_LITERAL_LIST = List.of(INPUT, TRUE_LITERAL);
     private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = List.of(INPUT);
-    private static final Comparator<Object[]> FIRST_CELL_ORDERING = OrderingByPosition.arrayOrdering(0, false, false);
+    private static final Comparator<Object[]> FIRST_CELL_ORDERING = OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false);
 
     private TestingRowConsumer consumer = new TestingRowConsumer();
 

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
@@ -60,7 +60,7 @@ public class SortingProjectorTest extends ESTestCase {
             List.of(input, Literal.of(true)),
             List.<CollectExpression<Row, ?>>of(input),
             numOutputs,
-            OrderingByPosition.arrayOrdering(0, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false),
             offset
         );
     }

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -71,7 +71,7 @@ public class WindowBatchIteratorTest {
     public void testWindowBatchIterator() throws Exception {
         BatchIteratorTester tester = new BatchIteratorTester(
             () -> {
-                Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(0, false, false);
+                Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false);
                 return WindowFunctionBatchIterator.of(
                     TestingBatchIterators.range(0, 10),
                     new IgnoreRowAccounting(),
@@ -95,7 +95,7 @@ public class WindowBatchIteratorTest {
     public void testWindowBatchIteratorWithBatchSimulatingSource() throws Exception {
         BatchIteratorTester tester = new BatchIteratorTester(
             () -> {
-                Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(0, false, false);
+                Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false);
                 return WindowFunctionBatchIterator.of(
                     new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 10), 4, 2, null),
                     new IgnoreRowAccounting(),
@@ -144,7 +144,7 @@ public class WindowBatchIteratorTest {
             rowsWithSpare,
             getComputeFrameStart(null, FrameBound.Type.UNBOUNDED_PRECEDING),
             getComputeFrameEnd(null, FrameBound.Type.CURRENT_ROW),
-            OrderingByPosition.arrayOrdering(0, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false),
             null,
             1,
             () -> 1,
@@ -186,12 +186,12 @@ public class WindowBatchIteratorTest {
             $(null, null, null),
             $(null, null, null)
         );
-        Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(1, false, false);
+        Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 1, false, false);
         var result = sortAndComputeWindowFunctions(
             rows,
             getComputeFrameStart(cmpOrderBy, FrameBound.Type.UNBOUNDED_PRECEDING),
             getComputeFrameEnd(cmpOrderBy, FrameBound.Type.CURRENT_ROW),
-            OrderingByPosition.arrayOrdering(0, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false),
             cmpOrderBy,
             2,
             () -> 1,
@@ -234,12 +234,12 @@ public class WindowBatchIteratorTest {
             $(null, null, null),
             $(null, null, null)
         );
-        Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(1, false, false);
+        Comparator<Object[]> cmpOrderBy = OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 1, false, false);
         var result = sortAndComputeWindowFunctions(
             rows,
             getComputeFrameStart(cmpOrderBy, FrameBound.Type.CURRENT_ROW),
             getComputeFrameEnd(cmpOrderBy, FrameBound.Type.UNBOUNDED_FOLLOWING),
-            OrderingByPosition.arrayOrdering(0, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false),
             cmpOrderBy,
             2,
             () -> 1,
@@ -312,7 +312,7 @@ public class WindowBatchIteratorTest {
             rows,
             getComputeFrameStart(null, FrameBound.Type.CURRENT_ROW),
             getComputeFrameEnd(null, FrameBound.Type.UNBOUNDED_FOLLOWING),
-            OrderingByPosition.arrayOrdering(0, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false),
             null,
             1,
             () -> 1,
@@ -374,7 +374,7 @@ public class WindowBatchIteratorTest {
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> 0,
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> currentIndex,
             null,
-            OrderingByPosition.arrayOrdering(0, true, true),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, true, true),
             1,
             () -> 1,
             Runnable::run,

--- a/server/src/test/java/io/crate/execution/engine/window/WindowFunctionBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowFunctionBatchIteratorTest.java
@@ -45,6 +45,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
 
 public class WindowFunctionBatchIteratorTest extends ESTestCase {
 
@@ -60,8 +61,8 @@ public class WindowFunctionBatchIteratorTest extends ESTestCase {
             ),
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> 0,
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> currentIndex,
-            OrderingByPosition.arrayOrdering(0, false, false),
-            OrderingByPosition.arrayOrdering(1, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.STRING, 0, false, false),
+            OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 1, false, false),
             2,
             () -> 1,
             Runnable::run,

--- a/server/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import io.crate.data.CollectionBucket;
 import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
+import io.crate.types.DataTypes;
 
 public class JoinGroupByIntegrationTests extends IntegTestCase {
 
@@ -216,7 +217,7 @@ public class JoinGroupByIntegrationTests extends IntegTestCase {
         );
 
         List<Object[]> rows = Arrays.asList(response.rows());
-        rows.sort(OrderingByPosition.arrayOrdering(1, false, false));
+        rows.sort(OrderingByPosition.arrayOrdering(DataTypes.FLOAT, 1, false, false));
         assertThat(
             TestingHelpers.printedTable(new CollectionBucket(rows)),
             is("yellow| 5.0\n" +
@@ -234,7 +235,7 @@ public class JoinGroupByIntegrationTests extends IntegTestCase {
         );
 
         List<Object[]> rows = Arrays.asList(response.rows());
-        rows.sort(OrderingByPosition.arrayOrdering(1, false, false));
+        rows.sort(OrderingByPosition.arrayOrdering(DataTypes.FLOAT, 1, false, false));
 
         assertThat(
             TestingHelpers.printedTable(new CollectionBucket(rows)),

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
@@ -50,6 +51,7 @@ import io.crate.testing.Asserts;
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
+import io.crate.types.DataTypes;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class JoinIntegrationTest extends IntegTestCase {
@@ -234,7 +236,10 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         List<Object[]> rows = Arrays.asList(response.rows());
         Collections.sort(rows, OrderingByPosition.arrayOrdering(
-            new int[]{0, 1}, new boolean[]{false, false}, new boolean[]{false, false}));
+            List.of(DataTypes.STRING, DataTypes.STRING),
+            new int[]{0, 1},
+            new boolean[]{false, false},
+            new boolean[]{false, false}));
         assertThat(response).hasRows(
             "blue| large",
             "blue| small",
@@ -320,7 +325,11 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         List<Object[]> rows = Arrays.asList(response.rows());
         Collections.sort(rows, OrderingByPosition.arrayOrdering(
-            new int[]{0, 1}, new boolean[]{false, true}, new boolean[]{false, true}));
+            List.of(DataTypes.INTEGER, DataTypes.INTEGER),
+            new int[]{0, 1},
+            new boolean[]{false, true},
+            new boolean[]{false, true}
+        ));
 
         assertThat(rows).containsExactly(
             new Object[][]{

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -48,6 +48,7 @@ import io.crate.statistics.TableStats;
 import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseRandomizedOptimizerRules;
+import io.crate.types.DataTypes;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class SubSelectIntegrationTest extends IntegTestCase {
@@ -183,7 +184,7 @@ public class SubSelectIntegrationTest extends IntegTestCase {
                 "  select min(age) as minAge from characters group by gender) as ch " +
                 "group by minAge");
         List<Object[]> rows = Arrays.asList(response.rows());
-        Collections.sort(rows, OrderingByPosition.arrayOrdering(0, true, true));
+        Collections.sort(rows, OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, true, true));
         assertThat(TestingHelpers.printedTable(rows.toArray(new Object[0][])),
             is("1\n1\n"));
     }
@@ -197,7 +198,7 @@ public class SubSelectIntegrationTest extends IntegTestCase {
                 "group by race");
 
         List<Object[]> rows = Arrays.asList(response.rows());
-        Collections.sort(rows, OrderingByPosition.arrayOrdering(0, false, true));
+        Collections.sort(rows, OrderingByPosition.arrayOrdering(DataTypes.STRING, 0, false, true));
         assertThat(printedTable(rows.toArray(new Object[0][])),
             is("Android| NULL\n" +
                "Human| 73.0\n" +


### PR DESCRIPTION
Instead of relying on the value type implementing `Comparable`.
This is a requirement for https://github.com/crate/crate/issues/13576
