### PR TITLE
Change some acl cols in pg_catalog tables to Array(STRING).

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -43,6 +43,10 @@ Unreleased Changes
 Breaking Changes
 ================
 
+- Changed ``pg_attribute.spcacl``, ``pg_class.relacl`` and
+  ``pg_namespace.nspacl`` columns type from ``OBJECT[]`` to ``STRING[]`` to be
+  in sync with other similar columns, e.g.: ``pg_database.datacl``.
+
 - Raise an exception if duplicate columns are detected on
   :ref:`named index column definition <named-index-column>` instead of
   silently ignoring them.

--- a/server/src/main/java/io/crate/metadata/pgcatalog/OidHash.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/OidHash.java
@@ -39,6 +39,8 @@ import static org.apache.lucene.util.StringHelper.murmurhash3_x86_32;
 
 public final class OidHash {
 
+    private OidHash() {}
+
     public enum Type {
         SCHEMA,
         TABLE,

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAmTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAmTable.java
@@ -29,6 +29,8 @@ public final class PgAmTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_am");
 
+    private PgAmTable() {}
+
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)
             .add("oid", DataTypes.INTEGER, ignored -> null)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAttrDefTable.java
@@ -29,9 +29,11 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 
 
-public class PgAttrDefTable {
+public final class PgAttrDefTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attrdef");
+
+    private PgAttrDefTable() {}
 
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -25,7 +25,6 @@ import io.crate.expression.reference.information.ColumnContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.protocols.postgres.types.PGTypes;
-import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 import io.crate.types.Regclass;
 
@@ -63,7 +62,9 @@ public class PgAttributeTable {
             .add("attislocal", BOOLEAN, c -> true)
             .add("attinhcount", INTEGER, c -> 0)
             .add("attcollation", INTEGER, c -> 0)
-            .add("attacl", new ArrayType<>(DataTypes.UNTYPED_OBJECT), c -> null)
+            // should be `aclitem[]` but we lack `aclitem`, so going with same choice that Cockroach made:
+            // https://github.com/cockroachdb/cockroach/blob/45deb66abbca3aae56bd27910a36d90a6a8bcafe/pkg/sql/vtable/pg_catalog.go#L92
+            .add("attacl", DataTypes.STRING_ARRAY, ignored -> null)
             .add("attoptions", STRING_ARRAY, c -> null)
             .add("attfdwoptions", STRING_ARRAY, c -> null)
             .build();

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgAttributeTable.java
@@ -36,9 +36,11 @@ import static io.crate.types.DataTypes.REGCLASS;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 import static io.crate.types.DataTypes.isArray;
 
-public class PgAttributeTable {
+public final class PgAttributeTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_attribute");
+
+    private PgAttributeTable() {}
 
     public static SystemTable<ColumnContext> create() {
         return SystemTable.<ColumnContext>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogModule.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogModule.java
@@ -25,13 +25,11 @@ import io.crate.metadata.table.SchemaInfo;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 
-public class PgCatalogModule extends AbstractModule {
-
-    protected MapBinder<String, SchemaInfo> schemaBinder;
+public final class PgCatalogModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        schemaBinder = MapBinder.newMapBinder(binder(), String.class, SchemaInfo.class);
+        var schemaBinder = MapBinder.newMapBinder(binder(), String.class, SchemaInfo.class);
         schemaBinder.addBinding(PgCatalogSchemaInfo.NAME).to(PgCatalogSchemaInfo.class).asEagerSingleton();
         bind(PgCatalogTableDefinitions.class).asEagerSingleton();
     }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -45,7 +45,7 @@ import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionTable;
 import io.crate.statistics.TableStats;
 
 @Singleton
-public class PgCatalogSchemaInfo implements SchemaInfo {
+public final class PgCatalogSchemaInfo implements SchemaInfo {
 
     public static final String NAME = "pg_catalog";
     private final Map<String, TableInfo> tableInfoMap;

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -48,7 +48,7 @@ import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionTable;
 import io.crate.statistics.TableStats;
 import io.crate.user.Privilege;
 
-public class PgCatalogTableDefinitions {
+public final class PgCatalogTableDefinitions {
 
     private final Map<RelationName, StaticTableDefinition<?>> tableDefinitions;
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
@@ -35,10 +35,12 @@ import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 import static io.crate.types.DataTypes.REGCLASS;
 
-public class PgClassTable {
+public final class PgClassTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_class");
     private static final String PERSISTENCE_PERMANENT = "p";
+
+    private PgClassTable() {}
 
     public static SystemTable<Entry> create(TableStats tableStats) {
         return SystemTable.<Entry>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
@@ -24,6 +24,7 @@ package io.crate.metadata.pgcatalog;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.statistics.TableStats;
+import io.crate.types.DataTypes;
 import io.crate.types.Regclass;
 
 import static io.crate.types.DataTypes.BOOLEAN;
@@ -72,8 +73,9 @@ public class PgClassTable {
             .add("relispartition", BOOLEAN, x -> false)
             .add("relfrozenxid", INTEGER,x -> 0)
             .add("relminmxid", INTEGER, x -> 0)
-            .startObjectArray("relacl", x -> null)
-            .endObjectArray()
+            // should be `aclitem[]` but we lack `aclitem`, so going with same choice that Cockroach made:
+            // https://github.com/cockroachdb/cockroach/blob/45deb66abbca3aae56bd27910a36d90a6a8bcafe/pkg/sql/vtable/pg_catalog.go#L181
+            .add("relacl", DataTypes.STRING_ARRAY, ignored -> null)
             .add("reloptions", STRING_ARRAY, x -> null)
             .add("relpartbound", STRING, x -> null)
             .build();

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgConstraintTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgConstraintTable.java
@@ -35,12 +35,14 @@ import io.crate.metadata.SystemTable;
 import io.crate.metadata.table.ConstraintInfo;
 import io.crate.types.DataTypes;
 
-public class PgConstraintTable {
+public final class PgConstraintTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_constraint");
 
     private static final String NO_ACTION = "a";
     private static final String MATCH_SIMPLE = "s";
+
+    private PgConstraintTable() {}
 
     public static SystemTable<ConstraintInfo> create() {
         return SystemTable.<ConstraintInfo>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCursors.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCursors.java
@@ -31,6 +31,8 @@ public final class PgCursors {
     public static final String NAME = "pg_cursors";
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, NAME);
 
+    private PgCursors() {}
+
     public static SystemTable<Cursor> create() {
         return SystemTable.<Cursor>builder(IDENT)
             .add("name", DataTypes.STRING, Cursor::name)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
@@ -30,9 +30,11 @@ import io.crate.Constants;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 
-public class PgDatabaseTable {
+public final class PgDatabaseTable {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_database");
+
+    private PgDatabaseTable() {}
 
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(NAME)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgDatabaseTable.java
@@ -50,6 +50,8 @@ public class PgDatabaseTable {
             .add("datfrozenxid", INTEGER, c -> null)
             .add("datminmxid", INTEGER, c -> null)
             .add("dattablespace", INTEGER, c -> null)
+            // should be `aclitem[]` but we lack `aclitem`, so going with same choice that Cockroach made:
+            // https://github.com/cockroachdb/cockroach/blob/45deb66abbca3aae56bd27910a36d90a6a8bcafe/pkg/sql/vtable/pg_catalog.go#L277
             .add("datacl", STRING_ARRAY, c -> null)
             .build();
     }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgDescriptionTable.java
@@ -31,6 +31,8 @@ public final class PgDescriptionTable {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_description");
 
+    private PgDescriptionTable() {}
+
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(NAME)
             .add("objoid", INTEGER, c -> null)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgEnumTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgEnumTable.java
@@ -32,6 +32,8 @@ public final class PgEnumTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_enum");
 
+    private PgEnumTable() {}
+
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)
             .add("oid", INTEGER, ignored -> null)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
@@ -34,9 +34,11 @@ import static io.crate.types.DataTypes.SHORT_ARRAY;
 import static io.crate.types.DataTypes.REGCLASS;
 import static io.crate.types.DataTypes.STRING;
 
-public class PgIndexTable {
+public final class PgIndexTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_index");
+
+    private PgIndexTable() {}
 
     public static SystemTable<Entry> create() {
         return SystemTable.<Entry>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexesTable.java
@@ -25,9 +25,11 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.types.DataTypes;
 
-public class PgIndexesTable {
+public final class PgIndexesTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_indexes");
+
+    private PgIndexesTable() {}
 
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgLocksTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgLocksTable.java
@@ -25,9 +25,11 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.types.DataTypes;
 
-public class PgLocksTable {
+public final class PgLocksTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_locks");
+
+    private PgLocksTable() {}
 
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
@@ -30,9 +30,11 @@ import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class PgNamespaceTable {
+public final class PgNamespaceTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_namespace");
+
+    private PgNamespaceTable() {}
 
     public static SystemTable<SchemaInfo> create() {
         return SystemTable.<SchemaInfo>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgNamespaceTable.java
@@ -24,12 +24,11 @@ package io.crate.metadata.pgcatalog;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.metadata.table.SchemaInfo;
-import io.crate.types.ArrayType;
-import io.crate.types.DataTypes;
 
 import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.STRING_ARRAY;
 
 public class PgNamespaceTable {
 
@@ -40,7 +39,9 @@ public class PgNamespaceTable {
             .add("oid", INTEGER, s -> schemaOid(s.name()))
             .add("nspname", STRING, SchemaInfo::name)
             .add("nspowner", INTEGER, c -> 0)
-            .add("nspacl", new ArrayType<>(DataTypes.UNTYPED_OBJECT), c -> null)
+            // should be `aclitem[]` but we lack `aclitem`, so going with same choice that Cockroach made:
+            // https://github.com/cockroachdb/cockroach/blob/45deb66abbca3aae56bd27910a36d90a6a8bcafe/pkg/sql/vtable/pg_catalog.go#L508
+            .add("nspacl", STRING_ARRAY, c -> null)
             .build();
     }
 }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -107,6 +107,8 @@ public class PgProcTable {
             .add("prosrc", STRING, x -> x.functionName.name())
             .add("probin", STRING, x -> null)
             .add("proconfig", STRING_ARRAY, x -> null)
+            // should be `aclitem[]` but we lack `aclitem`, so going with same choice that Cockroach made:
+            // https://github.com/cockroachdb/cockroach/blob/45deb66abbca3aae56bd27910a36d90a6a8bcafe/pkg/sql/vtable/pg_catalog.go#L608
             .add("proacl", STRING_ARRAY, x -> null)
             .build();
     }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -49,11 +49,13 @@ import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.STRING_ARRAY;
 
-public class PgProcTable {
+public final class PgProcTable {
 
     public static final RelationName IDENT = new RelationName(
         PgCatalogSchemaInfo.NAME,
         "pg_proc");
+
+    private PgProcTable() {}
 
     public static SystemTable<Entry> create() {
         return SystemTable.<Entry>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRangeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRangeTable.java
@@ -30,6 +30,8 @@ public final class PgRangeTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_range");
 
+    private PgRangeTable() {}
+
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)
             .add("rngtypid", INTEGER, ignored -> null)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
@@ -34,6 +34,8 @@ public final class PgRolesTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_roles");
 
+    private PgRolesTable() {}
+
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)
             .add("oid", INTEGER, ignored -> null)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgSettingsTable.java
@@ -31,9 +31,11 @@ import io.crate.metadata.SystemTable;
 import io.crate.metadata.settings.session.NamedSessionSetting;
 
 
-public class PgSettingsTable {
+public final class PgSettingsTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_settings");
+
+    private PgSettingsTable() {}
 
     public static SystemTable<NamedSessionSetting> create() {
         return SystemTable.<NamedSessionSetting>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgShdescriptionTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgShdescriptionTable.java
@@ -31,6 +31,8 @@ public final class PgShdescriptionTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_shdescription");
 
+    private PgShdescriptionTable() {}
+
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)
             .add("objoid", INTEGER, c -> null)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgStatsTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgStatsTable.java
@@ -29,9 +29,11 @@ import io.crate.statistics.ColumnStatsEntry;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 
-public class PgStatsTable {
+public final class PgStatsTable {
 
     public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_stats");
+
+    private PgStatsTable() {}
 
     public static SystemTable<ColumnStatsEntry> create() {
         return SystemTable.<ColumnStatsEntry>builder(NAME)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgTablesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgTablesTable.java
@@ -33,6 +33,8 @@ public final class PgTablesTable {
     public static final String NAME = "pg_tables";
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, NAME);
 
+    private PgTablesTable() {}
+
     public static SystemTable<TableInfo> create() {
         return SystemTable.<TableInfo>builder(IDENT)
             .add("schemaname", STRING, r -> r.ident().schema())

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgTablespaceTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgTablespaceTable.java
@@ -29,6 +29,8 @@ public final class PgTablespaceTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_tablespace");
 
+    private PgTablespaceTable() {}
+
     public static SystemTable<Void> create() {
         return SystemTable.<Void>builder(IDENT)
             .add("oid", DataTypes.INTEGER, ignored -> null)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
@@ -32,11 +32,13 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.protocols.postgres.types.PGType;
 
-public class PgTypeTable {
+public final class PgTypeTable {
 
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, "pg_type");
 
     private static final Integer TYPE_NAMESPACE_OID = schemaOid(PgCatalogSchemaInfo.NAME);
+
+    private PgTypeTable() {}
 
     public static SystemTable<PGType<?>> create() {
         return SystemTable.<PGType<?>>builder(IDENT)

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgViewsTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgViewsTable.java
@@ -33,6 +33,8 @@ public final class PgViewsTable {
     public static final String NAME = "pg_views";
     public static final RelationName IDENT = new RelationName(PgCatalogSchemaInfo.NAME, NAME);
 
+    private PgViewsTable() {}
+
     public static SystemTable<ViewInfo> create() {
         return SystemTable.<ViewInfo>builder(IDENT)
             .add("schemaname", STRING, r -> r.ident().schema())


### PR DESCRIPTION
- To be consisent in all tables regarding acl columns, changed
``pg_attribute.spcacl``, ``pg_class.relacl`` and ``pg_namespace.nspacl``
columns type from ``OBJECT[]`` to ``STRING[]``.

- Minor code improvements for pg_catalog tables: make all classes final and add the private ctor to prevent instantiation.


Relates: #13418
Follows: #13420
