### PR TITLE
Improve error message for default on object cols

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -177,6 +177,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Improved error message when providing
+  :ref:`DEFAULT clause <sql-create-table-default-clause>` for columns of type
+  ``OBJECT``.
+
 - Fixed a regression introduced in 5.3.0 that could lead to ``INSERT INTO``
   statements with a ``ON CONFLICT`` clause to mix up values and target columns,
   leading to validation errors or storing the wrong values in the wrong columns.

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -130,6 +130,40 @@ statement that doesn't contain an explicit value for it.
 The default clause :ref:`expression <gloss-expression>` is variable-free, it
 means that subqueries and cross-references to other columns are not allowed.
 
+.. NOTE::
+
+    Default values are not allowed for columns of type ``OBJECT``, e.g.::
+
+      CREATE TABLE tbl(obj OBJECT DEFAULT {key='foo'}
+
+    but they are allowed for sub columns of an object column, e.g.::
+
+      CREATE TABLE tbl(obj OBJECT AS(key TEXT DEFAULT 'foo'))
+
+    The effect of the later, is different though, as if no value is provided for
+    the column ``obj`` then the value inserted is ``NULL``, but if a value for
+    the ``obj`` column is provided, but there is no value for ``key``
+    sub-column, then the ``key`` acquires the default value defined. e.g.::
+
+      CREATE TABLE tbl(i INT, obj OBJECT AS(key TEXT DEFAULT 'foo'))
+      INSERT INTO tbl(i) VALUES(1)
+      SELECT * FROM tbl
+      +---+------+
+      | i | obj  |
+      +---+------+
+      | 1 | NULL |
+      +---+------+
+
+    vs::
+
+      INSERT INTO tbl(i, obj) VALUES(1, {value=10})
+      SELECT * FROM tbl
+      +---+-----------------------------+
+      | i | obj                         |
+      +---+-----------------------------+
+      | 1 | {"key": "foo", "value": 10} |
+      +---+-----------------------------+
+
 
 .. _sql-create-table-generated-columns:
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -422,6 +422,9 @@ public class AnalyzedColumnDefinition<T> {
         for (AnalyzedColumnDefinition<T> child : children) {
             child.validate();
         }
+        if (dataType.id() == ObjectType.ID && defaultExpression != null) {
+            throw new IllegalArgumentException("Default values are not allowed for object columns: " + name);
+        }
     }
 
     private void ensureTypeCanBeUsedAsKey() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -138,6 +138,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         protected static boolean parseObjectOrDocumentTypeProperties(String fieldName, Object fieldNode, ParserContext parserContext, ObjectMapper.Builder builder) {
+            assert !fieldName.equals("default_expr") : "Default values are not allowed for object columns";
+
             if (fieldName.equals("position")) {
                 builder.position(nodeIntegerValue(fieldNode));
                 return true;

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -22,7 +22,6 @@
 package io.crate.execution.dml;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
@@ -48,6 +47,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.carrotsearch.hppc.IntArrayList;
@@ -180,8 +180,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             {"o": {"x": 10}}
             """
         );
-        assertThat(doc.doc().getFields("o.x")).hasSize(0);
-        assertThat(doc.doc().getFields("o.y")).hasSize(0);
+        assertThat(doc.doc().getFields("o.x")).isEmpty();
+        assertThat(doc.doc().getFields("o.y")).isEmpty();
         assertThat(doc.doc().getFields())
             .as("source, seqNo, id...")
             .hasSize(6);
@@ -335,6 +335,14 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    @Ignore("https://github.com/crate/crate/issues/14189")
+    /*
+     * This isolated test would pass without the validation in {@link AnalyzedColumnDefintion} since it covers only
+     * part of code path but actually running a {@code CREATE TABLE tbl (x int, o object as (x int) default {x=10})}
+     * throws:
+     *    MapperParsingException[Failed to parse mapping: Mapping definition for [o] has unsupported
+     *    parameters:  [default_expr : {"x"=10}]]}
+     */
     public void test_default_for_full_object() throws Exception {
         var executor = SQLExecutor.builder(clusterService)
             .addTable("create table tbl (x int, o object as (x int) default {x=10})")


### PR DESCRIPTION
- Migrate `CreateAlterTableStatementAnalyzerTest` to assertj
- Since `default_expr` is not used at all in `ObjectMapper` validate and throw error early for default clause on object cols.

  Fixes: #14018
   
