### PR TITLE
Make SwapHashJoin always mark join as processed

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/rule/SwapHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/SwapHashJoin.java
@@ -70,6 +70,11 @@ public class SwapHashJoin implements Rule<HashJoin> {
                 plan.outputs()
             );
         }
-        return null;
+        return new HashJoin(
+            plan.lhs(),
+            plan.rhs(),
+            plan.joinCondition(),
+            true
+        );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The rule could run into an endless loop, when the hash-join is not marked.
Follow-up https://github.com/crate/crate/commit/63c5478f6ea9624f36a86709a7d0da5b706f4f49

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
