### PR TITLE
Add caching to plan stats

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -160,7 +160,7 @@ public class Session implements AutoCloseable {
     private final boolean isReadOnly;
     private final ParameterTypeExtractor parameterTypeExtractor;
     private final Runnable onClose;
-    private final PlanStats planStats;
+    private final TableStats tableStats;
 
     private TransactionState currentTransactionState = TransactionState.IDLE;
 
@@ -184,7 +184,7 @@ public class Session implements AutoCloseable {
         this.isReadOnly = isReadOnly;
         this.executor = executor;
         this.sessionSettings = sessionSettings;
-        this.planStats = new PlanStats(tableStats);
+        this.tableStats = tableStats;
         this.parameterTypeExtractor = new ParameterTypeExtractor();
         this.onClose = onClose;
     }
@@ -226,7 +226,7 @@ public class Session implements AutoCloseable {
             params,
             cursors,
             currentTransactionState,
-            planStats
+            new PlanStats(tableStats)
         );
         Plan plan;
         try {
@@ -280,7 +280,7 @@ public class Session implements AutoCloseable {
             params,
             cursors,
             currentTransactionState,
-            planStats
+            new PlanStats(tableStats)
         );
         Plan plan = planner.plan(stmt, plannerContext);
         plan.execute(executor, plannerContext, consumer, params, SubQueryResults.EMPTY);
@@ -662,7 +662,7 @@ public class Session implements AutoCloseable {
             null,
             cursors,
             currentTransactionState,
-            planStats
+            new PlanStats(tableStats)
         );
 
         PreparedStmt firstPreparedStatement = toExec.get(0).portal().preparedStmt();
@@ -750,7 +750,7 @@ public class Session implements AutoCloseable {
             params,
             cursors,
             currentTransactionState,
-            planStats
+            new PlanStats(tableStats)
         );
         var analyzedStmt = portal.analyzedStatement();
         String rawStatement = portal.preparedStmt().rawStatement();


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds caching for Stats for Logical Plans. Stats for Group References
are already stored and cached in the Memo, this adds caching for the rest
of the plans.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
