### PR TITLE
Introduce rule to swap sides of nl-loop

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -109,6 +109,7 @@ import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteNestedLoopJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
 import io.crate.planner.optimizer.rule.SwapHashJoin;
+import io.crate.planner.optimizer.rule.SwapNestedLoopJoin;
 import io.crate.types.DataTypes;
 
 /**
@@ -153,7 +154,8 @@ public class LogicalPlanner {
     );
 
     public static final List<Rule<?>> JOIN_ORDER_OPTIMIZER_RULES = List.of(
-        new SwapHashJoin()
+        new SwapHashJoin(),
+        new SwapNestedLoopJoin()
     );
 
     public static final List<Rule<?>> FETCH_OPTIMIZER_RULES = List.of(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/SwapNestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/SwapNestedLoopJoin.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import java.util.function.Function;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+public class SwapNestedLoopJoin implements Rule<NestedLoopJoin> {
+
+    private final Pattern<NestedLoopJoin> pattern = typeOf(NestedLoopJoin.class)
+        .with(j -> j.orderByWasPushedDown() == false &&
+                   j.joinType().supportsInversion() == true);
+
+    @Override
+    public Pattern<NestedLoopJoin> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(NestedLoopJoin nestedLoop,
+                             Captures captures,
+                             PlanStats planStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+        // We move the smaller table to the right side since benchmarking
+        // revealed that this improves performance in most cases.
+        var lhStats = planStats.get(nestedLoop.lhs());
+        var rhStats = planStats.get(nestedLoop.rhs());
+        boolean expectedRowsAvailable = lhStats.numDocs() != -1 && rhStats.numDocs() != -1;
+        if (expectedRowsAvailable) {
+            if (lhStats.numDocs() < rhStats.numDocs()) {
+                // We need to keep the same order of the output symbols when lhs/rhs are swapped
+                // therefore we add an Eval on top with original output order
+                return Eval.create(
+                    new NestedLoopJoin(
+                        nestedLoop.rhs(),
+                        nestedLoop.lhs(),
+                        nestedLoop.joinType().invert(),
+                        nestedLoop.joinCondition(),
+                        nestedLoop.isFiltered(),
+                        nestedLoop.topMostLeftRelation(),
+                        nestedLoop.orderByWasPushedDown(),
+                        nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
+                        nestedLoop.isJoinConditionOptimised(),
+                        nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
+                    ),
+                    nestedLoop.outputs());
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -191,6 +191,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
             "optimizer_swap_hash_join| true| Indicates if the optimizer rule SwapHashJoin is activated.| NULL| NULL",
+            "optimizer_swap_nested_loop_join| true| Indicates if the optimizer rule SwapNestedLoopJoin is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
             "server_version| 14.0| Reports the emulated PostgreSQL version number| NULL| NULL",
             "server_version_num| 140000| Reports the emulated PostgreSQL version number| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -430,6 +430,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_rewrite_nested_loop_join_to_hash_join| true| Indicates if the optimizer rule RewriteNestedLoopJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
             "optimizer_swap_hash_join| true| Indicates if the optimizer rule SwapHashJoin is activated.",
+            "optimizer_swap_nested_loop_join| true| Indicates if the optimizer rule SwapNestedLoopJoin is activated.",
             "search_path| doc| Sets the schema search order.",
             "server_version| 14.0| Reports the emulated PostgreSQL version number",
             "server_version_num| 140000| Reports the emulated PostgreSQL version number",

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -243,9 +243,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNestedLoop_TablesAreNotSwitchedIfLeftHasAPushedDownOrderBy() {
-        // we use a subselect to simulate the pushed-down order by
-        QueriedSelectRelation mss = e.analyze("select users.id from (select id from users order by id) users, " +
-                                              "locations where users.id = locations.id");
+        QueriedSelectRelation mss = e.analyze("select users.id from users, locations where users.id = locations.id order by users.id");
 
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -247,7 +247,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
             )
         );
 
-        var nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.INNER, x, false, relation, false,false, false, false);
+        var nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.INNER, x, false, relation, false, false, false, false);
 
         var memo = new Memo(nestedLoopJoin);
         PlanStats planStats = new PlanStats(tableStats, memo);
@@ -256,7 +256,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(result.numDocs()).isEqualTo(9L);
         assertThat(result.sizeInBytes()).isEqualTo(32L);
 
-        nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.CROSS, x, false, relation, false,false, false, false);
+        nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.CROSS, x, false, relation, false, false, false, false);
 
         memo = new Memo(nestedLoopJoin);
         planStats = new PlanStats(tableStats, memo);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This moves the logic when the sides of a nestedloop join are swapped into a optimizer rule. It also introduces an own optimizer for join rules because it is a lot easier to swap when it's clear that none of the other logical operators change anymore.

Relates to https://github.com/crate/crate/issues/13501

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
