### PR TITLE
Move TableStats into PlannerContext

### DIFF
--- a/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -57,6 +57,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
+import io.crate.statistics.TableStats;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -136,7 +137,8 @@ public class PreExecutionBenchmark {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            new TableStats()
         );
         return planner.plan(analyzedStatement, plannerContext);
     }

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -91,6 +91,7 @@ import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.Declare.Hold;
 import io.crate.sql.tree.DiscardStatement.Target;
 import io.crate.sql.tree.Statement;
+import io.crate.statistics.TableStats;
 import io.crate.types.DataType;
 
 /**
@@ -158,6 +159,7 @@ public class Session implements AutoCloseable {
     private final boolean isReadOnly;
     private final ParameterTypeExtractor parameterTypeExtractor;
     private final Runnable onClose;
+    private final TableStats tableStats;
 
     private TransactionState currentTransactionState = TransactionState.IDLE;
 
@@ -170,6 +172,7 @@ public class Session implements AutoCloseable {
                    boolean isReadOnly,
                    DependencyCarrier executor,
                    CoordinatorSessionSettings sessionSettings,
+                   TableStats tableStats,
                    Runnable onClose) {
         this.id = sessionId;
         this.secret = ThreadLocalRandom.current().nextInt();
@@ -180,6 +183,7 @@ public class Session implements AutoCloseable {
         this.isReadOnly = isReadOnly;
         this.executor = executor;
         this.sessionSettings = sessionSettings;
+        this.tableStats = tableStats;
         this.parameterTypeExtractor = new ParameterTypeExtractor();
         this.onClose = onClose;
     }
@@ -220,7 +224,8 @@ public class Session implements AutoCloseable {
             0,
             params,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
         Plan plan;
         try {
@@ -273,7 +278,8 @@ public class Session implements AutoCloseable {
             0,
             params,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
         Plan plan = planner.plan(stmt, plannerContext);
         plan.execute(executor, plannerContext, consumer, params, SubQueryResults.EMPTY);
@@ -654,7 +660,8 @@ public class Session implements AutoCloseable {
             0,
             null,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
 
         PreparedStmt firstPreparedStatement = toExec.get(0).portal().preparedStmt();
@@ -741,7 +748,8 @@ public class Session implements AutoCloseable {
             maxRows,
             params,
             cursors,
-            currentTransactionState
+            currentTransactionState,
+            tableStats
         );
         var analyzedStmt = portal.analyzedStatement();
         String rawStatement = portal.preparedStmt().rawStatement();

--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -48,6 +48,7 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
+import io.crate.statistics.TableStats;
 import io.crate.user.Privilege.Clazz;
 import io.crate.user.Privilege.Type;
 import io.crate.user.User;
@@ -77,6 +78,7 @@ public class Sessions {
     private final Provider<DependencyCarrier> executorProvider;
     private final JobsLogs jobsLogs;
     private final ClusterService clusterService;
+    private final TableStats tableStats;
     private final boolean isReadOnly;
     private final AtomicInteger nextSessionId = new AtomicInteger();
     private final ConcurrentMap<Integer, Session> sessions = new ConcurrentHashMap<>();
@@ -92,13 +94,15 @@ public class Sessions {
                     Provider<DependencyCarrier> executorProvider,
                     JobsLogs jobsLogs,
                     Settings settings,
-                    ClusterService clusterService) {
+                    ClusterService clusterService,
+                    TableStats tableStats) {
         this.nodeCtx = nodeCtx;
         this.analyzer = analyzer;
         this.planner = planner;
         this.executorProvider = executorProvider;
         this.jobsLogs = jobsLogs;
         this.clusterService = clusterService;
+        this.tableStats = tableStats;
         this.isReadOnly = NODE_READ_ONLY_SETTING.get(settings);
         this.defaultStatementTimeout = STATEMENT_TIMEOUT.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(STATEMENT_TIMEOUT, statementTimeout -> {
@@ -120,6 +124,7 @@ public class Sessions {
             isReadOnly,
             executorProvider.get(),
             sessionSettings,
+            tableStats,
             () -> sessions.remove(sessionId)
         );
         sessions.put(sessionId, session);

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -179,7 +179,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                    SessionSettingRegistry sessionSettingRegistry) {
         this.clusterService = clusterService;
         this.tableStats = tableStats;
-        this.logicalPlanner = new LogicalPlanner(nodeCtx, tableStats, () -> clusterService.state().nodes().getMinNodeVersion());
+        this.logicalPlanner = new LogicalPlanner(nodeCtx, () -> clusterService.state().nodes().getMinNodeVersion());
         this.numberOfShards = numberOfShards;
         this.tableCreator = tableCreator;
         this.schemas = schemas;

--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -39,6 +39,7 @@ import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.TableInfo;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.statistics.TableStats;
 
 public class PlannerContext {
 
@@ -56,7 +57,8 @@ public class PlannerContext {
             fetchSize,
             context.params,
             context.cursors,
-            context.transactionState
+            context.transactionState,
+            context.tableStats
         );
     }
 
@@ -73,6 +75,7 @@ public class PlannerContext {
     private final String handlerNode;
     @Nullable
     private final Row params;
+    private final TableStats tableStats;
 
     /**
      * @param params See {@link #params()}
@@ -85,7 +88,8 @@ public class PlannerContext {
                           int fetchSize,
                           @Nullable Row params,
                           Cursors cursors,
-                          TransactionState transactionState) {
+                          TransactionState transactionState,
+                          TableStats tableStats) {
         this.routingProvider = routingProvider;
         this.nodeCtx = nodeCtx;
         this.params = params;
@@ -97,6 +101,7 @@ public class PlannerContext {
         this.handlerNode = clusterState.nodes().getLocalNodeId();
         this.cursors = cursors;
         this.transactionState = transactionState;
+        this.tableStats = tableStats;
     }
 
     /**
@@ -106,6 +111,10 @@ public class PlannerContext {
     @Nullable
     public Row params() {
         return params;
+    }
+
+    public TableStats tableStats() {
+        return tableStats;
     }
 
     public int fetchSize() {

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -50,6 +50,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
 import io.crate.sql.tree.Declare.Hold;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.user.Privilege;
 import io.crate.user.Privilege.State;
@@ -73,7 +74,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             () -> dependencies,
             new JobsLogs(() -> false),
             Settings.EMPTY,
-            clusterService
+            clusterService,
+            new TableStats()
         );
 
         KeyData keyData = new KeyData(10, 20);
@@ -142,7 +144,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             Settings.builder()
                 .put("statement_timeout", "30s")
                 .build(),
-            clusterService
+            clusterService,
+            new TableStats()
         );
         Session session = sessions.createSession("doc", User.CRATE_USER);
         assertThat(session.sessionSettings().statementTimeout())
@@ -157,7 +160,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             () -> mock(DependencyCarrier.class),
             new JobsLogs(() -> false),
             Settings.EMPTY,
-            clusterService
+            clusterService,
+            new TableStats()
         );
         return sessions;
     }

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -97,7 +97,8 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            e.tableStats()
         );
 
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -230,7 +230,6 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         var context = e.getPlannerContext(clusterService.state());
         var logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         var plan = logicalPlanner.plan(e.analyze(stmt), context);

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -78,7 +78,6 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation analyzedRelation = e.analyze("SELECT 123 AS alias, 456 AS alias2 FROM t ORDER BY alias, 2");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan operator = logicalPlanner.plan(analyzedRelation, plannerCtx);

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -70,7 +70,6 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
     private ProjectionBuilder projectionBuilder;
-    private PlannerContext plannerCtx;
     private final CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
@@ -84,7 +83,6 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addTable(T3.T4_DEFINITION)
             .build();
         projectionBuilder = new ProjectionBuilder(e.nodeCtx);
-        plannerCtx = e.getPlannerContext(clusterService.state());
     }
 
     @After
@@ -92,10 +90,14 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         txnCtx.sessionSettings().setHashJoinEnabled(true);
     }
 
-    private LogicalPlan createLogicalPlan(QueriedSelectRelation mss, TableStats tableStats) {
+    private LogicalPlan createLogicalPlan(QueriedSelectRelation mss) {
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        return createLogicalPlan(mss, plannerCtx);
+    }
+
+    private LogicalPlan createLogicalPlan(QueriedSelectRelation mss, PlannerContext plannerCtx) {
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, plannerCtx));
@@ -106,15 +108,21 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             new SubQueries(Map.of(), Map.of()),
             rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, true)
         );
-        return logicalPlanner.optimizer.optimize(plan, tableStats, txnCtx);
+        return logicalPlanner.optimizer.optimize(plan, e.tableStats(), txnCtx);
     }
 
     private Join buildJoin(LogicalPlan operator) {
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        return buildJoin(operator, plannerCtx);
+    }
+
+    private Join buildJoin(LogicalPlan operator, PlannerContext plannerCtx) {
         return (Join) operator.build(mock(DependencyCarrier.class), plannerCtx, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
     }
 
-    private Join plan(QueriedSelectRelation mss, TableStats tableStats) {
-        return buildJoin(createLogicalPlan(mss, tableStats));
+    private Join plan(QueriedSelectRelation mss) {
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        return buildJoin(createLogicalPlan(mss, plannerCtx), plannerCtx);
     }
 
     @Test
@@ -122,20 +130,19 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         txnCtx.sessionSettings().setHashJoinEnabled(false);
         QueriedSelectRelation mss = e.analyze("select * from users, locations where users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
 
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10_000, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        nl = plan(mss, tableStats);
+        nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
     }
 
@@ -144,16 +151,15 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         txnCtx.sessionSettings().setHashJoinEnabled(false);
         QueriedSelectRelation mss = e.analyze("select * from users left join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(0, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
         assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
     }
@@ -165,21 +171,19 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addTable(USER_TABLE_DEFINITION)
             .addTable(TEST_DOC_LOCATIONS_TABLE_DEFINITION)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
 
         txnCtx.sessionSettings().setHashJoinEnabled(false);
         QueriedSelectRelation mss = e.analyze("select * from users left join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(0, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(-1, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
         assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
     }
@@ -190,13 +194,12 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from users " +
                                               "join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(0, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
 
         Join join = buildJoin(operator);
@@ -207,7 +210,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNestedLoop_TablesAreSwitchedIfBlockJoinAndRightIsSmallerThanLeft() throws IOException {
         // blockNL is only possible on single node clusters
-        e = SQLExecutor.builder(clusterService)
+        resetClusterService();
+        e = SQLExecutor.builder(clusterService, 1, random(), List.of())
             .addTable("create table j.left_table (id int)")
             .addTable("create table j.right_table (id int)")
             .build();
@@ -216,21 +220,20 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         QueriedSelectRelation mss = e.analyze("select * from j.left_table as l left join j.right_table as r on l.id = r.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(leftName, new Stats(10, 0, Map.of()));
         rowCountByTable.put(rightName, new Stats(10_000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo(leftName.name());
         assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.LEFT);
 
         rowCountByTable.put(leftName, new Stats(10_000, 0, Map.of()));
         rowCountByTable.put(rightName, new Stats(10, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        nl = plan(mss, tableStats);
+        nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo(rightName.name());
         assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.RIGHT);  // ensure that also the join type inverted
     }
@@ -242,46 +245,27 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation mss = e.analyze("select users.id from (select id from users order by id) users, " +
                                               "locations where users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_0000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        PlannerContext context = e.getPlannerContext(clusterService.state());
-        LogicalPlanner logicalPlanner = new LogicalPlanner(
-            e.nodeCtx,
-            tableStats,
-            () -> clusterService.state().nodes().getMinNodeVersion()
-        );
-        SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, context));
-        LogicalPlan operator = JoinPlanBuilder.buildJoinTree(
-            mss.from(),
-            mss.where(),
-            mss.joinPairs(),
-            new SubQueries(Map.of(), Map.of()),
-            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, false)
-        );
-        Join nl = (Join) operator.build(
-            mock(DependencyCarrier.class), context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
-
+        Join nl = plan(mss);
         assertList(((Collect) nl.left()).collectPhase().toCollect()).isSQL("doc.users.id");
         assertThat(nl.resultDescription().orderBy()).isNotNull();
     }
 
     @Test
     public void testNestedLoop_TablesAreNotSwitchedAfterOrderByPushDown() {
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_0000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
         PlannerContext context = e.getPlannerContext(clusterService.state());
         context.transactionContext().sessionSettings().setHashJoinEnabled(false);
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan plan = logicalPlanner.plan(e.analyze("select users.id from users, locations " +
@@ -299,13 +283,12 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from users " +
                                               "join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(100, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
         assertThat(((HashJoin) operator).rhs().getRelationNames())
             .as("Smaller table must be on the right-hand-side")
@@ -321,13 +304,12 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from users " +
                                               "join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(100, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
         assertThat(((HashJoin) operator).rhs().getRelationNames())
             .as("Smaller table must be on the right-hand-side")
@@ -343,7 +325,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from t1 inner join t2 on t1.a = t2.b " +
                                               "inner join t3 on t3.c = t2.b");
 
-        LogicalPlan operator = createLogicalPlan(mss, new TableStats());
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
         LogicalPlan leftPlan = ((HashJoin) operator).lhs;
         assertThat(leftPlan).isExactlyInstanceOf(HashJoin.class);
@@ -360,7 +342,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from t1 inner join t2 on t1.a = t2.b " +
                                               "left join t3 on t3.c = t2.b");
 
-        LogicalPlan operator = createLogicalPlan(mss, new TableStats());
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
         LogicalPlan leftPlan = ((NestedLoopJoin) operator).lhs;
         assertThat(leftPlan).isExactlyInstanceOf(HashJoin.class);
@@ -379,11 +361,10 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
 
         QueriedSelectRelation mss = e.analyze("select * from t1, t4");
 
-        LogicalPlan operator = createLogicalPlan(mss, new TableStats());
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
@@ -405,13 +386,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         e = SQLExecutor.builder(clusterService)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
-            .setTableStats(tableStats)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
 
         QueriedSelectRelation mss = e.analyze("select * from t1, t4");
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
@@ -427,24 +406,21 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testBlockNestedLoopWhenRightSideIsSmallerAndOneExecutionNode() throws IOException {
-        TableStats tableStats = new TableStats();
-        Map<RelationName, Stats> stats = new HashMap<>();
-        stats.put(T3.T1, new Stats(23, 64, Map.of()));
-        stats.put(T3.T4, new Stats(42, 64, Map.of()));
-        tableStats.updateTableStats(stats);
-
         // rebuild executor + cluster state with 1 node
         resetClusterService();
         e = SQLExecutor.builder(clusterService)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
-            .setTableStats(tableStats)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
+
+        e.updateTableStats(Map.of(
+            T3.T1, new Stats(23, 64, Map.of()),
+            T3.T4, new Stats(42, 64, Map.of())
+        ));
 
         QueriedSelectRelation mss = e.analyze("select * from t4, t1");
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
@@ -460,25 +436,23 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNoBlockNestedLoopWithOrderBy() throws IOException {
-        TableStats tableStats = new TableStats();
-        Map<RelationName, Stats> stats = new HashMap<>();
-        stats.put(T3.T1, new Stats(23, 64, Map.of()));
-        stats.put(T3.T4, new Stats(42, 64, Map.of()));
-        tableStats.updateTableStats(stats);
-
         // rebuild executor + cluster state with 1 node
         resetClusterService();
         e = SQLExecutor.builder(clusterService)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
-            .setTableStats(tableStats)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
+
+        e.updateTableStats(Map.of(
+            T3.T1, new Stats(23, 64, Map.of()),
+            T3.T4, new Stats(42, 64, Map.of())
+        ));
+
+        var plannerCtx = e.getPlannerContext(clusterService.state());
 
         QueriedSelectRelation mss = e.analyze("select * from t1, t4 order by t1.x");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan operator = logicalPlanner.plan(mss, plannerCtx);
@@ -497,11 +471,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "JOIN t3 t3 on t3.c = t2.b");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            new TableStats(),
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
-        LogicalPlan join = logicalPlanner.plan(mss, plannerCtx);
 
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        LogicalPlan join = logicalPlanner.plan(mss, plannerCtx);
         WindowAgg windowAggOperator = (WindowAgg) ((Eval) ((RootRelationBoundary) join).source).source;
         assertThat(join.outputs()).contains(windowAggOperator.windowFunctions().get(0));
     }

--- a/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
@@ -34,14 +34,11 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.Stats;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 
-
 public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServiceUnitTest {
-
 
     @Test
     public void test_collect_operator_adapts_expected_row_count_based_on_selectivity_calculation() throws Throwable {
@@ -54,37 +51,36 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
             new ColumnIdent("x"),
             ColumnStats.fromSortedValues(numbers, DataTypes.INTEGER, 0, totalNumRows)
         );
-        Stats stats = new Stats(totalNumRows, DataTypes.INTEGER.fixedSize(), columnStats);
-        TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(new RelationName("doc", "tbl"), stats));
         SQLExecutor e = SQLExecutor.builder(clusterService)
-            .setTableStats(tableStats)
             .addTable("create table doc.tbl (x int)")
             .build();
+
+        Stats stats = new Stats(totalNumRows, DataTypes.INTEGER.fixedSize(), columnStats);
+        e.updateTableStats(Map.of(new RelationName("doc", "tbl"), stats));
 
         LogicalPlan plan = e.logicalPlan("select * from doc.tbl where x = 10");
         assertThat(plan.numExpectedRows()).isEqualTo(1L);
     }
 
-
     @Test
     public void test_group_operator_adapt_expected_row_count_based_on_column_stats() throws Throwable {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table doc.tbl (x int)")
+            .build();
+
         var samples = IntStream.concat(
             IntStream.generate(() -> 10).limit(50),
             IntStream.generate(() -> 20).limit(50)
         ).boxed().collect(Collectors.toList());
+
         long numDocs = 2_000L;
         Stats stats = new Stats(
             numDocs,
             DataTypes.INTEGER.fixedSize(),
             Map.of(new ColumnIdent("x"), ColumnStats.fromSortedValues(samples, DataTypes.INTEGER, 0, numDocs))
         );
-        TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(new RelationName("doc", "tbl"), stats));
-        SQLExecutor e = SQLExecutor.builder(clusterService)
-            .setTableStats(tableStats)
-            .addTable("create table doc.tbl (x int)")
-            .build();
+
+        e.updateTableStats(Map.of(new RelationName("doc", "tbl"), stats));
 
         LogicalPlan plan = e.logicalPlan("select x, count(*) from doc.tbl group by x");
         assertThat(plan.numExpectedRows()).isEqualTo(2L);

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -211,6 +211,7 @@ import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.SystemPropsTestLoggingListener;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
@@ -1765,6 +1766,7 @@ public abstract class IntegTestCase extends ESTestCase {
         Analyzer analyzer = cluster().getInstance(Analyzer.class, nodeName);
         Planner planner = cluster().getInstance(Planner.class, nodeName);
         NodeContext nodeCtx = cluster().getInstance(NodeContext.class, nodeName);
+        TableStats tableStats = cluster().getInstance(TableStats.class, nodeName);
 
         CoordinatorSessionSettings sessionSettings = new CoordinatorSessionSettings(
             User.CRATE_USER,
@@ -1781,7 +1783,8 @@ public abstract class IntegTestCase extends ESTestCase {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            tableStats
         );
         Plan plan = planner.plan(
             analyzer.analyze(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This moves the `TablesStats` from the `LogicalPlanner` into the `PlannerContext `and cleans up the `JoinTest` based on this change. The reason for this change is to be able to have access to the `TableStats` inside the build method of the `LogicalPlans` because stats are used to decide on the execution plan of the join. It also makes the `TableStats` handling a bit simpler in the tests because the stats can easily be accessed and updated.

This is a pre-requisite for introducing statistics for plans and finally moving more logic into optimizer rules.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
