### PR TITLE
Use `estimateSizeForColumns` for estimated left row size in hash joins

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -180,7 +180,7 @@ public class HashJoin extends JoinPlan {
             InputColumns.create(lhsHashSymbols, new InputColumns.SourceSymbols(leftOutputs)),
             InputColumns.create(rhsHashSymbols, new InputColumns.SourceSymbols(rightOutputs)),
             Symbols.typeView(leftOutputs),
-            lhStats.averageSizePerRowInBytes(),
+            lhStats.estimateSizeForColumns(leftOutputs),
             lhStats.numDocs());
         return new Join(
             joinPhase,

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import io.crate.common.annotations.VisibleForTesting;
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -110,10 +111,13 @@ public class Stats implements Writeable {
         for (int i = 0; i < toCollect.size(); i++) {
             Symbol symbol = toCollect.get(i);
             ColumnStats<?> columnStats = null;
+            while (symbol instanceof AliasSymbol alias) {
+                symbol = alias.symbol();
+            }
             if (symbol instanceof Reference ref) {
                 columnStats = statsByColumn.get(ref.column());
-            } else if (symbol instanceof ScopedSymbol) {
-                columnStats = statsByColumn.get(((ScopedSymbol) symbol).column());
+            } else if (symbol instanceof ScopedSymbol scopedSymbol) {
+                columnStats = statsByColumn.get(scopedSymbol.column());
             }
             if (columnStats == null) {
                 if (symbol.valueType() instanceof FixedWidthType) {


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14185 & https://github.com/crate/crate/pull/14119

If there are no stats yet, `averageSizePerRowInBytes` returns `-1`,
which leads to a way worse block size than using
`estimateSizeForColumns` which considers the number of columns and their
fixed sizes.

Without this change, the following would run into timeouts:

    cr8 run-crate "$(pwd)" -e CRATE_HEAP_SIZE=4G -s statement_timeout=30s \
    -- run-spec ~/dev/crate/crate-benchmarks/specs/select/hash_joins.toml '{node.http_url}'
