### PR TITLE
Always handle distributed result requests on downstream

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -131,6 +131,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that could lead to queries to become stuck instead of failing
+  with a circuit breaker error if a node is under memory pressure.
+
 - Improved an optimization rule to enable index lookups instead of table scans
   in more cases. This is a follow up to a fix in 5.2.7 which fixed a regression
   introduced in 5.2.3.

--- a/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -110,6 +110,11 @@ public class TransportDistributedResultAction extends TransportAction<NodeReques
         transportService.registerRequestHandler(
             DistributedResultAction.NAME,
             ThreadPool.Names.SAME, // <- we will dispatch later at the nodeOperation on non failures
+            true,
+            // Don't trip breaker on transport layer, but instead depend on ram-accounting in PageBucketReceivers
+            // We need to always handle requests to avoid jobs from getting stuck.
+            // (If we receive a request, but don't handle it, a task would remain open indefinitely)
+            false,
             DistributedResultRequest::new,
             new NodeActionRequestHandler<>(nodeAction));
     }


### PR DESCRIPTION
If a node is under memory pressure it could trip the circuit breaker in
the transport layer, preventing the `TransportDistributedResultAction`
from processing a request. This led to stuck queries.

Fixes https://github.com/crate/crate/issues/14111
