### PR TITLE
Improve error msg and docs for `date_bin`.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -117,6 +117,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+
+- Improved error message for :ref:`date_bin <date-bin>` scalar function when the
+  first argument of :ref:`INTERVAL data type <type-interval>` contains month
+  and/or year units.
+
 - Fixed an issue that caused ``AssertionError`` to be thrown when referencing
   previous relations, not explicitly joined, in an join condition, e.g.::
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1017,6 +1017,8 @@ is placed.
 If you use an interval with a single unit like ``1 second`` or ``1 minute``,
 this function returns the same result as :ref:`date_trunc <scalar-date_trunc>`.
 
+Intervals with months and/or year units are not allowed.
+
 If the interval is ``1 week``, ``date_bin`` only returns the same result as
 ``date_trunc`` if the origin is a Monday.
 

--- a/server/src/test/java/io/crate/expression/scalar/DateBinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateBinFunctionTest.java
@@ -55,6 +55,16 @@ public class DateBinFunctionTest extends ScalarTestCase {
     }
 
     @Test
+    public void test_interval_with_years_or_months_exception_thrown() {
+        Assertions.assertThatThrownBy(() -> assertEvaluate("date_bin('2 mons' :: INTERVAL, CURRENT_TIMESTAMP, 0)", null))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot use intervals containing months or years");
+        Assertions.assertThatThrownBy(() -> assertEvaluate("date_bin('2 years' :: INTERVAL, CURRENT_TIMESTAMP, 0)", null))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot use intervals containing months or years");
+    }
+
+    @Test
     public void test_interval_is_zero_exception_thrown() {
         Assertions.assertThatThrownBy(() -> assertEvaluate("date_bin('0 days' :: INTERVAL, CURRENT_TIMESTAMP, 0)", null))
             .isExactlyInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
`date_bin` function doesn't allow intervals with months and/or year units. Improve error message and docs. The behaviour is compatible with PostgreSQL:

```
matriv=> SELECT date_bin('1 month 2 hours'::INTERVAL, ts, '2021-01-01T05:00:00Z'::TIMESTAMP)
FROM unnest(ARRAY['2021-01-01T08:30:10Z']::TIMESTAMP[]) as tbl(ts);
ERROR:  timestamps cannot be binned into intervals containing months or years
```
