### PR TITLE
Fix ClassCastException while replicating dynamic long column

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -546,7 +546,7 @@ public class Indexer {
                 ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
                 xContentBuilder.field(reference.column().leafName());
                 valueIndexer.indexValue(
-                    value,
+                    reference.valueType().sanitizeValue(value),
                     xContentBuilder,
                     addField,
                     onDynamicColumn,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
See below scenario executed in a 2-node cluster:

```
cr> create table t (a int) with (column_policy ='dynamic');                                                                                         
CREATE OK, 1 row affected  (1.691 sec)
cr> insert into t(x) values (1);   <-- result in a column created dynamically that is a type of long but the value is an integer 1 causing ClassCastException but only when replicating                                                                                                               
INSERT OK, 1 row affected  (0.156 sec)
```

The exception message:
```
[2023-05-04T20:06:30,665][WARN ][i.c.e.d.u.TransportShardUpsertAction] [Pizzo del Sole] [[t][3]] failed to perform internal:crate:sql/data/write on replica [t][3], node[LBrHxfNqQmqga4uSCqrPRQ], [R], s[STARTED], a[id=E1EdqPhPSiC-13YnNccJfQ]
org.elasticsearch.transport.RemoteTransportException: [Erlspitze][127.0.0.1:4300][internal:crate:sql/data/write[r]]
Caused by: org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper: class_cast_exception: class java.lang.Integer cannot be cast to class java.lang.Long (java.lang.Integer and java.lang.Long are in module java.base of loader 'bootstrap')
	at io.crate.execution.dml.LongIndexer.indexValue(LongIndexer.java:43) ~[main/:?]
	at io.crate.execution.dml.Indexer.index(Indexer.java:548) ~[main/:?]
	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItemsOnReplica(TransportShardUpsertAction.java:360) ~[main/:?]
	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItemsOnReplica(TransportShardUpsertAction.java:100) ~[main/:?]
	at io.crate.execution.dml.TransportShardAction$2.call(TransportShardAction.java:135) ~[main/:?]
	at io.crate.execution.dml.TransportShardAction$2.call(TransportShardAction.java:132) ~[main/:?]
	at io.crate.execution.dml.TransportShardAction.wrapOperationInKillable(TransportShardAction.java:146) ~[main/:?]
	at io.crate.execution.dml.TransportShardAction.shardOperationOnReplica(TransportShardAction.java:138) ~[main/:?]
	at io.crate.execution.dml.TransportShardAction.shardOperationOnReplica(TransportShardAction.java:63) ~[main/:?]
	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncReplicaAction.onResponse(TransportReplicationAction.java:558) ~[main/:?]
	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncReplicaAction.onResponse(TransportReplicationAction.java:537) ~[main/:?]
	at org.elasticsearch.index.shard.IndexShard.lambda$innerAcquireReplicaOperationPermit$27(IndexShard.java:2925) ~[main/:?]
	at org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:103) ~[main/:?]
	at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:292) ~[main/:?]
	at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:242) ~[main/:?]
	at org.elasticsearch.index.shard.IndexShard.lambda$acquireReplicaOperationPermit$25(IndexShard.java:2860) ~[main/:?]
	at org.elasticsearch.index.shard.IndexShard.innerAcquireReplicaOperationPermit(IndexShard.java:2964) ~[main/:?]
	at org.elasticsearch.index.shard.IndexShard.acquireReplicaOperationPermit(IndexShard.java:2859) ~[main/:?]
	at org.elasticsearch.action.support.replication.TransportReplicationAction.acquireReplicaOperationPermit(TransportReplicationAction.java:882) ~[main/:?]
	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncReplicaAction.doRun(TransportReplicationAction.java:630) ~[main/:?]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[main/:?]
	at org.elasticsearch.action.support.replication.TransportReplicationAction.handleReplicaRequest(TransportReplicationAction.java:522) ~[main/:?]
	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:59) ~[main/:?]
	at org.elasticsearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:331) ~[main/:?]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[main/:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1589) ~[?:?]
	Suppressed: java.lang.IllegalStateException: Failed to close the XContentBuilder
		at org.elasticsearch.common.xcontent.XContentBuilder.close(XContentBuilder.java:933) ~[main/:?]
		at io.crate.execution.dml.Indexer.index(Indexer.java:530) ~[main/:?]
		at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItemsOnReplica(TransportShardUpsertAction.java:360) ~[main/:?]
		at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItemsOnReplica(TransportShardUpsertAction.java:100) ~[main/:?]
		at io.crate.execution.dml.TransportShardAction$2.call(TransportShardAction.java:135) ~[main/:?]
		at io.crate.execution.dml.TransportShardAction$2.call(TransportShardAction.java:132) ~[main/:?]
		at io.crate.execution.dml.TransportShardAction.wrapOperationInKillable(TransportShardAction.java:146) ~[main/:?]
		at io.crate.execution.dml.TransportShardAction.shardOperationOnReplica(TransportShardAction.java:138) ~[main/:?]
		at io.crate.execution.dml.TransportShardAction.shardOperationOnReplica(TransportShardAction.java:63) ~[main/:?]
		at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncReplicaAction.onResponse(TransportReplicationAction.java:558) ~[main/:?]
		at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncReplicaAction.onResponse(TransportReplicationAction.java:537) ~[main/:?]
		at org.elasticsearch.index.shard.IndexShard.lambda$innerAcquireReplicaOperationPermit$27(IndexShard.java:2925) ~[main/:?]
		at org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:103) ~[main/:?]
		at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:292) ~[main/:?]
		at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:242) ~[main/:?]
		at org.elasticsearch.index.shard.IndexShard.lambda$acquireReplicaOperationPermit$25(IndexShard.java:2860) ~[main/:?]
		at org.elasticsearch.index.shard.IndexShard.innerAcquireReplicaOperationPermit(IndexShard.java:2964) ~[main/:?]
		at org.elasticsearch.index.shard.IndexShard.acquireReplicaOperationPermit(IndexShard.java:2859) ~[main/:?]
		at org.elasticsearch.action.support.replication.TransportReplicationAction.acquireReplicaOperationPermit(TransportReplicationAction.java:882) ~[main/:?]
		at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncReplicaAction.doRun(TransportReplicationAction.java:630) ~[main/:?]
		at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[main/:?]
		at org.elasticsearch.action.support.replication.TransportReplicationAction.handleReplicaRequest(TransportReplicationAction.java:522) ~[main/:?]
		at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:59) ~[main/:?]
		at org.elasticsearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:331) ~[main/:?]
		at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[main/:?]
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
		at java.lang.Thread.run(Thread.java:1589) ~[?:?]
	Caused by: java.io.IOException: Unclosed object or array found
		at org.elasticsearch.common.xcontent.json.JsonXContentGenerator.close(JsonXContentGenerator.java:352) ~[main/:?]
		at org.elasticsearch.common.xcontent.XContentBuilder.close(XContentBuilder.java:931) ~[main/:?]
		... 27 more
[2023-05-04T20:06:30,677][INFO ][o.e.c.r.a.AllocationService] [Pizzo del Sole] Cluster health status changed from [GREEN] to [YELLOW] (reason: [shards failed [[t][3]]]).
[2023-05-04T20:06:31,976][INFO ][o.e.c.r.a.AllocationService] [Pizzo del Sole] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[t][3]]]).
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
