### PR TITLE
Support updating array elements

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -183,6 +183,8 @@ Changes
 
 - Added :ref:`array_set <scalar-array_set>` scalar function.
 
+- Added support for updating arrays by elements.
+
 Fixes
 =====
 

--- a/server/src/test/java/io/crate/expression/scalar/ArraySetFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySetFunctionTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -148,5 +149,14 @@ public class ArraySetFunctionTest extends ScalarTestCase {
         assertThatThrownBy(() -> assertEvaluateNull("array_set([1,2,3], [1], ['a'])"))
             .isExactlyInstanceOf(ConversionException.class)
             .hasMessage("Cannot cast `'a'` of type `text` to type `integer`");
+    }
+
+    @Test
+    public void test_set_elements_of_object_array() {
+        assertEvaluate("array_set([{a=1},{a=2}], [1,2,3], [{b=1},{b=2},{b=3}])",
+                       List.of(Map.of("b", 1),
+                               Map.of("b", 2),
+                               Map.of("b", 3)));
+        assertEvaluate("array_set([{a=1},{c='c'}]['a'], [1,2], [100,200])", List.of(100, 200));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves #13649

Updating object arrays' elements is still not supported but updating object arrays' objects is supported.
```
cr> create table t (o array(object as (a int)));                                                                                                  
CREATE OK, 1 row affected  (1.582 sec)
cr> insert into t values ([{a=1}]);                                                                                                               
INSERT OK, 1 row affected  (0.048 sec)
cr> update t set o['a'] = 3;                                                                                                                      
SQLParseException[Updating fields of object arrays is not supported]
cr> update t set o['a'][1] = 3;                                                                                                                   
SQLParseException[Updating fields of object arrays is not supported]
cr> update t set o[1] = {a=3};                                                                                                                    
UPDATE OK, 1 row affected  (0.045 sec)
cr> select * from t;                                                                                                                              
+------------+
| o          |
+------------+
| [{"a": 3}] |
+------------+
SELECT 1 row in set (0.002 sec)
```

This feature depends on [array_set](https://github.com/crate/crate/pull/14229) function so its limitations are carried over, which are:

1) negative indexes are rejected currently.
2) there is no circuit breaker in place for a large update resulting in out of memory error - ex) `update t set a[2147483647] = 1` (which adds a huge null padding). 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
