### PR TITLE
Fix DROP TABLE IF EXISTS with catalog prefix.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -117,6 +117,13 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that caused ``DROP TABLE IF EXISTS`` to wrongly return ``1``
+  row affected or ``SQLParseException`` (depending on user privileges), when
+  called on an existent schema, a non-existent table and with the ``crate``
+  catalog prefix, e.g.::
+
+    DROP TABLE IF EXISTS crate.doc.non_existent_table
+
 - Improved output representation of timestamp subtraction, by normalizing to
   bigger units, but no further than days, to be consistent with PostgreSQL
   behavior. e.g::

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -141,7 +141,8 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
             } else {
                 tableInfo = schemaInfo.getTableInfo(tableName);
                 if (tableInfo == null) {
-                    throw RelationUnknown.of(ident.toString(), getSimilarTables(user, tableName, schemaInfo.getTables()));
+                    throw RelationUnknown.of(identSchema + "." + tableName,
+                                             getSimilarTables(user, tableName, schemaInfo.getTables()));
                 }
             }
         }


### PR DESCRIPTION
Fix `RelationUnknown` exception thrown in case of an existent schema but a non-existent table to exlude the catalog (`crate`) prefix as `IndexParts` used internally doesn't recognize the catalog part.

Fixes: #14070
