### PR TITLE
Fix source columns building in BWC branch

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -497,10 +497,10 @@ public class DocIndexMetadata {
                         ColumnIdent targetIdent = ColumnIdent.fromPath(copyToColumn);
                         IndexReference.Builder builder = getOrCreateIndexBuilder(targetIdent);
                         builder.addColumn(new SimpleReference(
-                            refIdent(targetIdent),
-                            granularity(targetIdent),
+                            refIdent(newIdent),
+                            granularity(newIdent),
                             columnDataType,
-                            columnPolicy,
+                            ColumnPolicy.DYNAMIC,
                             columnIndexType,
                             nullable,
                             hasDocValues,

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -1686,4 +1686,31 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         indexReference = md.indices().get(new ColumnIdent("ft"));
         assertThat(indexReference.columns().get(0).isNullable()).isFalse();
     }
+
+    @Test
+    public void test_copy_to_ft_refers_to_sources() throws Exception {
+        XContentBuilder builder = JsonXContent.builder()
+            .startObject()
+            .startObject("properties")
+            .startObject("description")
+            .field("type", "string")
+            .field("position", 1)
+            .array("copy_to", "description_ft")
+            .endObject()
+            .startObject("description_ft")
+            .field("type", "string")
+            .field("position", 2)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        IndexMetadata metadata = getIndexMetadata("test1", builder);
+        DocIndexMetadata md = newMeta(metadata, "test1");
+
+        assertThat(md.indices()).hasSize(1);
+        IndexReference ref = md.indices().values().iterator().next();
+        assertThat(ref.columns()).satisfiesExactly(
+            x -> Asserts.assertThat(x).isReference("description")
+        );
+    }
 }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/f0c4e947396abf2d27b7b2c612733149ff509c3b

^ worked on master since it's already 5.4 and it doesn't have copy_to. 

In 5.3 backport PR this bug was hit (and can happen in rolling upgrades). Not backporting since already resolved this in https://github.com/crate/crate/pull/14136

