### PR TITLE
Fix gha gradle-build-action version ref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: 11
 
       - name: Run tests on ${{ matrix.os }}
-        uses: gradle/gradle-build-action@2.4.2
+        uses: gradle/gradle-build-action@v2.4.2
         env:
           CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 11
 
       - name: Run tests on ${{ matrix.os }}
-        uses: gradle/gradle-build-action@2.4.2
+        uses: gradle/gradle-build-action@v2.4.2
         env:
           CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
         with:


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14098

It didn't fail in the PR because we skip java tests if there are no code changes.
