### PR TITLE
Add own optimizer for join ordering

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -45,6 +45,7 @@ public class LoadedRules implements SessionSettingProvider {
     private static List<Class<? extends Rule<?>>> buildRules() {
         var rules = new ArrayList<Rule<?>>();
         rules.addAll(LogicalPlanner.ITERATIVE_OPTIMIZER_RULES);
+        rules.addAll(LogicalPlanner.JOIN_ORDER_OPTIMIZER_RULES);
         rules.addAll(LogicalPlanner.FETCH_OPTIMIZER_RULES);
         return Lists2.map(rules, x -> (Class<? extends Rule<?>>) x.getClass());
     }


### PR DESCRIPTION
This introduces an separate optimizer for join ordering. Join ordering optimization rules have their own optimizer, because these rules have little interaction with the other rules and we want to avoid unnecessary pattern matches on them.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
