### PR TITLE
tests: Fix flaky `testInsertStringGreaterThanDocValuesLimit`

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
@@ -40,7 +40,7 @@ public class StorageOptionsITest extends IntegTestCase {
         refresh();
 
         execute("select s from t1 limit 1");
-        assertThat(response).hasRows(bigString);
+        assertThat(response.rows()[0][0]).isEqualTo(bigString);
     }
 
     @Test


### PR DESCRIPTION
Revert `hasRows()` as its logic is dependent on new lines, and if the randomly generated string contains news lines it can break the assertion, use regular `isEqualTo()` on the response col directly.

Follows: 837db421e7df25d21b4d93cb415315767a3bca98
