### PR TITLE
Move hash-join swap logic into optimizer rule

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -109,6 +109,7 @@ import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteNestedLoopJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
+import io.crate.planner.optimizer.rule.SwapHashJoin;
 import io.crate.types.DataTypes;
 
 /**
@@ -147,7 +148,8 @@ public class LogicalPlanner {
         new OptimizeCollectWhereClauseAccess(),
         new RewriteGroupByKeysLimitToLimitDistinct(),
         new MoveConstantJoinConditionsBeneathNestedLoop(),
-        new RewriteNestedLoopJoinToHashJoin()
+        new RewriteNestedLoopJoinToHashJoin(),
+        new SwapHashJoin()
     );
 
     public static final List<Rule<?>> FETCH_OPTIMIZER_RULES = List.of(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -104,7 +104,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
             return new HashJoin(
                 newLhs,
                 newRhs,
-                AndOperator.join(nonConstantConditions)
+                AndOperator.join(nonConstantConditions),
+                false
             );
         }
     }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -190,6 +190,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.| NULL| NULL",
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
+            "optimizer_swap_hash_join| true| Indicates if the optimizer rule SwapHashJoin is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
             "server_version| 14.0| Reports the emulated PostgreSQL version number| NULL| NULL",
             "server_version_num| 140000| Reports the emulated PostgreSQL version number| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -429,6 +429,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.",
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
+            "optimizer_swap_hash_join| true| Indicates if the optimizer rule SwapHashJoin is activated.",
             "search_path| doc| Sets the schema search order.",
             "server_version| 14.0| Reports the emulated PostgreSQL version number",
             "server_version_num| 140000| Reports the emulated PostgreSQL version number",

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -309,13 +309,15 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(100, 0, Map.of()));
         e.updateTableStats(rowCountByTable);
 
-        LogicalPlan operator = createLogicalPlan(mss);
-        assertThat(operator).isExactlyInstanceOf(HashJoin.class);
-        assertThat(((HashJoin) operator).rhs().getRelationNames())
-            .as("Smaller table must be on the right-hand-side")
+        LogicalPlan eval = createLogicalPlan(mss);
+        assertThat(eval).isExactlyInstanceOf(Eval.class);
+        LogicalPlan hashjoin = eval.sources().get(0);
+        assertThat(hashjoin).isExactlyInstanceOf(HashJoin.class);
+        assertThat(((HashJoin) hashjoin).lhs().getRelationNames())
+            .as("Smaller table must be on the left-hand-side")
             .containsExactly(TEST_DOC_LOCATIONS_TABLE_IDENT);
 
-        Join join = buildJoin(operator);
+        Join join = buildJoin(hashjoin);
         assertThat(((Collect) join.left()).collectPhase().toCollect().get(1)).isReference("loc");
     }
 

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -87,7 +87,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
+        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"), false);
         assertThat(hashJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -203,7 +203,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
             )
         );
 
-        var hashjoin = new HashJoin(lhs, rhs, x);
+        var hashjoin = new HashJoin(lhs, rhs, x, false);
 
         var memo = new Memo(hashjoin);
         PlanStats planStats = new PlanStats(tableStats, memo);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds a rule to the optimizer to swap the smaller table to the right and removes the logic from the hash-join logical plan. 

Relates to https://github.com/crate/crate/issues/13501


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
