### PR TITLE
Skip array_unnest when creating Lucene query for ANY

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -31,6 +31,7 @@ import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.operator.OperatorModule;
 import io.crate.expression.operator.any.AnyRangeOperator.Comparison;
+import io.crate.expression.scalar.ArrayUnnestFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -158,6 +159,9 @@ public abstract sealed class AnyOperator extends Operator<Object>
         List<Symbol> args = function.arguments();
         Symbol probe = args.get(0);
         Symbol candidates = args.get(1);
+        while (candidates instanceof Function fn && fn.signature().equals(ArrayUnnestFunction.SIGNATURE)) {
+            candidates = fn.arguments().get(0);
+        }
         if (probe instanceof Literal<?> literal && candidates instanceof Reference ref) {
             return literalMatchesAnyArrayRef(function, literal, ref, context);
         } else if (probe instanceof Reference ref && candidates instanceof Literal<?> literal) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
@@ -46,7 +46,7 @@ import io.crate.types.DataType;
 public class ArrayUnnestFunction extends Scalar<List<Object>, List<List<Object>>> {
 
     public static final String NAME = "array_unnest";
-    private static final Signature SIGNATURE = Signature.scalar(
+    public static final Signature SIGNATURE = Signature.scalar(
         NAME,
         parseTypeSignature("array(array(E))"),
         parseTypeSignature("array(E)")


### PR DESCRIPTION
Given how the index works we can use a term query even if the reference
contains nested arrays.

Follow up to https://github.com/crate/crate/pull/14090