### PR TITLE
Convert empty arrays inserted dynamically into nulls

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -154,6 +154,29 @@ Fixes
   first argument of :ref:`INTERVAL data type <type-interval>` contains month
   and/or year units.
 
+- Added a workaround for an issue that allowed inserting a non-array value onto
+  a column that is dynamically created by inserting an empty array, ultimately
+  modifying the type of the column. The empty arrays will be convert to
+  ``nulls`` when queried. For example::
+
+    CREATE TABLE t (o OBJECT);
+    INSERT INTO t VALUES ({x=[]});
+    INSERT INTO t VALUES ({x={}});  /* this is the culprit statement, inserting an object onto an array typed column */
+    SHOW CREATE TABLE t;
+    +-----------------------------------------------------+
+    | SHOW CREATE TABLE doc.t                             |
+    +-----------------------------------------------------+
+    | CREATE TABLE IF NOT EXISTS "doc"."t" (              |
+    |    "o" OBJECT(DYNAMIC) AS (                         |
+    |       "x" OBJECT(DYNAMIC)  /* an array type modified to an object type */
+    SELECT * FROM t;
+    +-------------+
+    | o           |
+    +-------------+
+    | {"x": {}}   |
+    | {"x": null} |  /* an empty array converted to null */
+    +-------------+
+
 - Fixed an issue that caused ``AssertionError`` to be thrown when referencing
   previous relations, not explicitly joined, in an join condition, e.g.::
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -51,12 +51,14 @@ import io.crate.types.DataType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.GeoPointType;
+import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ObjectType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
 
+import static org.elasticsearch.common.xcontent.XContentParser.Token.START_ARRAY;
 import static org.elasticsearch.common.xcontent.XContentParser.Token.VALUE_NULL;
 
 public final class SourceParser {
@@ -155,6 +157,12 @@ public final class SourceParser {
                 var required = requiredColumns.get(fieldName);
                 if (required == null && !includeUnknown) {
                     parser.skipChildren();
+                } else if (token == START_ARRAY &&
+                           required instanceof DataType<?> && !(required instanceof ArrayType<?>) &&
+                           !(required instanceof GeoPointType) && !(required instanceof GeoShapeType)) {
+                    // due to a bug: https://github.com/crate/crate/issues/13990
+                    parser.skipChildren();
+                    values.put(fieldName, null);
                 } else if (token == VALUE_NULL) {
                     // If object value is null, we can short-circuit to NULL and continue further with other fields.
                     // We should not call parseObject() as current object's innerTypes can interfere with sibling columns

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -254,5 +255,26 @@ public class SourceParserTest extends ESTestCase {
                    )
             )
         );
+    }
+
+    /**
+     * https://github.com/crate/crate/issues/13990
+     */
+    @Test
+    public void test_convert_empty_or_null_arrays_added_dynamically_to_nulls() {
+        SourceParser sourceParser = new SourceParser();
+        var type = ObjectType.UNTYPED;
+        sourceParser.register(new ColumnIdent("_doc", List.of("x")), type);
+        var result = sourceParser.parse(
+            new BytesArray(
+                """
+                    {
+                        "x": [null]
+                    }
+                    """
+            ));
+        var expected = new HashMap<String, Object>();
+        expected.put("x", null);
+        assertThat(result).isEqualTo(expected);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
+import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import java.util.List;
@@ -465,6 +466,26 @@ public class SQLTypeMappingTest extends IntegTestCase {
                 " table_name='arr' order by ordinal_position desc limit 1");
             assertThat(res).hasRows("new| double precision_array");
         });
+    }
+
+    /**
+     * https://github.com/crate/crate/issues/13990
+     */
+    @Test
+    public void test_dynamic_null_array_overridden_to_integer_becomes_null() {
+        execute("create table t (a int) with (column_policy ='dynamic')");
+        execute("insert into t (x) values ([])");
+        execute("insert into t (x) values (1)");
+        refresh();
+        execute("select * from t");
+        assertThat(printedTable(response.rows())).contains("NULL| NULL", "NULL| 1");
+        // takes different paths than without order by like above
+        execute("select * from t order by x nulls first");
+        assertThat(printedTable(response.rows())).isEqualTo(
+            """
+                NULL| NULL
+                NULL| 1
+                """);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Work around for https://github.com/crate/crate/issues/13990, this only converts the initial empty arrays to nulls, and the buggy behaviour will continue to exist which should be handled by https://github.com/crate/crate/issues/14046

Below are a few concrete scenarios:
```
cr> create table t (o object);                                                                                                                      
CREATE OK, 1 row affected  (1.619 sec)
cr> insert into t values ({b=[], c=[]});                                                                                                            
INSERT OK, 1 row affected  (0.043 sec)
cr> insert into t values ({b=1, c={}});  <-- b, c should be arrays but this stmt succeeded                                                                                                             
INSERT OK, 1 row affected  (0.154 sec)
cr> select _raw, * from t;                                                                                                                          
+-----------------------+------------------------+
| _raw                  | o                      |
+-----------------------+------------------------+
| {"o":{"b":1,"c":{}}}  | {"b": 1, "c": {}}      |  <-- keeping these values and converting the empty arrays to nulls instead
| {"o":{"b":[],"c":[]}} | {"b": null, "c": null} |  <-- b, c are converted to nulls but from _raw it is still visible
+-----------------------+------------------------+
```

the same applies to table level columns:
```
cr> create table t (a int) with (column_policy='dynamic');                                                                                          
CREATE OK, 1 row affected  (1.612 sec)
cr> insert into t (b,c) values ([],[]);                                                                                                             
INSERT OK, 1 row affected  (0.044 sec)
cr> insert into t (b,c) values (1,{});                                                                                                              
INSERT OK, 1 row affected  (0.152 sec)
cr> select _raw, * from t;                                                                                                                          
+-----------------+------+------+------+
| _raw            |    a |    b | c    |
+-----------------+------+------+------+
| {"b":1,"c":{}}  | NULL |    1 | {}   |
| {"b":[],"c":[]} | NULL | NULL | NULL |  <-- b, c are converted to nulls 
+-----------------+------+------+------+
SELECT 2 rows in set (0.003 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
