### PR TITLE
RTD: Update to Ubuntu 22 and Python 3.11 (backport)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+python:
+  install:
+  - requirements: docs/requirements.txt
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
_Backport of GH-14052._

It is needed to compensate for the recent release of urllib3 2.x. Otherwise, the build process will fail like:

    Could not import extension sphinx.builders.linkcheck (exception:
    urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module
    is compiled with OpenSSL 1.0.2n  7 Dec 2017.
    See: urllib3/urllib3#2168)
