### PR TITLE
Fix SJK download url used by jmx blackbox tests

### DIFF
--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -56,7 +56,7 @@ enterprise_crate = CrateNode(
 
 class JmxClient:
 
-    SJK_JAR_URL = "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.gridkit.jvmtool&a=sjk&v=LATEST"
+    SJK_JAR_URL = "https://repo1.maven.org/maven2/org/gridkit/jvmtool/sjk/0.21/sjk-0.21.jar"
 
     CACHE_DIR = os.environ.get(
         'XDG_CACHE_HOME',


### PR DESCRIPTION
Use maven central as sonatype has "hiccups":
```
➭ wget https://repository.sonatype.org/service/local/artifact/maven/redirect\?r\=central-proxy\&g\=org.gridkit.jvmtool\&a\=sjk\&v\=LATEST
--2023-06-07 15:01:33--  https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.gridkit.jvmtool&a=sjk&v=LATEST
Resolving repository.sonatype.org (repository.sonatype.org)... 50.19.137.226, 52.207.204.11
Connecting to repository.sonatype.org (repository.sonatype.org)|50.19.137.226|:443... connected.
HTTP request sent, awaiting response... 401 Unauthorized

Username/Password Authentication Failed.
```

/cc @seut why did we revert this: https://github.com/crate/crate/commit/b2168a14bc7eebb28ccfe735eded0039c8cb3416 ?
Any issue to hit maven central directly?