### PR TITLE
Fix ON CONFLICT handling with generated primary key columns

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -182,4 +182,6 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Fixed a regression introduced in 5.3.0 which caused ``INSERT INTO`` statements
+  with a ``ON CONFLICT`` clause on tables with generated primary key columns to
+  fail with an ``ArrayIndexOutOfBoundsException``.

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
@@ -161,15 +161,17 @@ public final class UpdateToInsert {
                 this.columns.add(insertColumn);
             }
         }
-        for (var column : table.columns()) {
+        for (var ref : table.columns()) {
             // The Indexer later on injects the generated column values
             // We only include them here if they are provided in the `updateColumns` to validate
             // that users provided the right value (otherwise they'd get ignored and we'd generate them later)
-            if (column instanceof GeneratedReference && !Arrays.asList(updateColumns).contains(column.column().fqn())) {
+            if (ref instanceof GeneratedReference
+                    && !Arrays.asList(updateColumns).contains(ref.column().fqn())
+                    && !table.primaryKey().contains(ref.column())) {
                 continue;
             }
-            if (!this.columns.contains(column)) {
-                this.columns.add(column);
+            if (!this.columns.contains(ref)) {
+                this.columns.add(ref);
             }
         }
         for (String columnName : updateColumns) {


### PR DESCRIPTION
`UpdateToInsert` must generate the values for generated primary key
columns if they are missing from the insert values.

Fixes https://github.com/crate/crate/issues/14213