### PR TITLE
GHA: Update gradle-build-action to 2.4.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: 11
 
       - name: Run tests on ${{ matrix.os }}
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@2.4.2
         env:
           CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 11
 
       - name: Run tests on ${{ matrix.os }}
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@2.4.2
         env:
           CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
         with:


### PR DESCRIPTION
Silences dependabot alerts

https://github.com/gradle/gradle-build-action/releases/tag/v2.4.2
