### PR TITLE
Fix: empty partitioned tables not listed in sys.snapshots

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -177,6 +177,8 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed an issue that would exclude empty partitioned tables from being listed
+  in :ref:`sys.snapshots <sys-snapshots>`.
 
 - Fixed a regression introduced in 5.3.0 that prevented the evaluation of
   ``DEFAULT`` clauses on children of ``OBJECT`` columns if the object was

--- a/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshot.java
@@ -22,7 +22,7 @@
 package io.crate.expression.reference.sys.snapshot;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
@@ -33,6 +33,7 @@ public class SysSnapshot {
     private final String name;
     private final String repository;
     private final List<String> concreteIndices;
+    private final List<String> partitionedTables;
     private final Long started;
     private final Long finished;
     private final String version;
@@ -43,6 +44,7 @@ public class SysSnapshot {
     public SysSnapshot(String name,
                        String repository,
                        List<String> concreteIndices,
+                       List<String> partitionedTables,
                        Long started,
                        Long finished,
                        String version,
@@ -51,6 +53,7 @@ public class SysSnapshot {
         this.name = name;
         this.repository = repository;
         this.concreteIndices = concreteIndices;
+        this.partitionedTables = partitionedTables;
         this.started = started;
         this.finished = finished;
         this.version = version;
@@ -91,10 +94,9 @@ public class SysSnapshot {
     }
 
     public List<String> tables() {
-        return concreteIndices.stream()
-            .map(RelationName::fqnFromIndexName)
+        return Stream.concat(concreteIndices.stream().map(RelationName::fqnFromIndexName), partitionedTables.stream())
             .distinct()
-            .collect(Collectors.toList());
+            .toList();
     }
 
     public List<PartitionName> tablePartitions() {

--- a/server/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/snapshot/SysSnapshotsTest.java
@@ -21,9 +21,7 @@
 
 package io.crate.expression.reference.sys.snapshot;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -87,10 +85,8 @@ public class SysSnapshotsTest extends ESTestCase {
             Spliterators.spliteratorUnknownSize(sysSnapshots.currentSnapshots().get().iterator(), Spliterator.ORDERED),
             false
         );
-        assertThat(
-            currentSnapshots.map(SysSnapshot::name).collect(Collectors.toList()),
-            containsInAnyOrder("s1", "s2")
-        );
+        assertThat(currentSnapshots.map(SysSnapshot::name).collect(Collectors.toList()))
+            .containsExactlyInAnyOrder("s1", "s2");
     }
 
     @Test
@@ -103,6 +99,6 @@ public class SysSnapshotsTest extends ESTestCase {
         SysSnapshots sysSnapshots = new SysSnapshots(() -> List.of(r1));
         CompletableFuture<Iterable<SysSnapshot>> currentSnapshots = sysSnapshots.currentSnapshots();
         Iterable<SysSnapshot> iterable = currentSnapshots.get(5, TimeUnit.SECONDS);
-        assertThat(iterable.iterator().hasNext(), is(false));
+        assertThat(iterable.iterator().hasNext()).isFalse();
     }
 }


### PR DESCRIPTION
Previously, `SysSnapshot` was constructed only by use of `SnapshotInfo`
which only contains concrete indices and not the templates. Therefore,
empty partitioned tables(no partitions -> no concrete indices) were not
listed in `sys.snapshots`.   

Retrieve cluster state from the snapshot to get the templates which
list all partitioned tables and concatenate them with the tables      
extracted from the concrete indices, using distinct, so that non-empty
partitioned tables are not listed twice.

Fixes: #14165

