### PR TITLE
Release notes: Switch to AlmaLinux standard OCI image resolving K8s flaw

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -157,3 +157,6 @@ Fixes
 
 - Fixed an issue that prevented assigning default expression to ``ARRAY``
   columns.
+
+- Reverted base image change in the Docker image as it broke downstream components
+  which rely on some of the bundled tools like ``rev``.


### PR DESCRIPTION
Deploying CrateDB 5.3.0 on Kubernetes revealed some flaws on the bootstrapping procedure related to DNS resolution, which only partly have been investigated. By switching from `almalinux:9-minimal` back to `almalinux:9` (standard), it has been verified that it remedies those issues.

- Reference: https://github.com/crate/docker-crate/pull/222