### PR TITLE
Fix issue with join condition referencing a previous relation

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -111,4 +111,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed an issue that caused ``AssertionError`` to be thrown when referencing
+  previous relations, not explicitly joined, in an join condition, e.g.::
+
+    SELECT * FROM t1
+    CROSS JOIN t2
+    INNER JOIN t3 ON t3.x = t1.x AND t3.y = t2
+

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -43,6 +43,7 @@ import io.crate.analyze.relations.QuerySplitter;
 import io.crate.common.collections.Lists2;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.FieldsVisitor;
+import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
@@ -160,12 +161,25 @@ public class JoinPlanBuilder {
             return false;
         }
         boolean[] hasAdditionalDependencies = {false};
-        FieldsVisitor.visitFields(condition, scopedSymbol -> {
-            RelationName relation = scopedSymbol.relation();
-            if (!relation.equals(joinPair.left()) && !relation.equals(joinPair.right())) {
+
+        // Un-aliased tables
+        RefVisitor.visitRefs(condition, ref -> {
+            RelationName relationName = ref.ident().tableIdent();
+            if (!relationName.equals(joinPair.left()) && !relationName.equals(joinPair.right())) {
                 hasAdditionalDependencies[0] = true;
             }
         });
+
+        // Aliased tables
+        if (hasAdditionalDependencies[0] == false) {
+            FieldsVisitor.visitFields(condition, scopedSymbol -> {
+                RelationName relationName = scopedSymbol.relation();
+                if (!relationName.equals(joinPair.left()) && !relationName.equals(joinPair.right())) {
+                    hasAdditionalDependencies[0] = true;
+                }
+            });
+        }
+
         return hasAdditionalDependencies[0];
     }
 


### PR DESCRIPTION
Previously, the additional dependency was not recognized as the code was only checking `ScopedSymbol`s for the case relations were aliased. This led to the join order possible changed, and when the `JoinPair`, for which the condition was containing additional relations, could become 1st in the ordering, thus the required symbols from the additional relation were not available, e.g.:
```
SELECT * FROM t1
CROSS JOIN t2
INNER JOIN t3 ON t3.x = t1.x AND t3.y = t2
```
The `JoinPair` t2, t3 will become the 1st in order but it's referencing t1 in the join condition, which is not available, as it would be joined next in order.

Fixes: #13942
