### PR TITLE
Fix linkcheck failures

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -3593,7 +3593,7 @@ However, you cannot use it with any :ref:`scalar functions
 .. _Geohash: https://en.wikipedia.org/wiki/Geohash
 .. _GeoJSON geometry objects: https://tools.ietf.org/html/rfc7946#section-3.1
 .. _GeoJSON: https://geojson.org/
-.. _IEEE 754: https://ieeexplore.ieee.org/document/30711
+.. _IEEE 754: https://en.wikipedia.org/wiki/IEEE_754
 .. _IP address: https://en.wikipedia.org/wiki/IP_address
 .. _ISO 8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
 .. _ISO 8601 time zone designators: https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators


### PR DESCRIPTION
For some reason sphinx can't check https://ieeexplore.ieee.org/document/30711
This replaces the link with https://en.wikipedia.org/wiki/IEEE_754,
