### PR TITLE
Apply normalization to INTERVAL literals

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -55,6 +55,16 @@ None
 Changes
 =======
 
+- Changed literal :ref:`INTERVAL data type <type-interval>` to do normalization
+  up to day units, and comply with PostgreSQL behavior, e.g.::
+
+    cr> SELECT INTERVAL '1 month 42 days 126 hours 512 mins 7123 secs';
+    +------------------------------+
+    | 'P1M47DT16H30M43S'::interval |
+    +------------------------------+
+    | 1 mon 47 days 16:30:43       |
+    +------------------------------+
+
 - Array comparisons like ``= ANY`` will now automatically unnest the array
   argument to the required dimensions.
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1127,14 +1127,14 @@ Synopsis::
 
 .. NOTE::
 
-    When extracting from an :ref:`INTERVAL <type-interval>` there is no
-    normalization of units, e.g.::
+    When extracting from an :ref:`INTERVAL <type-interval>` there is
+    normalization of units, up to days e.g.::
 
-       cr> SELECT extract(year from INTERVAL '14 years 1250 days 49 hours') AS year;
+       cr> SELECT extract(day from INTERVAL '14 years 1250 days 49 hours') AS days;
        +------+
-       | year |
+       | days |
        +------+
-       |   14 |
+       | 1252 |
        +------+
        SELECT 1 row in set (... sec)
 

--- a/server/src/main/java/io/crate/interval/IntervalParser.java
+++ b/server/src/main/java/io/crate/interval/IntervalParser.java
@@ -22,6 +22,7 @@
 package io.crate.interval;
 
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.joda.time.format.ISOPeriodFormat;
 
 import javax.annotation.Nullable;
@@ -92,7 +93,7 @@ public final class IntervalParser {
                 }
             }
         }
-        return result.normalizedStandard();
+        return result.normalizedStandard(PeriodType.yearMonthDayTime());
     }
 
     static Period roundToPrecision(Period period, Precision start, Precision end) {

--- a/server/src/main/java/io/crate/interval/NumericalIntervalParser.java
+++ b/server/src/main/java/io/crate/interval/NumericalIntervalParser.java
@@ -36,10 +36,6 @@ final class NumericalIntervalParser {
     private NumericalIntervalParser() {
     }
 
-    static Period apply(String value) {
-        return apply(value, null, null);
-    }
-
     static Period apply(String value,
                         @Nullable IntervalParser.Precision start,
                         @Nullable IntervalParser.Precision end) {

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -32,7 +32,6 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static org.assertj.core.api.Assertions.anyOf;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -45,6 +44,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.junit.Test;
 
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -1152,7 +1152,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(stmt.orderBy().orderBySymbols()).satisfiesExactly(
             x -> assertThat(x)
                 .isAlias("interval")
-                .isLiteral(new Period(12, 0, 0, 0))
+                .isLiteral(new Period(12, 0, 0, 0)
+                               .withPeriodType(PeriodType.yearMonthDayTime()))
         );
         stmt = executor.analyze(
             "select current_timestamp - process['probe_timestamp'] AS \"interval\" from sys.nodes order by 1");

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -25,7 +25,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -347,13 +347,15 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testInterval() throws Exception {
         Symbol literal = expressions.asSymbol("INTERVAL '1' MONTH");
-        assertThat(literal).isLiteral(new Period().withMonths(1), DataTypes.INTERVAL);
+        assertThat(literal).isLiteral(new Period().withMonths(1).withPeriodType(PeriodType.yearMonthDayTime()),
+                                      DataTypes.INTERVAL);
     }
 
     @Test
     public void testIntervalConversion() throws Exception {
         Symbol literal = expressions.asSymbol("INTERVAL '1' HOUR to SECOND");
-        assertThat(literal).isLiteral(new Period().withSeconds(1), DataTypes.INTERVAL);
+        assertThat(literal).isLiteral(new Period().withSeconds(1).withPeriodType(PeriodType.yearMonthDayTime()),
+                                      DataTypes.INTERVAL);
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/expressions/IntervalAnalysisTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/IntervalAnalysisTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,58 +47,63 @@ public class IntervalAnalysisTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_psql_compact_format_from_string_with_start() {
         var symbol = e.asSymbol("INTERVAL '6 years 5 mons 4 days 03:02:01' YEAR");
-        assertThat(symbol).isLiteral(new Period().withYears(6));
+        assertThat(symbol).isLiteral(new Period().withYears(6).withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_psql_compact_format_from_string_with_start_end() {
         var symbol = e.asSymbol("INTERVAL '6 years 5 mons 4 days 03:02:01' YEAR TO MONTH");
-        assertThat(symbol).isLiteral(new Period().withYears(6).withMonths(5));
+        assertThat(symbol).isLiteral(new Period().withYears(6).withMonths(5)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_psql_compact_format_from_string_with_start_end1() {
         var symbol = e.asSymbol("INTERVAL '6 years 5 mons 4 days 03:02:01' DAY TO HOUR");
-        assertThat(symbol).isLiteral(new Period().withYears(6).withMonths(5).withDays(4).withHours(3));
+        assertThat(symbol).isLiteral(new Period().withYears(6).withMonths(5).withDays(4).withHours(3)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_interval() throws Exception {
         var symbol = e.asSymbol("INTERVAL '1' MONTH");
-        assertThat(symbol).isLiteral(new Period().withMonths(1));
+        assertThat(symbol).isLiteral(new Period().withMonths(1).withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_negative_interval() throws Exception {
         var symbol = e.asSymbol("INTERVAL '-1' MONTH");
-        assertThat(symbol).isLiteral(new Period().withMonths(-1));
+        assertThat(symbol).isLiteral(new Period().withMonths(-1).withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_negative_negative_interval() throws Exception {
         var symbol = e.asSymbol("INTERVAL -'-1' MONTH");
-        assertThat(symbol).isLiteral(new Period().withMonths(1));
+        assertThat(symbol).isLiteral(new Period().withMonths(1).withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_interval_conversion() throws Exception {
         var symbol = e.asSymbol("INTERVAL '1' HOUR to SECOND");
-        assertThat(symbol).isLiteral(new Period().withSeconds(1));
+        assertThat(symbol).isLiteral(new Period().withSeconds(1).withPeriodType(PeriodType.yearMonthDayTime()));
 
         symbol = e.asSymbol("INTERVAL '100' DAY TO SECOND");
-        assertThat(symbol).isLiteral(new Period().withMinutes(1).withSeconds(40));
+        assertThat(symbol).isLiteral(new Period().withMinutes(1).withSeconds(40)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_seconds_millis() throws Exception {
         var symbol = e.asSymbol("INTERVAL '1'");
-        assertThat(symbol).isLiteral(new Period().withSeconds(1));
+        assertThat(symbol).isLiteral(new Period().withSeconds(1).withPeriodType(PeriodType.yearMonthDayTime()));
 
         symbol = e.asSymbol("INTERVAL '1.1'");
-        assertThat(symbol).isLiteral(new Period().withSeconds(1).withMillis(100));
+        assertThat(symbol).isLiteral(new Period().withSeconds(1).withMillis(100)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
 
         symbol = e.asSymbol("INTERVAL '60.1'");
-        assertThat(symbol).isLiteral(new Period().withMinutes(1).withMillis(100));
+        assertThat(symbol).isLiteral(new Period().withMinutes(1).withMillis(100)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
@@ -110,7 +116,8 @@ public class IntervalAnalysisTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_odd() throws Exception {
         var symbol = e.asSymbol("INTERVAL '100.123' SECOND");
-        assertThat(symbol).isLiteral(new Period().withMinutes(1).withSeconds(40).withMillis(123));
+        assertThat(symbol).isLiteral(new Period().withMinutes(1).withSeconds(40).withMillis(123)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
@@ -118,5 +125,4 @@ public class IntervalAnalysisTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> e.asSymbol("INTERVAL '1-2 3 4-5-6'"))
             .isExactlyInstanceOf(ConversionException.class);
     }
-
 }

--- a/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
@@ -106,7 +106,7 @@ public class ExtractFunctionsTest extends ScalarTestCase {
     public void testExtractDay() throws Exception {
         assertEvaluate("extract(day from timestamp_tz)", 15);
         assertEvaluate("extract(day_of_month from timestamp_tz)", 15);
-        assertEvaluate("extract(day from INTERVAL '14 years 58 months 1250 days 49 hours' DAY TO HOUR)", 6);
+        assertEvaluate("extract(day from INTERVAL '14 years 58 months 1250 days 49 hours' DAY TO HOUR)", 1252);
         assertEvaluate("extract(day from INTERVAL '49 hours 127 minutes 43250 seconds')", 2);
         assertEvaluateIntervalException("day_of_month");
     }

--- a/server/src/test/java/io/crate/interval/IntervalParserTest.java
+++ b/server/src/test/java/io/crate/interval/IntervalParserTest.java
@@ -21,11 +21,12 @@
 
 package io.crate.interval;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.junit.Test;
 
 public class IntervalParserTest extends ESTestCase {
@@ -33,175 +34,200 @@ public class IntervalParserTest extends ESTestCase {
     @Test
     public void parse_year_month_day_hours_minutes() {
         Period result = IntervalParser.apply("120-1 1 15:30");
-        assertThat(result, is(new Period().withYears(120).withMonths(1).withDays(1).withHours(15).withMinutes(30)));
+        assertThat(result).isEqualTo(
+            new Period().withYears(120).withMonths(1).withDays(1).withHours(15).withMinutes(30)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void negative_parse_year_month_negative_day_negative_hours_minutes() {
         Period result = IntervalParser.apply("-120-1 -1 -15:30");
-        assertThat(result, is(new Period().withYears(-120).withMonths(-1).withDays(-1).withHours(-15).withMinutes(-30)));
+        assertThat(result).isEqualTo(
+            new Period().withYears(-120).withMonths(-1).withDays(-1).withHours(-15).withMinutes(-30)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_seconds() {
         Period result = IntervalParser.apply("1");
-        assertThat(result, is(new Period().withSeconds(1)));
+        assertThat(result).isEqualTo(new Period().withSeconds(1).withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_year_month_day() {
         Period result = IntervalParser.apply("120-1 1");
-        assertThat(result, is(new Period().withYears(120).withMonths(1).withDays(1)));
+        assertThat(result).isEqualTo(new Period().withYears(120).withMonths(1).withDays(1)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_negative_year_month_negative_day() {
         Period result = IntervalParser.apply("-120-1 -1");
-        assertThat(result, is(new Period().withYears(-120).withMonths(-1).withDays(-1)));
+        assertThat(result).isEqualTo(new Period().withYears(-120).withMonths(-1).withDays(-1)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_year_month() {
         Period result = IntervalParser.apply("120-1");
-        assertThat(result, is(new Period().withYears(120).withMonths(1)));
+        assertThat(result).isEqualTo(new Period().withYears(120).withMonths(1)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_negative_year_month() {
         Period result = IntervalParser.apply("-120-1");
-        assertThat(result, is(new Period().withYears(-120).withMonths(-1)));
+        assertThat(result).isEqualTo(
+            new Period().withYears(-120).withMonths(-1).withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_year_month_hours_minutes() {
         Period result = IntervalParser.apply("120-1 15:30");
-        assertThat(result, is(new Period().withYears(120).withMonths(1).withHours(15).withMinutes(30)));
+        assertThat(result).isEqualTo(
+            new Period().withYears(120).withMonths(1).withHours(15).withMinutes(30)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_hours_minutes() {
         Period result = IntervalParser.apply("15:30");
-        assertThat(result, is(new Period().withHours(15).withMinutes(30)));
+        assertThat(result).isEqualTo(new Period().withHours(15).withMinutes(30)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_negative_hours_minutes() {
         Period result = IntervalParser.apply("-15:30");
-        assertThat(result, is(new Period().withHours(-15).withMinutes(-30)));
+        assertThat(result).isEqualTo(new Period().withHours(-15).withMinutes(-30)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_hours_minutes_seconds() {
         Period result = IntervalParser.apply("15:30:10");
-        assertThat(result, is(new Period().withHours(15).withMinutes(30).withSeconds(10)));
+        assertThat(result).isEqualTo(new Period().withHours(15).withMinutes(30).withSeconds(10)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_days_hours_minutes_seconds() {
         Period result = IntervalParser.apply("1 15:30:10");
-        assertThat(result, is(new Period().withDays(1).withHours(15).withMinutes(30).withSeconds(10)));
+        assertThat(result).isEqualTo(new Period().withDays(1).withHours(15).withMinutes(30).withSeconds(10)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_negative_days_negative_hours_minutes_seconds() {
         Period result = IntervalParser.apply("-1 -15:30:10");
-        assertThat(result, is(new Period().withDays(-1).withHours(-15).withMinutes(-30).withSeconds(-10)));
+        assertThat(result).isEqualTo(new Period().withDays(-1).withHours(-15).withMinutes(-30).withSeconds(-10)
+                                         .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_days_seconds() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid interval format 1 1");
-        IntervalParser.apply("1 1");
+        assertThatThrownBy(() -> IntervalParser.apply("1 1"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format 1 1");
     }
 
     @Test
     public void parse_negative_days_negative_seconds() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid interval format -1 -1");
-        IntervalParser.apply("-1 -1");
+        assertThatThrownBy(() -> IntervalParser.apply("-1 -1"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format -1 -1");
     }
 
     @Test
     public void parse_invalid_input_0() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid interval format 10-1-1-1-1-1");
-        IntervalParser.apply("10-1-1-1-1-1");
+        assertThatThrownBy(() -> IntervalParser.apply("10-1-1-1-1-1"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format 10-1-1-1-1-1");
     }
 
     @Test
     public void parse_invalid_input_1() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid interval format 10:1:1:1:N1:1");
-        IntervalParser.apply("10:1:1:1:N1:1");
+        assertThatThrownBy(() -> IntervalParser.apply("10:1:1:1:N1:1"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format 10:1:1:1:N1:1");
     }
 
     @Test
     public void parse_invalid_input_2() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid interval format 1-2 3 4-5-6");
-        IntervalParser.apply("1-2 3 4-5-6");
+        assertThatThrownBy(() -> IntervalParser.apply("1-2 3 4-5-6"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format 1-2 3 4-5-6");
     }
 
     @Test
     public void parse_invalid_input_3() {
         Period result = IntervalParser.apply("0-0 0 0:0:0");
-        assertThat(result, is(Period.ZERO));
+        assertThat(result).isEqualTo(Period.ZERO.withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void parse_invalid_input_4() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid interval format A-B C D:E:F");
-        IntervalParser.apply("A-B C D:E:F");
+        assertThatThrownBy(() -> IntervalParser.apply("A-B C D:E:F"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format A-B C D:E:F");
     }
 
     @Test
     public void test_psql_format_from_string() {
         Period period = PGIntervalParser.apply("@ 1 year 1 mon 1 day 1 hour 1 minute 1 secs");
-        assertThat(period,
-                   is(new Period().withYears(1).withMonths(1).withDays(1).withHours(1).withMinutes(1).withSeconds(1)));
+        assertThat(period).isEqualTo(new Period().withYears(1).withMonths(1).withDays(1).withHours(1).withMinutes(1).withSeconds(1));
     }
 
     @Test
     public void test_psql_verbose_format_from_string_with_ago() {
         Period period = IntervalParser.apply("@ 1 year 1 mon 1 day 1 hour 1 minute 1 secs ago");
-        assertThat(period,
-                   is(new Period().withYears(-1).withMonths(-1).withDays(-1).withHours(-1).withMinutes(-1).withSeconds(-1)));
+        assertThat(period).isEqualTo(
+            new Period().withYears(-1).withMonths(-1).withDays(-1).withHours(-1).withMinutes(-1).withSeconds(-1)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_psql_verbose_format_from_string_with_negative_values() {
         Period period = IntervalParser.apply("@ 1 year -23 hours -3 mins -3.30 secs");
-        assertThat(period,
-                   is(new Period().withYears(1).withHours(-23).withMinutes(-3).withSeconds(-3).withMillis(-300)));
+        assertThat(period).isEqualTo(
+            new Period().withYears(1).withHours(-23).withMinutes(-3).withSeconds(-3).withMillis(-300)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_psql_verbose_format_from_string_with_negative_values_and_ago() {
         Period period = IntervalParser.apply("@ 1 year -23 hours -3 mins -3.30 secs ago");
-        assertThat(period,
-                   is(new Period().withYears(-1).withHours(23).withMinutes(3).withSeconds(3).withMillis(300)));
+        assertThat(period).isEqualTo(
+            new Period().withYears(-1).withHours(23).withMinutes(3).withSeconds(3).withMillis(300)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_psql_compact_format_from_string() {
         Period period = IntervalParser.apply("6 years 5 mons 4 days 03:02:01");
-        assertThat(period,
-                   is(new Period().withYears(6).withMonths(5).withDays(4).withHours(3).withMinutes(2).withSeconds(1)));
+        assertThat(period).isEqualTo(
+            new Period().withYears(6).withMonths(5).withDays(4).withHours(3).withMinutes(2).withSeconds(1)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_weeks() {
         Period period = IntervalParser.apply("1 week");
-        assertThat(period, is(new Period().withWeeks(1)));
+        assertThat(period).isEqualTo(new Period().withDays(7).withPeriodType(PeriodType.yearMonthDayTime()));
     }
 
     @Test
     public void test_characters() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid interval format a week b mons c days");
-        Period period = IntervalParser.apply("a week b mons c days");
-        assertThat(period, is(new Period().withDays(7)));
+        assertThatThrownBy(() -> IntervalParser.apply("a week b mons c days"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format a week b mons c days");
+    }
+
+    @Test
+    public void test_normalization() {
+        Period period = IntervalParser.apply("1 year 1 month 763 days 1204 hours 642 mins 7123 secs");
+        assertThat(period).isEqualTo(
+            new Period(1, 1, 0, 813, 16, 40, 43, 0)
+                .withPeriodType(PeriodType.yearMonthDayTime()));
     }
 }

--- a/server/src/test/java/io/crate/types/IntervalTypeTest.java
+++ b/server/src/test/java/io/crate/types/IntervalTypeTest.java
@@ -21,11 +21,9 @@
 
 package io.crate.types;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.hamcrest.Matchers;
 import org.joda.time.Period;
 import org.junit.Test;
 
@@ -40,7 +38,7 @@ public class IntervalTypeTest {
         var in = out.bytes().streamInput();
         var periodFromStream = IntervalType.INSTANCE.readValueFrom(in);
 
-        assertThat(periodFromStream, is(period));
+        assertThat(periodFromStream).isEqualTo(period);
     }
 
     @Test
@@ -48,6 +46,6 @@ public class IntervalTypeTest {
         var out = new BytesStreamOutput();
         IntervalType.INSTANCE.writeValueTo(out, null);
         var in = out.bytes().streamInput();
-        assertThat(IntervalType.INSTANCE.readValueFrom(in), Matchers.nullValue());
+        assertThat(IntervalType.INSTANCE.readValueFrom(in)).isNull();
     }
 }


### PR DESCRIPTION
Apply normalization up to the days unit to be compatible with PostgreSQL behavior. e.g.:
```
cr> SELECT INTERVAL '1 month 42 days 126 hours 512 mins 7123 secs';
+------------------------------+
| 'P1M47DT16H30M43S'::interval |
+------------------------------+
| 1 mon 47 days 16:30:43       |
+------------------------------+
```

Closes: #13362

