### PR TITLE
Validate dynamic column names while indexing

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -195,3 +195,25 @@ Fixes
 - Fixed a regression introduced in 5.3.0 which caused ``INSERT INTO`` statements
   with a ``ON CONFLICT`` clause on tables with generated primary key columns to
   fail with an ``ArrayIndexOutOfBoundsException``.
+
+- Fixed a regression introduced in 5.3.0 which caused ``INSERT INTO`` statements
+  to reject invalid dynamic columns and their value without raising an error or
+  skipping the whole record. An example ::
+
+    CREATE TABLE t(a INT) WITH (column_policy='dynamic');
+    INSERT INTO t(a, _b) VALUES (1, 2);
+    INSERT OK, 1 row affected  (0.258 sec)
+    INSERT INTO t(a, _b) (SELECT 2, 2);
+    INSERT OK, 1 row affected  (0.077 sec)
+    SELECT * FROM t;
+    +---+
+    | a |
+    +---+
+    | 1 |
+    | 2 |
+    +---+
+    SELECT 2 rows in set (0.594 sec)
+
+  In 5.2.0 neither variant inserted a record. The first ``INSERT`` raised an
+  error, and the second resulted in row count 0.
+

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -551,7 +551,11 @@ public class Indexer {
         Document doc = new Document();
         Consumer<? super IndexableField> addField = doc::add;
         ArrayList<Reference> newColumns = new ArrayList<>();
-        Consumer<? super Reference> onDynamicColumn = newColumns::add;
+        Consumer<? super Reference> onDynamicColumn = ref -> {
+            ColumnIdent.validateColumnName(ref.column().name());
+            ref.column().path().forEach(ColumnIdent::validateObjectKey);
+            newColumns.add(ref);
+        };
         for (var expression : expressions) {
             expression.setNextRow(item);
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/14249

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
