### PR TITLE
Docs: Remove brackets around the `TABLE` clause in `CREATE|RESTORE SNAPSHOT`

### DIFF
--- a/docs/sql/statements/create-snapshot.rst
+++ b/docs/sql/statements/create-snapshot.rst
@@ -23,7 +23,7 @@ Synopsis
 ::
 
     CREATE SNAPSHOT repository_name.snapshot_name
-    { TABLE ( table_ident [ PARTITION (partition_column = value [ , ... ])] [, ...] ) | ALL }
+    { TABLE table_ident [ PARTITION (partition_column = value [, ...])] [, ...] | ALL }
     [ WITH (snapshot_parameter [= value], [, ...]) ]
 
 
@@ -35,8 +35,8 @@ Description
 Create a new incremental snapshot inside a repository.
 
 A snapshot is a backup of the current state of the given tables and the cluster
-metadata at the point the CREATE SNAPSHOT query starts executing. Changes made
-after that are not considered for the snapshot.
+metadata at the point the ``CREATE SNAPSHOT`` query starts executing. Changes
+made after that are not considered for the snapshot.
 
 A snapshot is fully qualified by its ``snapshot_name`` and the name of the
 repository it should be created in (``repository_name``). A ``snapshot_name``
@@ -154,6 +154,6 @@ is created:
   ``false``.
 
 :ignore_unavailable:
-  (Default ``false``) if a given table does not exist the command will
+  (Default ``false``) If a given table does not exist the command will
   fail by default. If set to ``true`` these tables are ignored and not
   included in the snapshot.

--- a/docs/sql/statements/restore-snapshot.rst
+++ b/docs/sql/statements/restore-snapshot.rst
@@ -24,7 +24,7 @@ Synopsis
     RESTORE SNAPSHOT repository_name.snapshot_name
     { ALL |
       METADATA |
-      TABLE ( table_ident [ PARTITION (partition_column = value [ , ... ])] [, ...] ) |
+      TABLE table_ident [ PARTITION (partition_column = value [, ...])] [, ...] |
       data_section [, ...] }
     [ WITH (restore_parameter [= value], [, ...]) ]
 
@@ -120,7 +120,7 @@ exclusively.
 
 ::
 
-    [ PARTITION ( partition_column = value [ , ... ] ) ]
+    [ PARTITION ( partition_column = value [, ...] ) ]
 
 :partition_column:
   One of the column names used for table partitioning


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Brackets around the `TABLE` clause aren't required and produce a syntax error:
```sql
cr> CREATE SNAPSHOT r.s13 TABLE doc.q;
CREATE OK, 1 row affected  (0.160 sec)
cr> CREATE SNAPSHOT r.s14 TABLE (doc.q);
SQLParseException[line 1:56: extraneous input '(' expecting {'AUTHORIZATION', 'TO', 'AT', 'DEALLOCATE', 'ILIKE', 'IGNORE', 'RESPECT', 'FETCH', 'NEXT', 'SUBSTRING', 'TRIM', 'LEADING', 'TRAILING', 'BOTH', 'TIME', 'ZONE', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND', 'CURRENT_SCHEMA', 'INTERVAL', 'OVER', 'WINDOW', 'PARTITION', 'PROMOTE', 'RANGE', 'ROWS', 'PRECEDING', 'FOLLOWING', 'CURRENT', 'ROW', 'WITHOUT', 'BLOB', 'SWAP', 'GC', 'DANGLING', 'ARTIFACTS', 'DECOMMISSION', 'CLUSTER', 'REPOSITORY', 'SNAPSHOT', 'KILL', 'ONLY', 'OPEN', 'CLOSE', 'RENAME', 'REROUTE', 'MOVE', 'SHARD', 'ALLOCATE', 'REPLICA', 'CANCEL', 'RETRY', 'FAILED', 'BOOLEAN', 'BYTE', 'SHORT', 'INTEGER', 'INT', 'LONG', 'FLOAT', 'DOUBLE', 'PRECISION', 'TIMESTAMP', 'IP', 'CHARACTER', 'VARYING', 'STRING', 'GEO_POINT', 'GEO_SHAPE', 'GLOBAL', 'SESSION', 'LOCAL', 'BEGIN', 'START', 'COMMIT', 'WORK', 'TRANSACTION', 'TRANSACTION_ISOLATION', 'CHARACTERISTICS', 'ISOLATION', 'LEVEL', 'SERIALIZABLE', 'REPEATABLE', 'COMMITTED', 'UNCOMMITTED', 'READ', 'WRITE', 'DEFERRABLE', 'REPLACE', 'LANGUAGE', 'ANALYZE', 'DISCARD', 'PLANS', 'SEQUENCES', 'TEMPORARY', 'TEMP', 'CHECK', 'EXPLAIN', 'FORMAT', 'TYPE', 'TEXT', 'GRAPHVIZ', 'LOGICAL', 'DISTRIBUTED', 'SHOW', 'TABLES', 'SCHEMAS', 'CATALOGS', 'COLUMNS', 'PARTITIONS', 'FUNCTIONS', 'MATERIALIZED', 'VIEW', 'OPTIMIZE', 'REFRESH', 'RESTORE', 'ALIAS', 'SYSTEM', 'BERNOULLI', 'TABLESAMPLE', 'VALUES', 'KEY', 'DUPLICATE', 'CONFLICT', 'DO', 'NOTHING', 'COPY', 'CLUSTERED', 'SHARDS', 'OFF', 'FULLTEXT', 'FILTER', 'PLAIN', 'STORAGE', 'RETURNING', 'DYNAMIC', 'STRICT', 'IGNORED', 'ANALYZER', 'EXTENDS', 'TOKENIZER', 'TOKEN_FILTERS', 'CHAR_FILTERS', 'PARTITIONED', 'PREPARE', 'GENERATED', 'ALWAYS', 'PRIVILEGES', 'SCHEMA', 'RETURN', 'SUMMARY', 'METADATA', 'PUBLICATION', 'SUBSCRIPTION', 'CONNECTION', 'ENABLE', 'DISABLE', 'DECLARE', 'CURSOR', 'ASENSITIVE', 'INSENSITIVE', 'BINARY', 'NO', 'SCROLL', 'HOLD', 'ABSOLUTE', 'FORWARD', 'BACKWARD', 'RELATIVE', 'PRIOR', IDENTIFIER, DIGIT_IDENTIFIER, QUOTED_IDENTIFIER, BACKQUOTED_IDENTIFIER}]

cr> RESTORE SNAPSHOT r.s14 TABLE (doc.q);
SQLParseException[line 1:57: extraneous input '(' expecting {'AUTHORIZATION', 'TO', 'AT', 'DEALLOCATE', 'ILIKE', 'IGNORE', 'RESPECT', 'FETCH', 'NEXT', 'SUBSTRING', 'TRIM', 'LEADING', 'TRAILING', 'BOTH', 'TIME', 'ZONE', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND', 'CURRENT_SCHEMA', 'INTERVAL', 'OVER', 'WINDOW', 'PARTITION', 'PROMOTE', 'RANGE', 'ROWS', 'PRECEDING', 'FOLLOWING', 'CURRENT', 'ROW', 'WITHOUT', 'BLOB', 'SWAP', 'GC', 'DANGLING', 'ARTIFACTS', 'DECOMMISSION', 'CLUSTER', 'REPOSITORY', 'SNAPSHOT', 'KILL', 'ONLY', 'OPEN', 'CLOSE', 'RENAME', 'REROUTE', 'MOVE', 'SHARD', 'ALLOCATE', 'REPLICA', 'CANCEL', 'RETRY', 'FAILED', 'BOOLEAN', 'BYTE', 'SHORT', 'INTEGER', 'INT', 'LONG', 'FLOAT', 'DOUBLE', 'PRECISION', 'TIMESTAMP', 'IP', 'CHARACTER', 'VARYING', 'STRING', 'GEO_POINT', 'GEO_SHAPE', 'GLOBAL', 'SESSION', 'LOCAL', 'BEGIN', 'START', 'COMMIT', 'WORK', 'TRANSACTION', 'TRANSACTION_ISOLATION', 'CHARACTERISTICS', 'ISOLATION', 'LEVEL', 'SERIALIZABLE', 'REPEATABLE', 'COMMITTED', 'UNCOMMITTED', 'READ', 'WRITE', 'DEFERRABLE', 'REPLACE', 'LANGUAGE', 'ANALYZE', 'DISCARD', 'PLANS', 'SEQUENCES', 'TEMPORARY', 'TEMP', 'CHECK', 'EXPLAIN', 'FORMAT', 'TYPE', 'TEXT', 'GRAPHVIZ', 'LOGICAL', 'DISTRIBUTED', 'SHOW', 'TABLES', 'SCHEMAS', 'CATALOGS', 'COLUMNS', 'PARTITIONS', 'FUNCTIONS', 'MATERIALIZED', 'VIEW', 'OPTIMIZE', 'REFRESH', 'RESTORE', 'ALIAS', 'SYSTEM', 'BERNOULLI', 'TABLESAMPLE', 'VALUES', 'KEY', 'DUPLICATE', 'CONFLICT', 'DO', 'NOTHING', 'COPY', 'CLUSTERED', 'SHARDS', 'OFF', 'FULLTEXT', 'FILTER', 'PLAIN', 'STORAGE', 'RETURNING', 'DYNAMIC', 'STRICT', 'IGNORED', 'ANALYZER', 'EXTENDS', 'TOKENIZER', 'TOKEN_FILTERS', 'CHAR_FILTERS', 'PARTITIONED', 'PREPARE', 'GENERATED', 'ALWAYS', 'PRIVILEGES', 'SCHEMA', 'RETURN', 'SUMMARY', 'METADATA', 'PUBLICATION', 'SUBSCRIPTION', 'CONNECTION', 'ENABLE', 'DISABLE', 'DECLARE', 'CURSOR', 'ASENSITIVE', 'INSENSITIVE', 'BINARY', 'NO', 'SCROLL', 'HOLD', 'ABSOLUTE', 'FORWARD', 'BACKWARD', 'RELATIVE', 'PRIOR', IDENTIFIER, DIGIT_IDENTIFIER, QUOTED_IDENTIFIER, BACKQUOTED_IDENTIFIER}]
cr> RESTORE SNAPSHOT r.s14 TABLE doc.q;
RESTORE OK, 1 row affected  (0.536 sec)
```


## Checklist

 - [X] Added an entry in `CHANGES.txt` for user-facing changes
 - [X] Updated documentation & `sql_features` table for user-facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
