### PR TITLE
Added attgenerated col to pg_attributes

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -86,6 +86,10 @@ Changes
 - Bumped the version of PostgreSQL wire protocol to ``14`` since ``10`` has been
   deprecated.
 
+- Added ``attgenerated`` column to ``pg_catalog.pg_attribute`` table which
+  returns ``''`` (empty string) for normal columns and ``'s'`` for
+  :ref:`generated columns <ddl-generated-columns>`.
+
 - Allow casts in both forms: ``CAST(<literal or parameter> AS <datatype>)`` and
   ``<literal or parameter>::<datatype>`` for ``LIMIT`` and ``OFFSET`` clauses,
 

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -236,6 +236,11 @@ public class GeneratedReference implements Reference {
     }
 
     @Override
+    public boolean isGenerated() {
+        return true;
+    }
+
+    @Override
     public Reference getRelocated(ReferenceIdent referenceIdent) {
         return new GeneratedReference(
             ref.getRelocated(referenceIdent),

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -73,6 +73,8 @@ public interface Reference extends Symbol {
     @Nullable
     Symbol defaultExpression();
 
+    boolean isGenerated();
+
     Reference getRelocated(ReferenceIdent referenceIdent);
 
     /**

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -206,6 +206,11 @@ public class SimpleReference implements Reference {
     }
 
     @Override
+    public boolean isGenerated() {
+        return false;
+    }
+
+    @Override
     public Map<String, Object> toMapping() {
         DataType<?> innerType = ArrayType.unnest(type);
         Map<String, Object> mapping = new HashMap<>();

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -58,6 +58,7 @@ public class PgAttributeTable {
             .add("attnotnull", BOOLEAN, c -> !c.ref().isNullable())
             .add("atthasdef", BOOLEAN, c -> false) // don't support default values
             .add("attidentity", STRING, c -> "")
+            .add("attgenerated", STRING, c -> c.ref().isGenerated() ? "s" : "")
             .add("attisdropped", BOOLEAN, c -> false) // don't support dropping columns
             .add("attislocal", BOOLEAN, c -> true)
             .add("attinhcount", INTEGER, c -> 0)

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -562,7 +562,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(947);
+        assertThat(response.rowCount()).isEqualTo(948);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -42,7 +42,12 @@ public class PgCatalogITest extends IntegTestCase {
 
     @Before
     public void createRelations() {
-        execute("create table doc.t1 (id int primary key, s string, o object as (a int))");
+        execute("""
+            create table doc.t1 (
+                id int primary key,
+                s string, o object as (a int),
+                g generated always as s || '_foo')
+            """);
         execute("create view doc.v1 as select id from doc.t1");
     }
 
@@ -56,7 +61,7 @@ public class PgCatalogITest extends IntegTestCase {
         execute("select * from pg_catalog.pg_class where relname in ('t1', 'v1', 'tables', 'nodes') order by relname");
         assertThat(response).hasRows(
             "-1420189195| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| nodes| -458336339| 18| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0",
-            "728874843| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| t1| -2048275947| 3| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0",
+            "728874843| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| t1| -2048275947| 4| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0",
             "-1689918046| NULL| 0| 0| 0| 0| false| 0| false| false| true| false| false| false| false| true| false| r| 0| tables| 204690627| 16| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0",
             "845171032| NULL| 0| 0| 0| 0| false| 0| false| false| false| false| false| false| false| true| false| v| 0| v1| -2048275947| 1| 0| NULL| 0| 0| NULL| p| p| false| 0| 0| -1.0| 0");
     }
@@ -84,10 +89,11 @@ public class PgCatalogITest extends IntegTestCase {
             "select a.* from pg_catalog.pg_attribute as a join pg_catalog.pg_class as c on a.attrelid = c.oid where" +
             " c.relname = 't1' order by a.attnum");
         assertThat(response).hasRows(
-            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| 4| id| 0| true| 1| NULL| 728874843| 0| NULL| 23| -1",
-            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| -1| s| 0| false| 2| NULL| 728874843| 0| NULL| 1043| -1",
-            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| -1| o| 0| false| 3| NULL| 728874843| 0| NULL| 114| -1",
-            "NULL| NULL| false| -1| 0| NULL| false| | 0| false| true| 4| o['a']| 0| false| 4| NULL| 728874843| 0| NULL| 23| -1");
+            "NULL| NULL| false| -1| 0| NULL| | false| | 0| false| true| 4| id| 0| true| 1| NULL| 728874843| 0| NULL| 23| -1",
+            "NULL| NULL| false| -1| 0| NULL| | false| | 0| false| true| -1| s| 0| false| 2| NULL| 728874843| 0| NULL| 1043| -1",
+            "NULL| NULL| false| -1| 0| NULL| | false| | 0| false| true| -1| o| 0| false| 3| NULL| 728874843| 0| NULL| 114| -1",
+            "NULL| NULL| false| -1| 0| NULL| | false| | 0| false| true| 4| o['a']| 0| false| 4| NULL| 728874843| 0| NULL| 23| -1",
+            "NULL| NULL| false| -1| 0| NULL| s| false| | 0| false| true| -1| g| 0| false| 5| NULL| 728874843| 0| NULL| 1043| -1");
     }
 
     @Test
@@ -203,7 +209,7 @@ public class PgCatalogITest extends IntegTestCase {
         execute("select ct.oid, ct.relkind, ct.relname, ct.relnamespace, ct.relnatts, ct.relpersistence, ct.relreplident, ct.reltuples" +
                 " from pg_class ct, (select * from pg_index i, pg_class c where c.relname = 't1' and c.oid = i.indrelid) i" +
                 " where ct.oid = i.indexrelid;");
-        assertThat(response).hasRows("-649073482| i| t1_pkey| -2048275947| 3| p| p| 0.0");
+        assertThat(response).hasRows("-649073482| i| t1_pkey| -2048275947| 4| p| p| 0.0");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -630,7 +630,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(510L);
+            assertThat(response).hasRowCount(511L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");


### PR DESCRIPTION
Added `attgenerated` column to `pg_catalog.pg_attribute` table which returns `''` (empty string) for normal columns and `'s'` for generated columns. The column has been added with PostgreSQL 12 and since we've bumped our compatibility to 14 some tools (e.g. Metabase) was missing this column.

Follows: #13420
Closes: #14036
