### PR TITLE
Fix issue with implicit join pairs

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -103,6 +103,13 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused ``AssertionError`` to be thrown when referencing
+  previous relations, not explicitly joined, in an join condition, e.g.::
+
+    SELECT * FROM t1
+    CROSS JOIN t2
+    INNER JOIN t3 ON t3.x = t1.x AND t3.y = t2
+
 - Fixed a performance regression introduced in 5.2.3 which led to filters on
   object columns resulting in a table scan if used with views or virtual tables.
   See `#14015 <https://github.com/crate/crate/issues/14015>`_ for details.

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,7 +28,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashSet;


### PR DESCRIPTION
Previously, join pairs defined implicitly through join conditions where not recognized, causing `AssertionError` to be thrown at runtime.

Fixes: #13942
