### PR TITLE
Fix IS NULL on geo shape arrays

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -94,6 +94,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused ``geo_shape_array IS NULL`` expressions to fail
+  with an ``IllegalStateException``.
+
 - Fixed an issue that caused the actual cast/type conversion error to be hidden
   when it failed for a sub-column of an object column, when using a client
   statement with parameters i.e (python).::

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -57,6 +57,7 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import io.crate.types.StorageSupport;
@@ -131,33 +132,34 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
     @Nullable
     public static Query refExistsQuery(Reference ref, Context context, boolean countEmptyArrays) {
         String field = ref.column().fqn();
-        if (ref.valueType() instanceof ArrayType<?>) {
+        FieldType fieldType = context.queryShardContext().getMapperService().getLuceneFieldType(field);
+        DataType<?> valueType = ref.valueType();
+        boolean canUseFieldsExist = ref.hasDocValues() || (fieldType != null && !fieldType.omitNorms());
+        if (valueType instanceof ArrayType<?>) {
             if (countEmptyArrays) {
-                return new BooleanQuery.Builder()
-                    .setMinimumNumberShouldMatch(1)
-                    .add(new FieldExistsQuery(field), Occur.SHOULD)
-                    .add(Queries.not(isNullFuncToQuery(ref, context)), Occur.SHOULD)
-                    .build();
-            } else {
-                // An empty array has no dimension, array_length([]) = NULL, thus we don't count [] as existing.
-                return new FieldExistsQuery(field);
+                if (canUseFieldsExist) {
+                    return new BooleanQuery.Builder()
+                        .setMinimumNumberShouldMatch(1)
+                        .add(new FieldExistsQuery(field), Occur.SHOULD)
+                        .add(Queries.not(isNullFuncToQuery(ref, context)), Occur.SHOULD)
+                        .build();
+                } else {
+                    return null;
+                }
             }
+            // An empty array has no dimension, array_length([]) = NULL, thus we don't count [] as existing.
+            valueType = ArrayType.unnest(valueType);
         }
-        StorageSupport<?> storageSupport = ref.valueType().storageSupport();
+        StorageSupport<?> storageSupport = valueType.storageSupport();
         if (storageSupport == null && ref instanceof DynamicReference) {
             return new MatchNoDocsQuery("DynamicReference/type without storageSupport does not exist");
-        } else if (ref.hasDocValues()) {
+        } else if (canUseFieldsExist) {
             return new FieldExistsQuery(field);
         } else if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
             // Not indexed, need to use source lookup
             return null;
         } else if (storageSupport != null && storageSupport.hasFieldNamesIndex()) {
-            FieldType fieldType = context.queryShardContext().getMapperService().getLuceneFieldType(field);
-            if (fieldType != null && !fieldType.omitNorms()) {
-                return new FieldExistsQuery(field);
-            }
-
-            if (ref.valueType() instanceof ObjectType objType) {
+            if (valueType instanceof ObjectType objType) {
                 if (objType.innerTypes().isEmpty()) {
                     return null;
                 }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -338,10 +338,10 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     public void testIsNullOnObjectArray() throws Exception {
         Query isNull = convert("o_array IS NULL");
         assertThat(isNull.toString()).isEqualTo(
-            "+*:* -((FieldExistsQuery [field=o_array] (+*:* -(o_array IS NULL)))~1)");
+            "(o_array IS NULL)");
         Query isNotNull = convert("o_array IS NOT NULL");
         assertThat(isNotNull.toString()).isEqualTo(
-            "(FieldExistsQuery [field=o_array] (+*:* -(o_array IS NULL)))~1");
+            "(NOT (o_array IS NULL))");
     }
 
     @Test


### PR DESCRIPTION
Using `FieldsExistQuery` on a field that has no doc-values, norms or
vectors results in an exception.

The random-query-tests failed because of it with:

    IllegalStateException[FieldExistsQuery requires that the field indexes doc values, norms or vectors, but field 'ageo_shape' exists and indexes neither of these data structures] occurred using: {"stmt": "SELECT count(*) FROM \"benchmarks\".\"query_tests\" WHERE \"sbyte\" < -115 AND ageo_shape IS NULL;"}
