### PR TITLE
Fix `bin/crate -h`

### DIFF
--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -202,7 +202,7 @@ launch_service()
 }
 
 # Parse any command line options.
-while getopts "vh:D:X:C:" opt; do
+while getopts "vhD:X:C:" opt; do
     case $opt in
         v)
             "$JAVA" $JAVA_OPTS $CRATE_JAVA_OPTS -cp "$CRATE_CLASSPATH" $props \

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -80,6 +80,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed a regression that caused the ``-h`` option in ``bin/crate`` to fail with
+  an ``Error parsing arguments!`` error.
+
 - Added a :ref:`null_or_empty <scalar-null-or-empty>` scalar function that can
   be used as a faster alternative to `IS NULL` if it's acceptable to match on
   empty objects. This makes it possible to mitigate a performance regression


### PR DESCRIPTION
> OPTSTRING contains the option letters to be recognized; if a letter
> is followed by a colon, the option is expected to have an argument,
> which should be separated from it by white space.

Closes https://github.com/crate/crate/issues/13973
