### PR TITLE
Remove "ms" suffix from statement_timeout kill reason

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -598,7 +598,7 @@ public class Session implements AutoCloseable {
                 List.of(),
                 List.of(jobId),
                 sessionSettings.userName(),
-                "statement_timeout (" + TimeValue.timeValueMillis(timeoutMillis).toString() + " ms)"
+                "statement_timeout (" + TimeValue.timeValueMillis(timeoutMillis).toString() + ")"
             );
             executor.client().execute(KillJobsNodeAction.INSTANCE, request);
         };


### PR DESCRIPTION
`toString` of `TimeValue` already includes a unit (and chooses it
depending on the length of the duration)
