### PR TITLE
Introduce global column OID counter

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -71,6 +71,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, ToXContentFragment {
 
     private static final Logger LOGGER = LogManager.getLogger(Metadata.class);
+    public static long COLUMN_OID_UNASSIGNED = 0L;
 
     public static final String ALL = "_all";
     public static final String UNKNOWN_CLUSTER_UUID = "_na_";
@@ -141,6 +142,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     private final String clusterUUID;
     private final boolean clusterUUIDCommitted;
     private final long version;
+    private final long columnOID;
 
     private final CoordinationMetadata coordinationMetadata;
 
@@ -165,6 +167,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     Metadata(String clusterUUID,
              boolean clusterUUIDCommitted,
              long version,
+             long columnOID,
              CoordinationMetadata coordinationMetadata,
              Settings transientSettings,
              Settings persistentSettings,
@@ -178,6 +181,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         this.clusterUUID = clusterUUID;
         this.clusterUUIDCommitted = clusterUUIDCommitted;
         this.version = version;
+        this.columnOID = columnOID;
         this.coordinationMetadata = coordinationMetadata;
         this.transientSettings = transientSettings;
         this.persistentSettings = persistentSettings;
@@ -218,6 +222,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     public long version() {
         return this.version;
+    }
+
+    public long columnOID() {
+        return this.columnOID;
     }
 
     public String clusterUUID() {
@@ -429,6 +437,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     private static class MetadataDiff implements Diff<Metadata> {
 
         private final long version;
+        private final long columnOID;
 
         private final String clusterUUID;
         private final boolean clusterUUIDCommitted;
@@ -443,6 +452,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             clusterUUID = after.clusterUUID;
             clusterUUIDCommitted = after.clusterUUIDCommitted;
             version = after.version;
+            columnOID = after.columnOID;
             coordinationMetadata = after.coordinationMetadata;
             transientSettings = after.transientSettings;
             persistentSettings = after.persistentSettings;
@@ -460,6 +470,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             clusterUUID = in.readString();
             clusterUUIDCommitted = in.readBoolean();
             version = in.readLong();
+            if (in.getVersion().onOrAfter(Version.V_5_4_0)) {
+                columnOID = in.readLong();
+            } else {
+                columnOID = COLUMN_OID_UNASSIGNED;
+            }
             coordinationMetadata = new CoordinationMetadata(in);
             transientSettings = Settings.readSettingsFromStream(in);
             persistentSettings = Settings.readSettingsFromStream(in);
@@ -473,6 +488,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             out.writeString(clusterUUID);
             out.writeBoolean(clusterUUIDCommitted);
             out.writeLong(version);
+            if (out.getVersion().onOrAfter(Version.V_5_4_0)) {
+                out.writeLong(columnOID);
+            }
             coordinationMetadata.writeTo(out);
             Settings.writeSettingsToStream(transientSettings, out);
             Settings.writeSettingsToStream(persistentSettings, out);
@@ -487,6 +505,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             builder.clusterUUID(clusterUUID);
             builder.clusterUUIDCommitted(clusterUUIDCommitted);
             builder.version(version);
+            builder.columnOID(columnOID);
             builder.coordinationMetadata(coordinationMetadata);
             builder.transientSettings(transientSettings);
             builder.persistentSettings(persistentSettings);
@@ -500,6 +519,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     public static Metadata readFrom(StreamInput in) throws IOException {
         Builder builder = new Builder();
         builder.version = in.readLong();
+        if (in.getVersion().onOrAfter(Version.V_5_4_0)) {
+            builder.columnOID = in.readLong();
+        } else {
+            builder.columnOID = COLUMN_OID_UNASSIGNED;
+        }
         builder.clusterUUID = in.readString();
         builder.clusterUUIDCommitted = in.readBoolean();
         builder.coordinationMetadata(new CoordinationMetadata(in));
@@ -524,6 +548,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeLong(version);
+        if (out.getVersion().onOrAfter(Version.V_5_4_0)) {
+            out.writeLong(columnOID);
+        }
         out.writeString(clusterUUID);
         out.writeBoolean(clusterUUIDCommitted);
         coordinationMetadata.writeTo(out);
@@ -565,7 +592,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         private String clusterUUID;
         private boolean clusterUUIDCommitted;
         private long version;
-
+        private long columnOID;
         private CoordinationMetadata coordinationMetadata = CoordinationMetadata.EMPTY_METADATA;
         private Settings transientSettings = Settings.Builder.EMPTY_SETTINGS;
         private Settings persistentSettings = Settings.Builder.EMPTY_SETTINGS;
@@ -589,6 +616,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             this.transientSettings = metadata.transientSettings;
             this.persistentSettings = metadata.persistentSettings;
             this.version = metadata.version;
+            this.columnOID = metadata.columnOID;
             this.indices = ImmutableOpenMap.builder(metadata.indices);
             this.templates = ImmutableOpenMap.builder(metadata.templates);
             this.customs = ImmutableOpenMap.builder(metadata.customs);
@@ -746,6 +774,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
+        public Builder columnOID(long columnOID) {
+            this.columnOID = columnOID;
+            return this;
+        }
+
         public Builder clusterUUID(String clusterUUID) {
             this.clusterUUID = clusterUUID;
             return this;
@@ -813,7 +846,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             String[] allOpenIndicesArray = allOpenIndices.toArray(new String[allOpenIndices.size()]);
             String[] allClosedIndicesArray = allClosedIndices.toArray(new String[allClosedIndices.size()]);
 
-            return new Metadata(clusterUUID, clusterUUIDCommitted, version, coordinationMetadata, transientSettings, persistentSettings,
+            return new Metadata(clusterUUID, clusterUUIDCommitted, version, columnOID, coordinationMetadata, transientSettings, persistentSettings,
                                 indices.build(), templates.build(), customs.build(), allIndicesArray, allOpenIndicesArray, allClosedIndicesArray,
                                 aliasAndIndexLookup);
         }
@@ -846,6 +879,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             builder.startObject("meta-data");
 
             builder.field("version", metadata.version());
+            builder.field("column_oid", metadata.columnOID());
             builder.field("cluster_uuid", metadata.clusterUUID);
             builder.field("cluster_uuid_committed", metadata.clusterUUIDCommitted);
 
@@ -950,6 +984,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 } else if (token.isValue()) {
                     if ("version".equals(currentFieldName)) {
                         builder.version = parser.longValue();
+                    } else if ("column_oid".equals(currentFieldName)) {
+                        builder.columnOID = parser.longValue();
                     } else if ("cluster_uuid".equals(currentFieldName) || "uuid".equals(currentFieldName)) {
                         builder.clusterUUID = parser.text();
                     } else if ("cluster_uuid_committed".equals(currentFieldName)) {

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -58,4 +58,18 @@ public class XContentMapValues {
     public static boolean nodeBooleanValue(Object node) {
         return Booleans.parseBoolean(node.toString());
     }
+
+    public static long nodeLongValue(Object node) {
+        if (node instanceof Number) {
+            return Numbers.toLongExact((Number) node);
+        }
+        return Long.parseLong(node.toString());
+    }
+
+    public static long nodeLongValue(Object node, long defaultValue) {
+        if (node == null) {
+            return defaultValue;
+        }
+        return nodeLongValue(node);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
@@ -79,11 +79,12 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
 
     ArrayMapper(String simpleName,
                 int position,
+                long columnOID,
                 @Nullable String defaultExpression,
                 FieldType fieldType,
                 MappedFieldType defaultFieldType,
                 Mapper innerMapper) {
-        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, CopyTo.empty());
+        super(simpleName, position, columnOID, defaultExpression, fieldType, defaultFieldType, CopyTo.empty());
         this.innerMapper = innerMapper;
     }
 
@@ -113,6 +114,7 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
             return new ArrayMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 mappedFieldType,

--- a/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
@@ -43,6 +43,7 @@ public class BitStringFieldMapper extends FieldMapper {
 
     protected BitStringFieldMapper(String simpleName,
                                    int position,
+                                   long columnOID,
                                    Integer length,
                                    String defaultExpression,
                                    FieldType fieldType,
@@ -51,6 +52,7 @@ public class BitStringFieldMapper extends FieldMapper {
         super(
             simpleName,
             position,
+            columnOID,
             defaultExpression,
             fieldType,
             mappedFieldType,
@@ -99,6 +101,7 @@ public class BitStringFieldMapper extends FieldMapper {
             var mapper = new BitStringFieldMapper(
                 name,
                 position,
+                columnOID,
                 length,
                 defaultExpression,
                 fieldType,

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -71,6 +71,7 @@ public class BooleanFieldMapper extends FieldMapper {
             var mapper = new BooleanFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 new BooleanFieldType(buildFullName(context), indexed, hasDocValues),
@@ -107,11 +108,12 @@ public class BooleanFieldMapper extends FieldMapper {
 
     protected BooleanFieldMapper(String simpleName,
                                  int position,
+                                 long columnOID,
                                  @Nullable String defaultExpression,
                                  FieldType fieldType,
                                  MappedFieldType defaultFieldType,
                                  CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, defaultFieldType, copyTo);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
@@ -53,6 +53,7 @@ public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
             return new ArrayMapper(
                 name,
                 innerFieldMapper.position(),
+                innerFieldMapper.columnOID(),
                 null,
                 innerFieldMapper.fieldType,
                 mappedFieldType,

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -94,6 +94,7 @@ public class DateFieldMapper extends FieldMapper {
             var mapper = new DateFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 ft,
@@ -157,12 +158,13 @@ public class DateFieldMapper extends FieldMapper {
     private DateFieldMapper(
             String simpleName,
             int position,
+            long columnOID,
             @Nullable String defaultExpression,
             FieldType fieldType,
             MappedFieldType mappedFieldType,
             Boolean ignoreTimezone,
             CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, mappedFieldType, copyTo);
         this.ignoreTimezone = ignoreTimezone;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -37,6 +37,8 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 public abstract class FieldMapper extends Mapper implements Cloneable {
 
     public abstract static class Builder<T extends Builder<T>> extends Mapper.Builder<T> {
@@ -103,12 +105,14 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     protected FieldMapper(String simpleName,
                           int position,
+                          long columnOID,
                           @Nullable String defaultExpression,
                           FieldType fieldType,
                           MappedFieldType mappedFieldType,
                           CopyTo copyTo) {
         super(simpleName);
         this.position = position;
+        this.columnOID = columnOID;
         this.defaultExpression = defaultExpression;
         if (mappedFieldType.name().isEmpty()) {
             throw new IllegalArgumentException("name cannot be empty string");
@@ -121,6 +125,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     public int position() {
         return position;
+    }
+
+    public long columnOID() {
+        return columnOID;
     }
 
     @Override
@@ -312,6 +320,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
         if (includeDefaults || fieldType.stored() != storedByDefault()) {
             builder.field("store", fieldType.stored());
+        }
+
+        if (columnOID != COLUMN_OID_UNASSIGNED) {
+            builder.field("oid", columnOID);
         }
 
         copyTo.toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -71,6 +71,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
             var mapper = new GeoPointFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 ft,
@@ -93,11 +94,12 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
 
     public GeoPointFieldMapper(String simpleName,
                                int position,
+                               long columnOID,
                                @Nullable String defaultExpression,
                                FieldType fieldType,
                                MappedFieldType defaultFieldType,
                                CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, defaultFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, defaultFieldType, copyTo);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.index.mapper;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeLongValue;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -127,6 +129,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
             var mapper = new GeoShapeFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 ft,
@@ -186,6 +189,9 @@ public class GeoShapeFieldMapper extends FieldMapper {
                     iterator.remove();
                 } else if ("position".equals(fieldName)) {
                     builder.position(nodeIntegerValue(fieldNode));
+                    iterator.remove();
+                } else if ("oid".equals(fieldName)) {
+                    builder.columnOID(nodeLongValue(fieldNode));
                     iterator.remove();
                 }
             }
@@ -296,11 +302,12 @@ public class GeoShapeFieldMapper extends FieldMapper {
 
     public GeoShapeFieldMapper(String simpleName,
                                int position,
+                               long columnOID,
                                @Nullable String defaultExpression,
                                FieldType fieldType,
                                MappedFieldType mappedFieldType,
                                CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, mappedFieldType, copyTo);
     }
 
     @Override
@@ -365,6 +372,9 @@ public class GeoShapeFieldMapper extends FieldMapper {
         }
         if (position != NOT_TO_BE_POSITIONED) {
             builder.field("position", position);
+        }
+        if (columnOID != COLUMN_OID_UNASSIGNED) {
+            builder.field("oid", columnOID);
         }
         if (fieldType().treeLevels() != 0) {
             builder.field(Names.TREE_LEVELS, fieldType().treeLevels());

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -63,6 +63,7 @@ public class IpFieldMapper extends FieldMapper {
             var mapper = new IpFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 new IpFieldType(buildFullName(context), indexed, hasDocValues),
@@ -104,11 +105,12 @@ public class IpFieldMapper extends FieldMapper {
     private IpFieldMapper(
             String simpleName,
             int position,
+            long columnOID,
             String defaultExpression,
             FieldType fieldType,
             MappedFieldType mappedFieldType,
             CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, mappedFieldType, copyTo);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -113,6 +113,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             var mapper = new KeywordFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 buildFieldType(context),
@@ -183,6 +184,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     private KeywordFieldMapper(String simpleName,
                                int position,
+                               long columnOID,
                                @Nullable String defaultExpression,
                                FieldType fieldType,
                                MappedFieldType mappedFieldType,
@@ -190,7 +192,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                                Integer lengthLimit,
                                boolean blankPadding,
                                CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, mappedFieldType, copyTo);
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         this.lengthLimit = lengthLimit;
         this.blankPadding = blankPadding;

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -82,6 +82,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
         protected int position;
 
+        protected long columnOID;
+
         public String name() {
             return this.name;
         }
@@ -91,6 +93,10 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
         public void position(int position) {
             this.position = position;
+        }
+
+        public void columnOID(long columnOID) {
+            this.columnOID = columnOID;
         }
     }
 
@@ -147,6 +153,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     private final String simpleName;
 
     protected int position;
+
+    protected long columnOID;
 
     public Mapper(String simpleName) {
         Objects.requireNonNull(simpleName);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 import org.apache.lucene.document.FieldType;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 
 /**
  * A mapper for a builtin field containing metadata about a document.
@@ -63,6 +65,7 @@ public abstract class MetadataFieldMapper extends FieldMapper {
         super(
             mappedFieldType.name(),
             NOT_TO_BE_POSITIONED,
+            COLUMN_OID_UNASSIGNED,
             null,
             fieldType,
             mappedFieldType,

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -73,6 +73,7 @@ public class NumberFieldMapper extends FieldMapper {
             var mapper = new NumberFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 new NumberFieldType(buildFullName(context), type, indexed, hasDocValues),
@@ -467,11 +468,12 @@ public class NumberFieldMapper extends FieldMapper {
     private NumberFieldMapper(
             String simpleName,
             int position,
+            long columnOID,
             @Nullable String defaultExpression,
             FieldType fieldType,
             MappedFieldType mappedFieldType,
             CopyTo copyTo) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, mappedFieldType, copyTo);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
@@ -57,13 +57,14 @@ public class ObjectArrayMapper extends ObjectMapper {
         @Override
         protected ObjectMapper createMapper(String name,
                                             int position,
+                                            long columnOID,
                                             String fullPath,
                                             Dynamic dynamic,
                                             Map<String, Mapper> mappers,
                                             Settings settings) {
             return new ObjectArrayMapper(
                 name,
-                super.createMapper(name, position, fullPath, dynamic, mappers, settings),
+                super.createMapper(name, position, columnOID, fullPath, dynamic, mappers, settings),
                 settings
             );
         }
@@ -74,6 +75,7 @@ public class ObjectArrayMapper extends ObjectMapper {
     ObjectArrayMapper(String name, ObjectMapper innerMapper, Settings settings) {
         super(name,
               innerMapper.position(),
+              innerMapper.columnOID(),
               innerMapper.fullPath(),
               innerMapper.dynamic(),
               Collections.emptyMap(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -19,8 +19,10 @@
 
 package org.elasticsearch.index.mapper;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeLongValue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -97,6 +99,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             var mapper = createMapper(
                 name,
                 position,
+                columnOID,
                 context.path().pathAsText(name),
                 dynamic,
                 mappers,
@@ -112,11 +115,12 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
         protected ObjectMapper createMapper(String name,
                                             int position,
+                                            long columnOID,
                                             String fullPath,
                                             Dynamic dynamic,
                                             Map<String, Mapper> mappers,
                                             @Nullable Settings settings) {
-            return new ObjectMapper(name, position, fullPath, dynamic, mappers, settings);
+            return new ObjectMapper(name, position, columnOID, fullPath, dynamic, mappers, settings);
         }
     }
 
@@ -140,6 +144,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
         protected static boolean parseObjectOrDocumentTypeProperties(String fieldName, Object fieldNode, ParserContext parserContext, ObjectMapper.Builder builder) {
             if (fieldName.equals("position")) {
                 builder.position(nodeIntegerValue(fieldNode));
+                return true;
+            } else if (fieldName.equals("oid")) {
+                builder.columnOID(nodeLongValue(fieldNode));
                 return true;
             } else if (fieldName.equals("dynamic")) {
                 String value = fieldNode.toString();
@@ -234,6 +241,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
     ObjectMapper(String name,
                  int position,
+                 long columnOID,
                  String fullPath,
                  Dynamic dynamic,
                  Map<String, Mapper> mappers,
@@ -245,6 +253,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
         this.fullPath = fullPath;
         this.position = position;
+        this.columnOID = columnOID;
         this.dynamic = dynamic;
         if (mappers == null) {
             this.mappers = new CopyOnWriteHashMap<>();
@@ -350,6 +359,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
     }
 
+    protected long columnOID() {
+        return columnOID;
+    }
+
     protected int position() {
         return position;
     }
@@ -367,6 +380,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
         if (position != NOT_TO_BE_POSITIONED) {
             builder.field("position", position);
+        }
+        if (columnOID != COLUMN_OID_UNASSIGNED) {
+            builder.field("oid", columnOID);
         }
         if (dynamic != null) {
             builder.field("dynamic", dynamic.name().toLowerCase(IsoLocale.ROOT));

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.settings.Settings;
 
 import io.crate.Constants;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 public class RootObjectMapper extends ObjectMapper {
 
     private ColumnPositionResolver<Mapper> columnPositionResolver = new ColumnPositionResolver<>();
@@ -44,7 +46,7 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         @Override
-        protected ObjectMapper createMapper(String name, int position, String fullPath, Dynamic dynamic,
+        protected ObjectMapper createMapper(String name, int position, long columnOID, String fullPath, Dynamic dynamic,
                 Map<String, Mapper> mappers, Settings settings) {
             assert name.equals(Constants.DEFAULT_MAPPING_TYPE) : "Name of root mapper must match `default`: " + name;
             return new RootObjectMapper(
@@ -78,7 +80,7 @@ public class RootObjectMapper extends ObjectMapper {
                      Dynamic dynamic,
                      Map<String, Mapper> mappers,
                      Settings settings) {
-        super(name, NOT_TO_BE_POSITIONED, name, dynamic, mappers, settings);
+        super(name, NOT_TO_BE_POSITIONED, COLUMN_OID_UNASSIGNED, name, dynamic, mappers, settings);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -161,6 +161,7 @@ public class TextFieldMapper extends FieldMapper {
             var mapper = new TextFieldMapper(
                 name,
                 position,
+                columnOID,
                 defaultExpression,
                 fieldType,
                 tft,
@@ -208,12 +209,13 @@ public class TextFieldMapper extends FieldMapper {
 
     protected TextFieldMapper(String simpleName,
                               int position,
+                              long columnOID,
                               String defaultExpression,
                               FieldType fieldType,
                               TextFieldType mappedFieldType,
                               CopyTo copyTo,
                               List<String> sources) {
-        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, copyTo);
+        super(simpleName, position, columnOID, defaultExpression, fieldType, mappedFieldType, copyTo);
         assert mappedFieldType.hasDocValues() == false;
         this.sources = sources;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeLongValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeStringValue;
 
 import java.util.ArrayList;
@@ -32,6 +33,8 @@ import org.apache.lucene.index.IndexOptions;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 public class TypeParsers {
 
@@ -192,6 +195,9 @@ public class TypeParsers {
                 iterator.remove();
             } else if (propName.equals("default_expr")) {
                 builder.defaultExpression(nodeStringValue(propNode, null));
+                iterator.remove();
+            } else if (propName.equals("oid")) {
+                builder.columnOID(nodeLongValue(propNode, COLUMN_OID_UNASSIGNED));
                 iterator.remove();
             }
         }


### PR DESCRIPTION
Taking first 2 commits from https://github.com/crate/crate/pull/14142 to keep it smaller. This is a feature branch, will adjust later if anything is needed.

Naming: I use `column_oid` in Metadata as we [discussed](https://crate.slack.com/archives/CBPLN6WJK/p1678455308356469?thread_ts=1678446209.842239&cid=CBPLN6WJK) internally that PG doesn't expose column oid. We will later introduce global oid for everything but columns will have their own. In FieldMappers (and later in Reference/mapping) I use "oid" since in the context of a column It's clear that it's column oid.





