### PR TITLE
Do not allow inserting undefined values resulting in dynamic column creations

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -106,4 +106,6 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue that allowed inserting undefined values resulting in
+  dynamic column creations. For example, an empty array cannot be used to
+  create a column dynamically since the inner type is undefined.

--- a/docs/general/ddl/column-policy.rst
+++ b/docs/general/ddl/column-policy.rst
@@ -54,7 +54,9 @@ which means as-is.
 .. NOTE::
 
    The data type of the new column is guessed from the data type of the value
-   provided in the insert statement that creates the column.
+   provided in the insert statement that creates the column. Therefore,
+   undefined values such as ``null``, ``[]``, or ``[null]`` cannot be used
+   to create new columns.
 
 If a new column ``a`` was added with type ``boolean``, adding strings to this
 column will result in an error, except the string can be implicit casted to a

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -80,8 +80,10 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
             type = guessType(value);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
+                var typeName = type.getName();
+                type = null;
                 throw new IllegalArgumentException(
-                    "Cannot create columns of type " + type.getName() + " dynamically. " +
+                    "Cannot create columns of type " + typeName + " dynamically. " +
                     "Storage is not supported for this type");
             }
             boolean nullable = true;

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -540,19 +540,18 @@ public class Indexer {
                 if (reference.granularity() == RowGranularity.PARTITION) {
                     continue;
                 }
-                if (value == null) {
-                    continue;
-                }
                 ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
-                xContentBuilder.field(reference.column().leafName());
-                valueIndexer.indexValue(
-                    value,
-                    xContentBuilder,
-                    addField,
-                    onDynamicColumn,
-                    synthetics,
-                    columnConstraints
-                );
+                if (value != null || valueIndexer instanceof DynamicIndexer) {
+                    xContentBuilder.field(reference.column().leafName());
+                    valueIndexer.indexValue(
+                        value,
+                        xContentBuilder,
+                        addField,
+                        onDynamicColumn,
+                        synthetics,
+                        columnConstraints
+                    );
+                }
             }
             for (var entry : synthetics.entrySet()) {
                 ColumnIdent column = entry.getKey();

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -157,10 +157,6 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             if (!isNewColumn) {
                 continue;
             }
-            if (innerValue == null) {
-                xContentBuilder.nullField(innerName);
-                continue;
-            }
             if (ref.columnPolicy() == ColumnPolicy.STRICT) {
                 throw new IllegalArgumentException(String.format(
                     Locale.ENGLISH,
@@ -177,10 +173,6 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             innerValue = type.sanitizeValue(innerValue);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
-                xContentBuilder.field(innerName);
-                if (DynamicIndexer.handleEmptyArray(type, innerValue, xContentBuilder)) {
-                    continue;
-                }
                 throw new IllegalArgumentException(
                     "Cannot create columns of type " + type.getName() + " dynamically. " +
                     "Storage is not supported for this type");

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1874,8 +1874,8 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             "clustered into 6 shards " +
             "partitioned by (day)");
         ensureYellow();
-        execute("insert into event (day, data) values ('2015-01-03', {sessionid = null})");
         execute("insert into event (day, data) values ('2015-01-01', {sessionid = 'hello'})");
+        execute("insert into event (day, data) values ('2015-01-03', {sessionid = null})");
         execute("refresh table event");
         waitForMappingUpdateOnAll("event", "data.sessionid");
         execute("select data['sessionid'] from event group by data['sessionid'] " +
@@ -1894,8 +1894,8 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             ") clustered into 6 shards " +
             "partitioned by (day)");
         ensureYellow();
-        execute("insert into event (day, data) values ('2015-01-03', {sessionid = null})");
         execute("insert into event (day, data) values ('2015-01-01', {sessionid = 'hello'})");
+        execute("insert into event (day, data) values ('2015-01-03', {sessionid = null})");
         execute("insert into event (day, data) values ('2015-02-08', {sessionid = 'ciao'})");
         execute("refresh table event");
         waitForMappingUpdateOnAll("event", "data.sessionid");
@@ -1915,8 +1915,8 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             ") clustered into 6 shards" +
             " partitioned by (day)");
         ensureYellow();
-        execute("insert into event (day, data, number) values ('2015-01-03', {sessionid = null}, 42)");
         execute("insert into event (day, data, number) values ('2015-01-01', {sessionid = 'hello'}, 42)");
+        execute("insert into event (day, data, number) values ('2015-01-03', {sessionid = null}, 42)");
         execute("insert into event (day, data, number) values ('2015-02-08', {sessionid = 'ciao'}, 42)");
         execute("refresh table event");
         waitForMappingUpdateOnAll("event", "data.sessionid");
@@ -1955,8 +1955,8 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             ") clustered into 6 shards " +
             "partitioned by (day)");
         ensureYellow();
-        execute("insert into event (day, data, number) values ('2015-01-03', {sessionid = null}, 0)");
         execute("insert into event (day, data, number) values ('2015-01-01', {sessionid = 'hello'}, 21)");
+        execute("insert into event (day, data, number) values ('2015-01-03', {sessionid = null}, 0)");
         execute("insert into event (day, data, number) values ('2015-02-08', {sessionid = 'ciao'}, 42)");
         execute("insert into event (day, number) values ('2015-03-08', 84)");
         execute("refresh table event");
@@ -1968,7 +1968,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
                 "order by number");
         assertThat(response.rowCount(), is(2L));
         assertThat(printedTable(response.rows()), is(
-            "{sessionid=NULL}\n" +
+            "{}\n" +
             "NULL\n"));
 
         execute("select data " +

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -415,46 +415,6 @@ public class SQLTypeMappingTest extends IntegTestCase {
     } */
 
     @Test
-    public void test_dynamic_empty_array_does_not_result_in_new_column() throws Exception {
-        execute("create table arr (id short primary key, tags array(string)) " +
-                "with (number_of_replicas=0, column_policy = 'dynamic')");
-        ensureYellow();
-        execute("insert into arr (id, tags, new) values (1, ['wow', 'much', 'wow'], [])");
-        refresh();
-        waitNoPendingTasksOnAll();
-        execute("select column_name, data_type from information_schema.columns where table_name='arr' order by 1");
-        assertThat(response).hasRows(
-            "id| smallint",
-            "tags| text_array"
-        );
-        assertThat((String) execute("select _raw from arr").rows()[0][0]).isEqualToIgnoringWhitespace(
-            """
-            {"id":1,"tags":["wow","much","wow"],"new":[]}
-            """
-        );
-    }
-
-    @Test
-    public void testDynamicNullArray_does_not_result_in_new_column() throws Exception {
-        execute("create table arr (id short primary key, tags array(string)) " +
-                "with (number_of_replicas=0, column_policy = 'dynamic')");
-        ensureYellow();
-        execute("insert into arr (id, tags, new) values (2, ['wow', 'much', 'wow'], [null])");
-        refresh();
-        waitNoPendingTasksOnAll();
-        execute("select column_name, data_type from information_schema.columns where table_name='arr' order by 1");
-        assertThat(response).hasRows(
-            "id| smallint",
-            "tags| text_array"
-        );
-        assertThat((String) execute("select _raw from arr").rows()[0][0]).isEqualToIgnoringWhitespace(
-            """
-            {"id":2,"tags":["wow","much","wow"],"new":[null]}
-            """
-        );
-    }
-
-    @Test
     public void testDynamicNullArrayAndDouble() throws Exception {
         execute("create table arr (id short primary key, tags array(string)) " +
                 "with (number_of_replicas=0, column_policy = 'dynamic')");

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 
 import static io.crate.data.Row1.ERROR;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -170,11 +169,6 @@ public class TransportSQLActionSingleNodeTest extends IntegTestCase {
             });
         assertThat(rowCounts[0]).isEqualTo(ERROR);
         assertThat(rowCounts[1]).isEqualTo(1L);
-
-        waitForMappingUpdateOnAll("foo", "bar");
-        execute("select data_type from information_schema.columns where table_name = 'foo' and column_name = 'bar'");
-        // integer values for unknown columns will be result in a long type for range safety
-        assertThat(response.rows()[0][0]).isEqualTo("bigint_array");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 
+import static io.crate.data.Row1.ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -167,7 +168,7 @@ public class TransportSQLActionSingleNodeTest extends IntegTestCase {
                 new Object[]{listWithNull},
                 new Object[]{List.of(1, 2)},
             });
-        assertThat(rowCounts[0]).isEqualTo(1L);
+        assertThat(rowCounts[0]).isEqualTo(ERROR);
         assertThat(rowCounts[1]).isEqualTo(1L);
 
         waitForMappingUpdateOnAll("foo", "bar");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes the first half of https://github.com/crate/crate/issues/13990

Dynamic column creation requires the datatype of the value being inserted to be known. `[]`, `null` are undefined, it is decided to reject inserting such values.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
