### PR TITLE
Fix NPE while writing replica upsert items coming from older nodes 

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -258,3 +258,6 @@ Fixes
 
 - Fixed a race condition issue while concurrently accessing S3 repositories
   with different settings, e.g. by queries against ``sys.snapshots``.
+
+- Fixed an issue in a mixed cluster scenario that may cause incoming writes
+  written on a node < ``5.3.0`` to fail when replicated to a node >= ``5.3.0``.

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -450,6 +450,9 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             }
             if (in.readBoolean()) {
                 source = in.readBytesReference();
+            } else if (in.getVersion().before(Version.V_5_3_0)) {
+                // Below 5.3.0 a NULL source indicates a item to be skipped instead of the later introduced marker.
+                seqNo = SequenceNumbers.SKIP_ON_REPLICA;
             }
             if (streamPkValues(in.getVersion())) {
                 pkValues = in.readList(StreamInput::readString);

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -278,7 +278,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         boolean traceEnabled = logger.isTraceEnabled();
         Translog.Location location = null;
         for (ShardUpsertRequest.Item item : request.items()) {
-            if (item.seqNo() == SequenceNumbers.SKIP_ON_REPLICA) {
+            if (item.seqNo() == SequenceNumbers.SKIP_ON_REPLICA || item.source() == null) {
                 if (traceEnabled) {
                     logger.trace(
                         "[{} (R)] Document with id={}, marked as skip_on_replica",

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -48,6 +48,7 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
@@ -341,5 +342,40 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
         // verifies that it does not throw a ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Long
         transportShardUpsertAction.processRequestItemsOnReplica(indexShard, request);
+    }
+
+    /**
+     * This tests verifies a regression introduced in 5.3 where a marker was introduced in order to skip items instead
+     * of relying on a NULL source. On request coming from older nodes this marker isn't available and the source NULL
+     * check wasn't working as expected, resulted in an NPE.
+     */
+    @Test
+    public void testItemsWithoutSourceAreSkippedOnReplicaOperationBWC() throws Exception {
+        ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+                DUMMY_SESSION_INFO,
+                TimeValue.timeValueSeconds(30),
+                DuplicateKeyAction.UPDATE_OR_FAIL,
+                false,
+                null,
+                new SimpleReference[]{ID_REF},
+                null,
+                UUID.randomUUID(),
+                false
+        ).newRequest(shardId);
+
+        var itemWithSource = ShardUpsertRequest.Item.forInsert("1", List.of(), Translog.UNSET_AUTO_GENERATED_TIMESTAMP, new Object[]{1}, null);
+        itemWithSource.source(new BytesArray("{}"));
+        request.add(1, itemWithSource);
+
+        var itemWithoutSourceAndMarker = ShardUpsertRequest.Item.forInsert("1", List.of(), Translog.UNSET_AUTO_GENERATED_TIMESTAMP, new Object[]{1}, null);
+        request.add(2, itemWithoutSourceAndMarker);
+
+        reset(indexShard);
+
+        // would fail with NPE if not skipped
+        transportShardUpsertAction.processRequestItemsOnReplica(indexShard, request);
+        verify(indexShard, times(1)).applyIndexOperationOnReplica(
+                anyLong(), anyLong(), anyLong(), anyLong(), anyBoolean(), any(SourceToParse.class));
     }
 }


### PR DESCRIPTION
Upsert request items coming from older nodes uses a NULL source as the indication to skip it.
Since 5.3.0, we moved to a SEQ_NO marker as we do not use the source anymore (source is always NULL).

This change will use the new SEQ_NO marker if it detects items with a NULL source coming from older nodes.

Without this change, a request coming from an older node may result in a NPE, as some items may contain a source while follow up items not, which bypasses an existing legacy branch/check.

The 2nd commit could be seen as
 - an additional protection
 - an alternate fix
 
which could be also skipped but I tend to keep it as an additional protection.

Follow up of #13792.