### PR TITLE
Improve output representation of timestamp subtraction

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -117,6 +117,12 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Improved output representation of timestamp subtraction, by normalizing to
+  bigger units. e.g::
+
+    SELECT '2022-12-05T11:22:33.123456789+05:30'::timestamp - '2022-12-03T11:22:33.123456789-02:15'::timestamp
+
+  previously would return: ``PT40H15M`` and now returns: ``P1DT16H15M``.
 
 - Improved error message for :ref:`date_bin <date-bin>` scalar function when the
   first argument of :ref:`INTERVAL data type <type-interval>` contains month

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
@@ -33,6 +33,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
+import io.crate.types.IntervalType;
 
 public class SubtractTimestampScalar extends Scalar<Period, Object> {
 
@@ -76,6 +77,6 @@ public class SubtractTimestampScalar extends Scalar<Period, Object> {
         if (end == null || start == null) {
             return null;
         }
-        return new Period(end - start);
+        return IntervalType.subtractTimestamps(end, start);
     }
 }

--- a/server/src/main/java/io/crate/types/IntervalType.java
+++ b/server/src/main/java/io/crate/types/IntervalType.java
@@ -26,8 +26,11 @@ import io.crate.interval.IntervalParser;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.joda.time.DateTimeConstants;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
+import org.joda.time.Interval;
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
 
@@ -168,5 +171,32 @@ public class IntervalType extends DataType<Period> implements FixedWidthType, St
         millis += (p.getMonths() * (DateTimeConstants.MILLIS_PER_DAY * 30L));
         millis += (p.getYears() * (DateTimeConstants.MILLIS_PER_DAY * 365L));
         return new Duration(millis);
+    }
+
+    /**
+     * returns Period in yearMonthDayTime which corresponds to Postgres default Interval output format.
+     * See https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-INTERVAL-OUTPUT
+     */
+    public static Period subtractTimestamps(long timestamp1, long timestamp2) {
+        /*
+         PeriodType is important as it affects the internal representation of the Period object.
+         PeriodType.yearMonthDayTime() is needed to return 8 days but not 1 week 1 day.
+         Streamer of the IntervalType will simply put 0 in 'out.writeVInt(p.getWeeks())' as getWeeks() returns zero for unused fields.
+         */
+
+        if (timestamp1 < timestamp2) {
+            /*
+            In Postgres second argument is subtracted from the first.
+            Interval's first argument must be smaller than second and thus we swap params and negate.
+
+            We need to pass UTC timezone to be sure that Interval doesn't end up using system default time zone.
+            Currently, timestamps are in UTC (see https://github.com/crate/crate/issues/10037 and
+            https://github.com/crate/crate/issues/12064) but if https://github.com/crate/crate/issues/7196 ever gets
+            implemented, we need to pass here not UTC but time zone set by SET TIMEZONE.
+            */
+            return new Interval(timestamp1, timestamp2, DateTimeZone.UTC).toPeriod(PeriodType.yearMonthDayTime()).negated();
+        } else {
+            return new Interval(timestamp2, timestamp1, DateTimeZone.UTC).toPeriod(PeriodType.yearMonthDayTime());
+        }
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TimestampArithmeticTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TimestampArithmeticTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -39,11 +40,14 @@ public class TimestampArithmeticTest extends ScalarTestCase {
     @Test
     public void test_timestamp_subtract() {
         assertEvaluate("'2000-03-21T23:33:44.999999999'::timestamp - '2022-12-05T11:22:33.123456789'::timestamp",
-                       Period.hours(-199043).withMinutes(-48).withSeconds(-48).withMillis(-124));
+                       new Period(-22, -8, 0, -13, -11, -48, -48, -124,
+                                  PeriodType.yearMonthDayTime()));
         assertEvaluate("'2022-12-05T11:22:33.123456789'::timestamp - '-2000-03-21T23:33:44.999999999'::timestamp",
-                       Period.hours(35262323).withMinutes(48).withSeconds(48).withMillis(124));
+                       new Period(4022, 8, 0, 13, 11, 48, 48, 124,
+                                  PeriodType.yearMonthDayTime()));
         assertEvaluate("'2022-12-05T11:22:33.123456789+05:30'::timestamptz - '2022-12-03T11:22:33.123456789-02:15'::timestamptz",
-                       Period.hours(40).withMinutes(15));
+                       new Period(0, 0, 0, 1, 16, 15, 0, 0,
+                                  PeriodType.yearMonthDayTime()));
     }
 
     @Test


### PR DESCRIPTION
Improve output representation of timestamp subtraction, by normalizing to bigger units. e.g:
```
SELECT '2022-12-05T11:22:33.123456789+05:30'::timestamp - '2022-12-03T11:22:33.123456789-02:15'::timestamp
```
previously would return: `PT40H15M` and now returns: `P1DT16H15M`.

Follows: #13345
