### PR TITLE
Add assertion in order to verify that there is no holes in positions sequence

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -23,15 +23,17 @@ package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Rule;
@@ -63,6 +65,24 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
                 insert into t values (1, {x=1})
                 """);
         execute("refresh table t");
+
+        AtomicBoolean dmlStatementsFinished = new AtomicBoolean(false);
+        HashMap<String, Integer> columnPositions = new HashMap<>();
+        Thread checkPositions = new Thread(() -> {
+            while (dmlStatementsFinished.get() == false) {
+                synchronized (response) {
+                    execute("select column_name, ordinal_position from information_schema.columns where table_name = 't'");
+                    String columnName = (String) response.rows()[0][0];
+                    Integer newPosition = (Integer) response.rows()[0][1];
+                    Integer previousPosition = columnPositions.put(columnName, newPosition);
+                    if (previousPosition != null && previousPosition.equals(newPosition) == false) {
+                        throw new IllegalStateException(
+                            String.format(Locale.ENGLISH, "Column %s had position %d which is recomputed to %d", columnName, previousPosition, newPosition)
+                        );
+                    }
+                }
+            }
+        });
 
         Thread concurrentUpdates1 = new Thread(() -> {
             for (int i = 0; i < 5; i++) {
@@ -110,6 +130,7 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
             }
         });
 
+        checkPositions.start();
         concurrentUpdates1.start();
         concurrentUpdates2.start();
         concurrentUpdates3.start();
@@ -129,6 +150,8 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         concurrentUpdates7.join();
         concurrentUpdates8.join();
         concurrentUpdates9.join();
+
+        dmlStatementsFinished.set(true);
 
         execute("""
             SELECT
@@ -191,6 +214,23 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
             "b['newcol84']",
             "b['x']"
         );
+
+        // Verify that there are no holes in positions sequence for a concrete table
+        execute("""
+            SELECT
+                column_name, ordinal_position
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = 't'
+            AND
+                ordinal_position > 48
+            """
+        );
+        assertThat(response.rows())
+            .as("No holes in positions sequence for a concrete table")
+            .isEmpty();
+
         execute("select count(distinct ordinal_position), max(ordinal_position) from information_schema.columns where table_name = 't'");
         assertThat(response.rows()[0][0])
             .as("distinct ordinal positions")


### PR DESCRIPTION
`test_concurrent_statements_that_add_columns_to_partitioned_table_result_in_dynamic_mapping_updates` is flaky, 

number of distinct positions is correct (48) but max position is 49. When this will fail because of flakiness, we will figure out column name and thus problematic operation - as we know intervals for add/insert/update with code like `b['newcol" + i + "'] `