### PR TITLE
Enable `columnstore = off` for numeric & timestamp data types

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -86,6 +86,11 @@ None
 Changes
 =======
 
+- Added support to disable :ref:`column storage <ddl-storage-columnstore>` for
+  :ref:`numeric data types <data-types-numeric>`,
+  :ref:`timestamp <type-timestamp>` and
+  :ref:`timestamp with timezone`<type-timestamp-with-tz>`.
+
 - Updated Lucene to 9.6.0
 
 - Added support for :ref:`AVG() aggregation <aggregation-avg>` on

--- a/docs/general/ddl/storage.rst
+++ b/docs/general/ddl/storage.rst
@@ -52,6 +52,9 @@ Controlling if values are stored into a `Column Store`_ is only supported on
 following data types:
 
  - :ref:`type-text`
+ - :ref:`data-types-numeric`
+ - :ref:`type-timestamp`
+ - :ref:`type-timestamp-with-tz`
 
 For all other :ref:`data-types-primitive` and :ref:`data-types-geo-point` it is
 enabled by default and cannot be disabled. :ref:`data-types-container` and

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -363,12 +363,14 @@ public class AnalyzedColumnDefinition<T> {
                     DataType<?> dataType = definition.dataType();
                     boolean val = storageSettings.getAsBoolean(property, true);
                     if (val == false) {
-                        if (dataType.id() != DataTypes.STRING.id()) {
+                        if (dataType.storageSupport().supportsDocValuesOff()) {
+                            definition.docValues = false;
+                        } else {
                             throw new IllegalArgumentException(
-                                String.format(Locale.ENGLISH, "Invalid storage option \"columnstore\" for data type \"%s\"",
-                                    dataType.getName()));
+                                String.format(Locale.ENGLISH,
+                                              "Invalid storage option \"columnstore\" for data type \"%s\"",
+                                              dataType.getName()));
                         }
-                        definition.docValues = false;
                     }
                 } else {
                     throw new IllegalArgumentException(

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
@@ -82,16 +82,20 @@ public class OptimizeQueryForSearchAfter implements Function<FieldDoc, Query> {
                     BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
                     booleanQuery.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
                     if (orderBy.reverseFlags()[i]) {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, null, value, false, true), BooleanClause.Occur.MUST_NOT);
+                        booleanQuery.add(eqQuery.rangeQuery(columnName, null, value, false, true, ref.hasDocValues()),
+                                         BooleanClause.Occur.MUST_NOT);
                     } else {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, value, null, true, false), BooleanClause.Occur.MUST_NOT);
+                        booleanQuery.add(eqQuery.rangeQuery(columnName, value, null, true, false, ref.hasDocValues()),
+                                         BooleanClause.Occur.MUST_NOT);
                     }
                     orderQuery = booleanQuery.build();
                 } else {
                     if (orderBy.reverseFlags()[i]) {
-                        orderQuery = eqQuery.rangeQuery(columnName, value, null, false, false);
+                        orderQuery = eqQuery.rangeQuery(
+                                columnName, value, null, false, false, ref.hasDocValues());
                     } else {
-                        orderQuery = eqQuery.rangeQuery(columnName, null, value, false, false);
+                        orderQuery = eqQuery.rangeQuery(
+                                columnName, null, value, false, false, ref.hasDocValues());
                     }
                 }
                 queryBuilder.add(orderQuery, BooleanClause.Occur.MUST);

--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -93,10 +93,14 @@ public final class CmpOperator extends Operator<Object> {
         }
         String field = ref.column().fqn();
         return switch (functionName) {
-            case GtOperator.NAME -> eqQuery.rangeQuery(field, value, null, false, false);
-            case GteOperator.NAME -> eqQuery.rangeQuery(field, value, null, true, false);
-            case LtOperator.NAME -> eqQuery.rangeQuery(field, null, value, false, false);
-            case LteOperator.NAME -> eqQuery.rangeQuery(field, null, value, false, true);
+            case GtOperator.NAME -> eqQuery.rangeQuery(
+                    field, value, null, false, false, ref.hasDocValues());
+            case GteOperator.NAME -> eqQuery.rangeQuery(
+                    field, value, null, true, false, ref.hasDocValues());
+            case LtOperator.NAME ->
+                    eqQuery.rangeQuery(field, null, value, false, false, ref.hasDocValues());
+            case LteOperator.NAME ->
+                    eqQuery.rangeQuery(field, null, value, false, true, ref.hasDocValues());
             default -> throw new IllegalArgumentException(functionName + " is not a supported comparison operator");
         };
     }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -96,11 +96,11 @@ public final class AnyNeqOperator extends AnyOperator {
         BooleanQuery.Builder query = new BooleanQuery.Builder();
         query.setMinimumNumberShouldMatch(1);
         query.add(
-            eqQuery.rangeQuery(columnName, value, null, false, false),
+            eqQuery.rangeQuery(columnName, value, null, false, false, candidates.hasDocValues()),
             BooleanClause.Occur.SHOULD
         );
         query.add(
-            eqQuery.rangeQuery(columnName, null, value, false, false),
+            eqQuery.rangeQuery(columnName, null, value, false, false, candidates.hasDocValues()),
             BooleanClause.Occur.SHOULD
         );
         return query.build();

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -91,6 +91,7 @@ public class ArrayType<T> extends DataType<List<T>> {
         } else {
             this.storageSupport = new StorageSupport<T>(
                     innerStorage.docValuesDefault(),
+                    innerStorage.supportsDocValuesOff(),
                     innerStorage.hasFieldNamesIndex(),
                     innerStorage.eqQuery()) {
 

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -64,6 +64,7 @@ public final class BitStringType extends DataType<BitString> implements Streamer
 
     private static final StorageSupport<BitString> STORAGE = new StorageSupport<>(
         true,
+        false,
         true,
         new EqQuery<BitString>() {
 
@@ -77,7 +78,8 @@ public final class BitStringType extends DataType<BitString> implements Streamer
                                     BitString lowerTerm,
                                     BitString upperTerm,
                                     boolean includeLower,
-                                    boolean includeUpper) {
+                                    boolean includeUpper,
+                                    boolean hasDocValues) {
                 return null;
             }
         }

--- a/server/src/main/java/io/crate/types/BooleanType.java
+++ b/server/src/main/java/io/crate/types/BooleanType.java
@@ -66,13 +66,18 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
                                 Boolean lowerTerm,
                                 Boolean upperTerm,
                                 boolean includeLower,
-                                boolean includeUpper) {
+                                boolean includeUpper,
+                                boolean hasDocValues) {
             return new TermRangeQuery(
                 field, indexedValue(lowerTerm), indexedValue(upperTerm), includeLower, includeUpper);
         }
     };
 
-    private static final StorageSupport<Boolean> STORAGE = new StorageSupport<>(true, true, EQ_QUERY) {
+    private static final StorageSupport<Boolean> STORAGE = new StorageSupport<>(
+            true,
+            false,
+            true,
+            EQ_QUERY) {
 
         @Override
         public ValueIndexer<Boolean> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/ByteType.java
+++ b/server/src/main/java/io/crate/types/ByteType.java
@@ -40,7 +40,11 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
 
     public static final ByteType INSTANCE = new ByteType();
     public static final int ID = 2;
-    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery()) {
+    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(
+            true,
+            true,
+            true,
+            new IntEqQuery()) {
 
         @Override
         public ValueIndexer<Number> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -306,13 +306,14 @@ public final class DataTypes {
         entry(BitString.class, BitStringType.INSTANCE_ONE)
     );
 
+    @SuppressWarnings("unchecked")
     public static DataType<?> guessType(Object value) {
         if (value == null) {
             return UNDEFINED;
         } else if (value instanceof Map) {
             return UNTYPED_OBJECT;
-        } else if (value instanceof List) {
-            return valueFromList((List) value);
+        } else if (value instanceof List list) {
+            return valueFromList(list);
         } else if (value.getClass().isArray()) {
             return valueFromList(Arrays.asList((Object[]) value));
         }

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.function.Function;
 
 import org.apache.lucene.document.DoublePoint;
@@ -101,6 +102,9 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
         }
     };
 
+    private static final BigInteger DOUBLE_MAX = BigDecimal.valueOf(Double.MAX_VALUE).toBigInteger();
+    private static final BigInteger DOUBLE_MIN = BigDecimal.valueOf(-Double.MAX_VALUE).toBigInteger();
+
     private DoubleType() {
     }
 
@@ -133,8 +137,6 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
         } else if (value instanceof String s) {
             return Double.valueOf(s);
         } else if (value instanceof BigDecimal bigDecimalValue) {
-            var DOUBLE_MAX = BigDecimal.valueOf(Double.MAX_VALUE).toBigInteger();
-            var DOUBLE_MIN = BigDecimal.valueOf(-Double.MAX_VALUE).toBigInteger();
             if (DOUBLE_MAX.compareTo(bigDecimalValue.toBigInteger()) <= 0
                 || DOUBLE_MIN.compareTo(bigDecimalValue.toBigInteger()) >= 0) {
                 throw new IllegalArgumentException(getName() + " value out of range: " + value);

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -30,5 +30,10 @@ public interface EqQuery<T> {
 
     Query termQuery(String field, T value);
 
-    Query rangeQuery(String field, T lowerTerm, T upperTerm, boolean includeLower, boolean includeUpper);
+    Query rangeQuery(String field,
+                     T lowerTerm,
+                     T upperTerm,
+                     boolean includeLower,
+                     boolean includeUpper,
+                     boolean hasDocValues);
 }

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -51,6 +51,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
     private static final StorageSupport<Float> STORAGE = new StorageSupport<>(
         true,
         true,
+        true,
         new EqQuery<Float>() {
 
             @Override
@@ -63,7 +64,8 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                                     Float lowerTerm,
                                     Float upperTerm,
                                     boolean includeLower,
-                                    boolean includeUpper) {
+                                    boolean includeUpper,
+                                    boolean hasDocValues) {
                 float lower;
                 if (lowerTerm == null) {
                     lower = Float.NEGATIVE_INFINITY;
@@ -79,8 +81,14 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                 }
 
                 Query indexQuery = FloatPoint.newRangeQuery(field, lower, upper);
-                Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(field, NumericUtils.floatToSortableInt(lower), NumericUtils.floatToSortableInt(upper));
-                return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+                if (hasDocValues) {
+                    Query dvQuery = SortedNumericDocValuesField
+                            .newSlowRangeQuery(field,
+                                               NumericUtils.floatToSortableInt(lower),
+                                               NumericUtils.floatToSortableInt(upper));
+                    return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+                }
+                return indexQuery;
             }
         }
     ) {

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -87,15 +87,13 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
     public Point implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof Point) {
-            return ((Point) value);
-        } else if (value instanceof Double[]) {
-            Double[] doubles = (Double[]) value;
+        } else if (value instanceof Point point) {
+            return point;
+        } else if (value instanceof Double[] doubles) {
             checkLengthIs2(doubles.length);
             ensurePointsInRange(doubles[0], doubles[1]);
             return new PointImpl(doubles[0], doubles[1], JtsSpatialContext.GEO);
-        } else if (value instanceof Object[]) {
-            Object[] values = (Object[]) value;
+        } else if (value instanceof Object[] values) {
             checkLengthIs2(values.length);
             PointImpl point = new PointImpl(
                 ((Number) values[0]).doubleValue(),
@@ -103,10 +101,9 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
                 JtsSpatialContext.GEO);
             ensurePointsInRange(point.getX(), point.getY());
             return point;
-        } else if (value instanceof String) {
-            return pointFromString((String) value);
-        } else if (value instanceof List) {
-            List<?> values = (List<?>) value;
+        } else if (value instanceof String str) {
+            return pointFromString(str);
+        } else if (value instanceof List<?> values) {
             checkLengthIs2(values.size());
             PointImpl point = new PointImpl(
                 ((Number) values.get(0)).doubleValue(),
@@ -123,8 +120,7 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
     public Point sanitizeValue(Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof List) {
-            List<?> values = (List<?>) value;
+        } else if (value instanceof List values) {
             checkLengthIs2(values.size());
             PointImpl point = new PointImpl(
                 ((Number) values.get(0)).doubleValue(),

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -47,7 +47,7 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
 
     public static final int ID = 13;
     public static final GeoPointType INSTANCE = new GeoPointType();
-    private static StorageSupport<Point> STORAGE = new StorageSupport<>(true, true, null) {
+    private static StorageSupport<Point> STORAGE = new StorageSupport<>(true, false, true, null) {
 
         @Override
         public ValueIndexer<Point> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/GeoShapeType.java
+++ b/server/src/main/java/io/crate/types/GeoShapeType.java
@@ -48,7 +48,7 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
 
     public static final int ID = 14;
     public static final GeoShapeType INSTANCE = new GeoShapeType();
-    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, true, null) {
+    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, false, true, null) {
 
         @Override
         public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/IntEqQuery.java
+++ b/server/src/main/java/io/crate/types/IntEqQuery.java
@@ -38,7 +38,8 @@ public class IntEqQuery implements EqQuery<Number> {
                             Number lowerTerm,
                             Number upperTerm,
                             boolean includeLower,
-                            boolean includeUpper) {
+                            boolean includeUpper,
+                            boolean hasDocValues) {
         int lower = Integer.MIN_VALUE;
         if (lowerTerm != null) {
             lower = includeLower ? lowerTerm.intValue() : lowerTerm.intValue() + 1;
@@ -48,6 +49,10 @@ public class IntEqQuery implements EqQuery<Number> {
             upper = includeUpper ? upperTerm.intValue() : upperTerm.intValue() - 1;
         }
         Query indexquery = IntPoint.newRangeQuery(field, lower, upper);
-        return new IndexOrDocValuesQuery(indexquery, SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper));
+        if (hasDocValues) {
+            return new IndexOrDocValuesQuery(
+                    indexquery, SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper));
+        }
+        return indexquery;
     }
 }

--- a/server/src/main/java/io/crate/types/IntegerType.java
+++ b/server/src/main/java/io/crate/types/IntegerType.java
@@ -42,7 +42,7 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
     public static final IntegerType INSTANCE = new IntegerType();
     public static final int ID = 9;
     public static final int INTEGER_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Integer.class);
-    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery()) {
+    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, true, new IntEqQuery()) {
 
         @Override
         public ValueIndexer<Number> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/IntegerType.java
+++ b/server/src/main/java/io/crate/types/IntegerType.java
@@ -80,14 +80,13 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
     public Integer implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof Integer) {
-            return (Integer) value;
-        } else if (value instanceof String) {
-            return Integer.parseInt((String) value);
-        } else if (value instanceof Regproc) {
-            return ((Regproc) value).oid();
-        } else if (value instanceof BigDecimal) {
-            var bigDecimalValue = (BigDecimal) value;
+        } else if (value instanceof Integer i) {
+            return i;
+        } else if (value instanceof String str) {
+            return Integer.parseInt(str);
+        } else if (value instanceof Regproc regproc) {
+            return regproc.oid();
+        } else if (value instanceof BigDecimal bigDecimalValue) {
             var max = BigDecimal.valueOf(Integer.MAX_VALUE).toBigInteger();
             var min = BigDecimal.valueOf(Integer.MIN_VALUE).toBigInteger();
             if (max.compareTo(bigDecimalValue.toBigInteger()) <= 0
@@ -95,14 +94,14 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
                 throw new IllegalArgumentException(getName() + " value out of range: " + value);
             }
             return ((BigDecimal) value).intValue();
-        } else if (value instanceof Number) {
-            long longVal = ((Number) value).longValue();
+        } else if (value instanceof Number number) {
+            long longVal = number.longValue();
             if (longVal < Integer.MIN_VALUE || Integer.MAX_VALUE < longVal) {
                 throw new IllegalArgumentException("integer value out of range: " + longVal);
             }
             return ((Number) value).intValue();
-        } else if (value instanceof Regclass) {
-            return ((Regclass) value).oid();
+        } else if (value instanceof Regclass regclass) {
+            return regclass.oid();
         } else {
             throw new ClassCastException("Can't cast '" + value + "' to " + getName());
         }
@@ -112,8 +111,8 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
     public Integer sanitizeValue(Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Integer) {
-            return (Integer) value;
+        } else if (value instanceof Integer i) {
+            return i;
         } else {
             return ((Number) value).intValue();
         }

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -46,6 +46,7 @@ public class IpType extends DataType<String> implements Streamer<String> {
     public static final IpType INSTANCE = new IpType();
     private static final StorageSupport<String> STORAGE = new StorageSupport<>(
         true,
+        false,
         true,
         new EqQuery<String>() {
 
@@ -59,7 +60,8 @@ public class IpType extends DataType<String> implements Streamer<String> {
                                     String lowerTerm,
                                     String upperTerm,
                                     boolean includeLower,
-                                    boolean includeUpper) {
+                                    boolean includeUpper,
+                                    boolean hasDocValues) {
                 InetAddress lower;
                 if (lowerTerm == null) {
                     lower = InetAddressPoint.MIN_VALUE;

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -111,11 +111,11 @@ public class IpType extends DataType<String> implements Streamer<String> {
     public String implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof String) {
-            validate((String) value);
+        } else if (value instanceof String str) {
+            validate(str);
             return (String) value;
-        } else if (value instanceof Number) {
-            long longIp = ((Number) value).longValue();
+        } else if (value instanceof Number number) {
+            long longIp = number.longValue();
             if (longIp < 0) {
                 throw new IllegalArgumentException(
                     "Failed to convert long value: " + longIp + " to ipv4 address");

--- a/server/src/main/java/io/crate/types/LongEqQuery.java
+++ b/server/src/main/java/io/crate/types/LongEqQuery.java
@@ -38,7 +38,8 @@ public class LongEqQuery implements EqQuery<Long> {
                             Long lowerTerm,
                             Long upperTerm,
                             boolean includeLower,
-                            boolean includeUpper) {
+                            boolean includeUpper,
+                            boolean hasDocValues) {
         long lower = lowerTerm == null
             ? Long.MIN_VALUE
             : (includeLower ? lowerTerm : lowerTerm + 1);
@@ -46,6 +47,10 @@ public class LongEqQuery implements EqQuery<Long> {
             ? Long.MAX_VALUE
             : (includeUpper ? upperTerm : upperTerm - 1);
         Query indexQuery = LongPoint.newRangeQuery(field, lower, upper);
-        return new IndexOrDocValuesQuery(indexQuery, SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper));
+        if (hasDocValues) {
+            return new IndexOrDocValuesQuery(indexQuery,
+                                             SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper));
+        }
+        return indexQuery;
     }
 }

--- a/server/src/main/java/io/crate/types/LongType.java
+++ b/server/src/main/java/io/crate/types/LongType.java
@@ -45,6 +45,7 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
     private static final StorageSupport<Long> STORAGE = new StorageSupport<>(
         true,
         true,
+        true,
         new LongEqQuery()
     ) {
 

--- a/server/src/main/java/io/crate/types/LongType.java
+++ b/server/src/main/java/io/crate/types/LongType.java
@@ -82,12 +82,11 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
     public Long implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof Long) {
-            return (Long) value;
-        } else if (value instanceof String) {
-            return Long.valueOf((String) value);
-        } else if (value instanceof BigDecimal) {
-            var bigDecimalValue = (BigDecimal) value;
+        } else if (value instanceof Long l) {
+            return l;
+        } else if (value instanceof String str) {
+            return Long.valueOf(str);
+        } else if (value instanceof BigDecimal bigDecimalValue) {
             var max = BigDecimal.valueOf(Long.MAX_VALUE).toBigInteger();
             var min = BigDecimal.valueOf(Long.MIN_VALUE).toBigInteger();
             if (max.compareTo(bigDecimalValue.toBigInteger()) <= 0

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -69,7 +69,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     public static final ObjectType UNTYPED = new ObjectType();
     public static final int ID = 12;
     public static final String NAME = "object";
-    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, true, null) {
+    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, false, true, null) {
 
         @Override
         public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/ShortType.java
+++ b/server/src/main/java/io/crate/types/ShortType.java
@@ -80,18 +80,18 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
     public Short implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof Short) {
-            return (Short) value;
-        } else if (value instanceof String) {
-            return Short.valueOf((String) value);
-        } else if (value instanceof BigDecimal) {
+        } else if (value instanceof Short s) {
+            return s;
+        } else if (value instanceof String str) {
+            return Short.valueOf(str);
+        } else if (value instanceof BigDecimal bigDecimal) {
             try {
-                return ((BigDecimal) value).shortValueExact();
+                return bigDecimal.shortValueExact();
             } catch (ArithmeticException e) {
                 throw new IllegalArgumentException("short value out of range: " + value);
             }
-        } else if (value instanceof Number) {
-            int intVal = ((Number) value).intValue();
+        } else if (value instanceof Number number) {
+            int intVal = number.intValue();
             if (intVal < Short.MIN_VALUE || Short.MAX_VALUE < intVal) {
                 throw new IllegalArgumentException("short value out of range: " + intVal);
             }
@@ -105,8 +105,8 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
     public Short sanitizeValue(Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Short) {
-            return (Short) value;
+        } else if (value instanceof Short s) {
+            return s;
         } else {
             return ((Number) value).shortValue();
         }

--- a/server/src/main/java/io/crate/types/ShortType.java
+++ b/server/src/main/java/io/crate/types/ShortType.java
@@ -42,7 +42,7 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
     public static final ShortType INSTANCE = new ShortType();
     public static final int ID = 8;
     private static final int SHORT_SIZE = (int) RamUsageEstimator.shallowSizeOfInstance(Short.class);
-    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, new IntEqQuery()) {
+    private static final StorageSupport<Number> STORAGE = new StorageSupport<>(true, true, true, new IntEqQuery()) {
 
         @Override
         public ValueIndexer<Number> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -37,15 +37,18 @@ import io.crate.metadata.RelationName;
 public abstract class StorageSupport<T> {
 
     private final boolean docValuesDefault;
+    private final boolean supportsDocValuesOff;
     private final boolean hasFieldNamesIndex;
 
     @Nullable
     private final EqQuery<T> eqQuery;
 
     public StorageSupport(boolean docValuesDefault,
+                          boolean supportsDocValuesOff,
                           boolean hasFieldNamesIndex,
                           EqQuery<T> eqQuery) {
         this.docValuesDefault = docValuesDefault;
+        this.supportsDocValuesOff = supportsDocValuesOff;
         this.hasFieldNamesIndex = hasFieldNamesIndex;
         this.eqQuery = eqQuery;
     }
@@ -64,6 +67,10 @@ public abstract class StorageSupport<T> {
 
     public boolean docValuesDefault() {
         return docValuesDefault;
+    }
+
+    public boolean supportsDocValuesOff() {
+        return supportsDocValuesOff;
     }
 
     public boolean hasFieldNamesIndex() {

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -209,10 +209,10 @@ public class StringType extends DataType<String> implements Streamer<String> {
     protected String cast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof String) {
-            return (String) value;
-        } else if (value instanceof BytesRef) {
-            return ((BytesRef) value).utf8ToString();
+        } else if (value instanceof String str) {
+            return str;
+        } else if (value instanceof BytesRef bytesRef) {
+            return bytesRef.utf8ToString();
         } else if (value instanceof Boolean) {
             return (boolean) value ? T : F;
         } else if (value instanceof Map) {

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -74,6 +74,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
     private static final StorageSupport<Object> STORAGE = new StorageSupport<>(
         true,
         true,
+        true,
         new EqQuery<Object>() {
 
             @Override
@@ -86,7 +87,8 @@ public class StringType extends DataType<String> implements Streamer<String> {
                                     Object lowerTerm,
                                     Object upperTerm,
                                     boolean includeLower,
-                                    boolean includeUpper) {
+                                    boolean includeUpper,
+                                    boolean hasDocValues) {
                 return new TermRangeQuery(
                     field,
                     BytesRefs.toBytesRef(lowerTerm),

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -115,18 +115,18 @@ public final class TimestampType extends DataType<Long>
     public Long implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
-        } else if (value instanceof Long) {
-            return (Long) value;
-        } else if (value instanceof String) {
-            return parse.apply((String) value);
+        } else if (value instanceof Long l) {
+            return l;
+        } else if (value instanceof String str) {
+            return parse.apply(str);
         } else if (value instanceof Double) {
             // we treat float and double values as seconds with milliseconds as fractions
             // see timestamp documentation
             return ((Number) (((Double) value) * 1000)).longValue();
         } else if (value instanceof Float) {
             return ((Number) (((Float) value) * 1000)).longValue();
-        } else if (value instanceof Number) {
-            return ((Number) value).longValue();
+        } else if (value instanceof Number number) {
+            return number.longValue();
         } else {
             throw new ClassCastException("Can't cast '" + value + "' to " + getName());
         }
@@ -136,8 +136,8 @@ public final class TimestampType extends DataType<Long>
     public Long sanitizeValue(Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Long) {
-            return (Long) value;
+        } else if (value instanceof Long l) {
+            return l;
         } else {
             return ((Number) value).longValue();
         }

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -68,7 +68,7 @@ public final class TimestampType extends DataType<Long>
         TimestampType::parseTimestampIgnoreTimeZone,
         Precedence.TIMESTAMP);
 
-    private static final StorageSupport<Long> STORAGE = new StorageSupport<>(true, true, new LongEqQuery()) {
+    private static final StorageSupport<Long> STORAGE = new StorageSupport<>(true, true, true, new LongEqQuery()) {
 
         @Override
         public ValueIndexer<Long> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/UncheckedObjectType.java
+++ b/server/src/main/java/io/crate/types/UncheckedObjectType.java
@@ -48,7 +48,7 @@ public class UncheckedObjectType extends DataType<Map<Object, Object>> implement
     public static final int ID = 16;
 
     public static final String NAME = "unchecked_object";
-    private static final StorageSupport<Map<Object, Object>> STORAGE = new StorageSupport<>(false, false, null) {
+    private static final StorageSupport<Map<Object, Object>> STORAGE = new StorageSupport<>(false, false, false, null) {
 
         @Override
         public ValueIndexer<Map<Object, Object>> valueIndexer(RelationName table,

--- a/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
@@ -127,10 +127,13 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_is_null_does_not_match_empty_arrays_with_index_and_column_store_off() throws Exception {
-        // Turning off columnstore is currently supported only for TEXT.
-        // We can enable this case for all types once https://github.com/crate/crate/issues/11652 is implemented.
-        String createStatement = "create table t_text (xs array(text) index off storage with (columnstore = false))";
-        assertMatches(createStatement, true, ARRAY_VALUES);
+        for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            if (dataType.storageSupport() != null && dataType.storageSupport().supportsDocValuesOff()) {
+                var createStmt =
+                        "create table t_text (xs array(" + dataType + ") index off storage with (columnstore = false))";
+                assertMatches(createStmt, true, ARRAY_VALUES);
+            }
+        }
     }
 
     @Test
@@ -174,10 +177,13 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_is_not_null_does_not_match_empty_arrays_with_index_and_column_store_off() throws Exception {
-        // Turning off columnstore is currently supported only for TEXT.
-        // We can enable this case for all types once https://github.com/crate/crate/issues/11652 is implemented.
-        String createStatement = "create table t_text (xs array(text) index off storage with (columnstore = false))";
-        assertMatches(createStatement, false, ARRAY_VALUES);
+        for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+            if (dataType.storageSupport() != null && dataType.storageSupport().supportsDocValuesOff()) {
+                var createStmt =
+                        "create table t (xs array(" + dataType + ") index off storage with (columnstore = false))";
+                assertMatches(createStmt, false, ARRAY_VALUES);
+            }
+        }
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -26,7 +26,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.DataTypeTesting.randomType;
 import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.function.Supplier;

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -55,6 +55,7 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
             " content string index using fulltext," +
             " text_no_index text index off storage with (columnstore = false)," +
             " x integer not null," +
+            " x_no_docvalues int storage with (columnstore = false)," +
             " f float," +
             " d double," +
             " obj object as (" +
@@ -64,6 +65,7 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
             " obj_ignored object (ignored), " +
             " d_array array(double)," +
             " y_array array(long)," +
+            " x_array_no_docvalues array(int) storage with (columnstore = false)," +
             " o_array array(object as (xs array(integer)))," +
             " ts_array array(timestamp with time zone)," +
             " shape geo_shape," +

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -1566,7 +1566,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testColumnStoreBooleanIsParsedCorrectly() throws Exception {
         DocIndexMetadata md = getDocIndexMetadataFromStatement(
-            "create table t1 (x string STORAGE WITH (columnstore = false))");
+                "create table t1 (x string STORAGE WITH (columnstore = false))");
         assertThat(md.columns().iterator().next().hasDocValues()).isFalse();
     }
 


### PR DESCRIPTION
Pass `hasDocValues()` flag to `rangeQuery()` to be able to determine if the returned range query should be wrapped in a `IndexOrDocValuesQuery`.

Closes: #11652
