### PR TITLE
Handle all columns in position computation check

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -72,13 +72,15 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
             while (dmlStatementsFinished.get() == false) {
                 synchronized (response) {
                     execute("select column_name, ordinal_position from information_schema.columns where table_name = 't'");
-                    String columnName = (String) response.rows()[0][0];
-                    Integer newPosition = (Integer) response.rows()[0][1];
-                    Integer previousPosition = columnPositions.put(columnName, newPosition);
-                    if (previousPosition != null && previousPosition.equals(newPosition) == false) {
-                        throw new IllegalStateException(
-                            String.format(Locale.ENGLISH, "Column %s had position %d which is recomputed to %d", columnName, previousPosition, newPosition)
-                        );
+                    for (int i = 0; i < response.rowCount(); i++) {
+                        String columnName = (String) response.rows()[0][0];
+                        Integer newPosition = (Integer) response.rows()[0][1];
+                        Integer previousPosition = columnPositions.put(columnName, newPosition);
+                        if (previousPosition != null && previousPosition.equals(newPosition) == false) {
+                            throw new IllegalStateException(
+                                String.format(Locale.ENGLISH, "Column %s had position %d which is recomputed to %d", columnName, previousPosition, newPosition)
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Was keeping en eye on test runs and saw that prev commit has a bug(

Follow up to https://github.com/crate/crate/commit/e1dd27ceffeaa30b60b2a14e8c582e1e20f829d2

```
REPRODUCE WITH: ./gradlew :server:test --tests "io.crate.integrationtests.DynamicMappingUpdateITest.test_concurrent_statements_that_add_columns_to_partitioned_table_result_in_dynamic_mapping_updates" -Dtests.seed=8C5769EAE669F4E9 -Dtests.nightly=true -Dtests.locale=nds-NL -Dtests.timezone=Africa/Kampala
com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=716, name=Thread-5, state=RUNNABLE, group=TGRP-DynamicMappingUpdateITest]
	at __randomizedtesting.SeedInfo.seed([8C5769EAE669F4E9:38F1FFD7DC328E84]:0)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at __randomizedtesting.SeedInfo.seed([8C5769EAE669F4E9]:0)
	at io.crate.integrationtests.DynamicMappingUpdateITest.lambda$execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates$0(DynamicMappingUpdateITest.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1589)
```


