### PR TITLE
Remove inferModulePath = false workaround

### DIFF
--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -66,9 +66,6 @@ tasks.withType(JavaCompile) {
             options.forkOptions.executable = jdks.runtime.getBinJavaPath()
         }
     }
-    // See https://github.com/eclipse/buildship/issues/1072
-    // Prevents `The package org.joda.time.format conflicts with a package accessible from another module: org.joda.time` errors
-    modularity.inferModulePath = false
 
 
     options.warnings = false


### PR DESCRIPTION
Looks like the issue was fixed in gradle 7.0.1
