### PR TITLE
Always move filter below eval

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -117,6 +117,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Improved an optimization rule to enable index lookups instead of table scans
+  in more cases. This is a follow up to a fix in 5.2.7 which fixed a regression
+  introduced in 5.2.3.
+
 - Fixed an issue that caused ``DROP TABLE IF EXISTS`` to wrongly return ``1``
   row affected or ``SQLParseException`` (depending on user privileges), when
   called on an existent schema, a non-existent table and with the ``crate``

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -88,7 +88,7 @@ import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathCorrelatedJoin;
-import io.crate.planner.optimizer.rule.MoveFilterBeneathFetchOrEval;
+import io.crate.planner.optimizer.rule.MoveFilterBeneathEval;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
@@ -128,7 +128,7 @@ public class LogicalPlanner {
         new MergeAggregateRenameAndCollectToCount(),
         new MergeFilters(),
         new MoveFilterBeneathRename(),
-        new MoveFilterBeneathFetchOrEval(),
+        new MoveFilterBeneathEval(),
         new MoveFilterBeneathOrder(),
         new MoveFilterBeneathProjectSet(),
         new MoveFilterBeneathJoin(),

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -129,4 +129,9 @@ public class GroupReference implements LogicalPlan {
     public List<AbstractTableRelation<?>> baseTables() {
         throw new UnsupportedOperationException(ERROR_MESSAGE);
     }
+
+    @Override
+    public String toString() {
+        return "GroupReference{" + groupId + "}";
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -170,7 +170,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.| NULL| NULL",
             "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.| NULL| NULL",
-            "optimizer_move_filter_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveFilterBeneathFetchOrEval is activated.| NULL| NULL",
+            "optimizer_move_filter_beneath_eval| true| Indicates if the optimizer rule MoveFilterBeneathEval is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_group_by| true| Indicates if the optimizer rule MoveFilterBeneathGroupBy is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_join| true| Indicates if the optimizer rule MoveFilterBeneathJoin is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_order| true| Indicates if the optimizer rule MoveFilterBeneathOrder is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -409,7 +409,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.",
             "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.",
-            "optimizer_move_filter_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveFilterBeneathFetchOrEval is activated.",
+            "optimizer_move_filter_beneath_eval| true| Indicates if the optimizer rule MoveFilterBeneathEval is activated.",
             "optimizer_move_filter_beneath_group_by| true| Indicates if the optimizer rule MoveFilterBeneathGroupBy is activated.",
             "optimizer_move_filter_beneath_join| true| Indicates if the optimizer rule MoveFilterBeneathJoin is activated.",
             "optimizer_move_filter_beneath_order| true| Indicates if the optimizer rule MoveFilterBeneathOrder is activated.",

--- a/server/src/testFixtures/java/io/crate/testing/ProjectionAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ProjectionAssert.java
@@ -25,8 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.AbstractAssert;
 
+import io.crate.execution.dsl.projection.FilterProjection;
 import io.crate.execution.dsl.projection.LimitAndOffsetProjection;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.expression.symbol.Symbol;
 
 public final class ProjectionAssert extends AbstractAssert<ProjectionAssert, Projection> {
 
@@ -40,5 +42,12 @@ public final class ProjectionAssert extends AbstractAssert<ProjectionAssert, Pro
         assertThat(((LimitAndOffsetProjection) actual).limit()).isEqualTo(expectedLimit);
         assertThat(((LimitAndOffsetProjection) actual).offset()).isEqualTo(expectedOffset);
         return this;
+    }
+
+    public SymbolAssert isFilterWithQuery() {
+        isNotNull();
+        isExactlyInstanceOf(FilterProjection.class);
+        Symbol query = ((FilterProjection) actual).query();
+        return new SymbolAssert(query);
     }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/crate/crate/pull/14021

It didn't handle aliased columns.
`extractColumns` unwrapped the alias, and then it no longer
matched on the source column which still contained an alias.

This removes the containment/intersection check altogether because
`Eval` never adds information, it only re-arranges columns or evaluates
functions. The `FilterProjection` can evaluate functions as well so a
`Eval` is not needed for it.

See https://github.com/crate/crate/issues/14015#issuecomment-1536301022
