### PR TITLE
Ensure that default expression is assigned to ARRAY types

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -138,3 +138,6 @@ Fixes
 - Fixed an issue that caused ``ALTER TABLE ADD COLUMN`` statement to assign a
   wrong type to ``ARRAY(TEXT)`` column and create a ``TEXT`` column instead if
   column has a ``FULLTEXT`` index.
+
+- Fixed an issue that prevented assigning default expression to ``ARRAY``
+  columns.

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -460,6 +460,16 @@ public class AnalyzedColumnDefinition<T> {
             mapping.put("copy_to", definition.copyToTargets);
         }
 
+        if (definition.docValues() != definition.dataType.storageSupport().getComputedDocValuesDefault(definition.indexType)) {
+            // definition.docValues falls back to default if not specified.
+            // If computed value is non-default it means doc values are supported but disabled.
+            mapping.put(DOC_VALUES, "false");
+        }
+
+        if (definition.formattedDefaultExpression != null) {
+            mapping.put("default_expr", definition.formattedDefaultExpression);
+        }
+
         if ("array".equals(definition.collectionType)) {
             Map<String, Object> outerMapping = new HashMap<>();
             outerMapping.put("type", "array");
@@ -470,16 +480,6 @@ public class AnalyzedColumnDefinition<T> {
             return outerMapping;
         } else if (definition.dataType().id() == ObjectType.ID) {
             objectMapping(mapping, definition);
-        }
-
-        if (definition.docValues() != definition.dataType.storageSupport().getComputedDocValuesDefault(definition.indexType)) {
-            // definition.docValues falls back to default if not specified.
-            // If computed value is non-default it means doc values are supported but disabled.
-            mapping.put(DOC_VALUES, "false");
-        }
-
-        if (definition.formattedDefaultExpression != null) {
-            mapping.put("default_expr", definition.formattedDefaultExpression);
         }
 
         return mapping;

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1194,9 +1195,9 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "   obj object as (key text) default {key=''}," +
             "   arr array(long) default [1, 2])");
 
-        assertThat(mapToSortedString(analysis.mappingProperties()), is(
-            "arr={inner={position=3, type=long}, type=array}, " +
-            "obj={default_expr={\"key\"=''}, dynamic=true, position=1, properties={key={position=2, type=keyword}}, type=object}"));
+        assertThat(mapToSortedString(analysis.mappingProperties())).isEqualTo(
+            "arr={inner={default_expr=_cast([1, 2], 'array(bigint)'), position=3, type=long}, type=array}, " +
+                "obj={default_expr={\"key\"=''}, dynamic=true, position=1, properties={key={position=2, type=keyword}}, type=object}");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -201,12 +201,19 @@ public class DDLIntegrationTest extends IntegTestCase {
 
     @Test
     public void testCreateColumnWithDefaultExpression() throws Exception {
-        execute("create table test (col1 text default 'foo')");
+        execute("create table test (id int, col1 text default 'foo', col2 int[] default [1,2])");
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"strict\",\"_meta\":{}," +
-                                 "\"properties\":{\"col1\":{\"type\":\"keyword\",\"position\":1,\"default_expr\":\"'foo'\"}}}}";
+            "\"dynamic\":\"strict\"," +
+            "\"_meta\":{}," +
+            "\"properties\":{" +
+            "\"col1\":{\"type\":\"keyword\",\"position\":2,\"default_expr\":\"'foo'\"}," +
+            "\"col2\":{\"type\":\"array\",\"inner\":{\"type\":\"integer\",\"position\":3,\"default_expr\":\"_cast([1, 2], 'array(integer)')\"}}," +
+            "\"id\":{\"type\":\"integer\",\"position\":1}}}}";
         assertEquals(expectedMapping, getIndexMapping("test"));
-
+        execute("insert into test(id) values(1)");
+        execute("refresh table test");
+        execute("select id, col1, col2 from test");
+        assertThat(response).hasRows("1| foo| [1, 2]");
     }
 
     @Test


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/13148

in case of array we return early: `return outerMapping` and default expression handling is not reached.

Accidentally spot this in CREATE TABLE refactoring PR which works for default ARRAY-s and assertion in `testCreateTableWithDefaultExpressionAsCompoundTypes` got broken.

Reported issue also mentions objects but it's a bit more complex as it's case when default expression might cause dynamic mapping update, left it out of the fix scope.
