### PR TITLE
Fix output representation for ts subtraction

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -118,7 +118,8 @@ Fixes
 .. an automated mergify backport.
 
 - Improved output representation of timestamp subtraction, by normalizing to
-  bigger units. e.g::
+  bigger units, but no further than days, to be consistent with PostgreSQL
+  behavior. e.g::
 
     SELECT '2022-12-05T11:22:33.123456789+05:30'::timestamp - '2022-12-03T11:22:33.123456789-02:15'::timestamp
 

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -24,7 +24,10 @@ package io.crate.expression.scalar;
 
 import static io.crate.metadata.functions.Signature.scalar;
 
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
@@ -35,7 +38,6 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
-import io.crate.types.IntervalType;
 
 public class AgeFunction extends Scalar<Period, Object> {
 
@@ -97,13 +99,40 @@ public class AgeFunction extends Scalar<Period, Object> {
         if (args.length == 1) {
             long curDateMillis = txnCtx.currentInstant().toEpochMilli();
             curDateMillis = curDateMillis - curDateMillis % 86400000; // current_date at midnight, similar to CurrentDateFunction implementation.
-            return IntervalType.subtractTimestamps(curDateMillis, (long) arg1);
+            return getPeriod(curDateMillis, (long) arg1);
         } else {
             var arg2 = args[1].value();
             if (arg2 == null) {
                 return null;
             }
-            return IntervalType.subtractTimestamps((long) arg1, (long) arg2);
+            return getPeriod((long) arg1, (long) arg2);
+        }
+    }
+
+    /**
+     * returns Period in yearMonthDayTime which corresponds to Postgres default Interval output format.
+     * See https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-INTERVAL-OUTPUT
+     */
+    public static Period getPeriod(long timestamp1, long timestamp2) {
+        /*
+         PeriodType is important as it affects the internal representation of the Period object.
+         PeriodType.yearMonthDayTime() is needed to return 8 days but not 1 week 1 day.
+         Streamer of the IntervalType will simply put 0 in 'out.writeVInt(p.getWeeks())' as getWeeks() returns zero for unused fields.
+         */
+
+        if (timestamp1 < timestamp2) {
+            /*
+            In Postgres second argument is subtracted from the first.
+            Interval's first argument must be smaller than second and thus we swap params and negate.
+
+            We need to pass UTC timezone to be sure that Interval doesn't end up using system default time zone.
+            Currently, timestamps are in UTC (see https://github.com/crate/crate/issues/10037 and
+            https://github.com/crate/crate/issues/12064) but if https://github.com/crate/crate/issues/7196 ever gets
+            implemented, we need to pass here not UTC but time zone set by SET TIMEZONE.
+            */
+            return new Interval(timestamp1, timestamp2, DateTimeZone.UTC).toPeriod(PeriodType.yearMonthDayTime()).negated();
+        } else {
+            return new Interval(timestamp2, timestamp1, DateTimeZone.UTC).toPeriod(PeriodType.yearMonthDayTime());
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 import java.util.List;
 
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
@@ -33,7 +34,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import io.crate.types.IntervalType;
 
 public class SubtractTimestampScalar extends Scalar<Period, Object> {
 
@@ -77,6 +77,6 @@ public class SubtractTimestampScalar extends Scalar<Period, Object> {
         if (end == null || start == null) {
             return null;
         }
-        return IntervalType.subtractTimestamps(end, start);
+        return new Period(end - start).normalizedStandard(PeriodType.yearMonthDayTime());
     }
 }

--- a/server/src/main/java/io/crate/types/IntervalType.java
+++ b/server/src/main/java/io/crate/types/IntervalType.java
@@ -21,20 +21,18 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
-import io.crate.interval.IntervalParser;
+import java.io.IOException;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.joda.time.DateTimeConstants;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
-import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.joda.time.PeriodType;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
 
-import java.io.IOException;
+import io.crate.Streamer;
+import io.crate.interval.IntervalParser;
 
 public class IntervalType extends DataType<Period> implements FixedWidthType, Streamer<Period> {
 
@@ -171,32 +169,5 @@ public class IntervalType extends DataType<Period> implements FixedWidthType, St
         millis += (p.getMonths() * (DateTimeConstants.MILLIS_PER_DAY * 30L));
         millis += (p.getYears() * (DateTimeConstants.MILLIS_PER_DAY * 365L));
         return new Duration(millis);
-    }
-
-    /**
-     * returns Period in yearMonthDayTime which corresponds to Postgres default Interval output format.
-     * See https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-INTERVAL-OUTPUT
-     */
-    public static Period subtractTimestamps(long timestamp1, long timestamp2) {
-        /*
-         PeriodType is important as it affects the internal representation of the Period object.
-         PeriodType.yearMonthDayTime() is needed to return 8 days but not 1 week 1 day.
-         Streamer of the IntervalType will simply put 0 in 'out.writeVInt(p.getWeeks())' as getWeeks() returns zero for unused fields.
-         */
-
-        if (timestamp1 < timestamp2) {
-            /*
-            In Postgres second argument is subtracted from the first.
-            Interval's first argument must be smaller than second and thus we swap params and negate.
-
-            We need to pass UTC timezone to be sure that Interval doesn't end up using system default time zone.
-            Currently, timestamps are in UTC (see https://github.com/crate/crate/issues/10037 and
-            https://github.com/crate/crate/issues/12064) but if https://github.com/crate/crate/issues/7196 ever gets
-            implemented, we need to pass here not UTC but time zone set by SET TIMEZONE.
-            */
-            return new Interval(timestamp1, timestamp2, DateTimeZone.UTC).toPeriod(PeriodType.yearMonthDayTime()).negated();
-        } else {
-            return new Interval(timestamp2, timestamp1, DateTimeZone.UTC).toPeriod(PeriodType.yearMonthDayTime());
-        }
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TimestampArithmeticTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TimestampArithmeticTest.java
@@ -40,13 +40,16 @@ public class TimestampArithmeticTest extends ScalarTestCase {
     @Test
     public void test_timestamp_subtract() {
         assertEvaluate("'2000-03-21T23:33:44.999999999'::timestamp - '2022-12-05T11:22:33.123456789'::timestamp",
-                       new Period(-22, -8, 0, -13, -11, -48, -48, -124,
+                       new Period(0, 0, 0, -8293, -11, -48, -48, -124,
                                   PeriodType.yearMonthDayTime()));
         assertEvaluate("'2022-12-05T11:22:33.123456789'::timestamp - '-2000-03-21T23:33:44.999999999'::timestamp",
-                       new Period(4022, 8, 0, 13, 11, 48, 48, 124,
+                       new Period(0, 0, 0, 1469263, 11, 48, 48, 124,
                                   PeriodType.yearMonthDayTime()));
         assertEvaluate("'2022-12-05T11:22:33.123456789+05:30'::timestamptz - '2022-12-03T11:22:33.123456789-02:15'::timestamptz",
                        new Period(0, 0, 0, 1, 16, 15, 0, 0,
+                                  PeriodType.yearMonthDayTime()));
+        assertEvaluate("'2022-11-13T01:22:33.123456789'::timestamp - '2022-12-05T21:22:33.123456789'::timestamp",
+                       new Period(0, 0, 0, -22, -20, 0, 0, 0,
                                   PeriodType.yearMonthDayTime()));
     }
 


### PR DESCRIPTION
Seems that when the result of the subtraction are more than 30 days, Postgres, doesn't round up to months and then years, instead it keeps a large value of days, so it's doesn't behave like age for those cases:
```
matriv=> select '2022-12-05T11:22:33.123456789'::timestamp - '2000-03-21T23:33:44.999999999'::timestamp;
         ?column?
---------------------------
 8293 days 11:48:48.123457
(1 row)

matriv=> select age('2022-12-05T11:22:33.123456789'::timestamp, '2000-03-21T23:33:44.999999999'::timestamp);
                   age
-----------------------------------------
 22 years 8 mons 14 days 11:48:48.123457
(1 row)

```
So, change the subtraction to not use the logic of `age()` but only normalize the result.

Follows: #14065
