### PR TITLE
Fix NPE due to missing null check for DataTypes.guessType

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -196,6 +196,9 @@ Fixes
   with a ``ON CONFLICT`` clause on tables with generated primary key columns to
   fail with an ``ArrayIndexOutOfBoundsException``.
 
+- Fixed an issue that caused an ``NullPointerException`` while inserting
+  a ``TIMETZ`` typed value dynamically which is not supported.
+
 - Fixed a regression introduced in 5.3.0 which caused ``INSERT INTO`` statements
   to reject invalid dynamic columns and their value without raising an error or
   skipping the whole record. An example ::

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -318,7 +318,9 @@ public final class DataTypes {
             return valueFromList(Arrays.asList((Object[]) value));
         }
         DataType<?> dataType = POJO_TYPE_MAPPING.get(value.getClass());
-        assert dataType != null : "Must be able to guess type of value: " + value;
+        if (dataType == null) {
+            throw new IllegalArgumentException("Cannot detect the type of the value: " + value);
+        }
         return dataType;
     }
 

--- a/server/src/test/java/io/crate/DataTypeTest.java
+++ b/server/src/test/java/io/crate/DataTypeTest.java
@@ -22,6 +22,7 @@
 package io.crate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -49,6 +50,7 @@ import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import io.crate.types.Regproc;
 import io.crate.types.RowType;
+import io.crate.types.TimeTZ;
 import io.crate.types.UndefinedType;
 
 public class DataTypeTest extends ESTestCase {
@@ -274,5 +276,12 @@ public class DataTypeTest extends ESTestCase {
     public void test_estimate_size_of_record() throws Exception {
         var type = new RowType(List.of(DataTypes.LONG, DataTypes.INTEGER));
         assertThat(type.valueBytes(new RowN(20L, 10))).isEqualTo(40L);
+    }
+
+    @Test
+    public void test_guess_timetz_type() {
+        assertThatThrownBy(() -> DataTypes.guessType(new TimeTZ(46800000000L, 0)))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot detect the type of the value: 13:00:00");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/14276

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
