### PR TITLE
Fix issue with `?` in LIKE/ILIKE pattern

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -177,6 +177,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that :ref:`LIKE and ILIKE <sql_dql_like>` operators would
+  produce wrong results when the ``?`` is used in the pattern string, e.g.::
+
+    SELECT * FROM tbl WHERE q ILIKE '%.com?apiPath%'
+
 - Fixed an issue that would cause all tables within a
   :ref:`Snapshot <snapshot-restore>` to be restored, when trying to restore an
   empty partitioned table, e.g.::

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -231,6 +231,7 @@ public class LikeOperators {
                             case '+':
                             case '{':
                             case '}':
+                            case '?':
                                 regex.append('\\');
                                 break;
                             default:

--- a/server/src/test/java/io/crate/expression/operator/LikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/LikeOperatorTest.java
@@ -153,8 +153,8 @@ public class LikeOperatorTest extends ScalarTestCase {
 
     @Test
     public void testExpressionToRegexMaliciousPatterns() {
-        String expression = "fo(ooo)o[asdf]o\\bar^$.*";
-        assertEquals("^fo\\(ooo\\)o\\[asdf\\]obar\\^\\$\\.\\*$", patternToRegex(expression, DEFAULT_ESCAPE, true));
+        String expression = "fo(ooo)?o[asdf]o\\bar^$.*";
+        assertEquals("^fo\\(ooo\\)\\?o\\[asdf\\]obar\\^\\$\\.\\*$", patternToRegex(expression, DEFAULT_ESCAPE, true));
     }
 
     @Test
@@ -162,6 +162,7 @@ public class LikeOperatorTest extends ScalarTestCase {
         assertEvaluate("'foobarbaz' like 'foo%baz'", true);
         assertEvaluate("'foobarbaz' like 'foo_baz'", false);
         assertEvaluate("'characters' like 'charac%'", true);
+        assertEvaluate("'my.domain.com?path' like '%com?path%'", true);
 
         assertEvaluateNull("'foobarbaz' like name", Literal.NULL);
         assertEvaluateNull("name like 'foobarbaz'", Literal.NULL);
@@ -172,6 +173,7 @@ public class LikeOperatorTest extends ScalarTestCase {
         assertEvaluate("'FOOBARBAZ' ilike 'foo%baz'", true);
         assertEvaluate("'FOOBARBAZ' ilike 'foo___baz'", true);
         assertEvaluate("'characters' ilike 'CHaraC%'", true);
+        assertEvaluate("'my.domain.com?path' ilike '%com?pATh%'", true);
 
         assertEvaluateNull("'foobarbaz' ilike name", Literal.NULL);
         assertEvaluateNull("name ilike 'foobarbaz'", Literal.NULL);


### PR DESCRIPTION
Escape `?` when using java regex matching, which is the case when LIKE/ILIKE are used as operators in SELECT clause or when ILIKE is used as a filter in the WHERE clause, e.g.:
```
SELECT 'my.domain.com?apiPath' LIKE '%com?apiPath%'
SELECT * FROM tbl WHERE q ILIKE '%com?apipath%'
```

Fixes: #14167
