### PR TITLE
Remove numExpectedRows and estimatedRowSize from Collect

### DIFF
--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -365,9 +365,7 @@ public class ExplainPlan implements Plan {
             var optimizedCollect = new Collect(
                 collect.relation(),
                 collect.outputs(),
-                collect.where().map(s -> Optimizer.optimizeCasts(s, context)),
-                collect.numExpectedRows(),
-                collect.estimatedRowSize()
+                collect.where().map(s -> Optimizer.optimizeCasts(s, context))
             );
             return visitPlan(optimizedCollect, context);
         }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -337,12 +337,12 @@ public class LogicalPlanner {
 
         @Override
         public LogicalPlan visitDocTableRelation(DocTableRelation relation, List<Symbol> outputs) {
-            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, planStats, params);
+            return new Collect(relation, outputs, WhereClause.MATCH_ALL);
         }
 
         @Override
         public LogicalPlan visitTableRelation(TableRelation relation, List<Symbol> outputs) {
-            return Collect.create(relation, outputs, WhereClause.MATCH_ALL, planStats, params);
+            return new Collect(relation, outputs, WhereClause.MATCH_ALL);
         }
 
         @Override

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -32,8 +32,6 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.planner.selectivity.SelectivityFunctions;
-import io.crate.statistics.Stats;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
@@ -64,14 +62,11 @@ public class MergeFilterAndCollect implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
-        Stats stats = planStats.get(collect.relation().tableInfo().ident());
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(
             collect.relation(),
             collect.outputs(),
-            newWhere,
-            SelectivityFunctions.estimateNumRows(stats, newWhere.queryOrFallback(), null),
-            stats.averageSizePerRowInBytes()
+            newWhere
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -161,12 +161,10 @@ public final class CopyToPlan implements Plan {
             outputFormat,
             boundedCopyTo.withClauseOptions());
 
-        LogicalPlan collect = Collect.create(
+        LogicalPlan collect = new Collect(
             new DocTableRelation(boundedCopyTo.table()),
             boundedCopyTo.outputs(),
-            boundedCopyTo.whereClause(),
-            planStats,
-            context.params()
+            boundedCopyTo.whereClause()
         );
         LogicalPlan source = optimizeCollect(context, planStats, collect);
         ExecutionPlan executionPlan = source.build(

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -63,7 +63,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL);
         var eval = new Eval(
             collect,
             List.of(
@@ -98,7 +98,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         Reference x = (Reference) e.asSymbol("x");
         var relation = new DocTableRelation(tableInfo);
         var alias = new AliasedAnalyzedRelation(relation, new RelationName(null, "t1"));
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL);
         Symbol t1X = alias.getField(x.column(), Operation.READ, true);
         assertThat(t1X).isNotNull();
         var rename = new Rename(List.of(t1X), alias.relationName(), alias, collect);
@@ -135,7 +135,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tableInfo = e.resolveTableInfo("tbl");
         var x = new AliasSymbol("x_alias", e.asSymbol("x"));
         var relation = new DocTableRelation(tableInfo);
-        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var collect = new Collect(relation, List.of(x), WhereClause.MATCH_ALL);
         var eval = new Eval(
             collect,
             List.of(x)

--- a/server/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_LIMIT;
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_OFFSET;
-import static io.crate.planner.optimizer.costs.PlanStatsTest.PLAN_STATS_EMPTY;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLimitAndOffset;
 import static org.mockito.Mockito.mock;
@@ -62,12 +61,10 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan plan = Limit.create(
             Limit.create(
-                Collect.create(
+                new Collect(
                     ((AbstractTableRelation<?>) queriedDocTable.from().get(0)),
                     queriedDocTable.outputs(),
-                    new WhereClause(queriedDocTable.where()),
-                    PLAN_STATS_EMPTY,
-                    null
+                    new WhereClause(queriedDocTable.where())
                 ),
                 Literal.of(10L),
                 Literal.of(5L)

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -46,7 +46,6 @@ import io.crate.sql.tree.JoinType;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
-import io.crate.types.DataTypes;
 
 public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnitTest {
 
@@ -71,7 +70,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
         t1Relation = new DocTableRelation(t1);
         t1RenamedRelationName = new RelationName("doc", "t1_renamed");
         var t1Alias = new AliasedAnalyzedRelation(t1Relation, t1RenamedRelationName);
-        var t1Collect = new Collect(t1Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var t1Collect = new Collect(t1Relation, List.of(x), WhereClause.MATCH_ALL);
         Symbol t1Output = t1Alias.getField(x.column(), Operation.READ, true);
         t1Rename = new Rename(List.of(t1Output), t1Alias.relationName(), t1Alias, t1Collect);
 
@@ -80,7 +79,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
         t2Relation = new DocTableRelation(t2);
         t2RenamedRelationName = new RelationName("doc", "t2_renamed");
         var t2Alias = new AliasedAnalyzedRelation(t2Relation, t2RenamedRelationName);
-        var t2Collect = new Collect(t2Relation, List.of(x), WhereClause.MATCH_ALL, 1L, DataTypes.INTEGER.fixedSize());
+        var t2Collect = new Collect(t2Relation, List.of(x), WhereClause.MATCH_ALL);
         Symbol t2Output = t2Alias.getField(y.column(), Operation.READ, true);
         t2Rename = new Rename(List.of(t2Output), t2Alias.relationName(), t2Alias, t2Collect);
     }
@@ -123,7 +122,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_collect() {
-        var collect = new Collect(t1Relation, List.of(), new WhereClause(null), 1,1);
+        var collect = new Collect(t1Relation, List.of(), new WhereClause(null));
         assertThat(collect.baseTables(), containsInAnyOrder(t1Relation));
         assertThat(collect.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
     }

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -62,9 +62,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var x = e.asSymbol("x");
         var source = new Collect(new DocTableRelation(a),
                                  List.of(x),
-                                 WhereClause.MATCH_ALL,
-                                 1L,
-                                 DataTypes.INTEGER.fixedSize());
+                                 WhereClause.MATCH_ALL);
 
         TableStats tableStats = new TableStats();
         tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, DataTypes.INTEGER.fixedSize(), Map.of())));
@@ -85,11 +83,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo a = e.resolveTableInfo("a");
 
         var x = e.asSymbol("x");
-        var source = new Collect(new DocTableRelation(a),
-                                 List.of(x),
-                                 WhereClause.MATCH_ALL,
-                                 1L,
-                                 DataTypes.INTEGER.fixedSize());
+        var source = new Collect(new DocTableRelation(a), List.of(x), WhereClause.MATCH_ALL);
         var groupReference = new GroupReference(1, source.outputs(), Set.of());
 
         TableStats tableStats = new TableStats();
@@ -111,11 +105,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo a = e.resolveTableInfo("a");
 
         var x = e.asSymbol("x");
-        var source = new Collect(new DocTableRelation(a),
-                                 List.of(x),
-                                 WhereClause.MATCH_ALL,
-                                 10L,
-                                 DataTypes.INTEGER.fixedSize());
+        var source = new Collect(new DocTableRelation(a), List.of(x), WhereClause.MATCH_ALL);
 
         TableStats tableStats = new TableStats();
         tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
@@ -141,17 +131,9 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var x = e.asSymbol("x");
         var y = e.asSymbol("x");
 
-        var lhs = new Collect(new DocTableRelation(aDoc),
-                                 List.of(x),
-                                 WhereClause.MATCH_ALL,
-                                 9L,
-                                 DataTypes.INTEGER.fixedSize());
+        var lhs = new Collect(new DocTableRelation(aDoc), List.of(x), WhereClause.MATCH_ALL);
 
-        var rhs = new Collect(new DocTableRelation(bDoc),
-                                 List.of(y),
-                                 WhereClause.MATCH_ALL,
-                                 1L,
-                                 DataTypes.INTEGER.fixedSize());
+        var rhs = new Collect(new DocTableRelation(bDoc), List.of(y), WhereClause.MATCH_ALL);
 
         TableStats tableStats = new TableStats();
         tableStats.updateTableStats(
@@ -183,17 +165,9 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var x = e.asSymbol("x");
         var y = e.asSymbol("x");
 
-        var lhs = new Collect(new DocTableRelation(aDoc),
-                              List.of(x),
-                              WhereClause.MATCH_ALL,
-                              9L,
-                              DataTypes.INTEGER.fixedSize());
+        var lhs = new Collect(new DocTableRelation(aDoc), List.of(x), WhereClause.MATCH_ALL);
 
-        var rhs = new Collect(new DocTableRelation(bDoc),
-                              List.of(y),
-                              WhereClause.MATCH_ALL,
-                              1L,
-                              DataTypes.INTEGER.fixedSize());
+        var rhs = new Collect(new DocTableRelation(bDoc), List.of(y), WhereClause.MATCH_ALL);
 
         TableStats tableStats = new TableStats();
         tableStats.updateTableStats(
@@ -227,17 +201,9 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var y = e.asSymbol("x");
 
         DocTableRelation relation = new DocTableRelation(aDoc);
-        var lhs = new Collect(relation,
-                              List.of(x),
-                              WhereClause.MATCH_ALL,
-                              9L,
-                              DataTypes.INTEGER.fixedSize());
+        var lhs = new Collect(relation, List.of(x), WhereClause.MATCH_ALL);
 
-        var rhs = new Collect(new DocTableRelation(bDoc),
-                              List.of(y),
-                              WhereClause.MATCH_ALL,
-                              2L,
-                              DataTypes.INTEGER.fixedSize());
+        var rhs = new Collect(new DocTableRelation(bDoc), List.of(y), WhereClause.MATCH_ALL);
 
         TableStats tableStats = new TableStats();
         tableStats.updateTableStats(

--- a/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/matcher/PatternTest.java
@@ -63,7 +63,7 @@ public class PatternTest {
 
     @Test
     public void test_with_source_matching() {
-        Collect source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 1, 1);
+        Collect source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL);
         Filter filter = new Filter(source, mock(Symbol.class));
         var pattern = typeOf(Filter.class).with(source(), typeOf(Collect.class));
         assertMatch(pattern, filter);
@@ -82,7 +82,7 @@ public class PatternTest {
 
     @Test
     public void test_with_match_group_referenced_source() {
-        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
+        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL);
         var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 
@@ -108,7 +108,7 @@ public class PatternTest {
 
     @Test
     public void test_with_property_match_group_referenced_source() {
-        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL, 100, 10);
+        var source = new Collect(mock(AbstractTableRelation.class), List.of(), WhereClause.MATCH_ALL);
         var groupReferenceSource = new GroupReference(1, source.outputs(), Set.of());
         var filter = new Filter(groupReferenceSource, mock(Symbol.class));
 
@@ -125,7 +125,7 @@ public class PatternTest {
         Capture<Collect> capture = new Capture<>();
         Pattern<Filter> pattern = typeOf(Filter.class)
                                     .with(source(), typeOf(Collect.class)
-                                    .with(s -> s.estimatedRowSize() == 10).capturedAs(capture));
+                                    .with(s -> s.where() != null).capturedAs(capture));
 
         Match<Filter> match = pattern.accept(filter, Captures.empty(), groupReferenceResolver);
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -59,7 +59,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testMergeFiltersMatchesOnAFilterWithAnotherFilterAsChild() {
-        Collect source = new Collect(tr1, Collections.emptyList(), WhereClause.MATCH_ALL, 100, 10);
+        Collect source = new Collect(tr1, Collections.emptyList(), WhereClause.MATCH_ALL);
         Filter sourceFilter = new Filter(source, e.asSymbol("x > 10"));
         Filter parentFilter = new Filter(sourceFilter, e.asSymbol("y > 10"));
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -65,8 +65,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var t1 = (AbstractTableRelation<?>) sources.get(T3.T1);
         var t2 = (AbstractTableRelation<?>) sources.get(T3.T2);
 
-        Collect c1 = new Collect(t1, Collections.emptyList(), WhereClause.MATCH_ALL, 1, 1);
-        Collect c2 = new Collect(t2, Collections.emptyList(), WhereClause.MATCH_ALL, 1, 1);
+        Collect c1 = new Collect(t1, Collections.emptyList(), WhereClause.MATCH_ALL);
+        Collect c2 = new Collect(t2, Collections.emptyList(), WhereClause.MATCH_ALL);
 
         // This condition has a non-constant part `doc.t1.x = doc.t2.y` and a constant part `doc.t2.b = 'abc'`
         var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t2.b = 'abc'");

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -96,9 +96,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
         var collect = new Collect(
             tr1,
             Collections.emptyList(),
-            new WhereClause(e.asSymbol(query)),
-            100,
-            10
+            new WhereClause(e.asSymbol(query))
         );
         var plan = (io.crate.planner.node.dql.Collect) collect.build(
             mock(DependencyCarrier.class),


### PR DESCRIPTION
This removes numExpectedRows and estimatedRowSize because these are never used and replaced by stats now.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
