### PR TITLE
Handle default expression on Reference serialization

### DIFF
--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -221,6 +221,9 @@ public class SimpleReference implements Reference {
                 mapping.put(TypeParsers.DOC_VALUES, Boolean.toString(hasDocValues));
             }
         }
+        if (defaultExpression != null) {
+            mapping.put("default_expr", defaultExpression.toString(Style.UNQUALIFIED));
+        }
         innerType.addMappingOptions(mapping);
         return mapping;
     }

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -157,4 +157,23 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
         assertThat(Maps.getByPath(sourceAsMap, "properties.xs")).isEqualTo(mapping);
     }
+
+    @Test
+    public void test_mapping_generation_default_expression() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (xs string default 'foo')")
+            .build();
+        DocTableInfo table = e.resolveTableInfo("tbl");
+        Reference reference = table.getReference(new ColumnIdent("xs"));
+        Map<String, Object> mapping = reference.toMapping();
+        assertThat(mapping)
+            .containsEntry("position", 1)
+            .containsEntry("type", "keyword")
+            .containsEntry("default_expr", "'foo'")
+            .hasSize(3);
+        IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
+        Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
+        assertThat(Maps.getByPath(sourceAsMap, "properties.xs")).isEqualTo(mapping);
+    }
+
 }


### PR DESCRIPTION
port of https://github.com/crate/crate/pull/14011

`toMapping` code path does face ADD COLUMN(s) and dynamic mapping updates but neither of them has default expression support so null check eliminates any behavioural changes.