### PR TITLE
Fix issue with empty arrays, selecting by id

### DIFF
--- a/docs/appendices/release-notes/5.3.2.rst
+++ b/docs/appendices/release-notes/5.3.2.rst
@@ -105,10 +105,10 @@ Fixes
   first argument of :ref:`INTERVAL data type <type-interval>` contains month
   and/or year units.
 
-- Added a workaround for an issue that allowed inserting a non-array value onto
-  a column that is dynamically created by inserting an empty array, ultimately
-  modifying the type of the column. The empty arrays will be convert to
-  ``nulls`` when queried. For example::
+- Fixed an issue that allowed inserting a non-array value into a column that is
+  dynamically created by inserting an empty array, ultimately modifying the type
+  of the column. The empty arrays will be convert to ``nulls`` when queried. For
+  example::
 
     CREATE TABLE t (o OBJECT);
     INSERT INTO t VALUES ({x=[]});

--- a/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
@@ -23,7 +23,9 @@ package io.crate.expression.reference;
 
 import static io.crate.execution.engine.collect.NestableCollectExpression.forFunction;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import io.crate.common.collections.Maps;
@@ -36,6 +38,8 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.ObjectType;
 
 /**
  * ReferenceResolver implementation which can be used to retrieve {@link CollectExpression}s to extract values from {@link Doc}
@@ -112,13 +116,30 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                     } catch (ClassCastException | ConversionException e) {
                         // due to a bug: https://github.com/crate/crate/issues/13990
                         Object value = ValueExtractors.fromMap(response.getSource(), column);
-                        if (value instanceof List<?> list && list.stream().allMatch(Objects::isNull) &&
-                            !(ref.valueType() instanceof ArrayType<?>)) {
-                            return null;
-                        }
-                        throw e;
+                        return replaceArraysWithNull(value, ref.valueType(), e);
                     }
                 });
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Object replaceArraysWithNull(Object value, DataType<?> valueType, RuntimeException e)
+        throws RuntimeException {
+
+        if (value instanceof List<?> list && list.stream().allMatch(Objects::isNull) &&
+            valueType.id() != ArrayType.ID) {
+            return null;
+        } else if (value instanceof Map<?, ?> valueMap) {
+            Map newMap = new HashMap<>(valueMap.size());
+            for (var entry : valueMap.entrySet()) {
+                Object entryKey = entry.getKey();
+                Object entryValue = entry.getValue();
+                DataType<?> innerType = ((ObjectType) valueType).innerType((String) entryKey);
+                newMap.put(entryKey, replaceArraysWithNull(entryValue, innerType, e));
+            }
+            return newMap;
+        } else {
+            throw e;
         }
     }
 }


### PR DESCRIPTION
When selecting by id (primary key) another path is followed, so it's necessary to properly check and return a valid value (object -> Map) in this case.

Workaround for: #13990
Follows: #14049
