### PR TITLE
Fix Stats calculation for Collect operator

### DIFF
--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -21,59 +21,30 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.optimizer.costs.PlanStatsTest.PLAN_STATS_EMPTY;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
 
 import io.crate.analyze.QueriedSelectRelation;
-import io.crate.analyze.WhereClause;
-import io.crate.analyze.relations.DocTableRelation;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
-import io.crate.expression.symbol.Symbol;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
-import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import io.crate.types.DataTypes;
 
 public class CollectTest extends CrateDummyClusterServiceUnitTest {
-
-    @Test
-    public void test_prune_output_of_collect_updates_estimated_row_size() throws Exception {
-        var e = SQLExecutor.builder(clusterService)
-            .addTable("create table t (x int, y int)")
-            .build();
-        TableStats tableStats = new TableStats();
-        Symbol x = e.asSymbol("x");
-        Collect collect = Collect.create(
-            new DocTableRelation(e.resolveTableInfo("t")),
-            List.of(x, e.asSymbol("y")),
-            WhereClause.MATCH_ALL,
-            PLAN_STATS_EMPTY,
-            Row.EMPTY
-        );
-        assertThat(collect.estimatedRowSize(), is(DataTypes.INTEGER.fixedSize() * 2L));
-        LogicalPlan prunedCollect = collect.pruneOutputsExcept(tableStats, List.of(x));
-        assertThat(e.getStats(prunedCollect).sizeInBytes(), is((long) DataTypes.INTEGER.fixedSize()));
-    }
 
     @Test
     public void test() throws Exception {
         var e = SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE t (x int)")
             .build();
-        TableStats tableStats = new TableStats();
         PlannerContext plannerCtx = e.getPlannerContext(clusterService.state());
         ProjectionBuilder projectionBuilder = new ProjectionBuilder(e.nodeCtx);
         QueriedSelectRelation analyzedRelation = e.analyze("SELECT 123 AS alias, 456 AS alias2 FROM t ORDER BY alias, 2");
@@ -94,6 +65,6 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
             Row.EMPTY,
             SubQueryResults.EMPTY
         );
-        assertThat((((RoutedCollectPhase) ((io.crate.planner.node.dql.Collect) build).collectPhase())).orderBy(), is(nullValue()));
+        assertThat((((RoutedCollectPhase) ((io.crate.planner.node.dql.Collect) build).collectPhase())).orderBy()).isNull();
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,6 +23,7 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -68,9 +69,10 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_collect_derives_estimated_size_per_row_from_stats_and_types() {
-        // no stats -> size derived FROM fixed with type
         LogicalPlan plan = plan("SELECT x FROM t1");
-        assertThat(sqlExecutor.getStats(plan).sizeInBytes()).isEqualTo((long) DataTypes.INTEGER.fixedSize());
+        assertThat(sqlExecutor.getStats(plan).sizeInBytes())
+            .as("No stats available")
+            .isEqualTo(-1L);
 
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
         ColumnStats<Integer> columnStats = new ColumnStats<>(
@@ -79,7 +81,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         // stats present -> size derived FROM them (although bogus fake stats in this case)
         plan = plan("SELECT x FROM t1");
-        assertThat(sqlExecutor.getStats(plan).sizeInBytes()).isEqualTo(50L);
+        assertThat(sqlExecutor.getStats(plan).sizeInBytes()).isEqualTo(100L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -210,7 +210,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var result = planStats.get(hashjoin);
         // lhs is the larger table which 9 entries, so the join will at max emit 9 entries
         assertThat(result.numDocs()).isEqualTo(9L);
-        assertThat(result.sizeInBytes()).isEqualTo(1L);
+        assertThat(result.sizeInBytes()).isEqualTo(2L);
     }
 
     @Test
@@ -254,7 +254,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var result = planStats.get(nestedLoopJoin);
         // lhs is the larger table which 9 entries, so the join will at max emit 9 entries
         assertThat(result.numDocs()).isEqualTo(9L);
-        assertThat(result.sizeInBytes()).isEqualTo(9L);
+        assertThat(result.sizeInBytes()).isEqualTo(32L);
 
         nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.CROSS, x, false, relation, false,false, false, false);
 
@@ -262,7 +262,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         planStats = new PlanStats(tableStats, memo);
         result = planStats.get(nestedLoopJoin);
         assertThat(result.numDocs()).isEqualTo(18L);
-        assertThat(result.sizeInBytes()).isEqualTo(9L);
+        assertThat(result.sizeInBytes()).isEqualTo(32L);
     }
 
 }


### PR DESCRIPTION
Follow up to f1919609fa8cfa3681d87de3c9b3d84a4f97271c

The `Stats` constructor takes the total size in bytes, not an average.
Using the average per row led to taking an average from the average in
the `HashJoin` operator, which led to a small block size and performance
regression.

The nightly benchmarks ran into timeouts because of this.
