### PR TITLE
Improve performance of AVG(<interval>) aggregation

### DIFF
--- a/server/src/main/java/io/crate/types/IntervalType.java
+++ b/server/src/main/java/io/crate/types/IntervalType.java
@@ -173,7 +173,7 @@ public class IntervalType extends DataType<Period> implements FixedWidthType, St
 
         BigInteger result = BigInteger.valueOf(millis);
         result = result.add(BigInteger.valueOf(p.getMonths() * 30 * (long) DateTimeConstants.MILLIS_PER_DAY));
-        result = result.add(BigInteger.valueOf(p.getYears() * 12 * 30 * (long) DateTimeConstants.MILLIS_PER_DAY));
+        result = result.add(BigInteger.valueOf(p.getYears() * 365 * (long) DateTimeConstants.MILLIS_PER_DAY));
         return result;
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -169,7 +169,7 @@ public class AverageAggregationTest extends AggregationTestCase {
             {Period.days(4).withHours(7).withMinutes(39).withSeconds(45)},
             {Period.days(2).withHours(27).withMinutes(52).withSeconds(25)}
         }))
-            .isEqualTo(new Period(0, 0, 0, 763, 14, 54, 26, 0,
+            .isEqualTo(new Period(0, 0, 0, 773, 14, 54, 26, 0,
                                   PeriodType.yearMonthDayTime()));
 
         assertThat(executeIntervalAvgAgg(new Object[][]{{null}, {null}}))


### PR DESCRIPTION
- Fix calculation for years to use 365 days. It's not so important for the current usage (comparisons) since the same calculation is applied to both periods, but to be 100% correct, changed `12 * 30 * millis_per_day` to `365 * millis_per_day`.

- Improve performance of AVG(<interval>) aggregation
  Instead of using BigInteger which will create new object for every addition (and subtraction), use an array of longs, where each value represents one of the Period units (years, months, ..., millis). At the end, use a `OverflowAwareMutableLong` to calculate the total sum of millis and divide by the count of entries (rows) to get back a long used to construct the returned `Period` value of the `AVG` agg.

- Added a JMH benchmark method on top of the existing one testing the `SUM` aggregation on intervals.

Follows: #14058
