### PR TITLE
Remove raw type from Stats 

### DIFF
--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -48,7 +48,7 @@ public class Stats implements Writeable {
     @VisibleForTesting
     final long sizeInBytes;
 
-    private final Map<ColumnIdent, ColumnStats> statsByColumn;
+    private final Map<ColumnIdent, ColumnStats<?>> statsByColumn;
 
     private Stats() {
         numDocs = -1;
@@ -56,7 +56,7 @@ public class Stats implements Writeable {
         statsByColumn = Map.of();
     }
 
-    public Stats(long numDocs, long sizeInBytes, Map<ColumnIdent, ColumnStats> statsByColumn) {
+    public Stats(long numDocs, long sizeInBytes, Map<ColumnIdent, ColumnStats<?>> statsByColumn) {
         this.numDocs = numDocs;
         this.sizeInBytes = sizeInBytes;
         this.statsByColumn = statsByColumn;
@@ -97,7 +97,7 @@ public class Stats implements Writeable {
         }
     }
 
-    public Map<ColumnIdent, ColumnStats> statsByColumn() {
+    public Map<ColumnIdent, ColumnStats<?>> statsByColumn() {
         return statsByColumn;
     }
 

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -195,7 +195,7 @@ public final class TransportAnalyzeAction {
     static Stats createTableStats(Samples samples, List<Reference> primitiveColumns) {
         List<Row> records = samples.records;
         List<Object> columnValues = new ArrayList<>(records.size());
-        Map<ColumnIdent, ColumnStats> statsByColumn = new HashMap<>(primitiveColumns.size());
+        Map<ColumnIdent, ColumnStats<?>> statsByColumn = new HashMap<>(primitiveColumns.size());
         for (int i = 0; i < primitiveColumns.size(); i++) {
             Reference primitiveColumn = primitiveColumns.get(i);
             columnValues.clear();

--- a/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
@@ -21,14 +21,13 @@
 
 package io.crate.planner.operators;
 
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import io.crate.metadata.ColumnIdent;
@@ -46,7 +45,7 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
 
     @Test
     public void test_collect_operator_adapts_expected_row_count_based_on_selectivity_calculation() throws Throwable {
-        var columnStats = new HashMap<ColumnIdent, ColumnStats>();
+        var columnStats = new HashMap<ColumnIdent, ColumnStats<?>>();
         long totalNumRows = 20000;
         var numbers = IntStream.range(1, 20001)
             .boxed()
@@ -64,7 +63,7 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
             .build();
 
         LogicalPlan plan = e.logicalPlan("select * from doc.tbl where x = 10");
-        assertThat(plan.numExpectedRows(), Matchers.is(1L));
+        assertThat(plan.numExpectedRows()).isEqualTo(1L);
     }
 
 
@@ -88,6 +87,6 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
             .build();
 
         LogicalPlan plan = e.logicalPlan("select x, count(*) from doc.tbl group by x");
-        assertThat(plan.numExpectedRows(), Matchers.is(2L));
+        assertThat(plan.numExpectedRows()).isEqualTo(2L);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds some minor cleanups such as removing Raw types from Stats and moving the relevant tests to assertj. 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
