### PR TITLE
 Minor code cleanups around `Reference` & assertj migrations

### DIFF
--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -175,46 +175,57 @@ public class GeneratedReference implements Reference {
         return column().quotedOutputName() + " AS " + formattedGeneratedExpression;
     }
 
+    @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitReference(this, context);
     }
 
+    @Override
     public ReferenceIdent ident() {
         return ref.ident();
     }
 
+    @Override
     public ColumnIdent column() {
         return ref.column();
     }
 
+    @Override
     public IndexType indexType() {
         return ref.indexType();
     }
 
+    @Override
     public ColumnPolicy columnPolicy() {
         return ref.columnPolicy();
     }
 
+    @Override
     public boolean isNullable() {
         return ref.isNullable();
     }
 
+    @Override
     public RowGranularity granularity() {
         return ref.granularity();
     }
 
+    @Override
     public int position() {
         return ref.position();
     }
 
+    @Override
     public boolean hasDocValues() {
         return ref.hasDocValues();
     }
 
+    @Override
     public DataType<?> valueType() {
         return ref.valueType();
     }
 
+    @Override
     public Symbol cast(DataType<?> targetType, CastMode... modes) {
         Symbol result = ref.cast(targetType, modes);
         if (ref == result) {

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -223,7 +223,7 @@ public class IndexReference extends SimpleReference {
         mapping.put("type", "text");
 
         if (columns.isEmpty() == false) {
-            mapping.put("sources", columns.stream().map(ref -> ref.column().fqn()).collect(Collectors.toList()));
+            mapping.put("sources", columns.stream().map(ref -> ref.column().fqn()).toList());
         }
 
         return mapping;

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -24,7 +24,6 @@ package io.crate.metadata;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +42,7 @@ public interface Reference extends Symbol {
 
     static int indexOf(Iterable<? extends Reference> refs, ColumnIdent column) {
         int i = 0;
-        Iterator<? extends Reference> it = refs.iterator();
-        while (it.hasNext()) {
-            var ref = it.next();
+        for (Reference ref : refs) {
             if (ref.column().equals(column)) {
                 return i;
             }

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -126,6 +126,7 @@ public class SimpleReference implements Reference {
     /**
      * Returns a cloned Reference with the given ident
      */
+    @Override
     public Reference getRelocated(ReferenceIdent newIdent) {
         return new SimpleReference(
             newIdent,
@@ -168,39 +169,48 @@ public class SimpleReference implements Reference {
         return column().quotedOutputName();
     }
 
+    @Override
     public ReferenceIdent ident() {
         return ident;
     }
 
+    @Override
     public ColumnIdent column() {
         return ident.columnIdent();
     }
 
+    @Override
     public RowGranularity granularity() {
         return granularity;
     }
 
+    @Override
     public ColumnPolicy columnPolicy() {
         return columnPolicy;
     }
 
+    @Override
     public IndexType indexType() {
         return indexType;
     }
 
+    @Override
     public boolean isNullable() {
         return nullable;
     }
 
+    @Override
     public boolean hasDocValues() {
         return hasDocValues;
     }
 
+    @Override
     public int position() {
         return position;
     }
 
     @Nullable
+    @Override
     public Symbol defaultExpression() {
         return defaultExpression;
     }

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -85,7 +84,7 @@ public final class SystemTable<T> implements TableInfo {
             : getRouting;
         this.rootColumns = columns.values().stream()
             .filter(x -> x.column().isTopLevel())
-            .collect(Collectors.toList());
+            .toList();
         this.expressions = expressions;
         this.primaryKeys = primaryKeys;
         this.dynamicColumns = dynamicColumns;

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -144,7 +144,7 @@ public class DocTableInfoFactory {
                 indexMetadata,
                 relation,
                 publicationsMetadata);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new UnhandledServerException("Unable to build DocIndexMetadata", e);
         }
         try {

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -183,11 +183,11 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_is_no_op_if_columns_exist() throws Exception {
-        /**
+        /*
          * The cluster state update logic later asserts that the mapping source must have changed if
          * the version increases. Without no-op check this assertion would trip
          * if there are concurrent alter table (or more likely: Dynamic mapping updates due to concurrent inserts)
-         **/
+         */
         var e = SQLExecutor.builder(clusterService)
             .addTable("create table tbl (x int)")
             .build();

--- a/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
@@ -22,8 +22,7 @@
 
 package io.crate.execution.dsl.projection;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -95,7 +94,7 @@ public class SourceIndexWriterProjectionSerializationTest {
         StreamInput in = out.bytes().streamInput();
         in.setVersion(Version.V_4_6_0);
 
-        assertThat(new SourceIndexWriterProjection(in).failFast(), is((!expected.failFast())));
+        assertThat(new SourceIndexWriterProjection(in).failFast()).isNotEqualTo(expected.failFast());
 
         BytesStreamOutput out2 = new BytesStreamOutput();
         out2.setVersion(Version.V_4_7_0);
@@ -104,7 +103,7 @@ public class SourceIndexWriterProjectionSerializationTest {
         StreamInput in2 = out2.bytes().streamInput();
         in2.setVersion(Version.V_4_7_0);
 
-        assertThat(new SourceIndexWriterProjection(in2).failFast(), is((expected.failFast())));
+        assertThat(new SourceIndexWriterProjection(in2).failFast()).isEqualTo((expected.failFast()));
     }
 
     @Test
@@ -152,7 +151,7 @@ public class SourceIndexWriterProjectionSerializationTest {
         StreamInput in = out.bytes().streamInput();
         in.setVersion(Version.V_4_7_0);
 
-        assertThat(new SourceIndexWriterProjection(in).validation(), is(true)); // validation flag value lost and set to default (true)
+        assertThat(new SourceIndexWriterProjection(in).validation()).isTrue(); // validation flag value lost and set to default (true)
 
         BytesStreamOutput out2 = new BytesStreamOutput();
         out2.setVersion(Version.V_4_8_0);
@@ -161,6 +160,6 @@ public class SourceIndexWriterProjectionSerializationTest {
         StreamInput in2 = out2.bytes().streamInput();
         in2.setVersion(Version.V_4_8_0);
 
-        assertThat(new SourceIndexWriterProjection(in2).validation(), is(false)); // validation flag value recovered
+        assertThat(new SourceIndexWriterProjection(in2).validation()).isFalse(); // validation flag value recovered
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -21,10 +21,8 @@
 
 package io.crate.execution.engine.collect;
 
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.createNodeContext;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -153,9 +151,8 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
 
         var rowConsumer = new TestingRowConsumer();
         rowConsumer.accept(it, null);
-        assertThat(
-            rowConsumer.getResult(),
-            containsInAnyOrder(new Object[]{0L, 6L}, new Object[]{1L, 4L}));
+        assertThat(rowConsumer.getResult()).containsExactlyInAnyOrder(
+            new Object[]{0L, 6L}, new Object[]{1L, 4L});
     }
 
     @Test
@@ -228,22 +225,20 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
         var rowConsumer = new TestingRowConsumer();
         rowConsumer.accept(it, null);
 
-        assertThat(
-            rowConsumer.getResult(),
-            containsInAnyOrder(new Object[]{"0", 0L, 6L}, new Object[]{"1", 1L, 4L})
-        );
+        assertThat(rowConsumer.getResult()).containsExactlyInAnyOrder(
+            new Object[]{"0", 0L, 6L}, new Object[]{"1", 1L, 4L});
     }
 
     @Test
     public void test_optimized_iterator_stop_processing_on_kill() throws Exception {
         Throwable expectedException = stopOnInterrupting(it -> it.kill(new InterruptedException("killed")));
-        assertThat(expectedException, instanceOf(InterruptedException.class));
+        assertThat(expectedException).isExactlyInstanceOf(InterruptedException.class);
     }
 
     @Test
     public void test_optimized_iterator_stop_processing_on_close() throws Exception {
         Throwable expectedException = stopOnInterrupting(BatchIterator::close);
-        assertThat(expectedException, instanceOf(IllegalStateException.class));
+        assertThat(expectedException).isExactlyInstanceOf(IllegalStateException.class);
     }
 
     private Throwable stopOnInterrupting(Consumer<BatchIterator<Row>> interrupt) throws Exception {

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -177,7 +177,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(info.getDynamic(columnIdent, false, false)).isNull();
 
         // forWrite: true, errorOnUnknownObjectKey: false, parentPolicy: strict
-        Assertions.assertThatThrownBy(() -> assertThat(info.getDynamic(columnIdent, true, false)).isNull())
+        Assertions.assertThatThrownBy(() -> info.getDynamic(columnIdent, true, false))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessageContaining("Column foobar['foo']['bar'] unknown");
 
@@ -188,7 +188,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(info.getDynamic(columnIdent2, false, true)).isNull();
 
         // forWrite: true, errorOnUnknownObjectKey: true, parentPolicy: strict
-        Assertions.assertThatThrownBy(() -> assertThat(info.getDynamic(columnIdent2, true, true)).isNull())
+        Assertions.assertThatThrownBy(() -> info.getDynamic(columnIdent2, true, true))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessageContaining("Column foobar['foo'] unknown");
 
@@ -196,7 +196,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(info.getDynamic(columnIdent2, false, false)).isNull();
 
         // forWrite: true, errorOnUnknownObjectKey: false, parentPolicy: strict
-        Assertions.assertThatThrownBy(() -> assertThat(info.getDynamic(columnIdent2, true, false)).isNull())
+        Assertions.assertThatThrownBy(() -> info.getDynamic(columnIdent2, true, false))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessageContaining("Column foobar['foo'] unknown");
 

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -571,6 +571,7 @@ public abstract class AggregationTestCase extends ESTestCase {
         IOUtils.close(() -> shard.close("test", false), shard.store());
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     protected Symbol normalize(String functionName, Object value, DataType type) {
         return normalize(functionName, Literal.of(type, value));
     }


### PR DESCRIPTION
- Minor code cleanups around `Reference`
- tests: Migrate to assertj 
    - AddColumnTest
    - SourceIndexWriterProjectionSerializationTest
    - DocValuesGroupByOptimizedIteratorTest
