### PR TITLE
Raise nicer error on string -> object casts

### DIFF
--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -172,10 +172,9 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     @SuppressWarnings("unchecked")
     private Map<String, Object> convert(Object value,
                                         BiFunction<DataType<?>, Object, Object> innerType) {
-        if (value instanceof String) {
-            value = mapFromJSONString((String) value);
+        if (value instanceof String str) {
+            value = mapFromJSONString(str);
         }
-        //noinspection unchecked
         Map<String, Object> map = (Map<String, Object>) value;
         if (map == null || innerTypes == null) {
             return map;
@@ -207,7 +206,9 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
             );
             return parser.map();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            var conversionException = new ConversionException(value, UNTYPED);
+            conversionException.addSuppressed(e);
+            throw conversionException;
         }
     }
 

--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -38,6 +39,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import io.crate.common.collections.MapBuilder;
+import io.crate.exceptions.ConversionException;
 
 public class ObjectTypeTest extends ESTestCase {
 
@@ -185,5 +187,12 @@ public class ObjectTypeTest extends ESTestCase {
             .setInnerType("inner field", DataTypes.STRING)
             .build();
         assertThat(objectType.getTypeSignature().createType(), is(objectType));
+    }
+
+    @Test
+    public void test_raises_conversion_exception_on_string_parsing_errors() throws Exception {
+        assertThatThrownBy(() -> ObjectType.UNTYPED.implicitCast("foo"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast value `foo` to type `object`");
     }
 }


### PR DESCRIPTION
Instead of:

    java.lang.RuntimeException: com.fasterxml.jackson.core.JsonParseException: Unrecognized token

It now shows a regular cast error:

    Cannot cast value `foo` to type `object`
