### PR TITLE
Fix NPE from MetadataIndexUpgrader

### DIFF
--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -154,7 +154,7 @@ public class MetadataIndexUpgrader implements BiFunction<IndexMetadata, IndexTem
             if (ArrayType.NAME.equals(type)) {
                 Map<String, Object> innerMapping = Maps.get(columnProperties, "inner");
                 String innerType = Maps.get(innerMapping, "type");
-                if (ObjectType.UNTYPED.equals(DataTypes.ofMappingName(innerType))) {
+                if (innerType == null || ObjectType.UNTYPED.equals(DataTypes.ofMappingName(innerType))) {
                     updated |= addIndexColumnSources(rootMapping, innerMapping, columnFQN);
                 }
             } else {

--- a/server/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
@@ -389,4 +389,24 @@ public class IndexTemplateUpgraderTest {
         assertThat(actualMap)
             .isEqualTo(expectedMap);
     }
+
+    @Test
+    public void test_upgrade_deep_nested_object_mapping() throws Exception {
+        String templateName = PartitionName.templateName("doc", "events");
+        var template = IndexTemplateMetadata.builder(templateName)
+            .patterns(List.of("*"))
+            .putMapping(MappingConstants.DEEP_NESTED_MAPPING)
+            .build();
+
+
+        IndexTemplateUpgrader upgrader = new IndexTemplateUpgrader();
+        Map<String, IndexTemplateMetadata> result = upgrader.apply(Map.of(templateName, template));
+        IndexTemplateMetadata updatedTemplate = result.get(templateName);
+
+        Map actualMap = XContentHelper.toMap(updatedTemplate.mapping().uncompressed(), XContentType.JSON);
+        Map expectedMap = MapperService.parseMapping(NamedXContentRegistry.EMPTY, MappingConstants.DEEP_NESTED_MAPPING);
+
+        assertThat(actualMap)
+            .isEqualTo(expectedMap);
+    }
 }

--- a/server/src/test/java/io/crate/metadata/upgrade/MappingConstants.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/MappingConstants.java
@@ -111,4 +111,90 @@ public class MappingConstants {
                 "\"nested_col_fulltext\":{\"type\":\"text\",\"position\":7,\"analyzer\":\"stop\",\"sources\":[\"author.name\",\"title\"]}," +
                 "\"title\":{\"type\":\"keyword\",\"position\":1,\"copy_to\":[\"nested_col_fulltext\",\"title_desc_fulltext\"]}," +
                 "\"title_desc_fulltext\":{\"type\":\"text\",\"position\":6,\"analyzer\":\"standard\",\"sources\":[\"description\",\"title\"]}}}}";
+
+    // Obtained by executing test_copy_deep_nested_object_to_partitioned_table_results_in_dynamic_mapping_updates manually.
+    static final String DEEP_NESTED_MAPPING =
+        """
+            {
+              "default": {
+                "_meta": {
+                  "partitioned_by": [
+                    [
+                      "p",
+                      "integer"
+                    ]
+                  ]
+                },
+                "dynamic": "true",
+                "properties": {
+                  "p": {
+                    "index": false,
+                    "position": 2,
+                    "type": "integer"
+                  },
+                  "tb": {
+                    "type": "array",
+                    "inner": {
+                      "dynamic": "true",
+                      "position": 1,
+                      "type": "object",
+                      "properties": {
+                        "t1": {
+                          "type": "array",
+                          "inner": {
+                            "position": 3,
+                            "properties": {
+                              "t6": {
+                                "type": "array",
+                                "inner": {
+                                  "position": 6,
+                                  "type": "long"
+                                }
+                              },
+                              "t3": {
+                                "position": 5,
+                                "properties": {
+                                  "t4": {
+                                    "position": 7,
+                                    "properties": {
+                                      "t5": {
+                                        "position": 8,
+                                        "type": "long"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "t2": {
+                          "position": 4,
+                          "type": "object"
+                        }
+                      }
+                    }
+                  },
+                  "o": {
+                    "position": 9,
+                    "properties": {
+                      "a": {
+                        "position": 10,
+                        "properties": {
+                          "b": {
+                            "position": 12,
+                            "type": "long"
+                          }
+                        }
+                      },
+                      "b": {
+                        "position": 11,
+                        "type": "long"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
 }


### PR DESCRIPTION
Noticed an NPE from [wacklig](https://wacklig.pipifein.dev/github/crate/crate/c6de9d54-b441-40f3-b0f6-1168c9ee3ce5/d29c17ec-86f4-41c7-affe-d62d46f2752f/stdout):

```
[2023-06-10T00:07:28,723][WARN ][o.e.c.s.ClusterApplierService] [[cratedb[node_sm1][clusterApplierService#updateTask][T#1]]] failed to notify ClusterStateListener
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "pk" is null
	at java.util.ImmutableCollections$MapN.probe(ImmutableCollections.java:1321) ~[?:?]
	at java.util.ImmutableCollections$MapN.get(ImmutableCollections.java:1235) ~[?:?]
	at io.crate.types.DataTypes.ofMappingName(DataTypes.java:514) ~[crate-server.jar:?]
	at io.crate.metadata.upgrade.MetadataIndexUpgrader.addIndexColumnSources(MetadataIndexUpgrader.java:157) ~[crate-server.jar:?]
	at io.crate.metadata.upgrade.MetadataIndexUpgrader.addIndexColumnSources(MetadataIndexUpgrader.java:158) ~[crate-server.jar:?]
	at io.crate.metadata.upgrade.IndexTemplateUpgrader.archiveUnknownOrInvalidSettings(IndexTemplateUpgrader.java:105) ~[crate-server.jar:?]
	at io.crate.metadata.upgrade.IndexTemplateUpgrader.apply(IndexTemplateUpgrader.java:65) ~[crate-server.jar:?]
	at io.crate.metadata.upgrade.IndexTemplateUpgrader.apply(IndexTemplateUpgrader.java:54) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.metadata.TemplateUpgradeService.lambda$new$0(TemplateUpgradeService.java:89) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.metadata.TemplateUpgradeService.calculateTemplateChanges(TemplateUpgradeService.java:220) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.metadata.TemplateUpgradeService.clusterChanged(TemplateUpgradeService.java:125) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateListener(ClusterApplierService.java:518) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateListeners(ClusterApplierService.java:508) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:476) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:416) ~[crate-server.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:163) ~[crate-server.jar:?]
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:259) ~[crate-server.jar:?]
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:222) ~[crate-server.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1623) ~[?:?]
```