### PR TITLE
Add `array_set` scalar function

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -181,6 +181,8 @@ Changes
   has been lowered from `HIGH` to `MEDIUM` as leaving these to default
   or suboptimal values does not translate into data corruption or loss.
 
+- Added :ref:`array_set <scalar-array_set>` scalar function.
+
 Fixes
 =====
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2820,6 +2820,31 @@ return value is ``NULL``. Example:
     +------+
     SELECT 1 row in set (... sec)
 
+.. _scalar-array_set:
+
+``array_set(source_array, indexes_array, values_array)``
+--------------------------------------------------------
+
+The ``array_set`` function returns the source array updated according to the
+given indexes and values. Depending on the indexes provided, ``array_set``
+updates or appends the values and also fills any gaps with ``nulls``.
+
+Returns: ``array``
+
+::
+
+    cr> select array_set(['_', 'b'], [1, 4], ['a', 'd']) AS arr;
+    +-----------------------+
+    | arr                   |
+    +-----------------------+
+    | ["a", "b", null, "d"] |
+    +-----------------------+
+    SELECT 1 row in set (... sec)
+
+.. NOTE::
+
+    Updating indexes less than or equal to 0 is currently not supported.
+
 .. _scalar-array_slice:
 
 ``array_slice(anyarray, from, to)``

--- a/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static io.crate.types.TypeSignature.parseTypeSignature;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crate.data.Input;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+public class ArraySetFunction extends Scalar<List<Object>, Object> {
+
+    public static final String NAME = "array_set";
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                parseTypeSignature("array(E)"),
+                new ArrayType(DataTypes.INTEGER).getTypeSignature(),
+                parseTypeSignature("array(E)"),
+                parseTypeSignature("array(E)")
+            ).withTypeVariableConstraints(typeVariable("E")),
+            ArraySetFunction::new
+        );
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    public ArraySetFunction(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    @SafeVarargs
+    public final List<Object> evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>... args) {
+        List<Object> inputArray = (List<Object>) args[0].value();
+        if (inputArray == null) {
+            return null;
+        }
+        List<Integer> indexesToUpdate = (List<Integer>) args[1].value();
+        List<Object> targetValues = (List<Object>) args[2].value();
+        if (indexesToUpdate == null && targetValues == null) {
+            return inputArray;
+        }
+
+        List<Object> updated = new ArrayList<>(inputArray);
+
+        if (indexesToUpdate == null || targetValues == null || indexesToUpdate.size() != targetValues.size()) {
+            throw new IllegalArgumentException(
+                "`array_set(array, indexes, values)`: the size of indexes and values must match or both be nulls");
+        }
+
+        for (int i = 0; i < indexesToUpdate.size(); i++) {
+            setElement(updated, indexesToUpdate.get(i), targetValues.get(i));
+        }
+        return updated;
+    }
+
+    private void setElement(List<Object> source, int index, Object value) {
+        if (index <= 0) {
+            throw new UnsupportedOperationException("Updating arrays with indexes <= 0 is not supported");
+        }
+        index--; // Since array indexes in CrateDB start from 1
+        if (index < source.size()) {
+            source.set(index, value);
+        } else {
+            for (int i = source.size(); i < index; i++) {
+                source.add(null);
+            }
+            source.add(value);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -201,6 +201,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         ArraySliceFunction.register(this);
         ArrayPositionFunction.register(this);
         ArrayUnnestFunction.register(this);
+        ArraySetFunction.register(this);
 
         CoalesceFunction.register(this);
         GreatestFunction.register(this);

--- a/server/src/test/java/io/crate/expression/scalar/ArraySetFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySetFunctionTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.exceptions.ConversionException;
+
+public class ArraySetFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_indexes_out_of_range() {
+        assertThatThrownBy(() -> assertEvaluateNull("array_set([1,1,1], [-2147483649], [2])"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `-2147483649::bigint` of type `bigint` to type `integer`");
+        assertThatThrownBy(() -> assertEvaluateNull("array_set([1,1,1], [2147483648], [2])"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `2147483648::bigint` of type `bigint` to type `integer`");
+    }
+
+    @Test
+    public void test_long_indexes_that_fit_into_integer() {
+        assertEvaluate("array_set([1,2,3], [3::long], [-1])", List.of(1, 2, -1));
+    }
+
+    @Test
+    public void test_set_to_long_values_that_fit_into_integer() {
+        assertEvaluate("array_set([1,2,3], [3::long], [-1::long])", List.of(1L, 2L, -1L));
+    }
+
+    @Test
+    public void test_appending_value_at_the_end() {
+        assertEvaluate("array_set([1,2,3], [4], [-1])", List.of(1, 2, 3, -1));
+    }
+
+    @Test
+    public void test_null_padding_added_in_between_array_set_index_and_max_index_of_source_array() {
+        ArrayList<Integer> expected = new ArrayList<>(List.of(1, 2, 3));
+        expected.add(null);
+        expected.add(-1);
+        assertEvaluate("array_set([1,2,3], [5], [-1])", expected);  // expected = [1, 2, 3, null, -1]
+    }
+
+    @Test
+    public void test_negative_index() {
+        assertThatThrownBy(
+            () -> assertEvaluate(
+                "array_set([1,2,3], [0, -1], [0, -1])",
+                List.of(-1, 0, 1, 2, 3)))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Updating arrays with indexes <= 0 is not supported");
+    }
+
+    @Test
+    public void test_empty_array_for_target_indexes_and_empty_array_for_target_values() {
+        assertEvaluate("array_set([1,2,3], [], [])", List.of(1, 2, 3));
+    }
+
+    @Test
+    public void test_null_for_target_indexes_and_null_for_target_values() {
+        assertEvaluate("array_set([1,2,3], null, null)", List.of(1, 2, 3));
+    }
+
+    @Test
+    public void test_either_target_indexes_or_target_values_are_null() {
+        assertThatThrownBy(() -> assertEvaluateNull("array_set([1,2,3], null, [1])"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("`array_set(array, indexes, values)`: the size of indexes and values must match or both be nulls");
+        assertThatThrownBy(() -> assertEvaluateNull("array_set([1,2,3], [1], null)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("`array_set(array, indexes, values)`: the size of indexes and values must match or both be nulls");
+    }
+
+    @Test
+    public void test_unmatched_number_of_target_values_and_target_indexes() {
+        assertThatThrownBy(() -> assertEvaluateNull("array_set([1,2,3], [1], [])"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("`array_set(array, indexes, values)`: the size of indexes and values must match or both be nulls");
+        assertThatThrownBy(() -> assertEvaluateNull("array_set([1,2,3], [], [1])"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("`array_set(array, indexes, values)`: the size of indexes and values must match or both be nulls");
+    }
+
+    @Test
+    public void test_source_is_null() {
+        assertEvaluateNull("array_set(null, [1], [1])");
+        assertEvaluateNull("array_set(null, null, null)");
+    }
+
+    @Test
+    public void test_source_is_empty_array() {
+        assertEvaluate("array_set([], [1], [1])", List.of(1));
+    }
+
+    @Test
+    public void test_set_single_index_multiple_times() {
+        assertEvaluate("array_set([1,2,3], [1,1,1], [1,2,3])", List.of(3,2,3));
+    }
+
+    @Test
+    public void test_set_single_array_element_to_wrong_type() {
+        assertThatThrownBy(() -> assertEvaluateNull("array_set([1,2,3], [1], ['a'])"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'a'` of type `text` to type `integer`");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This scalar function is a prerequisite for supporting updating array by the elements, see https://github.com/crate/crate/pull/14140#pullrequestreview-1450330940.

NOTE: 
1) negative indexes are rejected currently.
2) there is no circuit breaker in place for a large update resulting in out of memory error - ex) `update t set a[2147483647] = 1` (which adds a huge null padding). 

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
