### PR TITLE
Unnest arrays in ANY to number of dimensions required

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -55,6 +55,18 @@ None
 Changes
 =======
 
+- Array comparisons like ``= ANY`` will now automatically unnest the array
+  argument to the required dimensions.
+
+  An example::
+
+    cr> SELECT 1 = ANY([ [1, 2], [3, 4] ]);   -- automatic unnesting
+    True
+
+    cr> SELECT [1] = ANY([ [1, 2], [3, 4] ]); -- no unnesting
+    False
+
+
 - Added a :ref:`array_unnest <scalar-array_unnest>` scalar function.
 
 - Updated the bundled JDK to 20.0.1+9

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -574,6 +574,19 @@ This query selects any locations with at least one (i.e., :ref:`ANY
     +-------------------+---------------------------+
     SELECT 2 rows in set (... sec)
 
+
+``ANY`` automatically unnests the array argument to the number of
+dimensions required::
+
+    cr> SELECT 1 = ANY([[1, 2], [3, 4]]);
+    +------+
+    | true |
+    +------+
+    | TRUE |
+    +------+
+    SELECT 1 row in set (... sec)
+
+
 .. NOTE::
 
     It is possible to use ``ANY`` to compare values directly against the

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -347,6 +347,18 @@ public class ArrayType<T> extends DataType<List<T>> {
         return dataType;
     }
 
+    /**
+     * @return number of array dimensions/levels of the type. 0 if not an array
+     */
+    public static int dimensions(DataType<?> type) {
+        int dimensions = 0;
+        while (type instanceof ArrayType<?> arrayType) {
+            type = arrayType.innerType;
+            dimensions++;
+        }
+        return dimensions;
+    }
+
     static class ArrayStreamer<T> implements Streamer<List<T>> {
 
         private final DataType<T> innerType;


### PR DESCRIPTION
Restores support for the case mentioned in https://github.com/crate/crate/issues/4212

This is without query optimization, we can follow up and prune the
`array_unnest` functions in some cases for Lucene queries.
