### PR TITLE
insert null from subquery into partitioned table is flaky

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -187,6 +187,21 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @Repeat(iterations = 100)
+    public void test_insert_null_from_subquery_into_partitioned_table() {
+        execute("CREATE TABLE times (" +
+            "   time timestamp with time zone" +
+            ") partitioned by (time)");
+
+        execute("insert into times (time) (select null from sys.cluster)");
+        refresh();
+
+        execute("select time from times");
+        assertThat(response.rowCount()).isEqualTo(1L);
+        assertThat(response.rows()[0][0]).isNull();
+    }
+
+    @Test
     public void testInsertBadIPAddress() throws Exception {
         execute("create table t (i ip) with (number_of_replicas=0)");
         ensureYellow();

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -188,7 +188,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
 
     @Test
     @Repeat(iterations = 100)
-    public void test_insert_null_from_subquery_into_partitioned_table() {
+    public void test_insert_null_from_subquery_into_partitioned_table() throws Exception {
         execute("CREATE TABLE times (" +
             "   time timestamp with time zone" +
             ") partitioned by (time)");
@@ -196,9 +196,12 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("insert into times (time) (select null from sys.cluster)");
         refresh();
 
-        execute("select time from times");
-        assertThat(response.rowCount()).isEqualTo(1L);
-        assertThat(response.rows()[0][0]).isNull();
+        assertBusy(() -> {
+                execute("select time from times");
+                assertThat(response.rowCount()).isEqualTo(1L);
+                assertThat(response.rows()[0][0]).isNull();
+            }
+        );
     }
 
     @Test


### PR DESCRIPTION
Similar to `testCopyFromToPartitionedTableWithNullValue` (after _raw removal it's similar and flaky)

On 5.2 it's also flaky https://github.com/crate/crate/pull/14231