### PR TITLE
Fix handling of defaults on object child columns

### DIFF
--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -498,7 +498,11 @@ def load_tests(loader, suite, ignore):
                             'sql/statements/values.rst'):
         tests.append(docsuite(fn, setUp=setUpLocationsAndQuotes))
 
-    for fn in doctest_files('general/occ.rst', 'sql/statements/refresh.rst'):
+    for fn in doctest_files(
+            'general/occ.rst',
+            'sql/statements/refresh.rst',
+            'sql/statements/create-table.rst',
+        ):
         tests.append(docsuite(fn, setUp=setUp))
 
     for fn in doctest_files('general/dql/geo.rst',):

--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -177,6 +177,11 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+
+- Fixed a regression introduced in 5.3.0 that prevented the evaluation of
+  ``DEFAULT`` clauses on children of ``OBJECT`` columns if the object was
+  missing entirely from an ``INSERT INTO`` statement.
+
 - Improved error message when providing
   :ref:`DEFAULT clause <sql-create-table-default-clause>` for columns of type
   ``OBJECT``.

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -132,37 +132,33 @@ means that subqueries and cross-references to other columns are not allowed.
 
 .. NOTE::
 
-    Default values are not allowed for columns of type ``OBJECT``, e.g.::
+    Default values are not allowed for columns of type ``OBJECT``::
 
-      CREATE TABLE tbl(obj OBJECT DEFAULT {key='foo'}
+      cr> CREATE TABLE tbl (obj OBJECT DEFAULT {key='foo'})
+      SQLParseException[Default values are not allowed for object columns: obj]
 
-    but they are allowed for sub columns of an object column, e.g.::
+    They are allowed for sub columns of an object column. If an object column
+    has at least one child with a default expression it will implicitly create
+    the full object unless it's within an array.
 
-      CREATE TABLE tbl(obj OBJECT AS(key TEXT DEFAULT 'foo'))
+    An example::
 
-    The effect of the later, is different though, as if no value is provided for
-    the column ``obj`` then the value inserted is ``NULL``, but if a value for
-    the ``obj`` column is provided, but there is no value for ``key``
-    sub-column, then the ``key`` acquires the default value defined. e.g.::
+      cr> CREATE TABLE object_defaults (id int, obj OBJECT AS (key TEXT DEFAULT ''))
+      CREATE OK, 1 row affected  (... sec)
 
-      CREATE TABLE tbl(i INT, obj OBJECT AS(key TEXT DEFAULT 'foo'))
-      INSERT INTO tbl(i) VALUES(1)
-      SELECT * FROM tbl
-      +---+------+
-      | i | obj  |
-      +---+------+
-      | 1 | NULL |
-      +---+------+
+      cr> INSERT INTO object_defaults (id) VALUES (1)
+      INSERT OK, 1 row affected  (... sec)
 
-    vs::
+      cr> REFRESH TABLE object_defaults
+      REFRESH OK, 1 row affected  (... sec)
 
-      INSERT INTO tbl(i, obj) VALUES(1, {value=10})
-      SELECT * FROM tbl
-      +---+-----------------------------+
-      | i | obj                         |
-      +---+-----------------------------+
-      | 1 | {"key": "foo", "value": 10} |
-      +---+-----------------------------+
+      cr> SELECT obj FROM object_defaults
+      +-------------+
+      | obj         |
+      +-------------+
+      | {"key": ""} |
+      +-------------+
+      SELECT 1 row in set (... sec)
 
 
 .. _sql-create-table-generated-columns:

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
@@ -447,5 +448,26 @@ public class ColumnIdent implements Comparable<ColumnIdent>, Accountable {
         return SHALLOW_SIZE
             + RamUsageEstimator.sizeOf(name)
             + path.stream().mapToLong(RamUsageEstimator::sizeOf).sum();
+    }
+
+    public Iterable<ColumnIdent> parents() {
+        return () -> new Iterator<>() {
+
+            int level = path.size();
+
+            @Override
+            public boolean hasNext() {
+                return level > 0;
+            }
+
+            @Override
+            public ColumnIdent next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException("ColumnIdent has no more parents");
+                }
+                level--;
+                return new ColumnIdent(name, path.subList(0, level));
+            }
+        };
     }
 }

--- a/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
+++ b/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
@@ -22,11 +22,13 @@
 package io.crate.metadata;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -84,6 +86,25 @@ public class ColumnIdentTest {
 
         ColumnIdent fooBar = new ColumnIdent("foo", "bar");
         assertThat(fooBar.prepend("x"), is(new ColumnIdent("x", Arrays.asList("foo", "bar"))));
+    }
+
+    @Test
+    public void test_get_parents() throws Exception {
+        assertThat(new ColumnIdent("foo").parents()).hasSize(0);
+        assertThat(new ColumnIdent("foo", "x").parents()).containsExactly(
+            new ColumnIdent("foo")
+        );
+
+        assertThat(new ColumnIdent("foo", List.of("x", "y")).parents()).containsExactly(
+            new ColumnIdent("foo", "x"),
+            new ColumnIdent("foo")
+        );
+
+        assertThat(new ColumnIdent("foo", List.of("x", "y", "z")).parents()).containsExactly(
+            new ColumnIdent("foo", List.of("x", "y")),
+            new ColumnIdent("foo", "x"),
+            new ColumnIdent("foo")
+        );
     }
 
     @Test


### PR DESCRIPTION
See https://github.com/crate/crate/pull/14190#discussion_r1203465852

5.3.0 unintentionally changed the behavior.

Closes https://github.com/crate/crate/issues/14189
