### PR TITLE
Fixed a race condition issue when accessing S3 repositories

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -252,3 +252,5 @@ Fixes
 - Fixed an issue that caused the default expressions on columns of type
   ``GEO_SHAPE`` to be ignored on writes.
 
+- Fixed a race condition issue while concurrently accessing S3 repositories
+  with different settings, e.g. by queries against ``sys.snapshots``.

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -19,17 +19,6 @@
 
 package org.elasticsearch.repositories.s3;
 
-import com.amazonaws.Protocol;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.BasicSessionCredentials;
-import javax.annotation.Nullable;
-import org.elasticsearch.common.settings.SecureString;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
-
-import java.util.Objects;
-
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.ACCESS_KEY_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.ENDPOINT_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.MAX_RETRIES_SETTING;
@@ -42,6 +31,19 @@ import static org.elasticsearch.repositories.s3.S3RepositorySettings.READ_TIMEOU
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SECRET_KEY_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SESSION_TOKEN_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.USE_THROTTLE_RETRIES_SETTING;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 
 /**
  * A container for settings used to create an S3 client.
@@ -176,6 +178,21 @@ final class S3ClientSettings {
                Objects.equals(proxyHost, that.proxyHost) &&
                Objects.equals(proxyUsername, that.proxyUsername) &&
                Objects.equals(proxyPassword, that.proxyPassword);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(credentials.getAWSAccessKeyId(),
+                            credentials.getAWSSecretKey(),
+                            endpoint,
+                            protocol,
+                            proxyHost,
+                            proxyPort,
+                            proxyUsername,
+                            proxyPassword,
+                            readTimeoutMillis,
+                            maxRetries,
+                            throttleRetries);
     }
 
     private boolean compareCredentials(@Nullable AWSCredentials first, @Nullable AWSCredentials second) {

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -24,9 +24,19 @@ package org.elasticsearch.repositories.s3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,19 +44,26 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
 import io.crate.exceptions.InvalidArgumentException;
 
 public class AwsS3ServiceImplTests extends ESTestCase {
 
     private S3Service service;
+    private ExecutorService executor;
 
     @Before
     public void beforeTest() {
         service = new S3Service();
+        executor = Executors.newFixedThreadPool(100);
     }
 
-    public void afterTest() {
+    @After
+    public void afterTest() throws Exception {
+        executor.shutdown();
+        executor.awaitTermination(500, TimeUnit.MILLISECONDS);
         service.close();
         service = null;
     }
@@ -93,6 +110,67 @@ public class AwsS3ServiceImplTests extends ESTestCase {
 
         clientRef.client().shutdown();
         newClientRef.client().shutdown();
+    }
+
+    /**
+     * Tests a regression where wrong clients were returned from a local cache.
+     * Repeat it in order to catch at least one failure.
+     */
+    @Repeat(iterations = 30)
+    @Test
+    public void test_concurrent_repro_access_does_not_return_wrong_client() throws Exception {
+        Settings settings1 = Settings.builder()
+                .put("access_key", "repo1_access_key")
+                .put("secret_key", "repo1_secret_key")
+                .build();
+
+        Settings settings2 = Settings.builder()
+                .put("access_key", "repo2_access_key")
+                .put("secret_key", "repo2_secret_key")
+                .build();
+
+        RepositoryMetadata metadata1 = new RepositoryMetadata("repo1", "", settings1);
+        RepositoryMetadata metadata2 = new RepositoryMetadata("repo2", "", settings2);
+
+        // high number of threads are required to let if fail reliably on the old buggy code
+        int numThreads = 100;
+        final CyclicBarrier barrier = new CyclicBarrier(1 + numThreads);
+        AtomicReference<AmazonS3> clientRef1 = new AtomicReference<>();
+        AtomicReference<AmazonS3> clientRef2 = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+
+        for (int i = 0; i < numThreads; i++) {
+            if (i % 2 == 0) {
+                executor.submit(() -> {
+                    try {
+                        barrier.await();
+                    } catch (final BrokenBarrierException | InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    var clientRef = service.client(metadata1);
+                    clientRef1.set(clientRef.client());
+                    latch.countDown();
+                    clientRef.close();
+                });
+            } else {
+                executor.submit(() -> {
+                    try {
+                        barrier.await();
+                    } catch (final BrokenBarrierException | InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    var clientRef = service.client(metadata2);
+                    clientRef2.set(clientRef.client());
+                    latch.countDown();
+                    clientRef.close();
+                });
+            }
+
+        }
+        barrier.await();
+        latch.await();
+
+        assertThat(clientRef1.get()).isNotEqualTo(clientRef2.get());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
S3 clients are cached and reused to improve performance as such HTTP connection pools are used.
This will fix an existing race condition, a cached client could have changed after verifying it's cached settings, introduced by https://github.com/crate/crate/commit/7f1fb8713ac1ab02007b7635bef3b969022e525b

Additionally, this will (re-)introduce caching multiple different clients, just caching the actual used client may not result in wanted behaviour as the cache may overwritten immediately when accessing multiple repositories.

Fixes #13743.
