### PR TITLE
Fix wrong results (or 0) returned for inner join

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -65,6 +65,12 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue introduced in 5.2.0 which led ``INNER JOIN`` queries to produce
+  0 or wrong results when filtering with a constant value is used in the join
+  condition, e.g.::
+
+    SELECT * FROM t1 INNER JOIN t2 ON t1.a = 10 AND t1.x = t2.y
+
 - Fixed a performance regression introduced in 5.2.3 which led to filters on
   object columns resulting in a table scan if used with views or virtual tables.
   See `#14015 <https://github.com/crate/crate/issues/14015>`_ for details.

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -68,13 +68,17 @@ public class HashJoin implements LogicalPlan {
     final LogicalPlan rhs;
     final LogicalPlan lhs;
 
+    final boolean joinConditionOptimised;
+
     public HashJoin(LogicalPlan lhs,
                     LogicalPlan rhs,
-                    Symbol joinCondition) {
+                    Symbol joinCondition,
+                    boolean joinConditionOptimised) {
         this.outputs = Lists2.concat(lhs.outputs(), rhs.outputs());
         this.lhs = lhs;
         this.rhs = rhs;
         this.joinCondition = joinCondition;
+        this.joinConditionOptimised = joinConditionOptimised;
     }
 
     public JoinType joinType() {
@@ -254,7 +258,8 @@ public class HashJoin implements LogicalPlan {
         return new HashJoin(
             sources.get(0),
             sources.get(1),
-            joinCondition
+            joinCondition,
+            joinConditionOptimised
         );
     }
 
@@ -276,7 +281,8 @@ public class HashJoin implements LogicalPlan {
         return new HashJoin(
             newLhs,
             newRhs,
-            joinCondition
+            joinCondition,
+            joinConditionOptimised
         );
     }
 
@@ -304,11 +310,11 @@ public class HashJoin implements LogicalPlan {
             new HashJoin(
                 lhsFetchRewrite == null ? lhs : lhsFetchRewrite.newPlan(),
                 rhsFetchRewrite == null ? rhs : rhsFetchRewrite.newPlan(),
-                joinCondition
+                joinCondition,
+                joinConditionOptimised
             )
         );
     }
-
 
     @Override
     public long numExpectedRows() {
@@ -339,6 +345,10 @@ public class HashJoin implements LogicalPlan {
                 lhs::print,
                 rhs::print
             );
+    }
+
+    public boolean isJoinConditionOptimised() {
+        return joinConditionOptimised;
     }
 
     private List<Symbol> setModuloDistribution(List<Symbol> joinSymbols,

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -183,7 +183,8 @@ public class JoinPlanBuilder {
             return new HashJoin(
                 lhsPlan,
                 rhsPlan,
-                joinCondition
+                joinCondition,
+                false
             );
         } else {
             return new NestedLoopJoin(

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -83,6 +83,7 @@ import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
+import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathHashJoin;
 import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
@@ -147,7 +148,8 @@ public class LogicalPlanner {
                 new DeduplicateOrder(),
                 new OptimizeCollectWhereClauseAccess(),
                 new RewriteGroupByKeysLimitToLimitDistinct(),
-                new MoveConstantJoinConditionsBeneathNestedLoop()
+                new MoveConstantJoinConditionsBeneathNestedLoop(),
+                new MoveConstantJoinConditionsBeneathHashJoin()
             )
         );
         this.fetchOptimizer = new Optimizer(

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -87,7 +87,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
+        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"), true);
         assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathHashJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathHashJoinTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.RelationName;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
+
+public class MoveConstantJoinConditionsBeneathHashJoinTest extends CrateDummyClusterServiceUnitTest {
+
+    private SqlExpressions sqlExpressions;
+    private Map<RelationName, AnalyzedRelation> sources;
+
+    @Before
+    public void prepare() throws Exception {
+        sources = T3.sources(clusterService);
+        sqlExpressions = new SqlExpressions(sources);
+    }
+
+    @Test
+    public void test_optimize_hashjoin_when_constant_can_be_pused_down() {
+        var t1 = (AbstractTableRelation<?>) sources.get(T3.T1);
+        var t2 = (AbstractTableRelation<?>) sources.get(T3.T2);
+
+        Collect c1 = new Collect(t1, Collections.emptyList(), WhereClause.MATCH_ALL, 1, 1);
+        Collect c2 = new Collect(t2, Collections.emptyList(), WhereClause.MATCH_ALL, 1, 1);
+
+        // This condition has a non-constant part `doc.t1.x = doc.t2.y` and a constant part `doc.t2.b = 'abc'`
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t2.b = 'abc'");
+        var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
+        var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
+
+        HashJoin hashJoin = new HashJoin(c1, c2, joinCondition, false);
+        var rule = new MoveConstantJoinConditionsBeneathHashJoin();
+        Match<HashJoin> match = rule.pattern().accept(hashJoin, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(hashJoin);
+
+        HashJoin result = (HashJoin) rule.apply(match.value(),
+                                                match.captures(),
+                                                new TableStats(),
+                                                CoordinatorTxnCtx.systemTransactionContext(),
+                                                sqlExpressions.nodeCtx);
+
+        assertThat(result.joinCondition()).isEqualTo(nonConstantPart);
+        assertThat(result.lhs()).isEqualTo(c1);
+        Filter filter = (Filter) result.rhs();
+        assertThat(filter.source()).isEqualTo(c2);
+        assertThat(filter.query()).isEqualTo(constantPart);
+    }
+}


### PR DESCRIPTION
When an INNER JOIN uses a filtering with constant value in the join condition, e.g.:
```
SELECT * FROM t1 INNER JOIN t2 ON t1.a = 10 AND t1.x = t2.y
```
the filtering (`t1.a = 10`) is not pushed down but remains part of the `joinCondition` of the `HashJoin`, which in turn messes up the `hashSymbols` of the `HashJoin` and the computed hash includes irrelevant columns, thus, not matching rows from left and right relations. Probably introduced with: https://github.com/crate/crate/pull/12460/

It has been fixed in 5.3.0 and onwards with: https://github.com/crate/crate/pull/13802

Fixes: #14003

