### PR TITLE
Remove numExpectedRows from GroupHashAggregate

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Distinct.java
+++ b/server/src/main/java/io/crate/planner/operators/Distinct.java
@@ -21,23 +21,17 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.operators.GroupHashAggregate.approximateDistinctValues;
-
 import java.util.Collections;
 import java.util.List;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.planner.optimizer.costs.PlanStats;
-import io.crate.statistics.Stats;
 
 public final class Distinct {
 
-    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs, PlanStats planStats) {
+    public static LogicalPlan create(LogicalPlan source, boolean distinct, List<Symbol> outputs) {
         if (!distinct) {
             return source;
         }
-        Stats stats = planStats.get(source);
-        long numExpectedRows = approximateDistinctValues(stats, outputs);
-        return new GroupHashAggregate(source, outputs, Collections.emptyList(), numExpectedRows);
+        return new GroupHashAggregate(source, outputs, Collections.emptyList());
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -377,8 +377,7 @@ public class LogicalPlanner {
                     rhsRel.accept(this, rhsRel.outputs()),
                     union.outputs()),
                 union.isDistinct(),
-                union.outputs(),
-                planStats
+                union.outputs()
             );
         }
 
@@ -457,8 +456,7 @@ public class LogicalPlanner {
                                     splitPoints.tableFunctions()
                                 ),
                                 relation.isDistinct(),
-                                relation.outputs(),
-                                planStats
+                                relation.outputs()
                             ),
                             relation.orderBy()
                         ),
@@ -476,11 +474,7 @@ public class LogicalPlanner {
                                            List<Function> aggregates,
                                            PlanStats planStats) {
         if (!groupKeys.isEmpty()) {
-            long numExpectedRows = GroupHashAggregate.approximateDistinctValues(
-                planStats.get(source),
-                groupKeys
-            );
-            return new GroupHashAggregate(source, groupKeys, aggregates, numExpectedRows);
+            return new GroupHashAggregate(source, groupKeys, aggregates);
         }
         if (!aggregates.isEmpty()) {
             return new HashAggregate(source, aggregates);

--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -213,7 +213,7 @@ public class PlanStats {
         @Override
         public Stats visitGroupHashAggregate(GroupHashAggregate groupHashAggregate, Void context) {
             var stats = groupHashAggregate.source().accept(this, context);
-            return stats.withNumDocs(groupHashAggregate.numExpectedRows());
+            return stats.withNumDocs(GroupHashAggregate.approximateDistinctValues(stats, groupHashAggregate.groupKeys()));
         }
 
         @Override


### PR DESCRIPTION
This moves the calculation of the expected rows into `PlanStats` to
match other operators.

Part of the motivation is also to make it easier to integrate
histogram/most-common-values sampling into the `SelectivityFunctions`,
which will add a new `TransactionContext` dependency.
