### PR TITLE
Add temporary changes to get more details of column position test failure

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -37,6 +37,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import io.crate.testing.UseRandomizedOptimizerRules;
 
 public class DynamicMappingUpdateITest extends IntegTestCase {
@@ -50,6 +52,7 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates();
     }
 
+    @Repeat(iterations = 300)
     @Test
     public void test_concurrent_statements_that_add_columns_to_partitioned_table_result_in_dynamic_mapping_updates() throws InterruptedException {
         execute("create table t (a int, b object as (x int)) partitioned by (a)");

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -129,6 +129,8 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         concurrentUpdates8.join();
         concurrentUpdates9.join();
 
+        refresh();
+
         execute("""
             SELECT
                 column_name


### PR DESCRIPTION
Logs more details like:
```
[2023-06-14T13:17:25,505][INFO ][o.e.c.m.ColumnPositionResolver] [[cratedb[node_sm0][masterService#updateTask][T#1]]] [Column[name=b.newcol23., columnOrdering=-1, setPosition=io.crate.execution.ddl.TransportSchemaUpdateAction$$Lambda$4683/0x0000000801a25a20@8ec8eb1, column={position=-1, type=long}]]: position updated to 46
[2023-06-14T13:17:25,591][INFO ][o.e.c.m.ColumnPositionResolver] [[cratedb[node_sm0][masterService#updateTask][T#1]]] [Column[name=b.newcol4., columnOrdering=-1, setPosition=io.crate.execution.ddl.TransportSchemaUpdateAction$$Lambda$4683/0x0000000801a25a20@8ec8eb1, column={position=-1, type=long}]]: position updated to 47
```

I think this would help confirm that there is no re-calculation for sure and that the issue is bounded to `TransportSchemaUpdateAction` only.