### PR TITLE
Fix insert into with on conflict column order handling

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -177,6 +177,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed a regression introduced in 5.3.0 that could lead to ``INSERT INTO``
+  statements with a ``ON CONFLICT`` clause to mix up values and target columns,
+  leading to validation errors or storing the wrong values in the wrong columns.
+
 - Fixed an issue that :ref:`LIKE and ILIKE <sql_dql_like>` operators would
   produce wrong results when the ``?`` is used in the pattern string, e.g.::
 


### PR DESCRIPTION
We mixed up the column <-> value assignment if there was a ON CONFLICT
clause.

With a:

    CREATE TABLE tbl (x int, y int, z int)

    INSERT INTO tbl (z, y, x) VALUES (1, 2, 3)
      ON CONFLICT (x) DO UPDATE SET y = ?

We switched from `insertColumns` `(z, y, x)` to `updateToInsert.columns()`,
which used the table ordering `(x, y, z)`.

That's okay for the ON CONFLICT case because it also uses the values
generated by `updateToInsert`, but it was wrong for the INSERT case,
where the values are in the order of the `insertColumns`.

To fix it, `UpdateToInsert` now preserves the insertColumns ordering.

Fixes https://github.com/crate/crate/issues/14159
