### PR TITLE
Adjust allowed array index range from Integer.MIN_VALUE to Integer.MAX_VALUE

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -76,6 +76,12 @@ Breaking Changes
   :ref:`named index column definition <named-index-column>` instead of
   silently ignoring them.
 
+- Adjusted allowed array index range to be from ``Integer.MIN_VALUE`` to
+  ``Integer.MAX_VALUE``. The behavior is now also consistent between subscripts
+  on array literals and on columns, and between index literals and index
+  expressions. That means something like ``tags[-1]`` will now return ``NULL``
+  just like ``ARRAY['AUT', 'GER'][-1]`` or ``ARRAY['AUT', 'GER'][1 - 5]`` did.
+
 
 Deprecations
 ============

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -220,7 +220,7 @@ are likely to be larger due to additional metadata.
         including further child objects.
     * - ``ARRAY``
       - variable
-      - The theoretical maximum length is slightly below Java's ``Integer.MAX_VALUE``.
+      - The theoretical maximum length (number of elements) is slightly below Java's ``Integer.MAX_VALUE``.
       - An array is structured as a sequence of any other type.
     * - ``GEO_POINT``
       - 16 bytes

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -736,8 +736,8 @@ with ``landmarks[n]``, where ``n`` is the integer array index, like so::
 
 .. NOTE::
 
-    The first index value is ``1``. The maximum array index is ``2147483648``.
-    Using an index greater than the array size results in a NULL value.
+    The minimum index value is ``-2147483648``. The maximum array index is
+    ``2147483647``. Using an index out of the range results in an exception.
 
 Individual array elements can also be addressed in the :ref:`where clause
 <sql_dql_where_clause>`, like so::

--- a/server/src/main/java/io/crate/analyze/SubscriptValidator.java
+++ b/server/src/main/java/io/crate/analyze/SubscriptValidator.java
@@ -24,12 +24,10 @@ package io.crate.analyze;
 import io.crate.sql.tree.ArrayLiteral;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Cast;
-import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.LongLiteral;
-import io.crate.sql.tree.NegativeExpression;
 import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedNameReference;
@@ -40,9 +38,13 @@ import io.crate.sql.tree.TryCast;
 
 import java.util.Locale;
 
+/**
+ * NOTE: Array index out of bound validation cannot happen here since array index expressions such as
+ * `-1` or `x + 1` are not yet evaluated. The actual validation is handled by implicit cast of
+ * the array indexes to the target type (integer) of {@link io.crate.expression.scalar.SubscriptFunction}.
+ * See {@link io.crate.analyze.expressions.ExpressionAnalyzer#cast}
+ */
 public final class SubscriptValidator {
-
-    private static final Long MAX_VALUE = Integer.MAX_VALUE + 1L;
 
     private SubscriptValidator() {
     }
@@ -116,12 +118,6 @@ public final class SubscriptValidator {
 
         private static final SubscriptIndexVisitor INSTANCE = new SubscriptIndexVisitor();
 
-        private static void raiseInvalidIndexValue() {
-            throw new UnsupportedOperationException(
-                String.format(Locale.ENGLISH, "Array index must be in range 1 to %s",
-                              MAX_VALUE));
-        }
-
         @Override
         public Void visitParameterExpression(ParameterExpression node, SubscriptContext context) {
             throw new UnsupportedOperationException("Parameter substitution is not supported in subscript index");
@@ -133,35 +129,18 @@ public final class SubscriptValidator {
             return null;
         }
 
-
         @Override
         protected Void visitLongLiteral(LongLiteral node, SubscriptContext context) {
             validateNestedArrayAccess(context);
-            long value = node.getValue();
-
-            if (value < 1 || value > MAX_VALUE) {
-                raiseInvalidIndexValue();
-            }
-            context.index(new Cast(node, new ColumnType<>("integer")));
+            context.index(node);
             return null;
         }
-
 
         @Override
         protected Void visitIntegerLiteral(IntegerLiteral node, SubscriptContext context) {
             validateNestedArrayAccess(context);
-            if (node.getValue() < 1) {
-                raiseInvalidIndexValue();
-            }
-            context.index(new Cast(node, new ColumnType<>("integer")));
+            context.index(node);
             return null;
-        }
-
-        @Override
-        protected Void visitNegativeExpression(NegativeExpression node, SubscriptContext context) {
-            throw new UnsupportedOperationException(
-                String.format(Locale.ENGLISH, "Array index must be in range 1 to %s",
-                    MAX_VALUE));
         }
 
         @Override

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1696,9 +1696,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var executor = SQLExecutor.builder(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
-        assertThatThrownBy(() -> executor.analyze("select tags[0] from users"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Array index must be in range 1 to 2147483648");
+        assertThatThrownBy(() -> executor.analyze("select tags[-2147483649] from users"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `-2147483649::bigint` of type `bigint` to type `integer`");
     }
 
     @Test
@@ -1706,9 +1706,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var executor = SQLExecutor.builder(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
-        assertThatThrownBy(() -> executor.analyze("select tags[2147483649] from users"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Array index must be in range 1 to 2147483648");
+        assertThatThrownBy(() -> executor.analyze("select tags[2147483648] from users"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `2147483648::bigint` of type `bigint` to type `integer`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SubscriptValidatorTest.java
+++ b/server/src/test/java/io/crate/analyze/SubscriptValidatorTest.java
@@ -78,21 +78,21 @@ public class SubscriptValidatorTest extends ESTestCase {
         SubscriptContext context = analyzeSubscript("[1,2,3][1]");
         assertThat(context.expression()).isNotNull();
         assertThat(context.expression()).isExactlyInstanceOf(ArrayLiteral.class);
-        assertThat(context.index()).isSQL("CAST(1 AS integer)");
+        assertThat(context.index()).isSQL("1");
     }
 
     @Test
     public void testSubscriptOnCast() throws Exception {
         SubscriptContext context = analyzeSubscript("cast([1.1,2.1] as array(integer))[2]");
         assertThat(context.expression()).isExactlyInstanceOf(Cast.class);
-        assertThat(context.index()).isSQL("CAST(2 AS integer)");
+        assertThat(context.index()).isSQL("2");
     }
 
     @Test
     public void testSubscriptOnTryCast() throws Exception {
         SubscriptContext context = analyzeSubscript("try_cast([1] as array(double))[1]");
         assertThat(context.expression()).isExactlyInstanceOf(TryCast.class);
-        assertThat(context.index()).isSQL("CAST(1 AS integer)");
+        assertThat(context.index()).isSQL("1");
     }
 
     @Test
@@ -117,12 +117,8 @@ public class SubscriptValidatorTest extends ESTestCase {
         assertThatThrownBy(() -> analyzeSubscript("a[1][2]"))
             .isExactlyInstanceOf(UnsupportedOperationException.class)
             .hasMessage("Nested array access is not supported");
-    }
-
-    @Test
-    public void testNegativeArrayAccess() throws Exception {
-        assertThatThrownBy(() -> analyzeSubscript("ref[-1]"))
+        assertThatThrownBy(() -> analyzeSubscript("a[2147483648][1]"))
             .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Array index must be in range 1 to 2147483648");
+            .hasMessage("Nested array access is not supported");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/14149

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
