### PR TITLE
Fix flaky join integration  test

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
@@ -1154,6 +1153,8 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         execute("refresh table t1, t2, t3");
         execute("analyze");
+        waitNoPendingTasksOnAll();
+
         String stmt =
             """
                     SELECT


### PR DESCRIPTION
This fixes the flaky test by making  sure `analyze` and it's subtasks are finished and statistics are updated. Flakiness occurs when the top NestedLoopJoin is reordered by rule based on misleading statistics, because they are not fully updated yet.

```
expected: 
  "NestedLoopJoin[LEFT | (id = id)]
    ├ Eval[id, a, id, b, id, c]
    │  └ HashJoin[(id = id)]
    │    ├ Collect[doc.t3 | [id, c] | true]
    │    └ HashJoin[(id = id)]
    │      ├ Collect[doc.t1 | [id, a] | true]
    │      └ Get[doc.t2 | id, b | DocKeys{1; 2} | ((id = 1) OR (id = 2))]
    └ Collect[doc.t4 | [id, d] | true]"
 but was: 
  "Eval[id, a, id, b, id, c, id, d]   
    └ NestedLoopJoin[RIGHT | (id = id)]  <- This join was swapped based on incorrect stats
      ├ Collect[doc.t4 | [id, d] | true]
      └ Eval[id, a, id, b, id, c]
        └ HashJoin[(id = id)]
          ├ Collect[doc.t3 | [id, c] | true]
          └ HashJoin[(id = id)]
            ├ Collect[doc.t1 | [id, a] | true]
            └ Get[doc.t2 | id, b | DocKeys{1; 2} | ((id = 1) OR (id = 2))]"
```

Fixes https://github.com/crate/crate/issues/14253

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
