### PR TITLE
Use runtime information to calculate block size in hash joins

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -130,7 +130,7 @@ public class RowsBatchIteratorBenchmark {
             InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             new CombinedRow(1, 1),
-            () -> 1000,
+            ignored -> 1000,
             new NoRowAccounting<>()
         );
         while (crossJoin.moveNext()) {
@@ -161,7 +161,7 @@ public class RowsBatchIteratorBenchmark {
             row -> Objects.equals(row.get(0), row.get(1)),
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
-            () -> 1000
+            ignored -> 1000
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
@@ -183,7 +183,7 @@ public class RowsBatchIteratorBenchmark {
                 return value < 500 ? value : (value % 100) + 500;
             },
             row -> (Integer) row.get(0) % 500,
-            () -> 1000
+            ignored -> 1000
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
@@ -217,7 +217,8 @@ public class RowsBatchIteratorBenchmark {
     private static class NoRowAccounting<T> implements RowAccounting<T> {
 
         @Override
-        public void accountForAndMaybeBreak(T row) {
+        public long accountForAndMaybeBreak(T row) {
+            return 42L;
         }
 
         @Override

--- a/benchmarks/src/main/java/io/crate/execution/engine/sort/SortingLimitAndOffsetCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/sort/SortingLimitAndOffsetCollectorBenchmark.java
@@ -72,7 +72,8 @@ public class SortingLimitAndOffsetCollectorBenchmark {
             new RowAccounting<Object[]>() {
 
                 @Override
-                public void accountForAndMaybeBreak(Object[] row) {
+                public long accountForAndMaybeBreak(Object[] row) {
+                    return 42;
                 }
 
                 @Override
@@ -90,7 +91,8 @@ public class SortingLimitAndOffsetCollectorBenchmark {
             new RowAccounting<Object[]>() {
 
                 @Override
-                public void accountForAndMaybeBreak(Object[] row) {
+                public long accountForAndMaybeBreak(Object[] row) {
+                    return 42;
                 }
 
                 @Override

--- a/libs/dex/src/main/java/io/crate/data/breaker/RowAccounting.java
+++ b/libs/dex/src/main/java/io/crate/data/breaker/RowAccounting.java
@@ -31,9 +31,10 @@ public interface RowAccounting<T> {
      * Accounts memory usage of the supplied row representation.
      * May throw an exception if it thinks that the entities accounted for
      * occupy too much memory.
+     * @return estimated number of bytes for the row
      * @throws CircuitBreakingException if too much memory would be consumer after materializing this row.
      */
-    void accountForAndMaybeBreak(T row);
+    long accountForAndMaybeBreak(T row);
 
     /**
      * Stops accounting for previously accounted rows.

--- a/server/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
+++ b/server/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
@@ -63,10 +63,12 @@ public class RowAccountingWithEstimators implements RowAccounting<Row> {
      * This should only be used if the values are stored/buffered in another in-memory data structure.
      */
     @Override
-    public void accountForAndMaybeBreak(Row row) {
+    public long accountForAndMaybeBreak(Row row) {
         // Container size of the row is excluded because here it's unknown where the values will be saved to.
         // As size estimation is generally "best-effort" this should be good enough.
-        ramAccounting.addBytes(estimateRowSize.applyAsLong(row) + extraSizePerRow);
+        long bytes = estimateRowSize.applyAsLong(row) + extraSizePerRow;
+        ramAccounting.addBytes(bytes);
+        return bytes;
     }
 
     @Override

--- a/server/src/main/java/io/crate/breaker/RowCellsAccountingWithEstimators.java
+++ b/server/src/main/java/io/crate/breaker/RowCellsAccountingWithEstimators.java
@@ -55,8 +55,10 @@ public class RowCellsAccountingWithEstimators implements RowAccounting<Object[]>
      * This should only be used if the values are stored/buffered in another in-memory data structure.
      */
     @Override
-    public void accountForAndMaybeBreak(Object[] rowCells) {
-        ramAccounting.addBytes(accountRowBytes(rowCells));
+    public long accountForAndMaybeBreak(Object[] rowCells) {
+        long rowBytes = accountRowBytes(rowCells);
+        ramAccounting.addBytes(rowBytes);
+        return rowBytes;
     }
 
     public long accountRowBytes(Object[] rowCells) {

--- a/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -57,8 +57,7 @@ public class HashJoinOperation implements CompletionListenable {
                              TransactionContext txnCtx,
                              InputFactory inputFactory,
                              CircuitBreaker circuitBreaker,
-                             long estimatedRowSizeForLeft,
-                             long numberOfRowsForLeft) {
+                             long estimatedRowSizeForLeft) {
 
         this.resultConsumer = nlResultConsumer;
         this.leftConsumer = new CapturingRowConsumer(nlResultConsumer.requiresScroll(), nlResultConsumer.completionFuture());
@@ -80,8 +79,7 @@ public class HashJoinOperation implements CompletionListenable {
                             new RamBlockSizeCalculator(
                                 Paging.PAGE_SIZE,
                                 circuitBreaker,
-                                estimatedRowSizeForLeft,
-                                numberOfRowsForLeft
+                                estimatedRowSizeForLeft
                             )
                         );
                         nlResultConsumer.accept(joinIterator, null);

--- a/server/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
@@ -23,7 +23,6 @@ package io.crate.execution.engine.join;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.IntSupplier;
 import java.util.function.Predicate;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -123,16 +122,29 @@ public class NestedLoopOperation implements CompletionListenable {
         final CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
         switch (joinType) {
             case CROSS:
-                return buildCrossJoinBatchIterator(left, right, combiner,
-                    circuitBreaker, ramAccounting, leftSideColumnTypes,
-                    estimatedRowsSizeLeft, estimatedNumberOfRowsLeft, blockNestedLoop);
+                return buildCrossJoinBatchIterator(
+                    left,
+                    right,
+                    combiner,
+                    circuitBreaker,
+                    ramAccounting,
+                    leftSideColumnTypes,
+                    estimatedRowsSizeLeft,
+                    blockNestedLoop
+                );
 
             case INNER:
                 return new FilteringBatchIterator<>(
-                    buildCrossJoinBatchIterator(left, right, combiner,
-                        circuitBreaker, ramAccounting, leftSideColumnTypes,
-                        estimatedRowsSizeLeft, estimatedNumberOfRowsLeft, blockNestedLoop),
-                    joinCondition);
+                    buildCrossJoinBatchIterator(
+                        left,
+                        right,
+                        combiner,
+                        circuitBreaker,
+                        ramAccounting,
+                        leftSideColumnTypes,
+                        estimatedRowsSizeLeft,
+                        blockNestedLoop),
+                        joinCondition);
 
             case LEFT:
                 return new LeftJoinNLBatchIterator<>(left, right, combiner, joinCondition);
@@ -161,14 +173,12 @@ public class NestedLoopOperation implements CompletionListenable {
                                                                   RamAccounting ramAccounting,
                                                                   List<DataType<?>> leftSideColumnTypes,
                                                                   long estimatedRowsSizeLeft,
-                                                                  long estimatedNumberOfRowsLeft,
                                                                   boolean blockNestedLoop) {
         if (blockNestedLoop) {
-            IntSupplier blockSizeCalculator = new RamBlockSizeCalculator(
+            var blockSizeCalculator = new RamBlockSizeCalculator(
                 Paging.PAGE_SIZE,
                 circuitBreaker,
-                estimatedRowsSizeLeft,
-                estimatedNumberOfRowsLeft
+                estimatedRowsSizeLeft
             );
             var rowAccounting = new RowCellsAccountingWithEstimators(leftSideColumnTypes, ramAccounting, 0);
             return new CrossJoinBlockNLBatchIterator(left, right, combiner, blockSizeCalculator, rowAccounting);

--- a/server/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
+++ b/server/src/main/java/io/crate/execution/engine/join/RamBlockSizeCalculator.java
@@ -21,58 +21,52 @@
 
 package io.crate.execution.engine.join;
 
-import org.elasticsearch.common.breaker.CircuitBreaker;
+import java.util.function.LongToIntFunction;
 
-import java.util.function.IntSupplier;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 
 /**
  * Calculates the number of rows to fit in a block, based on the available memory, the number of rows and the row size.
  */
-public class RamBlockSizeCalculator implements IntSupplier {
+public class RamBlockSizeCalculator implements LongToIntFunction {
 
     public static final int FALLBACK_SIZE = 500;
 
     private final int defaultBlockSize;
     private final CircuitBreaker circuitBreaker;
     private final long estimatedRowSizeForLeft;
-    private final long numberOfRowsForLeft;
 
     public RamBlockSizeCalculator(int defaultBlockSize,
                                   CircuitBreaker circuitBreaker,
-                                  long estimatedRowSizeForLeft,
-                                  long numberOfRowsForLeft) {
+                                  long estimatedRowSizeForLeft) {
         this.defaultBlockSize = defaultBlockSize;
         this.circuitBreaker = circuitBreaker;
         this.estimatedRowSizeForLeft = estimatedRowSizeForLeft;
-        this.numberOfRowsForLeft = numberOfRowsForLeft;
     }
 
     @Override
-    public int getAsInt() {
-        if (statisticsUnavailable(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)) {
+    public int applyAsInt(long averageSizeInBytes) {
+        long leftRowSize = averageSizeInBytes > 0 ? averageSizeInBytes : estimatedRowSizeForLeft;
+        if (leftRowSize <= 0) {
+            return FALLBACK_SIZE;
+        }
+        if (circuitBreaker.getLimit() == -1) {
             return FALLBACK_SIZE;
         }
         long availableMemory = circuitBreaker.getLimit() - circuitBreaker.getUsed();
-        long numRowsFittingIntoAvailableMemory = availableMemory / estimatedRowSizeForLeft;
+        long numRowsFittingIntoAvailableMemory = availableMemory / leftRowSize;
 
         // Restrict the number of rows per block by whatever is lowest:
-        // - numberOfRowsForLeft because we don't have to create blocks larger than the table is expected to be
+        // - numRowsFittingIntoAvailableMemory
         // - defaultBlockSize it is an integer, the blockSize must not exceed Integer.MAX_SIZE to fit into the buffer structure and:
         //      for distributed hash joins, we must ensure that each parallel executed join is switching to the same relation
         //      eventually and does not load the next batch while another is already switching. this would result in a
         //      dead lock caused by the constraint that all receivers must response to the collect nodes before a next batch
         //      is sent.
-        int cap = (int) Math.min(numberOfRowsForLeft, defaultBlockSize);
-        int blockSize = (int) Math.min(cap, numRowsFittingIntoAvailableMemory);
+        int blockSize = (int) Math.min(defaultBlockSize, numRowsFittingIntoAvailableMemory);
 
         // In case no mem available from circuit breaker then still allocate a small blockSize,
         // so that at least some rows (min 10) could be processed and a CircuitBreakerException can be triggered.
         return blockSize <= 0 ? 10 : blockSize;
-    }
-
-    private static boolean statisticsUnavailable(CircuitBreaker circuitBreaker,
-                                                 long estimatedRowSizeForLeft,
-                                                 long numberOfRowsForLeft) {
-        return estimatedRowSizeForLeft <= 0 || numberOfRowsForLeft <= 0 || circuitBreaker.getLimit() == -1;
     }
 }

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -953,8 +953,8 @@ public class JobSetup {
                 context.transactionContext,
                 inputFactory,
                 breaker(),
-                phase.estimatedRowSizeForLeft(),
-                phase.numberOfRowsForLeft());
+                phase.estimatedRowSizeForLeft()
+            );
             DistResultRXTask left = pageDownstreamContextForNestedLoop(
                 phase.phaseId(),
                 context,

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorBehaviouralTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorBehaviouralTest.java
@@ -72,7 +72,7 @@ public class HashInnerJoinBatchIteratorBehaviouralTest {
                 row -> Objects.equals(row.get(0), row.get(1)),
                 row -> Objects.hash(row.get(0)),
                 row -> Objects.hash(row.get(0)),
-                () -> 2
+                ignored -> 2
             );
 
         TestingRowConsumer consumer = new TestingRowConsumer();
@@ -102,7 +102,7 @@ public class HashInnerJoinBatchIteratorBehaviouralTest {
             row -> Objects.equals(row.get(0), row.get(1)),
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
-            () -> 500000
+            ignored -> 500000
         );
 
         TestingRowConsumer consumer = new TestingRowConsumer();

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorMemoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorMemoryTest.java
@@ -80,7 +80,7 @@ public class HashInnerJoinBatchIteratorMemoryTest {
             getCol0EqCol1JoinCondition(),
             getHashForLeft(),
             getHashForRight(),
-            () -> 2
+            ignored -> 2
         );
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(it, null);

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
@@ -136,7 +136,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashForLeft(),
             getHashForRight(),
-            () -> 5
+            ignored -> 5
         );
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -152,7 +152,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashWithCollisions(),
             getHashWithCollisions(),
-            () -> 5
+            ignored -> 5
         );
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -168,7 +168,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashForLeft(),
             getHashForRight(),
-            () -> 1
+            ignored -> 1
         );
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -184,7 +184,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashForLeft(),
             getHashForRight(),
-            () -> 3
+            ignored -> 3
         );
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);

--- a/server/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
@@ -41,17 +41,16 @@ public class RamBlockSizeCalculatorTest {
         RamBlockSizeCalculator blockCalculator100leftRows = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            5,
-            100
+            5
         );
-        assertThat(blockCalculator100leftRows.getAsInt(), is(20));
+        assertThat(blockCalculator100leftRows.applyAsInt(-1), is(20));
         RamBlockSizeCalculator blockCalculator10LeftRows = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            5,
-            10
+            5
         );
-        assertThat(blockCalculator10LeftRows.getAsInt(), is(10));
+        assertThat(blockCalculator10LeftRows.applyAsInt(-1), is(20));
+        assertThat(blockCalculator10LeftRows.applyAsInt(50), is(2));
     }
 
     @Test
@@ -60,28 +59,25 @@ public class RamBlockSizeCalculatorTest {
         RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            10,
             10
         );
-        assertThat(blockSizeCalculator.getAsInt(), is(RamBlockSizeCalculator.FALLBACK_SIZE));
+        assertThat(blockSizeCalculator.applyAsInt(-1), is(RamBlockSizeCalculator.FALLBACK_SIZE));
 
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
         RamBlockSizeCalculator blockCalculatorNoNumberOrRowsStats = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            10,
-            -1
+            10
         );
-        assertThat(blockCalculatorNoNumberOrRowsStats.getAsInt(), is(RamBlockSizeCalculator.FALLBACK_SIZE));
+        assertThat(blockCalculatorNoNumberOrRowsStats.applyAsInt(-1), is(10));
 
         RamBlockSizeCalculator blockCalculatorNoRowSizeStats = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            -1,
-            10
+            -1
         );
-        assertThat(blockCalculatorNoRowSizeStats.getAsInt(), is(RamBlockSizeCalculator.FALLBACK_SIZE));
+        assertThat(blockCalculatorNoRowSizeStats.applyAsInt(-1), is(RamBlockSizeCalculator.FALLBACK_SIZE));
     }
 
     @Test
@@ -91,10 +87,9 @@ public class RamBlockSizeCalculatorTest {
         RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            10,
             10
         );
-        assertThat(blockSizeCalculator.getAsInt(), is(10));
+        assertThat(blockSizeCalculator.applyAsInt(-1), is(10));
     }
 
     @Test
@@ -104,10 +99,9 @@ public class RamBlockSizeCalculatorTest {
         RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            1,
             1
         );
-        assertThat(blockSizeCalculator.getAsInt(), is(1));
+        assertThat(blockSizeCalculator.applyAsInt(-1), is(500_000));
     }
 
     @Test
@@ -117,9 +111,8 @@ public class RamBlockSizeCalculatorTest {
         RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
-            1,
-            defaultBlockSize * 2L
+            1
         );
-        assertThat(blockSizeCalculator.getAsInt(), is(defaultBlockSize));
+        assertThat(blockSizeCalculator.applyAsInt(-1), is(defaultBlockSize));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
@@ -1023,12 +1024,11 @@ public class JoinIntegrationTest extends IntegTestCase {
         RamBlockSizeCalculator ramBlockSizeCalculator = new RamBlockSizeCalculator(
             500_000,
             circuitBreaker,
-            rowSizeBytes,
-            rowsCount
+            rowSizeBytes
         );
         logger.info("\n\tThe block size for relation {}, total size {} bytes, with row count {} and row size {} bytes, " +
                     "if it would be used in a block join algorithm, would be {}",
-            relationName, tableSizeInBytes, rowsCount, rowSizeBytes, ramBlockSizeCalculator.getAsInt());
+            relationName, tableSizeInBytes, rowsCount, rowSizeBytes, ramBlockSizeCalculator.applyAsInt(-1));
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/execution/engine/sort/IgnoreRowCellsAccounting.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/sort/IgnoreRowCellsAccounting.java
@@ -26,7 +26,8 @@ import io.crate.data.breaker.RowAccounting;
 public class IgnoreRowCellsAccounting implements RowAccounting<Object[]> {
 
     @Override
-    public void accountForAndMaybeBreak(Object[] cells) {
+    public long accountForAndMaybeBreak(Object[] cells) {
+        return 42;
     }
 
     @Override

--- a/server/src/testFixtures/java/io/crate/execution/engine/window/IgnoreRowAccounting.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/window/IgnoreRowAccounting.java
@@ -27,7 +27,8 @@ import io.crate.data.breaker.RowAccounting;
 public class IgnoreRowAccounting implements RowAccounting<Row> {
 
     @Override
-    public void accountForAndMaybeBreak(Row row) {
+    public long accountForAndMaybeBreak(Row row) {
+        return 42;
     }
 
     @Override


### PR DESCRIPTION
This changes the block size calculation to no longer rely on the table
size, and only use the row-size stats for the initial block. For any
later block it uses the runtime information calculated by the
`RowAccounting` instance.

This reduces reliance on the statistics, and leads to better performance
if the stats estimates are bad.

An example are the queries in the `joins_many_tables.toml` spec file in
the crate-benchmarks repository:

    V1: 5.6.0-0016a7b05e481317f7ff66c5498e9bf7b64791c8
    V2: 5.6.0-d746f9655e0b610adec67a95832acc84f71b2b7d

    Q: SELECT *
                   FROM t1,t2,t3,t4,t5,t6,t7,t8,t9,t10
                  WHERE a7=9
                    AND a6=b1
                    AND b6=a5
                    AND b8=a1
                    AND a9=b2
                    AND a2=b5
                    AND b3=a7
                    AND a10=b9
                    AND a3=b10
                    AND b4=a8
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        3.096 ±    0.474 |      2.785 |      3.003 |      3.089 |     11.792 |
    |   V2    |        0.709 ±    1.143 |      0.520 |      0.613 |      0.655 |     34.056 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               - 125.46%                           - 132.19%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 125.46%
    The test has statistical significance
