### PR TITLE
Add swap join side rules

### DIFF
--- a/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -57,6 +57,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
+import io.crate.statistics.TableStats;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -136,7 +137,8 @@ public class PreExecutionBenchmark {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            new TableStats()
         );
         return planner.plan(analyzedStatement, plannerContext);
     }

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -91,6 +91,7 @@ import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.Declare.Hold;
 import io.crate.sql.tree.DiscardStatement.Target;
 import io.crate.sql.tree.Statement;
+import io.crate.statistics.TableStats;
 import io.crate.types.DataType;
 
 /**
@@ -157,6 +158,7 @@ public class Session implements AutoCloseable {
     private final JobsLogs jobsLogs;
     private final boolean isReadOnly;
     private final ParameterTypeExtractor parameterTypeExtractor;
+    private final TableStats tableStats;
     private final Runnable onClose;
 
     private TransactionState currentTransactionState = TransactionState.IDLE;
@@ -170,6 +172,7 @@ public class Session implements AutoCloseable {
                    boolean isReadOnly,
                    DependencyCarrier executor,
                    CoordinatorSessionSettings sessionSettings,
+                   TableStats tableStats,
                    Runnable onClose) {
         this.id = sessionId;
         this.secret = ThreadLocalRandom.current().nextInt();
@@ -181,6 +184,7 @@ public class Session implements AutoCloseable {
         this.executor = executor;
         this.sessionSettings = sessionSettings;
         this.parameterTypeExtractor = new ParameterTypeExtractor();
+        this.tableStats = tableStats;
         this.onClose = onClose;
     }
 
@@ -220,7 +224,8 @@ public class Session implements AutoCloseable {
             0,
             params,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
         Plan plan;
         try {
@@ -273,7 +278,8 @@ public class Session implements AutoCloseable {
             0,
             params,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
         Plan plan = planner.plan(stmt, plannerContext);
         plan.execute(executor, plannerContext, consumer, params, SubQueryResults.EMPTY);
@@ -654,7 +660,8 @@ public class Session implements AutoCloseable {
             0,
             null,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
 
         PreparedStmt firstPreparedStatement = toExec.get(0).portal().preparedStmt();
@@ -741,7 +748,8 @@ public class Session implements AutoCloseable {
             maxRows,
             params,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
         var analyzedStmt = portal.analyzedStatement();
         String rawStatement = portal.preparedStmt().rawStatement();

--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -39,6 +39,7 @@ import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.TableInfo;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.statistics.TableStats;
 
 public class PlannerContext {
 
@@ -56,7 +57,8 @@ public class PlannerContext {
             fetchSize,
             context.params,
             context.cursors,
-            context.transactionState
+            context.transactionState,
+            context.tableStats
         );
     }
 
@@ -73,6 +75,7 @@ public class PlannerContext {
     private final String handlerNode;
     @Nullable
     private final Row params;
+    private final TableStats tableStats;
 
     /**
      * @param params See {@link #params()}
@@ -85,7 +88,8 @@ public class PlannerContext {
                           int fetchSize,
                           @Nullable Row params,
                           Cursors cursors,
-                          TransactionState transactionState) {
+                          TransactionState transactionState,
+                          TableStats tableStats) {
         this.routingProvider = routingProvider;
         this.nodeCtx = nodeCtx;
         this.params = params;
@@ -97,6 +101,7 @@ public class PlannerContext {
         this.handlerNode = clusterState.nodes().getLocalNodeId();
         this.cursors = cursors;
         this.transactionState = transactionState;
+        this.tableStats = tableStats;
     }
 
     /**
@@ -161,5 +166,9 @@ public class PlannerContext {
 
     public TransactionState transactionState() {
         return transactionState;
+    }
+
+    public TableStats tableStats() {
+        return tableStats;
     }
 }

--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -366,6 +366,7 @@ public class ExplainPlan implements Plan {
                 collect.relation(),
                 collect.outputs(),
                 collect.where().map(s -> Optimizer.optimizeCasts(s, context)),
+                collect.params(),
                 collect.numExpectedRows(),
                 collect.estimatedRowSize()
             );

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -94,6 +94,8 @@ public class Collect implements LogicalPlan {
     private final long numExpectedRows;
     private final long estimatedRowSize;
     final WhereClause immutableWhere;
+    @Nullable
+    final Row params;
 
     WhereClause mutableBoundWhere;
     DetailedQuery detailedQuery;
@@ -108,6 +110,7 @@ public class Collect implements LogicalPlan {
             relation,
             toCollect,
             where,
+            params,
             SelectivityFunctions.estimateNumRows(stats, where.queryOrFallback(), params),
             stats.estimateSizeForColumns(toCollect)
         );
@@ -126,11 +129,14 @@ public class Collect implements LogicalPlan {
         this.immutableWhere = collect.immutableWhere;
         this.tableInfo = collect.relation.tableInfo();
         this.detailedQuery = detailedQuery;
+        this.params = collect.params;
     }
 
     public Collect(AbstractTableRelation<?> relation,
                    List<Symbol> outputs,
                    WhereClause where,
+                   @Nullable
+                   Row params,
                    long numExpectedRows,
                    long estimatedRowSize) {
         this.outputs = outputs;
@@ -144,6 +150,7 @@ public class Collect implements LogicalPlan {
         this.immutableWhere = where;
         this.mutableBoundWhere = where;
         this.tableInfo = relation.tableInfo();
+        this.params = params;
     }
 
     @Override
@@ -188,6 +195,10 @@ public class Collect implements LogicalPlan {
             limitAndOffset,
             positionalOrderBy
         );
+    }
+
+    public Row params() {
+        return params;
     }
 
     @Override
@@ -367,6 +378,7 @@ public class Collect implements LogicalPlan {
             relation,
             newOutputs,
             immutableWhere,
+            params,
             numExpectedRows,
             stats.estimateSizeForColumns(newOutputs)
         );
@@ -413,6 +425,7 @@ public class Collect implements LogicalPlan {
                 relation,
                 newOutputs,
                 immutableWhere,
+                params,
                 numExpectedRows,
                 stats.estimateSizeForColumns(newOutputs)
             )

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -184,16 +184,6 @@ public class CorrelatedJoin implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return inputPlan.numExpectedRows();
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return inputPlan.estimatedRowSize();
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitCorrelatedJoin(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -162,16 +162,6 @@ public class Count implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return 1L;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return Long.BYTES;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitCount(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Distinct.java
+++ b/server/src/main/java/io/crate/planner/operators/Distinct.java
@@ -31,11 +31,15 @@ import static io.crate.planner.operators.GroupHashAggregate.approximateDistinctV
 
 public final class Distinct {
 
-    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, TableStats tableStats) {
+    public static LogicalPlan create(LogicalPlan source,
+                                     long numDocs,
+                                     boolean distinct,
+                                     List<Symbol> outputs,
+                                     TableStats tableStats) {
         if (!distinct) {
             return source;
         }
-        long numExpectedRows = approximateDistinctValues(source.numExpectedRows(), tableStats, outputs);
+        long numExpectedRows = approximateDistinctValues(numDocs, tableStats, outputs);
         return new GroupHashAggregate(source, outputs, Collections.emptyList(), numExpectedRows);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -80,13 +80,4 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
         return source.dependencies();
     }
 
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return source.estimatedRowSize();
-    }
 }

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -260,12 +260,10 @@ public class Get implements LogicalPlan {
         return Map.of();
     }
 
-    @Override
     public long estimatedRowSize() {
         return estimatedSizePerRow;
     }
 
-    @Override
     public long numExpectedRows() {
         return docKeys.size();
     }

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -123,7 +123,6 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         this.groupKeys = groupKeys;
     }
 
-    @Override
     public long numExpectedRows() {
         return numExpectedRows;
     }

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -194,11 +194,6 @@ public class HashAggregate extends ForwardingLogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return 1L;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitHashAggregate(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -305,15 +305,6 @@ public class HashJoin extends JoinPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
-            return -1;
-        }
-        // We don't have any cardinality estimates, so just take the bigger table
-        return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitHashJoin(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -150,16 +150,6 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return 1;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return source.estimatedRowSize();
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitInsert(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -857,16 +857,6 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return -1L;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return 0L;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitInsert(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -69,11 +69,6 @@ public abstract class JoinPlan implements LogicalPlan {
         return joinType;
     }
 
-    @Override
-    public long estimatedRowSize() {
-        return lhs.estimatedRowSize() + rhs.estimatedRowSize();
-    }
-
     protected static MergePhase buildMergePhaseForJoin(PlannerContext plannerContext,
                                              ResultDescription resultDescription,
                                              Collection<String> executionNodes) {

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -143,14 +143,6 @@ public class Limit extends ForwardingLogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        if (limit instanceof Literal) {
-            return DataTypes.LONG.sanitizeValue(((Literal<?>) limit).value());
-        }
-        return source.numExpectedRows();
-    }
-
-    @Override
     public String toString() {
         return "Limit{" +
                "source=" + source +

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -34,6 +34,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
@@ -201,13 +202,19 @@ public interface LogicalPlan extends Plan {
     /**
      * Returns the total number of rows this logical operation is expected to return.
      * @return The number of expected rows if available, -1 otherwise.
+     *
+     * @deprecated Use {@link PlanStats} instead.
      */
+    @Deprecated
     long numExpectedRows();
 
     /**
      * Returns an estimation of the size (in bytes) of each row returned by the plan.
      * The estimation is based on the average size of a row of the concrete table(s) of the plan.
+     *
+     * @deprecated Use {@link PlanStats} instead.
      */
+    @Deprecated
     long estimatedRowSize();
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -34,7 +34,6 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
-import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.statistics.TableStats;
 
 import javax.annotation.Nullable;
@@ -198,24 +197,6 @@ public interface LogicalPlan extends Plan {
      * It's not necessary for each operator to expose it's own SelectSymbols; propagation is usually sufficient.
      */
     Map<LogicalPlan, SelectSymbol> dependencies();
-
-    /**
-     * Returns the total number of rows this logical operation is expected to return.
-     * @return The number of expected rows if available, -1 otherwise.
-     *
-     * @deprecated Use {@link PlanStats} instead.
-     */
-    @Deprecated
-    long numExpectedRows();
-
-    /**
-     * Returns an estimation of the size (in bytes) of each row returned by the plan.
-     * The estimation is based on the average size of a row of the concrete table(s) of the plan.
-     *
-     * @deprecated Use {@link PlanStats} instead.
-     */
-    @Deprecated
-    long estimatedRowSize();
 
     @Override
     default void executeOrFail(DependencyCarrier executor,

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -109,6 +109,8 @@ import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteNestedLoopJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
+import io.crate.planner.optimizer.rule.SwapHashJoin;
+import io.crate.planner.optimizer.rule.SwapNestedLoopJoin;
 import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
@@ -149,7 +151,9 @@ public class LogicalPlanner {
         new OptimizeCollectWhereClauseAccess(),
         new RewriteGroupByKeysLimitToLimitDistinct(),
         new MoveConstantJoinConditionsBeneathNestedLoop(),
-        new RewriteNestedLoopJoinToHashJoin()
+        new RewriteNestedLoopJoinToHashJoin(),
+        new SwapNestedLoopJoin(),
+        new SwapHashJoin()
     );
 
     public static final List<Rule<?>> FETCH_OPTIMIZER_RULES = List.of(

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -423,19 +423,6 @@ public class NestedLoopJoin extends JoinPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
-            return -1;
-        }
-        if (joinType == JoinType.CROSS) {
-            return lhs.numExpectedRows() * rhs.numExpectedRows();
-        } else {
-            // We don't have any cardinality estimates, so just take the bigger table
-            return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
-        }
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitNestedLoopJoin(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -25,10 +25,10 @@ import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -54,7 +54,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
     @Override
     public LogicalPlan apply(Insert plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -154,17 +154,6 @@ public final class TableFunction implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return -1;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        // We don't have any estimates for table functions, but could go through the types of `outputs` to make a guess
-        return 0;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitTableFunction(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -243,19 +243,6 @@ public class Union implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
-            return -1;
-        }
-        return lhs.numExpectedRows() + rhs.numExpectedRows();
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return Math.max(lhs.estimatedRowSize(), rhs.estimatedRowSize());
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitUnion(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -203,6 +203,14 @@ public class Union implements LogicalPlan {
         return new Union(sources.get(0), sources.get(1), outputs);
     }
 
+    public LogicalPlan lhs() {
+        return lhs;
+    }
+
+    public LogicalPlan rhs() {
+        return rhs;
+    }
+
     @Override
     public LogicalPlan pruneOutputsExcept(TableStats tableStats, Collection<Symbol> outputsToKeep) {
         IntArrayList outputIndicesToKeep = new IntArrayList();

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -26,9 +26,10 @@ import java.util.function.Function;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
+
 import org.elasticsearch.Version;
 
 public interface Rule<T> {
@@ -45,7 +46,7 @@ public interface Rule<T> {
      */
     LogicalPlan apply(T plan,
                       Captures captures,
-                      TableStats tableStats,
+                      PlanStats planStats,
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
                       Function<LogicalPlan, LogicalPlan> resolvePlan);

--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.CorrelatedJoin;
 import io.crate.planner.operators.Count;
@@ -67,6 +68,10 @@ public class PlanStats {
 
     public TableStats tableStats() {
         return tableStats;
+    }
+
+    public Stats apply(RelationName relationName) {
+        return tableStats.getStats(relationName);
     }
 
     public Stats apply(LogicalPlan logicalPlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.costs;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import io.crate.common.collections.Maps;
+import io.crate.expression.symbol.Literal;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.CorrelatedJoin;
+import io.crate.planner.operators.Count;
+import io.crate.planner.operators.Get;
+import io.crate.planner.operators.GroupHashAggregate;
+import io.crate.planner.operators.HashAggregate;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.Insert;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.operators.TableFunction;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.iterative.GroupReference;
+import io.crate.planner.optimizer.iterative.Memo;
+import io.crate.sql.tree.JoinType;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.types.DataTypes;
+
+public class PlanStats {
+
+    private final TableStats tableStats;
+    // Memo can be null when there are no Group References in the Logical Plans involved
+    @Nullable
+    private final Memo memo;
+
+    public PlanStats(TableStats tableStats) {
+        this(tableStats, null);
+    }
+
+    public PlanStats(TableStats tableStats, @Nullable Memo memo) {
+        this.tableStats = tableStats;
+        this.memo = memo;
+    }
+
+    public TableStats tableStats() {
+        return tableStats;
+    }
+
+    public Stats apply(LogicalPlan logicalPlan) {
+        var visitor = new StatsVisitor(tableStats, memo);
+        return logicalPlan.accept(visitor, null);
+    }
+
+    private static class StatsVisitor extends LogicalPlanVisitor<Void, Stats> {
+
+        private final TableStats tableStats;
+        @Nullable
+        private final Memo memo;
+
+        public StatsVisitor(TableStats tableStats, @Nullable Memo memo) {
+            this.tableStats = tableStats;
+            this.memo = memo;
+        }
+
+        @Override
+        public Stats visitGroupReference(GroupReference group, Void context) {
+            if (memo == null) {
+                throw new UnsupportedOperationException("Stats cannot be provided for GroupReference without a Memo");
+            }
+            var groupId = group.groupId();
+            var stats = memo.stats(groupId);
+            if (stats == null) {
+                // No stats for this group yet.
+                // Let's get the logical plan, calculate the stats
+                // and update the stats for this group
+                var logicalPlan = memo.resolve(groupId);
+                stats = logicalPlan.accept(this, context);
+                memo.addStats(groupId, stats);
+            }
+            return stats;
+        }
+
+        @Override
+        public Stats visitLimit(Limit limit, Void context) {
+            var stats = limit.source().accept(this, context);
+            if (limit.limit() instanceof Literal) {
+                var numberOfRows = DataTypes.LONG.sanitizeValue(((Literal<?>) limit.limit()).value());
+                return new Stats(numberOfRows, stats.sizeInBytes(), stats.statsByColumn());
+            }
+            return stats;
+        }
+
+        @Override
+        public Stats visitUnion(Union union, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = union.lhs().accept(this, context);
+            var rhsStats = union.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                numberOfRows = lhsStats.numDocs() + rhsStats.numDocs();
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = Math.max(lhsStats.sizeInBytes(), rhsStats.sizeInBytes());
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitNestedLoopJoin(NestedLoopJoin join, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = join.lhs().accept(this, context);
+            var rhsStats = join.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                if (join.joinType() == JoinType.CROSS) {
+                    numberOfRows = lhsStats.numDocs() * rhsStats.numDocs();
+                } else {
+                    // We don't have any cardinality estimates, so just take the bigger table
+                    numberOfRows = Math.max(lhsStats.numDocs(), rhsStats.numDocs());
+                }
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = lhsStats.sizeInBytes() + rhsStats.sizeInBytes();
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitHashJoin(HashJoin join, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = join.lhs().accept(this, context);
+            var rhsStats = join.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                // We don't have any cardinality estimates, so just take the bigger table
+                numberOfRows = Math.max(lhsStats.numDocs(), rhsStats.numDocs());
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = lhsStats.sizeInBytes() + rhsStats.sizeInBytes();
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitCollect(Collect collect, Void context) {
+            var stats = tableStats.getStats(collect.relation().relationName());
+            return new Stats(stats.numDocs(), stats.averageSizePerRowInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitCount(Count count, Void context) {
+            return new Stats(1, Long.BYTES, Map.of());
+        }
+
+        @Override
+        public Stats visitGet(Get get, Void context) {
+            return new Stats(get.numExpectedRows(), get.estimatedRowSize(), Map.of());
+        }
+
+        @Override
+        public Stats visitGroupHashAggregate(GroupHashAggregate groupHashAggregate, Void context) {
+            var stats = groupHashAggregate.source().accept(this, context);
+            return new Stats(groupHashAggregate.numExpectedRows(), stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitHashAggregate(HashAggregate hashAggregate, Void context) {
+            var stats = hashAggregate.source().accept(this, context);
+            return new Stats(1L, stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitInsert(Insert insert, Void context) {
+            var stats = insert.sources().get(0).accept(this, context);
+            return new Stats(1L, stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitCorrelatedJoin(CorrelatedJoin join, Void context) {
+            return join.sources().get(0).accept(this, context);
+        }
+
+        @Override
+        public Stats visitTableFunction(TableFunction tableFunction, Void context) {
+            // We don't have any estimates for table functions, but could go through the types of `outputs` to make a guess
+            return Stats.EMPTY;
+        }
+
+        @Override
+        public Stats visitPlan(LogicalPlan logicalPlan, Void context) {
+            // This covers all sub-classes of LogicalForwardPlan
+            if (logicalPlan.sources().size() == 1) {
+                return logicalPlan.sources().get(0).accept(this, context);
+            }
+            throw new UnsupportedOperationException("Plan stats not available");
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -87,16 +87,6 @@ public class GroupReference implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        throw new UnsupportedOperationException(ERROR_MESSAGE);
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        throw new UnsupportedOperationException(ERROR_MESSAGE);
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitGroupReference(this, context);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -36,6 +36,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Optimizer;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.statistics.TableStats;
 
 /**
@@ -70,7 +71,8 @@ public class IterativeOptimizer {
             return node;
         };
         var applicableRules = removeExcludedRules(rules, txnCtx.sessionSettings().excludedOptimizerRules());
-        exploreGroup(memo.getRootGroup(), new Context(memo, groupReferenceResolver, applicableRules, txnCtx, tableStats));
+        var planStats = new PlanStats(tableStats, memo);
+        exploreGroup(memo.getRootGroup(), new Context(memo, groupReferenceResolver, applicableRules, txnCtx, planStats));
         return memo.extract();
     }
 
@@ -120,7 +122,7 @@ public class IterativeOptimizer {
                 LogicalPlan transformed = Optimizer.tryMatchAndApply(
                     rule,
                     node,
-                    context.tableStats,
+                    context.planStats,
                     nodeCtx,
                     context.txnCtx,
                     resolvePlan,
@@ -163,6 +165,6 @@ public class IterativeOptimizer {
         Function<LogicalPlan, LogicalPlan> groupReferenceResolver,
         List<Rule<?>> rules,
         CoordinatorTxnCtx txnCtx,
-        TableStats tableStats
+        PlanStats planStats
     ) {}
 }

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
@@ -29,11 +29,14 @@ import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.carrotsearch.hppc.IntObjectHashMap;
 
 import io.crate.common.collections.Lists2;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.statistics.Stats;
 
 /**
  * Memo is used as part of an iterative Optimizer as an in-place
@@ -117,6 +120,19 @@ public class Memo {
         return resolveGroupReferences(node, GroupReferenceResolver.from(this::resolve));
     }
 
+    public void addStats(int groupId, Stats stats) {
+        Group group = group(groupId);
+        if (group.stats != null) {
+            evictStats(groupId);
+        }
+        group.stats = stats;
+    }
+
+    @Nullable
+    public Stats stats(int groupId) {
+        return group(groupId).stats;
+    }
+
     private Group group(int group) {
         if (!groups.containsKey(group)) {
             throw new IllegalStateException("Group not found");
@@ -144,7 +160,17 @@ public class Memo {
         incrementReferenceCounts(node, groupId);
         group.membership = node;
         decrementReferenceCounts(old, groupId);
+        evictStats(groupId);
         return node;
+    }
+
+    private void evictStats(int group) {
+        group(group).stats = null;
+        for (int parentGroup : group(group).incomingReferences) {
+            if (parentGroup != ROOT_GROUP_REF) {
+                evictStats(parentGroup);
+            }
+        }
     }
 
     private void incrementReferenceCounts(LogicalPlan fromNode, int fromGroup) {
@@ -217,6 +243,9 @@ public class Memo {
 
         private LogicalPlan membership;
         private final List<Integer> incomingReferences = new ArrayList<>();
+
+        @Nullable
+        private Stats stats;
 
         private Group(LogicalPlan member) {
             this.membership = requireNonNull(member, "member is null");

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
@@ -68,7 +68,7 @@ public final class DeduplicateOrder implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -27,7 +27,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Count;
 import io.crate.planner.operators.HashAggregate;
@@ -64,7 +64,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
     @Override
     public Count apply(HashAggregate aggregate,
                        Captures captures,
-                       TableStats tableStats,
+                       PlanStats planStats,
                        TransactionContext txnCtx,
                        NodeContext nodeCtx,
                        Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -38,10 +38,10 @@ import io.crate.planner.operators.HashAggregate;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate> {
 
@@ -76,7 +76,7 @@ public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate
     @Override
     public LogicalPlan apply(HashAggregate aggregate,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -70,6 +70,7 @@ public class MergeFilterAndCollect implements Rule<Filter> {
             collect.relation(),
             collect.outputs(),
             newWhere,
+            collect.params(),
             SelectivityFunctions.estimateNumRows(stats, newWhere.queryOrFallback(), null),
             stats.averageSizePerRowInBytes()
         );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -28,12 +28,12 @@ import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.planner.selectivity.SelectivityFunctions;
 import io.crate.statistics.Stats;
-import io.crate.statistics.TableStats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -59,12 +59,12 @@ public class MergeFilterAndCollect implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
-        Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
+        Stats stats = planStats.apply(collect);
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(
             collect.relation(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -26,7 +26,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
@@ -72,7 +72,7 @@ public class MergeFilters implements Rule<Filter> {
     @Override
     public Filter apply(Filter plan,
                         Captures captures,
-                        TableStats tableStats,
+                        PlanStats planStats,
                         TransactionContext txnCtx,
                         NodeContext nodeCtx,
                         Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -91,7 +91,9 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 nl.orderByWasPushedDown(),
                 nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                 true, // Mark joinConditionOptimised = true
-                nl.isRewriteNestedLoopJoinToHashJoinDone()
+                nl.isRewriteNestedLoopJoinToHashJoinDone(),
+                nl.swapSides(),
+                nl.isSwapSidesDone()
             );
         } else {
             // Push constant join condition down to source
@@ -104,7 +106,9 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
             return new HashJoin(
                 newLhs,
                 newRhs,
-                AndOperator.join(nonConstantConditions)
+                AndOperator.join(nonConstantConditions),
+                false,
+                false
             );
         }
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -36,6 +36,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.consumer.RelationNameCollector;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
@@ -43,7 +44,6 @@ import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedLoopJoin> {
 
@@ -64,7 +64,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
     @Override
     public LogicalPlan apply(NestedLoopJoin nl,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -36,10 +36,10 @@ import io.crate.planner.operators.CorrelatedJoin;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
 
@@ -60,7 +60,7 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathEval.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathEval implements Rule<Filter> {
 
@@ -57,7 +57,7 @@ public final class MoveFilterBeneathEval implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -39,10 +39,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.GroupHashAggregate;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /**
  * Transforms queries like
@@ -76,7 +76,7 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.JoinPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
@@ -63,7 +63,7 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -81,7 +81,7 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -40,10 +40,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.ProjectSet;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
 
@@ -64,7 +64,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -28,10 +28,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -58,7 +58,7 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -25,7 +25,7 @@ import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Union;
@@ -59,7 +59,7 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -32,10 +32,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +66,7 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveLimitBeneathEval implements Rule<Limit> {
 
@@ -57,7 +57,7 @@ public class MoveLimitBeneathEval implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveLimitBeneathRename implements Rule<Limit> {
 
@@ -57,7 +57,7 @@ public class MoveLimitBeneathRename implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
@@ -28,10 +28,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -60,7 +60,7 @@ public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -44,10 +44,10 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /* Move the orderBy expression to the sub-relation if possible.
  *
@@ -81,7 +81,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order order,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -110,7 +110,9 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     true,
                     nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                     false,
-                    nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
+                    nestedLoop.isRewriteNestedLoopJoinToHashJoinDone(),
+                    nestedLoop.swapSides(),
+                    nestedLoop.isSwapSidesDone()
                 );
             }
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -30,10 +30,10 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -79,7 +79,7 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Union;
@@ -58,7 +58,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order order,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -35,9 +35,9 @@ import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Get;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -65,7 +65,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
     @Override
     public LogicalPlan apply(Collect collect,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
@@ -87,7 +87,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
                 docKeys.get(),
                 detailedQuery.query(),
                 collect.outputs(),
-                tableStats.estimatedSizePerRow(relation.relationName())
+                planStats.apply(collect).averageSizePerRowInBytes()
             );
         } else if (!detailedQuery.clusteredBy().isEmpty() && collect.detailedQuery() == null) {
             return new Collect(collect, detailedQuery);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
@@ -54,7 +54,7 @@ public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
     @Override
     public LogicalPlan apply(Eval plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -40,6 +40,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -48,7 +49,6 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /**
  * If we can determine that a filter on an OUTER JOIN turns all NULL rows that the join could generate into a NO-MATCH
@@ -119,7 +119,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -261,7 +261,9 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             nl.orderByWasPushedDown(),
             true,
             false,
-            nl.isRewriteNestedLoopJoinToHashJoinDone()
+            nl.isRewriteNestedLoopJoinToHashJoinDone(),
+            nl.swapSides(),
+            nl.isSwapSidesDone()
         );
         assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";
         return splitQueries.isEmpty() ? newJoin : new Filter(newJoin, AndOperator.join(splitQueries.values()));

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -36,10 +36,10 @@ import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LimitDistinct;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
 
@@ -79,7 +79,7 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
 
     private static boolean eagerTerminateIsLikely(Limit limit,
                                                   GroupHashAggregate groupAggregate,
-                                                  Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                                                  PlanStats planStats) {
         if (groupAggregate.outputs().size() > 1 || !groupAggregate.outputs().get(0).valueType().equals(DataTypes.STRING)) {
             // `GroupByOptimizedIterator` can only be used for single text columns.
             // If that is not the case we can always use LimitDistinct even if a eagerTerminate isn't likely
@@ -91,11 +91,12 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
             var limitVal = DataTypes.INTEGER.sanitizeValue(((Literal<?>) limitSymbol).value());
             // Would consume all source rows -> prefer default group by implementation which has other optimizations
             // which are more beneficial in this scenario
-            if (limitVal > groupAggregate.numExpectedRows()) {
+            var stats = planStats.apply(groupAggregate);
+            if (limitVal > stats.numDocs()) {
                 return false;
             }
         }
-        long sourceRows = resolvePlan.apply(groupAggregate.source()).numExpectedRows();
+        long sourceRows = planStats.apply(groupAggregate.source()).numDocs();
         if (sourceRows == 0) {
             return false;
         }
@@ -166,12 +167,12 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         GroupHashAggregate groupBy = captures.get(groupCapture);
-        if (!eagerTerminateIsLikely(limit, groupBy, resolvePlan)) {
+        if (!eagerTerminateIsLikely(limit, groupBy, planStats)) {
             return null;
         }
         return new LimitDistinct(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -96,11 +96,12 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
                 return false;
             }
         }
+        long rows = planStats.apply(groupAggregate).numDocs();
         long sourceRows = planStats.apply(groupAggregate.source()).numDocs();
         if (sourceRows == 0) {
             return false;
         }
-        var cardinalityRatio = groupAggregate.numExpectedRows() / sourceRows;
+        var cardinalityRatio = rows / sourceRows;
         /*
          * The threshold was chosen after comparing `with limitDistinct` vs. `without limitDistinct`
          *

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
@@ -32,16 +32,16 @@ import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
 
     private final Pattern<NestedLoopJoin> pattern = typeOf(NestedLoopJoin.class)
         .with(nl -> nl.isRewriteNestedLoopJoinToHashJoinDone() == false &&
                     nl.orderByWasPushedDown() == false);
-    
+
     @Override
     public Pattern<NestedLoopJoin> pattern() {
         return pattern;
@@ -50,7 +50,7 @@ public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
     @Override
     public LogicalPlan apply(NestedLoopJoin nl,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -46,6 +46,7 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -77,14 +78,14 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }
-        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(tableStats, Set.of());
+        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(planStats.tableStats(), Set.of());
         if (fetchRewrite == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/SwapHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/SwapHashJoin.java
@@ -27,58 +27,43 @@ import java.util.function.Function;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.planner.operators.EquiJoinDetector;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 
-public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
+public class SwapHashJoin implements Rule<HashJoin> {
 
-    private final Pattern<NestedLoopJoin> pattern = typeOf(NestedLoopJoin.class)
-        .with(nl -> nl.isRewriteNestedLoopJoinToHashJoinDone() == false &&
-                    nl.orderByWasPushedDown() == false);
-
+    private static final Pattern<HashJoin> PATTERN = typeOf(HashJoin.class).with(j -> j.isSwapSideDone() == false);
     @Override
-    public Pattern<NestedLoopJoin> pattern() {
-        return pattern;
+    public Pattern<HashJoin> pattern() {
+        return PATTERN;
     }
 
     @Override
-    public LogicalPlan apply(NestedLoopJoin nl,
+    public LogicalPlan apply(HashJoin join,
                              Captures captures,
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
-
-        if (txnCtx.sessionSettings().hashJoinsEnabled() &&
-            EquiJoinDetector.isHashJoinPossible(nl.joinType(), nl.joinCondition())) {
-            return new HashJoin(
-                nl.lhs(),
-                nl.rhs(),
-                nl.joinCondition(),
-                false,
-                false
-            );
-        } else {
-            return new NestedLoopJoin(
-                nl.lhs(),
-                nl.rhs(),
-                nl.joinType(),
-                nl.joinCondition(),
-                nl.isFiltered(),
-                nl.topMostLeftRelation(),
-                nl.orderByWasPushedDown(),
-                nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                nl.isJoinConditionOptimised(),
-                true,
-                nl.swapSides(),
-                nl.isSwapSidesDone()
-            );
+       var lhsStats = planStats.apply(join.lhs());
+       var rhsStats = planStats.apply(join.rhs());
+        // We move smaller table to the right side since benchmarking
+        // revealed that this improves performance in most cases.
+        var swapSides = false;
+        var expectedRowsAvailable = lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1;
+        if (expectedRowsAvailable && lhsStats.numDocs() < rhsStats.numDocs()) {
+            swapSides = true;
         }
+        return new HashJoin(
+            join.lhs(),
+            join.rhs(),
+            join.joinCondition(),
+            swapSides,
+            true
+        );
     }
 }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -73,6 +73,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.planner.optimizer.rule.OptimizeCollectWhereClauseAccess;
@@ -184,7 +185,7 @@ public final class CopyToPlan implements Plan {
         if (match.isPresent()) {
             LogicalPlan plan = rewriteCollectToGet.apply(match.value(),
                                                          match.captures(),
-                                                         tableStats,
+                                                         new PlanStats(tableStats),
                                                          context.transactionContext(),
                                                          context.nodeContext(),
                                                          Function.identity());

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -87,6 +87,10 @@ public class Stats implements Writeable {
         return numDocs;
     }
 
+    public long sizeInBytes() {
+        return sizeInBytes;
+    }
+
     public long averageSizePerRowInBytes() {
         if (numDocs == -1) {
             return -1;

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -51,6 +51,7 @@ import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
 import io.crate.sql.tree.Declare.Hold;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.statistics.TableStats;
 import io.crate.user.Privilege;
 import io.crate.user.Privilege.State;
 import io.crate.user.User;
@@ -73,7 +74,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             () -> dependencies,
             new JobsLogs(() -> false),
             Settings.EMPTY,
-            clusterService
+            clusterService,
+            new TableStats()
         );
 
         KeyData keyData = new KeyData(10, 20);
@@ -142,7 +144,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             Settings.builder()
                 .put("statement_timeout", "30s")
                 .build(),
-            clusterService
+            clusterService,
+            new TableStats()
         );
         Session session = sessions.createSession("doc", User.CRATE_USER);
         assertThat(session.sessionSettings().statementTimeout())
@@ -157,7 +160,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             () -> mock(DependencyCarrier.class),
             new JobsLogs(() -> false),
             Settings.EMPTY,
-            clusterService
+            clusterService,
+            new TableStats()
         );
         return sessions;
     }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -190,6 +190,8 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.| NULL| NULL",
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
+            "optimizer_swap_hash_join| true| Indicates if the optimizer rule SwapHashJoin is activated.| NULL| NULL",
+            "optimizer_swap_nested_loop_join| true| Indicates if the optimizer rule SwapNestedLoopJoin is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
             "server_version| 14.0| Reports the emulated PostgreSQL version number| NULL| NULL",
             "server_version_num| 140000| Reports the emulated PostgreSQL version number| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -429,6 +429,8 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.",
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
+            "optimizer_swap_hash_join| true| Indicates if the optimizer rule SwapHashJoin is activated.",
+            "optimizer_swap_nested_loop_join| true| Indicates if the optimizer rule SwapNestedLoopJoin is activated.",
             "search_path| doc| Sets the schema search order.",
             "server_version| 14.0| Reports the emulated PostgreSQL version number",
             "server_version_num| 140000| Reports the emulated PostgreSQL version number",

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -49,6 +49,7 @@ import io.crate.planner.operators.LogicalPlanner;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.tree.Assignment;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -97,7 +98,8 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            new TableStats()
         );
 
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -235,12 +235,12 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
         var plan = logicalPlanner.plan(e.analyze(stmt), context);
         var union = (Union) plan.sources().get(0);
-        assertThat(union.numExpectedRows()).isEqualTo(-1L);
+        assertThat(e.planStats.apply(union).numDocs()).isEqualTo(-1L);
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         tableStats.updateTableStats(rowCountByTable);
         plan = logicalPlanner.plan(e.analyze(stmt), context);
         union = (Union) plan.sources().get(0);
-        assertThat(union.numExpectedRows()).isEqualTo(-1L);
+        assertThat(e.planStats.apply(union).numDocs()).isEqualTo(-1L);
     }
 }

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -189,12 +189,12 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan outerSubSelectPlan = rootPlanDependencies.keySet().iterator().next();
         SelectSymbol outerSubSelectSymbol = rootPlanDependencies.values().iterator().next();
         assertThat(outerSubSelectSymbol.getResultType(), is(SINGLE_COLUMN_SINGLE_VALUE));
-        assertThat(outerSubSelectPlan.numExpectedRows(), is(2L));
+        assertThat(e.planStats.apply(outerSubSelectPlan).numDocs(), is(2L));
 
         LogicalPlan innerSubSelectPlan = outerSubSelectPlan.dependencies().keySet().iterator().next();
         SelectSymbol innerSubSelectSymbol = outerSubSelectPlan.dependencies().values().iterator().next();
         assertThat(innerSubSelectSymbol.getResultType(), is(SINGLE_COLUMN_MULTIPLE_VALUES));
-        assertThat(innerSubSelectPlan.numExpectedRows(), is(-1L));
+        assertThat(e.planStats.apply(innerSubSelectPlan).numDocs(), is(-1L));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -64,7 +64,7 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
         );
         assertThat(collect.estimatedRowSize(), is(DataTypes.INTEGER.fixedSize() * 2L));
         LogicalPlan prunedCollect = collect.pruneOutputsExcept(tableStats, List.of(x));
-        assertThat(prunedCollect.estimatedRowSize(), is((long) DataTypes.INTEGER.fixedSize()));
+        assertThat(e.planStats.apply(prunedCollect).numDocs(), is((long) DataTypes.INTEGER.fixedSize()));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -63,7 +63,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, null, 1L, DataTypes.INTEGER.fixedSize());
         var eval = new Eval(
             collect,
             List.of(
@@ -98,7 +98,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         Reference x = (Reference) e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
         var alias = new AliasedAnalyzedRelation(relation, new RelationName(null, "t1"));
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, null, 1L, DataTypes.INTEGER.fixedSize());
         Symbol t1X = alias.getField(x.column(), Operation.READ, true);
         assertThat(t1X).isNotNull();
         var rename = new Rename(List.of(t1X), alias.relationName(), alias, collect);
@@ -135,7 +135,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = new AliasSymbol("x_alias", e.asSymbol("x"));
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, null, 1L, DataTypes.INTEGER.fixedSize());
         var eval = new Eval(
             collect,
             List.of(x)

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,7 +42,6 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;
 import io.crate.statistics.Stats;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
@@ -52,16 +50,13 @@ import io.crate.types.DataTypes;
 public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor sqlExecutor;
-    private TableStats tableStats;
 
     @Before
     public void prepare() throws IOException {
-        tableStats = new TableStats();
         sqlExecutor = SQLExecutor.builder(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
-            .setTableStats(tableStats)
             .addView(new RelationName("doc", "v2"), "SELECT a, x FROM doc.t1")
             .addView(new RelationName("doc", "v3"), "SELECT a, x FROM doc.t1")
             .build();
@@ -75,16 +70,16 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void test_collect_derives_estimated_size_per_row_from_stats_and_types() {
         // no stats -> size derived FROM fixed with type
         LogicalPlan plan = plan("SELECT x FROM t1");
-        assertThat(plan.estimatedRowSize()).isEqualTo((long) DataTypes.INTEGER.fixedSize());
+        assertThat(sqlExecutor.planStats.apply(plan).numDocs()).isEqualTo((long) DataTypes.INTEGER.fixedSize());
 
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
         ColumnStats<Integer> columnStats = new ColumnStats<>(
             0.0, 50L, 2, DataTypes.INTEGER, MostCommonValues.EMPTY, List.of());
-        tableStats.updateTableStats(Map.of(t1.ident(), new Stats(2L, 100L, Map.of(new ColumnIdent("x"), columnStats))));
+        sqlExecutor.tableStats.updateTableStats(Map.of(t1.ident(), new Stats(2L, 100L, Map.of(new ColumnIdent("x"), columnStats))));
 
         // stats present -> size derived FROM them (although bogus fake stats in this case)
         plan = plan("SELECT x FROM t1");
-        assertThat(plan.estimatedRowSize()).isEqualTo(50L);
+        assertThat(sqlExecutor.planStats.apply(plan).numDocs()).isEqualTo(50L);
     }
 
     @Test
@@ -474,7 +469,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_group_by_with_alias_and_limit_distinct_rewrite_creates_valid_plan() {
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
-        tableStats.updateTableStats(Map.of(t1.ident(), new Stats(100L, 100L, Map.of())));
+        sqlExecutor.tableStats.updateTableStats(Map.of(t1.ident(), new Stats(100L, 100L, Map.of())));
         LogicalPlan plan = plan("SELECT a as b FROM doc.t1 GROUP BY a LIMIT 10");
         assertThat(plan).isEqualTo(
             """

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -87,7 +87,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
+        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"), false, false);
         assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -71,7 +71,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
         t1Relation = new DocTableRelation(t1);
         t1RenamedRelationName = new RelationName("doc", "t1_renamed");
         var t1Alias = new AliasedAnalyzedRelation(t1Relation, t1RenamedRelationName);
-        var t1Collect = new Collect(t1Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var t1Collect = new Collect(t1Relation, List.of(x), WhereClause.MATCH_ALL, null, 1L, DataTypes.INTEGER.fixedSize());
         Symbol t1Output = t1Alias.getField(x.column(), Operation.READ, true);
         t1Rename = new Rename(List.of(t1Output), t1Alias.relationName(), t1Alias, t1Collect);
 
@@ -80,7 +80,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
         t2Relation = new DocTableRelation(t2);
         t2RenamedRelationName = new RelationName("doc", "t2_renamed");
         var t2Alias = new AliasedAnalyzedRelation(t2Relation, t2RenamedRelationName);
-        var t2Collect = new Collect(t2Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var t2Collect = new Collect(t2Relation, List.of(x), WhereClause.MATCH_ALL, null, 1L, DataTypes.INTEGER.fixedSize());
         Symbol t2Output = t2Alias.getField(y.column(), Operation.READ, true);
         t2Rename = new Rename(List.of(t2Output), t2Alias.relationName(), t2Alias, t2Collect);
     }
@@ -123,7 +123,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_collect() {
-        var collect = new Collect(t1Relation, List.of(), new WhereClause(null), 1,1);
+        var collect = new Collect(t1Relation, List.of(), new WhereClause(null), null, 1,1);
         assertThat(collect.baseTables(), containsInAnyOrder(t1Relation));
         assertThat(collect.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
     }

--- a/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
@@ -63,7 +64,8 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
             .build();
 
         LogicalPlan plan = e.logicalPlan("select * from doc.tbl where x = 10");
-        assertThat(plan.numExpectedRows()).isEqualTo(1L);
+        PlanStats planStats = new PlanStats(tableStats);
+        assertThat(planStats.apply(plan).numDocs()).isEqualTo(1L);
     }
 
 
@@ -87,6 +89,7 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
             .build();
 
         LogicalPlan plan = e.logicalPlan("select x, count(*) from doc.tbl group by x");
-        assertThat(plan.numExpectedRows()).isEqualTo(2L);
+        PlanStats planStats = new PlanStats(tableStats);
+        assertThat(planStats.apply(plan).numDocs()).isEqualTo(2L);
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.costs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.optimizer.iterative.GroupReference;
+import io.crate.planner.optimizer.iterative.Memo;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
+
+    public void test_collect() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 1L,
+                                 DataTypes.INTEGER.fixedSize());
+        var memo = new Memo(source);
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, 1, Map.of())));
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(source);
+        assertThat(result.numDocs()).isEqualTo(1L);
+    }
+
+    public void test_group_reference() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 1L,
+                                 DataTypes.INTEGER.fixedSize());
+        var groupReference = new GroupReference(1, source.outputs(), Set.of());
+        var memo = new Memo(source);
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, 1, Map.of())));
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(groupReference);
+        assertThat(result.numDocs()).isEqualTo(1L);
+    }
+
+    public void test_tree_of_operators() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 10L,
+                                 DataTypes.INTEGER.fixedSize());
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
+        var limit = new Limit(source, Literal.of(5), Literal.of(0));
+
+        var memo = new Memo(limit);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(limit);
+        assertThat(result.numDocs()).isEqualTo(5L);
+    }
+
+    public void test_update_table_stats() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 10L,
+                                 DataTypes.INTEGER.fixedSize());
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
+
+        var eval = Eval.create(source, List.of());
+
+        var memo = new Memo(eval);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.apply(eval);
+        assertThat(result.numDocs()).isEqualTo(10L);
+
+        // now update the tablestats
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(100L, 1, Map.of())));
+
+        planStats = new PlanStats(tableStats, memo);
+        result = planStats.apply(eval);
+        assertThat(result.numDocs()).isEqualTo(100L);
+
+    }
+}

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -55,6 +55,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var source = new Collect(new DocTableRelation(a),
                                  List.of(x),
                                  WhereClause.MATCH_ALL,
+                                 null,
                                  1L,
                                  DataTypes.INTEGER.fixedSize());
         var memo = new Memo(source);
@@ -76,6 +77,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var source = new Collect(new DocTableRelation(a),
                                  List.of(x),
                                  WhereClause.MATCH_ALL,
+                                 null,
                                  1L,
                                  DataTypes.INTEGER.fixedSize());
         var groupReference = new GroupReference(1, source.outputs(), Set.of());
@@ -98,6 +100,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var source = new Collect(new DocTableRelation(a),
                                  List.of(x),
                                  WhereClause.MATCH_ALL,
+                                 null,
                                  10L,
                                  DataTypes.INTEGER.fixedSize());
         TableStats tableStats = new TableStats();
@@ -121,6 +124,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var source = new Collect(new DocTableRelation(a),
                                  List.of(x),
                                  WhereClause.MATCH_ALL,
+                                 null,
                                  10L,
                                  DataTypes.INTEGER.fixedSize());
         TableStats tableStats = new TableStats();

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -50,6 +50,7 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanVisitor;
 import io.crate.planner.operators.PlanHint;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 
 
@@ -223,6 +224,29 @@ public class MemoTest {
             plan(newX.id(),
                  plan(y1.id(), plan(z.id())),
                  plan(y2.id(), plan(z.id()))));
+    }
+
+    @Test
+    public void test_store_and_evict_stats() {
+        var y = plan();
+        var x = plan(y);
+
+        Memo memo = new Memo(x);
+        int xGroup = memo.getRootGroup();
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        var xStats = new Stats(1, 1, Map.of());
+        var yStats = new Stats(3, 3, Map.of());
+
+        memo.addStats(yGroup, yStats);
+        memo.addStats(xGroup, xStats);
+
+        assertEquals(memo.stats(yGroup), yStats);
+        assertEquals(memo.stats(xGroup), xStats);
+
+        memo.replace(yGroup, plan());
+
+        assertThat(memo.stats(yGroup)).isNull();
+        assertThat(memo.stats(xGroup)).isNull();
     }
 
 

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -338,16 +338,6 @@ public class MemoTest {
         }
 
         @Override
-        public long numExpectedRows() {
-            return 0;
-        }
-
-        @Override
-        public long estimatedRowSize() {
-            return 0;
-        }
-
-        @Override
         public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
             return visitor.visitPlan(this, context);
         }

--- a/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
@@ -63,7 +63,7 @@ public class PatternTest {
 
     @Test
     public void test_with_source_matching() {
-        Collect source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 1, 1);
+        Collect source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, null, 1, 1);
         Filter filter = new Filter(source, mock(Symbol.class));
         var pattern = typeOf(Filter.class).with(source(), typeOf(Collect.class));
         assertMatch(pattern, filter);
@@ -82,7 +82,7 @@ public class PatternTest {
 
     @Test
     public void test_with_match_group_referenced_source() {
-        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
+        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, null, 100, 10);
         var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 
@@ -108,7 +108,7 @@ public class PatternTest {
 
     @Test
     public void test_with_property_match_group_referenced_source() {
-        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
+        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, null, 100, 10);
         var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -60,7 +60,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testMergeFiltersMatchesOnAFilterWithAnotherFilterAsChild() {
-        Collect source = new Collect(tr1, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
+        Collect source = new Collect(tr1, Collections.emptyList(), WhereClause.MATCH_ALL, null, 100, 10);
         Filter sourceFilter = new Filter(source, e.asSymbol("x > 10"));
         Filter parentFilter = new Filter(sourceFilter, e.asSymbol("y > 10"));
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -37,6 +37,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.statistics.TableStats;
@@ -71,7 +72,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
         Filter mergedFilter = mergeFilters.apply(match.value(),
                                                  match.captures(),
-                                                 new TableStats(),
+                                                 new PlanStats(new TableStats()),
                                                  CoordinatorTxnCtx.systemTransactionContext(),
                                                  e.nodeCtx,
                                                  Function.identity());

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -37,6 +37,7 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
@@ -82,7 +83,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
 
         HashJoin result = (HashJoin) rule.apply(match.value(),
                                                 match.captures(),
-                                                new TableStats(),
+                                                new PlanStats(new TableStats()),
                                                 CoordinatorTxnCtx.systemTransactionContext(),
                                                 sqlExpressions.nodeCtx,
                                                 Function.identity());

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -66,8 +66,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var t1 = (AbstractTableRelation<?>) sources.get(T3.T1);
         var t2 = (AbstractTableRelation<?>) sources.get(T3.T2);
 
-        Collect c1 = new Collect(t1, Collections.emptyList(), WhereClause.MATCH_ALL, 1, 1);
-        Collect c2 = new Collect(t2, Collections.emptyList(), WhereClause.MATCH_ALL, 1, 1);
+        Collect c1 = new Collect(t1, Collections.emptyList(), WhereClause.MATCH_ALL, null, 1, 1);
+        Collect c2 = new Collect(t2, Collections.emptyList(), WhereClause.MATCH_ALL, null, 1, 1);
 
         // This condition has a non-constant part `doc.t1.x = doc.t2.y` and a constant part `doc.t2.b = 'abc'`
         var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t2.b = 'abc'");

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -74,7 +74,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false, false);
+        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false, false, false, false);
         var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
         Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -36,6 +36,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.statistics.TableStats;
@@ -73,7 +74,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -101,7 +102,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -128,7 +129,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -162,7 +163,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -197,7 +198,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            new PlanStats(new TableStats()),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -97,6 +97,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
             tr1,
             Collections.emptyList(),
             new WhereClause(e.asSymbol(query)),
+            null,
             100,
             10
         );

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -203,6 +203,7 @@ public class SQLExecutor {
     public final Cursors cursors = new Cursors();
     public final JobsLogs jobsLogs;
     public final DependencyCarrier dependencyMock;
+    public final TableStats tableStats;
 
     public TransactionState transactionState = TransactionState.IDLE;
     public boolean jobsLogsEnabled;
@@ -228,7 +229,8 @@ public class SQLExecutor {
             -1,
             null,
             cursors,
-            transactionState
+            transactionState,
+            tableStats
         );
     }
 
@@ -420,7 +422,8 @@ public class SQLExecutor {
                 schemas,
                 random,
                 fulltextAnalyzerResolver,
-                udfService
+                udfService,
+                tableStats
             );
         }
 
@@ -770,7 +773,8 @@ public class SQLExecutor {
                         Schemas schemas,
                         Random random,
                         FulltextAnalyzerResolver fulltextAnalyzerResolver,
-                        UserDefinedFunctionService udfService) {
+                        UserDefinedFunctionService udfService,
+                        TableStats tableStats) {
         this.jobsLogsEnabled = false;
         this.jobsLogs = new JobsLogs(() -> SQLExecutor.this.jobsLogsEnabled);
         this.dependencyMock = mock(DependencyCarrier.class, Answers.RETURNS_MOCKS);
@@ -783,7 +787,8 @@ public class SQLExecutor {
             () -> dependencyMock,
             jobsLogs,
             clusterService.getSettings(),
-            clusterService
+            clusterService,
+            tableStats
         );
         this.analyzer = analyzer;
         this.planner = planner;
@@ -795,6 +800,7 @@ public class SQLExecutor {
         this.random = random;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         this.udfService = udfService;
+        this.tableStats = tableStats;
     }
 
     public FulltextAnalyzerResolver fulltextAnalyzerResolver() {
@@ -873,7 +879,8 @@ public class SQLExecutor {
             fetchSize,
             null,
             cursors,
-            transactionState
+            transactionState,
+            tableStats
         );
         Plan plan = planner.plan(analyzedStatement, plannerContext);
         if (plan instanceof LogicalPlan) {

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -246,11 +246,11 @@ public class SQLExecutor {
         private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
         private final UserDefinedFunctionService udfService;
         private final LogicalReplicationService logicalReplicationService;
+        private TableStats tableStats = new TableStats();
         private String[] searchPath = new String[]{Schemas.DOC_SCHEMA_NAME};
         private User user = User.CRATE_USER;
         private UserManager userManager = new StubUserManager();
 
-        private TableStats tableStats = new TableStats();
         private Schemas schemas;
         private LoadedRules loadedRules = new LoadedRules();
         private SessionSettingRegistry sessionSettingRegistry = new SessionSettingRegistry(Set.of(loadedRules));

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -162,6 +162,7 @@ import io.crate.planner.node.ddl.CreateTablePlan;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.planner.optimizer.LoadedRules;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.LogicalReplicationSettings;
@@ -204,6 +205,7 @@ public class SQLExecutor {
     public final JobsLogs jobsLogs;
     public final DependencyCarrier dependencyMock;
     public final TableStats tableStats;
+    public final PlanStats planStats;
 
     public TransactionState transactionState = TransactionState.IDLE;
     public boolean jobsLogsEnabled;
@@ -801,6 +803,7 @@ public class SQLExecutor {
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         this.udfService = udfService;
         this.tableStats = tableStats;
+        this.planStats = new PlanStats(tableStats);
     }
 
     public FulltextAnalyzerResolver fulltextAnalyzerResolver() {

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -77,6 +77,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
 import org.apache.logging.log4j.LogManager;
@@ -211,6 +212,7 @@ import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.SystemPropsTestLoggingListener;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
@@ -1765,6 +1767,7 @@ public abstract class IntegTestCase extends ESTestCase {
         Analyzer analyzer = cluster().getInstance(Analyzer.class, nodeName);
         Planner planner = cluster().getInstance(Planner.class, nodeName);
         NodeContext nodeCtx = cluster().getInstance(NodeContext.class, nodeName);
+        TableStats tableStats = cluster().getInstance(TableStats.class, nodeName);
 
         CoordinatorSessionSettings sessionSettings = new CoordinatorSessionSettings(
             User.CRATE_USER,
@@ -1781,7 +1784,8 @@ public abstract class IntegTestCase extends ESTestCase {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            tableStats
         );
         Plan plan = planner.plan(
             analyzer.analyze(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See second commit.

- This is a proof-of-concept to move the swap of lhs/rhs of hash/nl joins into optimizer rules to make them configurable. 
- The sides are only swapped in the final building part, otherwise, the order of the output fields would change which causes a lot of problems.
- The wiring of the table stats into the planner and the plan stats is still quite messy and needs to be cleaned up

Depending on https://github.com/crate/crate/pull/13968
Resolves https://github.com/crate/crate/issues/13501


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
