### PR TITLE
Introduce Stats for Logical Plans

### DIFF
--- a/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -54,9 +54,11 @@ import io.crate.metadata.RoutingProvider;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
+import io.crate.statistics.TableStats;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -136,7 +138,8 @@ public class PreExecutionBenchmark {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            new PlanStats(new TableStats())
         );
         return planner.plan(analyzedStatement, plannerContext);
     }

--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -48,6 +48,7 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
+import io.crate.statistics.TableStats;
 import io.crate.user.Privilege.Clazz;
 import io.crate.user.Privilege.Type;
 import io.crate.user.User;
@@ -77,6 +78,7 @@ public class Sessions {
     private final Provider<DependencyCarrier> executorProvider;
     private final JobsLogs jobsLogs;
     private final ClusterService clusterService;
+    private final TableStats tableStats;
     private final boolean isReadOnly;
     private final AtomicInteger nextSessionId = new AtomicInteger();
     private final ConcurrentMap<Integer, Session> sessions = new ConcurrentHashMap<>();
@@ -92,13 +94,15 @@ public class Sessions {
                     Provider<DependencyCarrier> executorProvider,
                     JobsLogs jobsLogs,
                     Settings settings,
-                    ClusterService clusterService) {
+                    ClusterService clusterService,
+                    TableStats tableStats) {
         this.nodeCtx = nodeCtx;
         this.analyzer = analyzer;
         this.planner = planner;
         this.executorProvider = executorProvider;
         this.jobsLogs = jobsLogs;
         this.clusterService = clusterService;
+        this.tableStats = tableStats;
         this.isReadOnly = NODE_READ_ONLY_SETTING.get(settings);
         this.defaultStatementTimeout = STATEMENT_TIMEOUT.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(STATEMENT_TIMEOUT, statementTimeout -> {
@@ -120,6 +124,7 @@ public class Sessions {
             isReadOnly,
             executorProvider.get(),
             sessionSettings,
+            tableStats,
             () -> sessions.remove(sessionId)
         );
         sessions.put(sessionId, session);

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -179,7 +179,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                    SessionSettingRegistry sessionSettingRegistry) {
         this.clusterService = clusterService;
         this.tableStats = tableStats;
-        this.logicalPlanner = new LogicalPlanner(nodeCtx, tableStats, () -> clusterService.state().nodes().getMinNodeVersion());
+        this.logicalPlanner = new LogicalPlanner(nodeCtx, () -> clusterService.state().nodes().getMinNodeVersion());
         this.numberOfShards = numberOfShards;
         this.tableCreator = tableCreator;
         this.schemas = schemas;

--- a/server/src/main/java/io/crate/planner/PlannerContext.java
+++ b/server/src/main/java/io/crate/planner/PlannerContext.java
@@ -38,6 +38,7 @@ import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.TableInfo;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.protocols.postgres.TransactionState;
 
 public class PlannerContext {
@@ -56,7 +57,8 @@ public class PlannerContext {
             fetchSize,
             context.params,
             context.cursors,
-            context.transactionState
+            context.transactionState,
+            context.planStats
         );
     }
 
@@ -73,6 +75,7 @@ public class PlannerContext {
     private final String handlerNode;
     @Nullable
     private final Row params;
+    private final PlanStats planStats;
 
     /**
      * @param params See {@link #params()}
@@ -85,7 +88,8 @@ public class PlannerContext {
                           int fetchSize,
                           @Nullable Row params,
                           Cursors cursors,
-                          TransactionState transactionState) {
+                          TransactionState transactionState,
+                          PlanStats planStats) {
         this.routingProvider = routingProvider;
         this.nodeCtx = nodeCtx;
         this.params = params;
@@ -97,6 +101,7 @@ public class PlannerContext {
         this.handlerNode = clusterState.nodes().getLocalNodeId();
         this.cursors = cursors;
         this.transactionState = transactionState;
+        this.planStats = planStats;
     }
 
     /**
@@ -106,6 +111,10 @@ public class PlannerContext {
     @Nullable
     public Row params() {
         return params;
+    }
+
+    public PlanStats planStats() {
+        return planStats;
     }
 
     public int fetchSize() {

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -71,6 +71,7 @@ import io.crate.planner.PositionalOrderBy;
 import io.crate.planner.WhereClauseOptimizer.DetailedQuery;
 import io.crate.planner.consumer.OrderByPositionVisitor;
 import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.symbol.Optimizer;
 import io.crate.planner.selectivity.SelectivityFunctions;
 import io.crate.statistics.Stats;
@@ -101,9 +102,9 @@ public class Collect implements LogicalPlan {
     public static Collect create(AbstractTableRelation<?> relation,
                                  List<Symbol> toCollect,
                                  WhereClause where,
-                                 TableStats tableStats,
+                                 PlanStats planStats,
                                  Row params) {
-        Stats stats = tableStats.getStats(relation.tableInfo().ident());
+        Stats stats = planStats.get(relation.tableInfo().ident());
         return new Collect(
             relation,
             toCollect,

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -184,16 +184,6 @@ public class CorrelatedJoin implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return inputPlan.numExpectedRows();
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return inputPlan.estimatedRowSize();
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitCorrelatedJoin(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -162,16 +162,6 @@ public class Count implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return 1L;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return Long.BYTES;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitCount(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Distinct.java
+++ b/server/src/main/java/io/crate/planner/operators/Distinct.java
@@ -22,7 +22,7 @@
 package io.crate.planner.operators;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 
 import java.util.Collections;
 import java.util.List;
@@ -31,11 +31,11 @@ import static io.crate.planner.operators.GroupHashAggregate.approximateDistinctV
 
 public final class Distinct {
 
-    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, TableStats tableStats) {
+    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, PlanStats planStats) {
         if (!distinct) {
             return source;
         }
-        long numExpectedRows = approximateDistinctValues(source.numExpectedRows(), tableStats, outputs);
+        long numExpectedRows = approximateDistinctValues(planStats.get(source).numDocs(), planStats.tableStats(), outputs);
         return new GroupHashAggregate(source, outputs, Collections.emptyList(), numExpectedRows);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -80,13 +80,4 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
         return source.dependencies();
     }
 
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return source.estimatedRowSize();
-    }
 }

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -260,12 +260,10 @@ public class Get implements LogicalPlan {
         return Map.of();
     }
 
-    @Override
     public long estimatedRowSize() {
         return estimatedSizePerRow;
     }
 
-    @Override
     public long numExpectedRows() {
         return docKeys.size();
     }

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -123,7 +123,6 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         this.groupKeys = groupKeys;
     }
 
-    @Override
     public long numExpectedRows() {
         return numExpectedRows;
     }

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -194,11 +194,6 @@ public class HashAggregate extends ForwardingLogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return 1L;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitHashAggregate(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -22,7 +22,6 @@
 package io.crate.planner.operators;
 
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_LIMIT;
-import static io.crate.planner.operators.NestedLoopJoin.buildMergePhaseForJoin;
 import static io.crate.planner.operators.NestedLoopJoin.createJoinProjection;
 
 import java.util.ArrayList;
@@ -101,11 +100,13 @@ public class HashJoin extends JoinPlan {
 
         LogicalPlan leftLogicalPlan = lhs;
         LogicalPlan rightLogicalPlan = rhs;
+        var lhStats = plannerContext.planStats().get(leftLogicalPlan);
+        var rhStats = plannerContext.planStats().get(rightLogicalPlan);
 
         // We move smaller table to the right side since benchmarking
         // revealed that this improves performance in most cases.
-        boolean expectedRowsAvailable = lhs.numExpectedRows() != -1 && rhs.numExpectedRows() != -1;
-        if (expectedRowsAvailable && lhs.numExpectedRows() < rhs.numExpectedRows()) {
+        boolean expectedRowsAvailable = lhStats.numDocs() != -1 && rhStats.numDocs() != -1;
+        if (expectedRowsAvailable && lhStats.numDocs() < rhStats.numDocs()) {
             leftLogicalPlan = rhs;
             rightLogicalPlan = lhs;
 
@@ -195,8 +196,8 @@ public class HashJoin extends JoinPlan {
             InputColumns.create(lhsHashSymbols, new InputColumns.SourceSymbols(leftOutputs)),
             InputColumns.create(rhsHashSymbols, new InputColumns.SourceSymbols(rightOutputs)),
             Symbols.typeView(leftOutputs),
-            leftLogicalPlan.estimatedRowSize(),
-            leftLogicalPlan.numExpectedRows());
+            lhStats.averageSizePerRowInBytes(),
+            lhStats.numDocs());
         return new Join(
             joinPhase,
             leftExecutionPlan,
@@ -287,15 +288,6 @@ public class HashJoin extends JoinPlan {
                 joinCondition
             )
         );
-    }
-    
-    @Override
-    public long numExpectedRows() {
-        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
-            return -1;
-        }
-        // We don't have any cardinality estimates, so just take the bigger table
-        return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -150,16 +150,6 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return 1;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return source.estimatedRowSize();
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitInsert(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -857,16 +857,6 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return -1L;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        return 0L;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitInsert(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -69,10 +69,6 @@ public abstract class JoinPlan implements LogicalPlan {
         return joinType;
     }
 
-    @Override
-    public long estimatedRowSize() {
-        return lhs.estimatedRowSize() + rhs.estimatedRowSize();
-    }
 
     protected static MergePhase buildMergePhaseForJoin(PlannerContext plannerContext,
                                              ResultDescription resultDescription,

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -142,13 +142,6 @@ public class Limit extends ForwardingLogicalPlan {
         return source.dependencies();
     }
 
-    @Override
-    public long numExpectedRows() {
-        if (limit instanceof Literal) {
-            return DataTypes.LONG.sanitizeValue(((Literal<?>) limit).value());
-        }
-        return source.numExpectedRows();
-    }
 
     @Override
     public String toString() {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -198,18 +198,6 @@ public interface LogicalPlan extends Plan {
      */
     Map<LogicalPlan, SelectSymbol> dependencies();
 
-    /**
-     * Returns the total number of rows this logical operation is expected to return.
-     * @return The number of expected rows if available, -1 otherwise.
-     */
-    long numExpectedRows();
-
-    /**
-     * Returns an estimation of the size (in bytes) of each row returned by the plan.
-     * The estimation is based on the average size of a row of the concrete table(s) of the plan.
-     */
-    long estimatedRowSize();
-
     @Override
     default void executeOrFail(DependencyCarrier executor,
                                PlannerContext plannerContext,

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -80,6 +80,7 @@ import io.crate.planner.SubqueryPlanner.SubQueries;
 import io.crate.planner.consumer.InsertFromSubQueryPlanner;
 import io.crate.planner.optimizer.Optimizer;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.iterative.IterativeOptimizer;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
@@ -108,7 +109,6 @@ import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteNestedLoopJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
-import io.crate.statistics.TableStats;
 import io.crate.types.DataTypes;
 
 /**
@@ -117,7 +117,6 @@ import io.crate.types.DataTypes;
 public class LogicalPlanner {
     @VisibleForTesting
     final IterativeOptimizer optimizer;
-    private final TableStats tableStats;
     private final Visitor statementVisitor = new Visitor();
     private final Optimizer writeOptimizer;
     private final Optimizer fetchOptimizer;
@@ -162,7 +161,7 @@ public class LogicalPlanner {
     private static final List<Rule<?>> WRITE_OPTIMIZER_RULES =
         List.of(new RewriteInsertFromSubQueryToInsertFromValues());
 
-    public LogicalPlanner(NodeContext nodeCtx, TableStats tableStats, Supplier<Version> minNodeVersionInCluster) {
+    public LogicalPlanner(NodeContext nodeCtx, Supplier<Version> minNodeVersionInCluster) {
         this.optimizer = new IterativeOptimizer(
             nodeCtx,
             minNodeVersionInCluster,
@@ -178,7 +177,6 @@ public class LogicalPlanner {
             minNodeVersionInCluster,
             WRITE_OPTIMIZER_RULES
         );
-        this.tableStats = tableStats;
     }
 
     public LogicalPlan plan(AnalyzedStatement statement, PlannerContext plannerContext) {
@@ -217,14 +215,15 @@ public class LogicalPlanner {
         var planBuilder = new PlanBuilder(
             subqueryPlanner,
             txnCtx,
-            tableStats,
+            plannerContext.planStats(),
             subSelectPlannerContext.params()
         );
         LogicalPlan plan = relation.accept(planBuilder, relation.outputs());
 
         plan = tryOptimizeForInSubquery(selectSymbol, relation, plan);
-        LogicalPlan optimizedPlan = optimizer.optimize(maybeApplySoftLimit.apply(plan), tableStats, txnCtx);
-        LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(tableStats, relation.outputs());
+        LogicalPlan optimizedPlan = optimizer.optimize(maybeApplySoftLimit.apply(plan),
+                                                       plannerContext.planStats(), txnCtx);
+        LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(plannerContext.planStats().tableStats(), relation.outputs());
         assert prunedPlan.outputs().equals(optimizedPlan.outputs()) : "Pruned plan must have the same outputs as original plan";
         return new RootRelationBoundary(prunedPlan);
     }
@@ -259,20 +258,21 @@ public class LogicalPlanner {
                             SubqueryPlanner subqueryPlanner,
                             boolean avoidTopLevelFetch) {
         CoordinatorTxnCtx coordinatorTxnCtx = plannerContext.transactionContext();
+        PlanStats planStats = plannerContext.planStats();
         var planBuilder = new PlanBuilder(
             subqueryPlanner,
             coordinatorTxnCtx,
-            tableStats,
+            planStats,
             plannerContext.params()
         );
         LogicalPlan logicalPlan = relation.accept(planBuilder, relation.outputs());
-        LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, tableStats, coordinatorTxnCtx);
+        LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, planStats, coordinatorTxnCtx);
         assert logicalPlan.outputs().equals(optimizedPlan.outputs()) : "Optimized plan must have the same outputs as original plan";
-        LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(tableStats, relation.outputs());
+        LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(planStats.tableStats(), relation.outputs());
         assert prunedPlan.outputs().equals(optimizedPlan.outputs()) : "Pruned plan must have the same outputs as original plan";
         LogicalPlan fetchOptimized = fetchOptimizer.optimize(
             prunedPlan,
-            tableStats,
+            planStats,
             coordinatorTxnCtx
         );
         if (fetchOptimized != prunedPlan || avoidTopLevelFetch) {
@@ -285,21 +285,21 @@ public class LogicalPlanner {
         //
         // The reason for this is that some plans are cheaper to execute as fetch
         // even if there is no operator that reduces the number of records
-        return RewriteToQueryThenFetch.tryRewrite(relation, fetchOptimized, tableStats);
+        return RewriteToQueryThenFetch.tryRewrite(relation, fetchOptimized, planStats.tableStats());
     }
 
     static class PlanBuilder extends AnalyzedRelationVisitor<List<Symbol>, LogicalPlan> {
 
         private final SubqueryPlanner subqueryPlanner;
-        private final TableStats tableStats;
+        private final PlanStats planStats;
         private final Row params;
 
         private PlanBuilder(SubqueryPlanner subqueryPlanner,
                             CoordinatorTxnCtx txnCtx,
-                            TableStats tableStats,
+                            PlanStats planStats,
                             Row params) {
             this.subqueryPlanner = subqueryPlanner;
-            this.tableStats = tableStats;
+            this.planStats = planStats;
             this.params = params;
         }
 
@@ -323,12 +323,12 @@ public class LogicalPlanner {
 
         @Override
         public LogicalPlan visitDocTableRelation(DocTableRelation relation, List<Symbol> outputs) {
-            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, tableStats, params);
+            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, planStats, params);
         }
 
         @Override
         public LogicalPlan visitTableRelation(TableRelation relation, List<Symbol> outputs) {
-            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, tableStats, params);
+            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, planStats, params);
         }
 
         @Override
@@ -364,7 +364,7 @@ public class LogicalPlanner {
                     union.outputs()),
                 union.isDistinct(),
                 union.outputs(),
-                tableStats
+                planStats
             );
         }
 
@@ -434,7 +434,7 @@ public class LogicalPlanner {
                                                 ),
                                                 relation.groupBy(),
                                                 splitPoints.aggregates(),
-                                                tableStats
+                                                planStats
                                             ),
                                             having
                                         ),
@@ -444,7 +444,7 @@ public class LogicalPlanner {
                                 ),
                                 relation.isDistinct(),
                                 relation.outputs(),
-                                tableStats
+                                planStats
                             ),
                             relation.orderBy()
                         ),
@@ -458,11 +458,13 @@ public class LogicalPlanner {
     }
 
     private static LogicalPlan groupByOrAggregate(LogicalPlan source,
-                                                  List<Symbol> groupKeys,
-                                                  List<Function> aggregates,
-                                                  TableStats tableStats) {
+                                           List<Symbol> groupKeys,
+                                           List<Function> aggregates,
+                                           PlanStats planStats) {
         if (!groupKeys.isEmpty()) {
-            long numExpectedRows = GroupHashAggregate.approximateDistinctValues(source.numExpectedRows(), tableStats, groupKeys);
+            long numExpectedRows = GroupHashAggregate.approximateDistinctValues(planStats.get(source).numDocs(),
+                                                                                planStats.tableStats(),
+                                                                                groupKeys);
             return new GroupHashAggregate(source, groupKeys, aggregates, numExpectedRows);
         }
         if (!aggregates.isEmpty()) {
@@ -606,7 +608,7 @@ public class LogicalPlanner {
                     context,
                     LogicalPlanner.this,
                     subqueryPlanner),
-                tableStats,
+                context.planStats(),
                 context.transactionContext()
             );
         }

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -178,11 +178,13 @@ public class NestedLoopJoin extends JoinPlan {
         boolean blockNlPossible = !isDistributed && isBlockNlPossible(left, right);
 
         JoinType joinType = this.joinType;
-        boolean expectedRowsAvailable = lhs.numExpectedRows() != -1 && rhs.numExpectedRows() != -1;
+        var lhStats = plannerContext.planStats().get(lhs);
+        var rhStats = plannerContext.planStats().get(rhs);
+        boolean expectedRowsAvailable = lhStats.numDocs() != -1 && rhStats.numDocs() != -1;
         if (expectedRowsAvailable) {
             if (!orderByWasPushedDown && joinType.supportsInversion() &&
-                (isDistributed && lhs.numExpectedRows() < rhs.numExpectedRows() && orderByFromLeft == null) ||
-                (blockNlPossible && lhs.numExpectedRows() > rhs.numExpectedRows())) {
+                (isDistributed && lhStats.numDocs() < rhStats.numDocs() && orderByFromLeft == null) ||
+                (blockNlPossible && lhStats.numDocs() > rhStats.numDocs())) {
                 // 1) The right side is always broadcast-ed, so for performance reasons we switch the tables so that
                 //    the right table is the smaller (numOfRows). If left relation has a pushed-down OrderBy that needs
                 //    to be preserved, then the switch is not possible.
@@ -221,8 +223,8 @@ public class NestedLoopJoin extends JoinPlan {
             joinType,
             joinInput,
             Symbols.typeView(leftLogicalPlan.outputs()),
-            leftLogicalPlan.estimatedRowSize(),
-            leftLogicalPlan.numExpectedRows(),
+            lhStats.averageSizePerRowInBytes(),
+            lhStats.numDocs(),
             blockNlPossible
         );
         return new Join(
@@ -399,19 +401,6 @@ public class NestedLoopJoin extends JoinPlan {
             outputs,
             new InputColumns.SourceSymbols(joinOutputs));
         return new EvalProjection(projectionOutputs);
-    }
-
-    @Override
-    public long numExpectedRows() {
-        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
-            return -1;
-        }
-        if (joinType == JoinType.CROSS) {
-            return lhs.numExpectedRows() * rhs.numExpectedRows();
-        } else {
-            // We don't have any cardinality estimates, so just take the bigger table
-            return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
-        }
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -25,10 +25,10 @@ import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -54,7 +54,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
     @Override
     public LogicalPlan apply(Insert plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -154,17 +154,6 @@ public final class TableFunction implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        return -1;
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        // We don't have any estimates for table functions, but could go through the types of `outputs` to make a guess
-        return 0;
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitTableFunction(this, context);
     }

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -234,17 +234,12 @@ public class Union implements LogicalPlan {
         return Maps.concat(lhs.dependencies(), rhs.dependencies());
     }
 
-    @Override
-    public long numExpectedRows() {
-        if (lhs.numExpectedRows() == -1 || rhs.numExpectedRows() == -1) {
-            return -1;
-        }
-        return lhs.numExpectedRows() + rhs.numExpectedRows();
+    public LogicalPlan lhs() {
+        return lhs;
     }
 
-    @Override
-    public long estimatedRowSize() {
-        return Math.max(lhs.estimatedRowSize(), rhs.estimatedRowSize());
+    public LogicalPlan rhs() {
+        return rhs;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -38,9 +38,9 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
-import io.crate.statistics.TableStats;
 
 public class Optimizer {
 
@@ -58,14 +58,14 @@ public class Optimizer {
         this.nodeCtx = nodeCtx;
     }
 
-    public LogicalPlan optimize(LogicalPlan plan, TableStats tableStats, CoordinatorTxnCtx txnCtx) {
+    public LogicalPlan optimize(LogicalPlan plan, PlanStats planStats, CoordinatorTxnCtx txnCtx) {
         var applicableRules = removeExcludedRules(rules, txnCtx.sessionSettings().excludedOptimizerRules());
-        LogicalPlan optimizedRoot = tryApplyRules(applicableRules, plan, tableStats, txnCtx);
-        var optimizedSources = Lists2.mapIfChange(optimizedRoot.sources(), x -> optimize(x, tableStats, txnCtx));
+        LogicalPlan optimizedRoot = tryApplyRules(applicableRules, plan, planStats, txnCtx);
+        var optimizedSources = Lists2.mapIfChange(optimizedRoot.sources(), x -> optimize(x, planStats, txnCtx));
         return tryApplyRules(
             applicableRules,
             optimizedSources == optimizedRoot.sources() ? optimizedRoot : optimizedRoot.replaceSources(optimizedSources),
-            tableStats,
+            planStats,
             txnCtx
         );
     }
@@ -88,7 +88,7 @@ public class Optimizer {
         return result;
     }
 
-    private LogicalPlan tryApplyRules(List<Rule<?>> rules, LogicalPlan plan, TableStats tableStats, TransactionContext txnCtx) {
+    private LogicalPlan tryApplyRules(List<Rule<?>> rules, LogicalPlan plan, PlanStats planStats, TransactionContext txnCtx) {
         final boolean isTraceEnabled = LOGGER.isTraceEnabled();
         LogicalPlan node = plan;
         // Some rules may only become applicable after another rule triggered, so we keep
@@ -103,7 +103,7 @@ public class Optimizer {
                 if (minVersion.before(rule.requiredVersion())) {
                     continue;
                 }
-                LogicalPlan transformedPlan = tryMatchAndApply(rule, node, tableStats, nodeCtx, txnCtx, resolvePlan, isTraceEnabled);
+                LogicalPlan transformedPlan = tryMatchAndApply(rule, node, planStats, nodeCtx, txnCtx, resolvePlan, isTraceEnabled);
                 if (transformedPlan != null) {
                     if (isTraceEnabled) {
                         LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' transformed the logical plan");
@@ -122,7 +122,7 @@ public class Optimizer {
     @Nullable
     public static <T> LogicalPlan tryMatchAndApply(Rule<T> rule,
                                                    LogicalPlan node,
-                                                   TableStats tableStats,
+                                                   PlanStats planStats,
                                                    NodeContext nodeCtx,
                                                    TransactionContext txnCtx,
                                                    Function<LogicalPlan, LogicalPlan> resolvePlan,
@@ -132,7 +132,7 @@ public class Optimizer {
             if (traceEnabled) {
                 LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' matched");
             }
-            return rule.apply(match.value(), match.captures(), tableStats, txnCtx, nodeCtx, resolvePlan);
+            return rule.apply(match.value(), match.captures(), planStats, txnCtx, nodeCtx, resolvePlan);
         }
         return null;
     }

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -26,9 +26,9 @@ import java.util.function.Function;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 import org.elasticsearch.Version;
 
 public interface Rule<T> {
@@ -45,7 +45,7 @@ public interface Rule<T> {
      */
     LogicalPlan apply(T plan,
                       Captures captures,
-                      TableStats tableStats,
+                      PlanStats planStats,
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
                       Function<LogicalPlan, LogicalPlan> resolvePlan);

--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.costs;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import io.crate.common.collections.Maps;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.RelationName;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.CorrelatedJoin;
+import io.crate.planner.operators.Count;
+import io.crate.planner.operators.Get;
+import io.crate.planner.operators.GroupHashAggregate;
+import io.crate.planner.operators.HashAggregate;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.Insert;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.LogicalPlanVisitor;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.operators.TableFunction;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.iterative.GroupReference;
+import io.crate.planner.optimizer.iterative.Memo;
+import io.crate.planner.selectivity.SelectivityFunctions;
+import io.crate.sql.tree.JoinType;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.types.DataTypes;
+
+public class PlanStats {
+
+    private final TableStats tableStats;
+    // Memo can be null when there are no Group References in the Logical Plans involved
+    @Nullable
+    private final Memo memo;
+
+    public PlanStats(TableStats tableStats) {
+        this(tableStats, null);
+    }
+
+    public PlanStats(TableStats tableStats, @Nullable Memo memo) {
+        this.tableStats = tableStats;
+        this.memo = memo;
+    }
+
+    public TableStats tableStats() {
+        return tableStats;
+    }
+
+    public Stats get(RelationName relationName) {
+        return tableStats.getStats(relationName);
+    }
+
+    public Stats get(LogicalPlan logicalPlan) {
+        var visitor = new StatsVisitor(tableStats, memo);
+        return logicalPlan.accept(visitor, null);
+    }
+
+    private static class StatsVisitor extends LogicalPlanVisitor<Void, Stats> {
+
+        private final TableStats tableStats;
+        @Nullable
+        private final Memo memo;
+
+        public StatsVisitor(TableStats tableStats, @Nullable Memo memo) {
+            this.tableStats = tableStats;
+            this.memo = memo;
+        }
+
+        @Override
+        public Stats visitGroupReference(GroupReference group, Void context) {
+            if (memo == null) {
+                throw new UnsupportedOperationException("Stats cannot be provided for GroupReference without a Memo");
+            }
+            var groupId = group.groupId();
+            var stats = memo.stats(groupId);
+            if (stats == null) {
+                // No stats for this group yet.
+                // Let's get the logical plan, calculate the stats
+                // and update the stats for this group
+                var logicalPlan = memo.resolve(groupId);
+                stats = logicalPlan.accept(this, context);
+                memo.addStats(groupId, stats);
+            }
+            return stats;
+        }
+
+        @Override
+        public Stats visitLimit(Limit limit, Void context) {
+            var stats = limit.source().accept(this, context);
+            if (limit.limit() instanceof Literal) {
+                var numberOfRows = DataTypes.LONG.sanitizeValue(((Literal<?>) limit.limit()).value());
+                return new Stats(numberOfRows, stats.sizeInBytes(), stats.statsByColumn());
+            }
+            return stats;
+        }
+
+        @Override
+        public Stats visitUnion(Union union, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = union.lhs().accept(this, context);
+            var rhsStats = union.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                numberOfRows = lhsStats.numDocs() + rhsStats.numDocs();
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = Math.max(lhsStats.sizeInBytes(), rhsStats.sizeInBytes());
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitNestedLoopJoin(NestedLoopJoin join, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = join.lhs().accept(this, context);
+            var rhsStats = join.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                if (join.joinType() == JoinType.CROSS) {
+                    numberOfRows = lhsStats.numDocs() * rhsStats.numDocs();
+                } else {
+                    // We don't have any cardinality estimates, so just take the bigger table
+                    numberOfRows = Math.max(lhsStats.numDocs(), rhsStats.numDocs());
+                }
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = lhsStats.sizeInBytes() + rhsStats.sizeInBytes();
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitHashJoin(HashJoin join, Void context) {
+            var numberOfRows = -1L;
+            var sizeInBytes = -1L;
+            var lhsStats = join.lhs().accept(this, context);
+            var rhsStats = join.rhs().accept(this, context);
+            if (lhsStats.numDocs() != -1 && rhsStats.numDocs() != -1) {
+                // We don't have any cardinality estimates, so just take the bigger table
+                numberOfRows = Math.max(lhsStats.numDocs(), rhsStats.numDocs());
+            }
+            if (lhsStats.sizeInBytes() != -1 && rhsStats.sizeInBytes() != -1) {
+                sizeInBytes = lhsStats.sizeInBytes() + rhsStats.sizeInBytes();
+            }
+            return new Stats(numberOfRows, sizeInBytes, Maps.concat(lhsStats.statsByColumn(), rhsStats.statsByColumn()));
+        }
+
+        @Override
+        public Stats visitCollect(Collect collect, Void context) {
+            var stats = tableStats.getStats(collect.relation().tableInfo().ident());
+            if (stats.equals(Stats.EMPTY)) {
+                return new Stats(-1, stats.estimateSizeForColumns(collect.outputs()), Map.of());
+            } else {
+                var query = collect.where().queryOrFallback();
+                var numberOfRows = SelectivityFunctions.estimateNumRows(stats, query, null);
+                return new Stats(numberOfRows, stats.averageSizePerRowInBytes(), stats.statsByColumn());
+            }
+        }
+
+        @Override
+        public Stats visitCount(Count count, Void context) {
+            return new Stats(1, Long.BYTES, Map.of());
+        }
+
+        @Override
+        public Stats visitGet(Get get, Void context) {
+            return new Stats(get.numExpectedRows(), get.estimatedRowSize(), Map.of());
+        }
+
+        @Override
+        public Stats visitGroupHashAggregate(GroupHashAggregate groupHashAggregate, Void context) {
+            var stats = groupHashAggregate.source().accept(this, context);
+            return new Stats(groupHashAggregate.numExpectedRows(), stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitHashAggregate(HashAggregate hashAggregate, Void context) {
+            var stats = hashAggregate.source().accept(this, context);
+            return new Stats(1L, stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitInsert(Insert insert, Void context) {
+            var stats = insert.sources().get(0).accept(this, context);
+            return new Stats(1L, stats.sizeInBytes(), stats.statsByColumn());
+        }
+
+        @Override
+        public Stats visitCorrelatedJoin(CorrelatedJoin join, Void context) {
+            return join.sources().get(0).accept(this, context);
+        }
+
+        @Override
+        public Stats visitTableFunction(TableFunction tableFunction, Void context) {
+            // We don't have any estimates for table functions, but could go through the types of `outputs` to make a guess
+            return Stats.EMPTY;
+        }
+
+        @Override
+        public Stats visitPlan(LogicalPlan logicalPlan, Void context) {
+            // This covers all sub-classes of LogicalForwardPlan
+            if (logicalPlan.sources().size() == 1) {
+                return logicalPlan.sources().get(0).accept(this, context);
+            }
+            throw new UnsupportedOperationException("Plan stats not available for " + logicalPlan.getClass().getSimpleName());
+        }
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -87,16 +87,6 @@ public class GroupReference implements LogicalPlan {
     }
 
     @Override
-    public long numExpectedRows() {
-        throw new UnsupportedOperationException(ERROR_MESSAGE);
-    }
-
-    @Override
-    public long estimatedRowSize() {
-        throw new UnsupportedOperationException(ERROR_MESSAGE);
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitGroupReference(this, context);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
@@ -68,7 +68,7 @@ public final class DeduplicateOrder implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -27,7 +27,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Count;
 import io.crate.planner.operators.HashAggregate;
@@ -64,7 +64,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
     @Override
     public Count apply(HashAggregate aggregate,
                        Captures captures,
-                       TableStats tableStats,
+                       PlanStats planStats,
                        TransactionContext txnCtx,
                        NodeContext nodeCtx,
                        Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -38,10 +38,10 @@ import io.crate.planner.operators.HashAggregate;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate> {
 
@@ -76,7 +76,7 @@ public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate
     @Override
     public LogicalPlan apply(HashAggregate aggregate,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -28,12 +28,12 @@ import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.planner.selectivity.SelectivityFunctions;
 import io.crate.statistics.Stats;
-import io.crate.statistics.TableStats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -59,12 +59,12 @@ public class MergeFilterAndCollect implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
-        Stats stats = tableStats.getStats(collect.relation().tableInfo().ident());
+        Stats stats = planStats.get(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(
             collect.relation(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -26,7 +26,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
@@ -72,7 +72,7 @@ public class MergeFilters implements Rule<Filter> {
     @Override
     public Filter apply(Filter plan,
                         Captures captures,
-                        TableStats tableStats,
+                        PlanStats planStats,
                         TransactionContext txnCtx,
                         NodeContext nodeCtx,
                         Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -36,6 +36,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.consumer.RelationNameCollector;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
@@ -43,7 +44,6 @@ import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedLoopJoin> {
 
@@ -64,7 +64,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
     @Override
     public LogicalPlan apply(NestedLoopJoin nl,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -36,10 +36,10 @@ import io.crate.planner.operators.CorrelatedJoin;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
 
@@ -60,7 +60,7 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathEval.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathEval implements Rule<Filter> {
 
@@ -57,7 +57,7 @@ public final class MoveFilterBeneathEval implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -39,10 +39,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.GroupHashAggregate;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /**
  * Transforms queries like
@@ -76,7 +76,7 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.JoinPlan;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
@@ -63,7 +63,7 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
@@ -81,7 +81,7 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -40,10 +40,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.ProjectSet;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
 
@@ -64,7 +64,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -28,10 +28,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -58,7 +58,7 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -25,7 +25,7 @@ import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Union;
@@ -59,7 +59,7 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -32,10 +32,10 @@ import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +66,7 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveLimitBeneathEval implements Rule<Limit> {
 
@@ -57,7 +57,7 @@ public class MoveLimitBeneathEval implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -33,10 +33,10 @@ import io.crate.planner.operators.Limit;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class MoveLimitBeneathRename implements Rule<Limit> {
 
@@ -57,7 +57,7 @@ public class MoveLimitBeneathRename implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathFetchOrEval.java
@@ -28,10 +28,10 @@ import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -60,7 +60,7 @@ public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -44,10 +44,10 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /* Move the orderBy expression to the sub-relation if possible.
  *
@@ -81,7 +81,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order order,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -30,10 +30,10 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.List;
 import java.util.function.Function;
@@ -79,7 +79,7 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Union;
@@ -58,7 +58,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
     @Override
     public LogicalPlan apply(Order order,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -35,9 +35,9 @@ import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Get;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -65,7 +65,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
     @Override
     public LogicalPlan apply(Collect collect,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
@@ -87,7 +87,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
                 docKeys.get(),
                 detailedQuery.query(),
                 collect.outputs(),
-                tableStats.estimatedSizePerRow(relation.relationName())
+                planStats.tableStats().estimatedSizePerRow(relation.relationName())
             );
         } else if (!detailedQuery.clusteredBy().isEmpty() && collect.detailedQuery() == null) {
             return new Collect(collect, detailedQuery);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantFetchOrEval.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.statistics.TableStats;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
@@ -54,7 +54,7 @@ public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
     @Override
     public LogicalPlan apply(Eval plan,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -40,6 +40,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -48,7 +49,6 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 /**
  * If we can determine that a filter on an OUTER JOIN turns all NULL rows that the join could generate into a NO-MATCH
@@ -119,7 +119,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
     @Override
     public LogicalPlan apply(Filter filter,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
@@ -32,16 +32,16 @@ import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.statistics.TableStats;
 
 public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
 
     private final Pattern<NestedLoopJoin> pattern = typeOf(NestedLoopJoin.class)
         .with(nl -> nl.isRewriteNestedLoopJoinToHashJoinDone() == false &&
                     nl.orderByWasPushedDown() == false);
-    
+
     @Override
     public Pattern<NestedLoopJoin> pattern() {
         return pattern;
@@ -50,7 +50,7 @@ public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
     @Override
     public LogicalPlan apply(NestedLoopJoin nl,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -46,6 +46,7 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -77,14 +78,14 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
     @Override
     public LogicalPlan apply(Limit limit,
                              Captures captures,
-                             TableStats tableStats,
+                             PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }
-        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(tableStats, Set.of());
+        FetchRewrite fetchRewrite = limit.source().rewriteToFetch(planStats.tableStats(), Set.of());
         if (fetchRewrite == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -87,6 +87,10 @@ public class Stats implements Writeable {
         return numDocs;
     }
 
+    public long sizeInBytes() {
+        return sizeInBytes;
+    }
+
     public long averageSizePerRowInBytes() {
         if (numDocs == -1) {
             return -1;

--- a/server/src/main/java/io/crate/statistics/TableStats.java
+++ b/server/src/main/java/io/crate/statistics/TableStats.java
@@ -27,9 +27,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.elasticsearch.common.inject.Singleton;
+
 /**
  * Holds table statistics that are updated periodically by {@link TableStatsService}.
  */
+@Singleton
 public class TableStats {
 
     private volatile Map<RelationName, Stats> tableStats = new HashMap<>();

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -50,6 +50,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
 import io.crate.sql.tree.Declare.Hold;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.user.Privilege;
 import io.crate.user.Privilege.State;
@@ -73,7 +74,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             () -> dependencies,
             new JobsLogs(() -> false),
             Settings.EMPTY,
-            clusterService
+            clusterService,
+            new TableStats()
         );
 
         KeyData keyData = new KeyData(10, 20);
@@ -142,7 +144,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             Settings.builder()
                 .put("statement_timeout", "30s")
                 .build(),
-            clusterService
+            clusterService,
+            new TableStats()
         );
         Session session = sessions.createSession("doc", User.CRATE_USER);
         assertThat(session.sessionSettings().statementTimeout())
@@ -157,7 +160,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             () -> mock(DependencyCarrier.class),
             new JobsLogs(() -> false),
             Settings.EMPTY,
-            clusterService
+            clusterService,
+            new TableStats()
         );
         return sessions;
     }

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -97,7 +97,8 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            e.planStats()
         );
 
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -230,17 +230,16 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         var context = e.getPlannerContext(clusterService.state());
         var logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         var plan = logicalPlanner.plan(e.analyze(stmt), context);
         var union = (Union) plan.sources().get(0);
-        assertThat(union.numExpectedRows()).isEqualTo(-1L);
+        assertThat(e.getStats(union).numDocs()).isEqualTo(-1L);
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         tableStats.updateTableStats(rowCountByTable);
         plan = logicalPlanner.plan(e.analyze(stmt), context);
         union = (Union) plan.sources().get(0);
-        assertThat(union.numExpectedRows()).isEqualTo(-1L);
+        assertThat(e.getStats(union).numDocs()).isEqualTo(-1L);
     }
 }

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -189,12 +189,12 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan outerSubSelectPlan = rootPlanDependencies.keySet().iterator().next();
         SelectSymbol outerSubSelectSymbol = rootPlanDependencies.values().iterator().next();
         assertThat(outerSubSelectSymbol.getResultType(), is(SINGLE_COLUMN_SINGLE_VALUE));
-        assertThat(outerSubSelectPlan.numExpectedRows(), is(2L));
+        assertThat(e.getStats(outerSubSelectPlan).numDocs(), is(2L));
 
         LogicalPlan innerSubSelectPlan = outerSubSelectPlan.dependencies().keySet().iterator().next();
         SelectSymbol innerSubSelectSymbol = outerSubSelectPlan.dependencies().values().iterator().next();
         assertThat(innerSubSelectSymbol.getResultType(), is(SINGLE_COLUMN_MULTIPLE_VALUES));
-        assertThat(innerSubSelectPlan.numExpectedRows(), is(-1L));
+        assertThat(e.getStats(innerSubSelectPlan).numDocs(), is(-1L));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -70,7 +70,6 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
     private ProjectionBuilder projectionBuilder;
-    private PlannerContext plannerCtx;
     private final CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 
     @Before
@@ -84,7 +83,6 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addTable(T3.T4_DEFINITION)
             .build();
         projectionBuilder = new ProjectionBuilder(e.nodeCtx);
-        plannerCtx = e.getPlannerContext(clusterService.state());
     }
 
     @After
@@ -92,10 +90,14 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         txnCtx.sessionSettings().setHashJoinEnabled(true);
     }
 
-    private LogicalPlan createLogicalPlan(QueriedSelectRelation mss, TableStats tableStats) {
+    private LogicalPlan createLogicalPlan(QueriedSelectRelation mss) {
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        return createLogicalPlan(mss, plannerCtx);
+    }
+
+    private LogicalPlan createLogicalPlan(QueriedSelectRelation mss, PlannerContext plannerCtx) {
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, plannerCtx));
@@ -106,15 +108,21 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             new SubQueries(Map.of(), Map.of()),
             rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, true)
         );
-        return logicalPlanner.optimizer.optimize(plan, tableStats, txnCtx);
+        return logicalPlanner.optimizer.optimize(plan, e.planStats(), txnCtx);
     }
 
     private Join buildJoin(LogicalPlan operator) {
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        return buildJoin(operator, plannerCtx);
+    }
+
+    private Join buildJoin(LogicalPlan operator, PlannerContext plannerCtx) {
         return (Join) operator.build(mock(DependencyCarrier.class), plannerCtx, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
     }
 
-    private Join plan(QueriedSelectRelation mss, TableStats tableStats) {
-        return buildJoin(createLogicalPlan(mss, tableStats));
+    private Join plan(QueriedSelectRelation mss) {
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        return buildJoin(createLogicalPlan(mss, plannerCtx), plannerCtx);
     }
 
     @Test
@@ -122,20 +130,19 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         txnCtx.sessionSettings().setHashJoinEnabled(false);
         QueriedSelectRelation mss = e.analyze("select * from users, locations where users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
 
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10_000, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        nl = plan(mss, tableStats);
+        nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
     }
 
@@ -144,16 +151,15 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         txnCtx.sessionSettings().setHashJoinEnabled(false);
         QueriedSelectRelation mss = e.analyze("select * from users left join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(0, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
         assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
     }
@@ -165,21 +171,19 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addTable(USER_TABLE_DEFINITION)
             .addTable(TEST_DOC_LOCATIONS_TABLE_DEFINITION)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
 
         txnCtx.sessionSettings().setHashJoinEnabled(false);
         QueriedSelectRelation mss = e.analyze("select * from users left join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(0, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(-1, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("users");
         assertThat(((Reference) ((Collect) nl.right()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo("locations");
     }
@@ -190,13 +194,12 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from users " +
                                               "join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(0, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
 
         Join join = buildJoin(operator);
@@ -207,7 +210,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNestedLoop_TablesAreSwitchedIfBlockJoinAndRightIsSmallerThanLeft() throws IOException {
         // blockNL is only possible on single node clusters
-        e = SQLExecutor.builder(clusterService)
+        resetClusterService();
+        e = SQLExecutor.builder(clusterService, 1, random(), List.of())
             .addTable("create table j.left_table (id int)")
             .addTable("create table j.right_table (id int)")
             .build();
@@ -216,21 +220,20 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         QueriedSelectRelation mss = e.analyze("select * from j.left_table as l left join j.right_table as r on l.id = r.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(leftName, new Stats(10, 0, Map.of()));
         rowCountByTable.put(rightName, new Stats(10_000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        Join nl = plan(mss, tableStats);
+        Join nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo(leftName.name());
         assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.LEFT);
 
         rowCountByTable.put(leftName, new Stats(10_000, 0, Map.of()));
         rowCountByTable.put(rightName, new Stats(10, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        nl = plan(mss, tableStats);
+        nl = plan(mss);
         assertThat(((Reference) ((Collect) nl.left()).collectPhase().toCollect().get(0)).ident().tableIdent().name()).isEqualTo(rightName.name());
         assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.RIGHT);  // ensure that also the join type inverted
     }
@@ -242,46 +245,27 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation mss = e.analyze("select users.id from (select id from users order by id) users, " +
                                               "locations where users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_0000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        PlannerContext context = e.getPlannerContext(clusterService.state());
-        LogicalPlanner logicalPlanner = new LogicalPlanner(
-            e.nodeCtx,
-            tableStats,
-            () -> clusterService.state().nodes().getMinNodeVersion()
-        );
-        SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, context));
-        LogicalPlan operator = JoinPlanBuilder.buildJoinTree(
-            mss.from(),
-            mss.where(),
-            mss.joinPairs(),
-            new SubQueries(Map.of(), Map.of()),
-            rel -> logicalPlanner.plan(rel, plannerCtx, subqueryPlanner, false)
-        );
-        Join nl = (Join) operator.build(
-            mock(DependencyCarrier.class), context, Set.of(), projectionBuilder, -1, 0, null, null, Row.EMPTY, SubQueryResults.EMPTY);
-
+        Join nl = plan(mss);
         assertList(((Collect) nl.left()).collectPhase().toCollect()).isSQL("doc.users.id");
         assertThat(nl.resultDescription().orderBy()).isNotNull();
     }
 
     @Test
     public void testNestedLoop_TablesAreNotSwitchedAfterOrderByPushDown() {
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_0000, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
         PlannerContext context = e.getPlannerContext(clusterService.state());
         context.transactionContext().sessionSettings().setHashJoinEnabled(false);
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan plan = logicalPlanner.plan(e.analyze("select users.id from users, locations " +
@@ -299,13 +283,12 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from users " +
                                               "join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(100, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
         assertThat(((HashJoin) operator).rhs().getRelationNames())
             .as("Smaller table must be on the right-hand-side")
@@ -321,13 +304,12 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from users " +
                                               "join locations on users.id = locations.id");
 
-        TableStats tableStats = new TableStats();
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(100, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
         assertThat(((HashJoin) operator).rhs().getRelationNames())
             .as("Smaller table must be on the right-hand-side")
@@ -343,7 +325,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from t1 inner join t2 on t1.a = t2.b " +
                                               "inner join t3 on t3.c = t2.b");
 
-        LogicalPlan operator = createLogicalPlan(mss, new TableStats());
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(HashJoin.class);
         LogicalPlan leftPlan = ((HashJoin) operator).lhs;
         assertThat(leftPlan).isExactlyInstanceOf(HashJoin.class);
@@ -360,7 +342,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "from t1 inner join t2 on t1.a = t2.b " +
                                               "left join t3 on t3.c = t2.b");
 
-        LogicalPlan operator = createLogicalPlan(mss, new TableStats());
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
         LogicalPlan leftPlan = ((NestedLoopJoin) operator).lhs;
         assertThat(leftPlan).isExactlyInstanceOf(HashJoin.class);
@@ -379,11 +361,10 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
 
         QueriedSelectRelation mss = e.analyze("select * from t1, t4");
 
-        LogicalPlan operator = createLogicalPlan(mss, new TableStats());
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
@@ -405,13 +386,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         e = SQLExecutor.builder(clusterService)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
-            .setTableStats(tableStats)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
 
         QueriedSelectRelation mss = e.analyze("select * from t1, t4");
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
@@ -427,24 +406,21 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testBlockNestedLoopWhenRightSideIsSmallerAndOneExecutionNode() throws IOException {
-        TableStats tableStats = new TableStats();
-        Map<RelationName, Stats> stats = new HashMap<>();
-        stats.put(T3.T1, new Stats(23, 64, Map.of()));
-        stats.put(T3.T4, new Stats(42, 64, Map.of()));
-        tableStats.updateTableStats(stats);
-
         // rebuild executor + cluster state with 1 node
         resetClusterService();
         e = SQLExecutor.builder(clusterService)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
-            .setTableStats(tableStats)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
+
+        e.updateTableStats(Map.of(
+            T3.T1, new Stats(23, 64, Map.of()),
+            T3.T4, new Stats(42, 64, Map.of())
+        ));
 
         QueriedSelectRelation mss = e.analyze("select * from t4, t1");
 
-        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        LogicalPlan operator = createLogicalPlan(mss);
         assertThat(operator).isExactlyInstanceOf(NestedLoopJoin.class);
 
         Join join = buildJoin(operator);
@@ -460,25 +436,23 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNoBlockNestedLoopWithOrderBy() throws IOException {
-        TableStats tableStats = new TableStats();
-        Map<RelationName, Stats> stats = new HashMap<>();
-        stats.put(T3.T1, new Stats(23, 64, Map.of()));
-        stats.put(T3.T4, new Stats(42, 64, Map.of()));
-        tableStats.updateTableStats(stats);
-
         // rebuild executor + cluster state with 1 node
         resetClusterService();
         e = SQLExecutor.builder(clusterService)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T4_DEFINITION)
-            .setTableStats(tableStats)
             .build();
-        plannerCtx = e.getPlannerContext(clusterService.state());
+
+        e.updateTableStats(Map.of(
+            T3.T1, new Stats(23, 64, Map.of()),
+            T3.T4, new Stats(42, 64, Map.of())
+        ));
+
+        var plannerCtx = e.getPlannerContext(clusterService.state());
 
         QueriedSelectRelation mss = e.analyze("select * from t1, t4 order by t1.x");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            tableStats,
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan operator = logicalPlanner.plan(mss, plannerCtx);
@@ -497,11 +471,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "JOIN t3 t3 on t3.c = t2.b");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
-            new TableStats(),
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
-        LogicalPlan join = logicalPlanner.plan(mss, plannerCtx);
 
+        var plannerCtx = e.getPlannerContext(clusterService.state());
+        LogicalPlan join = logicalPlanner.plan(mss, plannerCtx);
         WindowAgg windowAggOperator = (WindowAgg) ((Eval) ((RootRelationBoundary) join).source).source;
         assertThat(join.outputs()).contains(windowAggOperator.windowFunctions().get(0));
     }

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -23,6 +23,7 @@ package io.crate.planner.operators;
 
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_LIMIT;
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_OFFSET;
+import static io.crate.planner.optimizer.costs.PlanStatsTest.PLAN_STATS_EMPTY;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLimitAndOffset;
 import static org.mockito.Mockito.mock;
@@ -47,7 +48,6 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.node.dql.QueryThenFetch;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -66,7 +66,7 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
                     ((AbstractTableRelation<?>) queriedDocTable.from().get(0)),
                     queriedDocTable.outputs(),
                     new WhereClause(queriedDocTable.where()),
-                    new TableStats(),
+                    PLAN_STATS_EMPTY,
                     null
                 ),
                 Literal.of(10L),

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,7 +42,6 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;
 import io.crate.statistics.Stats;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
@@ -52,16 +50,13 @@ import io.crate.types.DataTypes;
 public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor sqlExecutor;
-    private TableStats tableStats;
 
     @Before
     public void prepare() throws IOException {
-        tableStats = new TableStats();
         sqlExecutor = SQLExecutor.builder(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
-            .setTableStats(tableStats)
             .addView(new RelationName("doc", "v2"), "SELECT a, x FROM doc.t1")
             .addView(new RelationName("doc", "v3"), "SELECT a, x FROM doc.t1")
             .build();
@@ -75,16 +70,16 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void test_collect_derives_estimated_size_per_row_from_stats_and_types() {
         // no stats -> size derived FROM fixed with type
         LogicalPlan plan = plan("SELECT x FROM t1");
-        assertThat(plan.estimatedRowSize()).isEqualTo((long) DataTypes.INTEGER.fixedSize());
+        assertThat(sqlExecutor.getStats(plan).sizeInBytes()).isEqualTo((long) DataTypes.INTEGER.fixedSize());
 
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
         ColumnStats<Integer> columnStats = new ColumnStats<>(
             0.0, 50L, 2, DataTypes.INTEGER, MostCommonValues.EMPTY, List.of());
-        tableStats.updateTableStats(Map.of(t1.ident(), new Stats(2L, 100L, Map.of(new ColumnIdent("x"), columnStats))));
+        sqlExecutor.updateTableStats(Map.of(t1.ident(), new Stats(2L, 100L, Map.of(new ColumnIdent("x"), columnStats))));
 
         // stats present -> size derived FROM them (although bogus fake stats in this case)
         plan = plan("SELECT x FROM t1");
-        assertThat(plan.estimatedRowSize()).isEqualTo(50L);
+        assertThat(sqlExecutor.getStats(plan).sizeInBytes()).isEqualTo(50L);
     }
 
     @Test
@@ -474,7 +469,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_group_by_with_alias_and_limit_distinct_rewrite_creates_valid_plan() {
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
-        tableStats.updateTableStats(Map.of(t1.ident(), new Stats(100L, 100L, Map.of())));
+        sqlExecutor.updateTableStats(Map.of(t1.ident(), new Stats(100L, 100L, Map.of())));
         LogicalPlan plan = plan("SELECT a as b FROM doc.t1 GROUP BY a LIMIT 10");
         assertThat(plan).isEqualTo(
             """

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.costs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.iterative.GroupReference;
+import io.crate.planner.optimizer.iterative.Memo;
+import io.crate.sql.tree.JoinType;
+import io.crate.statistics.Stats;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
+
+    public static final PlanStats PLAN_STATS_EMPTY = new PlanStats(new TableStats());
+
+    @Test
+    public void test_collect() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 1L,
+                                 DataTypes.INTEGER.fixedSize());
+
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, DataTypes.INTEGER.fixedSize(), Map.of())));
+
+        var memo = new Memo(source);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.get(source);
+        assertThat(result.numDocs()).isEqualTo(1L);
+        assertThat(result.sizeInBytes()).isEqualTo(DataTypes.INTEGER.fixedSize());
+    }
+
+    @Test
+    public void test_group_reference() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 1L,
+                                 DataTypes.INTEGER.fixedSize());
+        var groupReference = new GroupReference(1, source.outputs(), Set.of());
+
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, DataTypes.INTEGER.fixedSize(), Map.of())));
+
+        var memo = new Memo(source);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.get(groupReference);
+        assertThat(result.numDocs()).isEqualTo(1L);
+        assertThat(result.sizeInBytes()).isEqualTo(DataTypes.INTEGER.fixedSize());
+    }
+
+    @Test
+    public void test_limit() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .build();
+
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var x = e.asSymbol("x");
+        var source = new Collect(new DocTableRelation(a),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 10L,
+                                 DataTypes.INTEGER.fixedSize());
+
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
+
+        var limit = new Limit(source, Literal.of(5), Literal.of(0));
+
+        var memo = new Memo(limit);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.get(limit);
+        assertThat(result.numDocs()).isEqualTo(5L);
+    }
+
+    @Test
+    public void test_union() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .addTable("create table b (y int)")
+            .build();
+
+        DocTableInfo aDoc = e.resolveTableInfo("a");
+        DocTableInfo bDoc = e.resolveTableInfo("b");
+
+        var x = e.asSymbol("x");
+        var y = e.asSymbol("x");
+
+        var lhs = new Collect(new DocTableRelation(aDoc),
+                                 List.of(x),
+                                 WhereClause.MATCH_ALL,
+                                 9L,
+                                 DataTypes.INTEGER.fixedSize());
+
+        var rhs = new Collect(new DocTableRelation(bDoc),
+                                 List.of(y),
+                                 WhereClause.MATCH_ALL,
+                                 1L,
+                                 DataTypes.INTEGER.fixedSize());
+
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(
+            Map.of(
+                aDoc.ident(), new Stats(9L, 1, Map.of()),
+                bDoc.ident(), new Stats(1L, 1, Map.of())
+            )
+        );
+
+        var union = new Union(lhs, rhs, List.of());
+
+        var memo = new Memo(union);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.get(union);
+        assertThat(result.numDocs()).isEqualTo(10L);
+        assertThat(result.sizeInBytes()).isEqualTo(1L);
+    }
+
+    @Test
+    public void test_hash_join() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .addTable("create table b (y int)")
+            .build();
+
+        DocTableInfo aDoc = e.resolveTableInfo("a");
+        DocTableInfo bDoc = e.resolveTableInfo("b");
+
+        var x = e.asSymbol("x");
+        var y = e.asSymbol("x");
+
+        var lhs = new Collect(new DocTableRelation(aDoc),
+                              List.of(x),
+                              WhereClause.MATCH_ALL,
+                              9L,
+                              DataTypes.INTEGER.fixedSize());
+
+        var rhs = new Collect(new DocTableRelation(bDoc),
+                              List.of(y),
+                              WhereClause.MATCH_ALL,
+                              1L,
+                              DataTypes.INTEGER.fixedSize());
+
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(
+            Map.of(
+                aDoc.ident(), new Stats(9L, 1, Map.of()),
+                bDoc.ident(), new Stats(1L, 1, Map.of())
+            )
+        );
+
+        var hashjoin = new HashJoin(lhs, rhs, x);
+
+        var memo = new Memo(hashjoin);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.get(hashjoin);
+        // lhs is the larger table which 9 entries, so the join will at max emit 9 entries
+        assertThat(result.numDocs()).isEqualTo(9L);
+        assertThat(result.sizeInBytes()).isEqualTo(1L);
+    }
+
+    @Test
+    public void test_nl_join() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table a (x int)")
+            .addTable("create table b (y int)")
+            .build();
+
+        DocTableInfo aDoc = e.resolveTableInfo("a");
+        DocTableInfo bDoc = e.resolveTableInfo("b");
+
+        var x = e.asSymbol("x");
+        var y = e.asSymbol("x");
+
+        DocTableRelation relation = new DocTableRelation(aDoc);
+        var lhs = new Collect(relation,
+                              List.of(x),
+                              WhereClause.MATCH_ALL,
+                              9L,
+                              DataTypes.INTEGER.fixedSize());
+
+        var rhs = new Collect(new DocTableRelation(bDoc),
+                              List.of(y),
+                              WhereClause.MATCH_ALL,
+                              2L,
+                              DataTypes.INTEGER.fixedSize());
+
+        TableStats tableStats = new TableStats();
+        tableStats.updateTableStats(
+            Map.of(
+                aDoc.ident(), new Stats(9L, DataTypes.INTEGER.fixedSize(), Map.of()),
+                bDoc.ident(), new Stats(2L, DataTypes.INTEGER.fixedSize(), Map.of())
+            )
+        );
+
+        var nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.INNER, x, false, relation, false,false, false, false);
+
+        var memo = new Memo(nestedLoopJoin);
+        PlanStats planStats = new PlanStats(tableStats, memo);
+        var result = planStats.get(nestedLoopJoin);
+        // lhs is the larger table which 9 entries, so the join will at max emit 9 entries
+        assertThat(result.numDocs()).isEqualTo(9L);
+        assertThat(result.sizeInBytes()).isEqualTo(9L);
+
+        nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.CROSS, x, false, relation, false,false, false, false);
+
+        memo = new Memo(nestedLoopJoin);
+        planStats = new PlanStats(tableStats, memo);
+        result = planStats.get(nestedLoopJoin);
+        assertThat(result.numDocs()).isEqualTo(18L);
+        assertThat(result.sizeInBytes()).isEqualTo(9L);
+    }
+
+}

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/IterativeOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/IterativeOptimizerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.optimizer.iterative;
 
+import static io.crate.planner.optimizer.costs.PlanStatsTest.PLAN_STATS_EMPTY;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 
@@ -38,7 +39,6 @@ import io.crate.planner.operators.Order;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
-import io.crate.statistics.TableStats;
 
 public class IterativeOptimizerTest {
 
@@ -55,7 +55,7 @@ public class IterativeOptimizerTest {
                                                               () -> Version.CURRENT,
                                                               List.of(new MergeFilters()));
 
-        var result = optimizer.optimize(filter2, new TableStats(), ctx);
+        var result = optimizer.optimize(filter2, PLAN_STATS_EMPTY, ctx);
         assertThat(result).isEqualTo("Filter[(true AND true)]\n" +
                                              "  └ TestPlan[]");
     }
@@ -72,7 +72,7 @@ public class IterativeOptimizerTest {
                                                               () -> Version.CURRENT,
                                                               List.of(new MergeFilters(), new DeduplicateOrder()));
 
-        var result = optimizer.optimize(order2, new TableStats(), ctx);
+        var result = optimizer.optimize(order2, PLAN_STATS_EMPTY, ctx);
         assertThat(result).isEqualTo(
             """
             OrderBy[]
@@ -107,7 +107,7 @@ public class IterativeOptimizerTest {
                                                               () -> Version.CURRENT,
                                                               List.of(new MoveFilterBeneathOrder(), new DeduplicateOrder()));
 
-        var result = optimizer.optimize(order2, new TableStats(), ctx);
+        var result = optimizer.optimize(order2, PLAN_STATS_EMPTY, ctx);
 
         assertThat(result).isEqualTo(
             """

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.costs.PlanStatsTest.PLAN_STATS_EMPTY;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Collections;
@@ -39,7 +40,6 @@ import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
@@ -71,7 +71,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
         Filter mergedFilter = mergeFilters.apply(match.value(),
                                                  match.captures(),
-                                                 new TableStats(),
+                                                 PLAN_STATS_EMPTY,
                                                  CoordinatorTxnCtx.systemTransactionContext(),
                                                  e.nodeCtx,
                                                  Function.identity());

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.costs.PlanStatsTest.PLAN_STATS_EMPTY;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -44,7 +45,6 @@ import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
@@ -82,7 +82,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
 
         HashJoin result = (HashJoin) rule.apply(match.value(),
                                                 match.captures(),
-                                                new TableStats(),
+                                                PLAN_STATS_EMPTY,
                                                 CoordinatorTxnCtx.systemTransactionContext(),
                                                 sqlExpressions.nodeCtx,
                                                 Function.identity());

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -38,7 +38,6 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.WindowAgg;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -73,7 +72,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -101,7 +100,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -128,7 +127,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -162,7 +161,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()
@@ -197,7 +196,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         LogicalPlan newPlan = rule.apply(
             match.value(),
             match.captures(),
-            new TableStats(),
+            e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
             Function.identity()

--- a/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.statement;
 
+import static io.crate.planner.optimizer.costs.PlanStatsTest.PLAN_STATS_EMPTY;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -50,7 +51,6 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Merge;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.operators.SubQueryResults;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -96,7 +96,7 @@ public class CopyToPlannerTest extends CrateDummyClusterServiceUnitTest {
             mock(DependencyCarrier.class),
             boundedCopyTo,
             e.getPlannerContext(clusterService.state()),
-            new TableStats(),
+            PLAN_STATS_EMPTY,
             new ProjectionBuilder(e.nodeCtx),
             Row.EMPTY,
             SubQueryResults.EMPTY);

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -77,6 +77,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
 import org.apache.logging.log4j.LogManager;
@@ -211,6 +212,7 @@ import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
+import io.crate.statistics.TableStats;
 import io.crate.test.integration.SystemPropsTestLoggingListener;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
@@ -1765,6 +1767,8 @@ public abstract class IntegTestCase extends ESTestCase {
         Analyzer analyzer = cluster().getInstance(Analyzer.class, nodeName);
         Planner planner = cluster().getInstance(Planner.class, nodeName);
         NodeContext nodeCtx = cluster().getInstance(NodeContext.class, nodeName);
+        TableStats tableStats = cluster().getInstance(TableStats.class, nodeName);
+        PlanStats planStats = new PlanStats(tableStats);
 
         CoordinatorSessionSettings sessionSettings = new CoordinatorSessionSettings(
             User.CRATE_USER,
@@ -1781,7 +1785,8 @@ public abstract class IntegTestCase extends ESTestCase {
             0,
             null,
             Cursors.EMPTY,
-            TransactionState.IDLE
+            TransactionState.IDLE,
+            planStats
         );
         Plan plan = planner.plan(
             analyzer.analyze(


### PR DESCRIPTION
This introduces `Stats` for Logical Plans, which will be used in the `Optimizers` and the `Planners` with the following steps:

- Add support for `Stats` in the `Memo`, so it can be used in the `IterativeOptimizer`.
- Introduce `PlanStats` which provides `Stats` for `LogicalPlans`.
- Remove `numExpectedRows` and  `estimatedRowSize` from `LogicalPlan` and use `PlanStats` instead.
- Use `PlanStats` instead of `TableStats` in the Optimizer/Planner.

Requirement for https://github.com/crate/crate/pull/13999

The next step is to move the table swaps from nestedloop/hashjoin build methods into optimizer rules. 

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
